### PR TITLE
Use value of UIScreen.MainScreen.Scale to support retina display

### DIFF
--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             get
             {
-                return (int)UIScreen.MainScreen.Bounds.Width;
+                return (int)(UIScreen.MainScreen.Bounds.Width * UIScreen.MainScreen.Scale);
             }
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             get
             {
-                return (int)UIScreen.MainScreen.Bounds.Height;
+                return (int)(UIScreen.MainScreen.Bounds.Height * UIScreen.MainScreen.Scale);
             }
         }
 

--- a/MonoGame.Framework/IOSGameWindow.cs
+++ b/MonoGame.Framework/IOSGameWindow.cs
@@ -82,9 +82,10 @@ namespace Microsoft.Xna.Framework
 		{
 			LayerRetainsBacking = false; 
 			LayerColorFormat	= EAGLColorFormat.RGBA8;
+			ContentScaleFactor  = UIScreen.MainScreen.Scale;
 			
 			RectangleF rect = UIScreen.MainScreen.Bounds;
-			clientBounds = new Rectangle(0,0,(int) rect.Width,(int) rect.Height);
+			clientBounds = new Rectangle(0,0,(int) (rect.Width * UIScreen.MainScreen.Scale),(int) (rect.Height * UIScreen.MainScreen.Scale));
 			
 			// Enable multi-touch
 			MultipleTouchEnabled = true;
@@ -288,7 +289,7 @@ namespace Microsoft.Xna.Framework
 					break;
 				}
 			}
-			return translatedPosition;
+			return translatedPosition * UIScreen.MainScreen.Scale;
 		}
 		
 		public override void TouchesBegan (NSSet touches, UIEvent evt)


### PR DESCRIPTION
This is a pretty minor change that adds the screen point to screen pixel scale factor to support of retina screen resolutions. It updates both the rendering and touch input handling to use the screen's pixel size (MainScreen.Bounds \* MainScreen.Scale) instead of the screen's point size (MainScreen.Bounds). 
