### PR TITLE
Various SoundEffect improvements

### DIFF
--- a/MonoGame.Framework/Audio/AudioChannels.cs
+++ b/MonoGame.Framework/Audio/AudioChannels.cs
@@ -1,0 +1,51 @@
+#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+
+﻿using System;
+
+namespace Microsoft.Xna.Framework.Audio
+{
+    public enum AudioChannels
+    {
+        Mono = 1,
+        Stereo = 2
+    }
+}
+

--- a/MonoGame.Framework/Audio/Sound.cs
+++ b/MonoGame.Framework/Audio/Sound.cs
@@ -66,6 +66,26 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 		}
 		
+		public Sound(byte[] audiodata, float volume, bool looping)
+		{
+			var data = NSData.FromArray(audiodata);
+			_audioPlayer = AVAudioPlayer.FromData(data);
+			_audioPlayer.Volume = volume;
+			if ( looping )
+			{
+				_audioPlayer.NumberOfLoops = -1;
+			}
+			else
+			{
+				_audioPlayer.NumberOfLoops = 0;
+			}
+			
+			if (!_audioPlayer.PrepareToPlay())
+			{
+				throw new Exception("Unable to Prepare sound for playback!");
+			}
+		}
+		
 		public void Dispose()
 		{
 			_audioPlayer.Dispose();

--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -187,6 +187,9 @@ namespace Microsoft.Xna.Framework.Audio
 		{ 
 			get
 			{
+				if (_sound != null && soundState == SoundState.Playing && !_sound.Playing) {
+					soundState = SoundState.Stopped;
+				}
 				return soundState;
 			} 
 		}

--- a/MonoGame.Framework/MacOS/Audio/Sound.cs
+++ b/MonoGame.Framework/MacOS/Audio/Sound.cs
@@ -54,6 +54,13 @@ namespace Microsoft.Xna.Framework.Audio
 			_audioPlayer.Loops = looping;
 		}
 		
+		public Sound(byte[] audiodata, float volume, bool looping) {
+			var data = NSData.FromArray(audiodata);
+			_audioPlayer = new NSSound(data);
+			_audioPlayer.Volume = volume;
+			_audioPlayer.Loops = looping;
+		}
+		
 		public void Dispose()
 		{
 			_audioPlayer.Dispose();
@@ -124,7 +131,10 @@ namespace Microsoft.Xna.Framework.Audio
 		
 		public void Pause()
 		{		
-			_audioPlayer.Pause();
+			//HACK: Stopping or pausing NSSound is really slow (~200ms), don't if the sample is short :/
+			if (Duration > 2) {
+				_audioPlayer.Pause();
+			}
 		}
 		
 		public void Play()
@@ -134,7 +144,9 @@ namespace Microsoft.Xna.Framework.Audio
 		
 		public void Stop()
 		{			
-			_audioPlayer.Stop();
+			if (Duration > 2) { 
+				_audioPlayer.Stop();
+			}
 		}
 		
 		public float Volume

--- a/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Storage\StorageContainer.cs" />
     <Compile Include="Storage\StorageDevice.cs" />
+    <Compile Include="Audio\AudioChannels.cs" />
     <Compile Include="MacOS\Audio\Sound.cs" />
     <Compile Include="Audio\SoundEffect.cs" />
     <Compile Include="Audio\SoundEffectInstance.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Input\ThumbStickDefinition.cs" />
     <Compile Include="Input\Mouse.cs" />
     <Compile Include="Input\MouseState.cs" />
+    <Compile Include="Audio\AudioChannels.cs" />
     <Compile Include="Audio\SoundEffect.cs" />
     <Compile Include="Audio\SoundState.cs" />
     <Compile Include="Media\MediaPlayer.cs" />


### PR DESCRIPTION
-Fix SoundEffectReader to support arbitrary wave headers.
-Refractor SoundEffect and Sound to load from in-memory audio data instead of using temp files.
-Implement constructor SoundEffect(byte[] buffer, int sampleRate, AudioChannels channels)
-SoundEffectInstance SoundState fix
-NSSound.Stop lag hackaround. Probably have to move to a more low-level audio engine eventually.
