### PR TITLE
Android Touch events process correctly

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Android/AndroidGameWindow.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Xna.Framework
 
             GamePad.Instance.Update(e);
 
-            return base.OnTouchEvent(e);
+            return true;
         }
         
         public string ScreenDeviceName 


### PR DESCRIPTION
Return true to notify that the event has been handled, otherwise we get
strange behaviour.

Multi-Touch is still broken however and it looks like it will need quite a bit to update that.
