### PR TITLE
SamplerState/SpriteBatch fix

### DIFF
--- a/MonoGame.Framework/Linux/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Linux/Graphics/SpriteBatch.cs
@@ -174,8 +174,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			GL.Enable (EnableCap.CullFace);
 			GL.FrontFace (FrontFaceDirection.Cw);
 			GL.Color4 (1.0f, 1.0f, 1.0f, 1.0f);			
-			
-			_batcher.DrawBatch (_sortMode);
+
+			_batcher.DrawBatch (_sortMode, _samplerState);
 
 			// clear out the textures
 			graphicsDevice.Textures._textures.Clear ();

--- a/MonoGame.Framework/Linux/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Linux/Graphics/SpriteBatcher.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			return b.Depth.CompareTo(a.Depth);
 		}
 		
-		public void DrawBatch ( SpriteSortMode sortMode )
+		public void DrawBatch ( SpriteSortMode sortMode, SamplerState samplerState )
 		{
 			// nothing to do
 			if ( _batchItemList.Count == 0 )
@@ -145,6 +145,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
 					GL.ActiveTexture(TextureUnit.Texture0);
 					GL.BindTexture ( TextureTarget.Texture2D, texID );
+
+					samplerState.Activate();
 				}
 				// store the SpriteBatchItem data in our vertexArray
 				_vertexArray[index++] = item.vertexTL;

--- a/MonoGame.Framework/MonoGame.Framework.Linux.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Linux.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="3.5" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>MonoGame.Framework.Linux</RootNamespace>
     <AssemblyName>MonoGame.Framework.Linux</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,8 +39,13 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="OpenTK">
-      <HintPath>..\..\..\..\Downloads\opentk\Binaries\OpenTK\Debug\OpenTK.dll</HintPath>
+    <Reference Include="OpenTK, Version=1.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Sigge\libs\OpenTK.dll</HintPath>
+    </Reference>
+    <Reference Include="Lidgren.Network, Version=2011.3.12.0, Culture=neutral, PublicKeyToken=null">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\ThirdParty\Lidgren.Network\bin\Debug\Lidgren.Network.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -329,11 +335,5 @@
     <Folder Include="Linux\Graphics\Effect\" />
     <Folder Include="Linux\Input\" />
     <Folder Include="Linux\GamerServices\" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ThirdParty\Lidgren.Network\Lidgren.Network.Linux.csproj">
-      <Project>{AE483C29-042E-4226-BA52-D247CE7676DA}</Project>
-      <Name>Lidgren.Network.Linux</Name>
-    </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix SpriteBatch not setting up SamplerState. 

Filter modes are bound to texture objects in OpenGL, in XNA/D3D they are part of sampler state objects independent of textures. This patch fixes it for SpriteBatch, which now updates filter/wrap modes on the texture object every time it binds one. I added an internal Activate() method to SamplerState to make one "active" for this purpose.

(Texture2D.generateOpenGLTexture() just sets up the object to use linear filtering and leaves it at that.)
