### PR TITLE
SpriteBatchItem optimization

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatchItem.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatchItem.cs
@@ -13,46 +13,62 @@ namespace Microsoft.Xna.Framework.Graphics
 		public SpriteBatchItem ()
 		{
 			vertexTL = new VertexPosition2ColorTexture();
-			vertexTR = new VertexPosition2ColorTexture();
-			vertexBL = new VertexPosition2ColorTexture();
-			vertexBR = new VertexPosition2ColorTexture();
+            vertexTR = new VertexPosition2ColorTexture();
+            vertexBL = new VertexPosition2ColorTexture();
+            vertexBR = new VertexPosition2ColorTexture();            
 		}
 		
 		public void Set ( float x, float y, float w, float h, Color color, Vector2 texCoordTL, Vector2 texCoordBR )
 		{
-			vertexTL.Position = new Vector2(x,y);
+			vertexTL.Position.X = x;
+            vertexTL.Position.Y = y;
 			vertexTL.Color = color.GLPackedValue;
-			vertexTL.TextureCoordinate = texCoordTL;
+			vertexTL.TextureCoordinate.X = texCoordTL.X;
+            vertexTL.TextureCoordinate.Y = texCoordTL.Y;
 
-			vertexTR.Position = new Vector2(x+w,y);
+			vertexTR.Position.X = x+w;
+            vertexTR.Position.Y = y;
 			vertexTR.Color = color.GLPackedValue;
-			vertexTR.TextureCoordinate = new Vector2(texCoordBR.X,texCoordTL.Y);
+            vertexTR.TextureCoordinate.X = texCoordBR.X;
+            vertexTR.TextureCoordinate.Y = texCoordTL.Y;
 
-			vertexBL.Position = new Vector2(x,y+h);
+			vertexBL.Position.X = x;
+            vertexBL.Position.Y = y+h;
 			vertexBL.Color = color.GLPackedValue;
-			vertexBL.TextureCoordinate = new Vector2(texCoordTL.X,texCoordBR.Y);
+			vertexBL.TextureCoordinate.X = texCoordTL.X;
+            vertexBL.TextureCoordinate.Y = texCoordBR.Y;
 
-			vertexBR.Position = new Vector2(x+w,y+h);
+			vertexBR.Position.X = x+w;
+            vertexBR.Position.Y = y+h;
 			vertexBR.Color = color.GLPackedValue;
-			vertexBR.TextureCoordinate = texCoordBR;
+			vertexBR.TextureCoordinate.X = texCoordBR.X;
+            vertexBR.TextureCoordinate.Y = texCoordBR.Y;
 		}
 		public void Set ( float x, float y, float dx, float dy, float w, float h, float sin, float cos, Color color, Vector2 texCoordTL, Vector2 texCoordBR )
 		{
-			vertexTL.Position = new Vector2(x+dx*cos-dy*sin,y+dx*sin+dy*cos);
+			vertexTL.Position.X = x+dx*cos-dy*sin;
+            vertexTL.Position.Y = y+dx*sin+dy*cos;
 			vertexTL.Color = color.GLPackedValue;
-			vertexTL.TextureCoordinate = texCoordTL;
+            vertexTL.TextureCoordinate.X = texCoordTL.X;
+            vertexTL.TextureCoordinate.Y = texCoordTL.Y;
 
-			vertexTR.Position = new Vector2(x+(dx+w)*cos-dy*sin,y+(dx+w)*sin+dy*cos);
+			vertexTR.Position.X = x+(dx+w)*cos-dy*sin;
+            vertexTR.Position.Y = y+(dx+w)*sin+dy*cos;
 			vertexTR.Color = color.GLPackedValue;
-			vertexTR.TextureCoordinate = new Vector2(texCoordBR.X,texCoordTL.Y);
+            vertexTR.TextureCoordinate.X = texCoordBR.X;
+            vertexTR.TextureCoordinate.Y = texCoordTL.Y;
 
-			vertexBL.Position = new Vector2(x+dx*cos-(dy+h)*sin,y+dx*sin+(dy+h)*cos);
+			vertexBL.Position.X = x+dx*cos-(dy+h)*sin;
+            vertexBL.Position.Y = y+dx*sin+(dy+h)*cos;
 			vertexBL.Color = color.GLPackedValue;
-			vertexBL.TextureCoordinate = new Vector2(texCoordTL.X,texCoordBR.Y);
+            vertexBL.TextureCoordinate.X = texCoordTL.X;
+            vertexBL.TextureCoordinate.Y = texCoordBR.Y;
 
-			vertexBR.Position = new Vector2(x+(dx+w)*cos-(dy+h)*sin,y+(dx+w)*sin+(dy+h)*cos);
+			vertexBR.Position.X = x+(dx+w)*cos-(dy+h)*sin;
+            vertexBR.Position.Y = y+(dx+w)*sin+(dy+h)*cos;
 			vertexBR.Color = color.GLPackedValue;
-			vertexBR.TextureCoordinate = texCoordBR;
+            vertexBR.TextureCoordinate.X = texCoordBR.X;
+            vertexBR.TextureCoordinate.Y = texCoordBR.Y;
 		}
 	}
 }


### PR DESCRIPTION
The SpriteBatchItem already has allocated Vector2 's for Position and TextureCoords. The old code was creating new Vector2's for these rather than just Assigning the X and Y values to the existng properties.  As SpriteBatchItems are recycled it seemed a better idea to just reuse the exisitng allocated properties rather than re-create them each time the spritebatch item was set.
