### PR TITLE
Texture2D Dipose() fixes

### DIFF
--- a/MonoGame.Framework/iOS/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/iOS/Graphics/Texture2D.cs
@@ -165,9 +165,15 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 		
 		public override void Dispose()
-        {
+		{
 			base.Dispose();
-			texture.Dispose();
+
+			if (texture != null) {
+				texture.Dispose();
+			}
+			if (_textureId!=0) {
+				GL.DeleteTextures(1, ref _textureId);
+			}
 		}
 
         public Color GetPixel(int x, int y)


### PR DESCRIPTION
Fixed RenderTarget2D Dipose().
Added conditional Dipose() for Texture2D if texture is null (such as RenderTarget2D)
