### PR TITLE
Multithreaded iOS audio and Rectangle.Intersect fixes

### DIFF
--- a/MonoGame.Framework/Rectangle.cs
+++ b/MonoGame.Framework/Rectangle.cs
@@ -227,7 +227,10 @@ namespace Microsoft.Xna.Framework
                 int bottom_side = Math.Min(value1.Y + value1.Height, value2.Y + value2.Height);
                 result = new Rectangle(left_side, top_side, right_side - left_side, bottom_side - top_side);
             }
-            result = new Rectangle(0, 0, 0, 0);
+            else
+            {
+                result = new Rectangle(0, 0, 0, 0);
+            }
         }
 
         #endregion Public Methods

--- a/MonoGame.Framework/iOS/Audio/Sound.cs
+++ b/MonoGame.Framework/iOS/Audio/Sound.cs
@@ -153,8 +153,11 @@ namespace Microsoft.Xna.Framework.Audio
 		}
 		
 		public void Play()
-		{		
-			_audioPlayer.Play();
+		{
+            ThreadPool.QueueUserWorkItem(delegate
+            {
+                _audioPlayer.Play();
+            });
 		}
 		
 		public void Stop()


### PR DESCRIPTION
- Added multithreading to audio for iOS
  - Fixed a Rectangle.Intersect not returning correct values.
