### PR TITLE
Fix for Colors being inverted under windows

### DIFF
--- a/MonoGame.Framework/Graphics/ImageEx.cs
+++ b/MonoGame.Framework/Graphics/ImageEx.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace System.Drawing
+{
+    internal static class ImageEx
+    {
+
+        // RGB to BGR convert Matrix
+        private static float[][] rgbtobgr = new float[][]
+	      {
+		     new float[] {0, 0, 1, 0, 0},
+		     new float[] {0, 1, 0, 0, 0},
+		     new float[] {1, 0, 0, 0, 0},
+		     new float[] {0, 0, 0, 1, 0},
+		     new float[] {0, 0, 0, 0, 1}
+	      };
+
+        internal static void RGBToBGR(this Image bmp)
+        {
+            System.Drawing.Imaging.ImageAttributes ia = new System.Drawing.Imaging.ImageAttributes();
+            System.Drawing.Imaging.ColorMatrix cm = new System.Drawing.Imaging.ColorMatrix(rgbtobgr);
+
+            ia.SetColorMatrix(cm);
+            using (System.Drawing.Graphics g = System.Drawing.Graphics.FromImage(bmp))
+            {
+                g.DrawImage(bmp, new System.Drawing.Rectangle(0, 0, bmp.Width, bmp.Height), 0, 0, bmp.Width, bmp.Height, System.Drawing.GraphicsUnit.Pixel, ia);
+            }
+        }
+    }
+}

--- a/MonoGame.Framework/Windows/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Windows/Graphics/Texture2D.cs
@@ -277,6 +277,8 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 throw new ContentLoadException("Error loading file: " + filename);
             }
+            // Fix up the Image to match the expected format
+            image.RGBToBGR();
 
             ESImage theTexture;
 


### PR DESCRIPTION
Added internal ImageEx extension to support converting RGB System.Drawing.Image to BGR.

When loading Images from a non .xnb source (e.g png, jpeg) the colours are all wrong. This patch swaps over the colors . It might need to be applied to other platforms as well. The ImageEx.cs is a generic extension class and should be available to all platforms
