### PR TITLE
Android Render Target work around

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -331,6 +331,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			// rendertarget to the new one being passed if it is not null
 			if (renderTarget == null || currentRenderTargets != null)
 			{
+#if ANDROID
+                byte[] imageInfo = new byte[4];
+                GL.ReadPixels(0, 0, 1, 1, All.Rgba, All.UnsignedByte, imageInfo);
+#endif
 				// Detach the render buffers.
 				GL.Oes.FramebufferRenderbuffer(All.FramebufferOes, All.DepthAttachmentOes,
 						All.RenderbufferOes, 0);


### PR DESCRIPTION
HACK!! A fix to get render targets to work under Android. for some reason we need to call GL.ReadPixels to get the texture to work. We need to remove this. Also for some reason the wood.xnb file does not load correctly under android.
