### PR TITLE
Fixed Linux window resize

### DIFF
--- a/MonoGame.Framework/Linux/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/Linux/GraphicsDeviceManager.cs
@@ -145,7 +145,8 @@ namespace Microsoft.Xna.Framework
 		#endregion
 
 		public void ApplyChanges ()
-		{			
+		{		
+			_game.ResizeWindow(false);
 		}
 
 		private void Initialize ()


### PR DESCRIPTION
When applying changes on a GraphicsDeviceManager, the window wouldn't get resized to the new size.
