### PR TITLE
VideoPlayer taking a M.X.F.Game instance as arg?

### DIFF
--- a/MonoGame.Framework/Android/Game.cs
+++ b/MonoGame.Framework/Android/Game.cs
@@ -77,6 +77,9 @@ namespace Microsoft.Xna.Framework
 
 		internal static bool _playingVideo = false;
 		
+		private static Game _instance = null;
+		internal static Game Instance { get { return _instance; } }
+
 		delegate void InitialiseGameComponentsDelegate();
 
 		internal static AndroidGameActivity contextInstance;
@@ -95,6 +98,8 @@ namespace Microsoft.Xna.Framework
 
 		public Game()
 		{
+			_instance = this;
+
 			System.Diagnostics.Debug.Assert(contextInstance != null, "Must set Game.Activity before creating the Game instance");
 			contextInstance.Game = this;
 

--- a/MonoGame.Framework/Android/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/Android/Media/VideoPlayer.cs
@@ -52,10 +52,10 @@ namespace Microsoft.Xna.Framework.Media
 		private bool _isLooped;
 		private Game _game;
 
-        public VideoPlayer(Game game)
+        public VideoPlayer()
         {
 			_state = MediaState.Stopped;
-			_game = game;
+			_game = Game.Instance;
         }
 
         public Texture2D GetTexture()

--- a/MonoGame.Framework/Linux/Game.cs
+++ b/MonoGame.Framework/Linux/Game.cs
@@ -73,12 +73,17 @@ namespace Microsoft.Xna.Framework
 		private Texture2D splashScreen;
 		private bool _mouseVisible = false;
 
+		private static Game _instance = null;
+		internal static Game Instance { get { return _instance; } }
+
 		delegate void InitialiseGameComponentsDelegate ();
 
 		#region Ctor
 		
 		public Game ()
 		{
+			_instance = this;
+
 			// Initialize collections
 			_services = new GameServiceContainer ();
 			_gameComponentCollection = new GameComponentCollection ();

--- a/MonoGame.Framework/MacOS/Game.cs
+++ b/MonoGame.Framework/MacOS/Game.cs
@@ -87,10 +87,15 @@ namespace Microsoft.Xna.Framework
 		private List<IGameComponent> _gameComponentsToInitialize = new List<IGameComponent>();
 		private bool _wasResizeable;
 
+		private static Game _instance = null;
+		internal static Game Instance { get { return _instance; } }
+
 		delegate void InitialiseGameComponentsDelegate ();
 
 		public Game ()
 		{
+			_instance = this;
+
 			// Initialize collections
 			_services = new GameServiceContainer ();
 			_gameComponentCollection = new GameComponentCollection ();

--- a/MonoGame.Framework/MacOS/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/MacOS/Media/VideoPlayer.cs
@@ -58,10 +58,10 @@ namespace Microsoft.Xna.Framework.Media
 		// TODO Needed to bind OpenGL to Quicktime private QTVisualContextRef  textureContext;
     	// TODO Needed to grab frame as a texture private CVOpenGLTextureRef  currentFrame;
 		
-        public VideoPlayer(Game game)
+        public VideoPlayer()
         {
 			_state = MediaState.Stopped;
-			_game = game;
+			_game = Game.Instance;
         }
 
         public Texture2D GetTexture()

--- a/MonoGame.Framework/Windows/Game.cs
+++ b/MonoGame.Framework/Windows/Game.cs
@@ -76,11 +76,15 @@ namespace Microsoft.Xna.Framework
 		private SpriteBatch spriteBatch;
 		private Texture2D splashScreen;
 		
+		private static Game _instance = null;
+		internal static Game Instance { get { return _instance; } }
+
 		delegate void InitialiseGameComponentsDelegate();
        
 
 		public Game()
 		{
+			_instance = this;
 
 			// Initialize collections
 			_services = new GameServiceContainer();

--- a/MonoGame.Framework/iOS/Game.cs
+++ b/MonoGame.Framework/iOS/Game.cs
@@ -84,10 +84,15 @@ namespace Microsoft.Xna.Framework
 		private SpriteBatch spriteBatch;
 		private Texture2D splashScreen;
 		
+		private static Game _instance = null;
+		internal static Game Instance { get { return _instance; } }
+
 		delegate void InitialiseGameComponentsDelegate();
 		
 		public Game()
-        {           
+		{
+			_instance = this;
+
 			// Initialize collections
 			_services = new GameServiceContainer();
 			_gameComponentCollection = new GameComponentCollection();

--- a/MonoGame.Framework/iOS/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/iOS/Media/VideoPlayer.cs
@@ -53,10 +53,10 @@ namespace Microsoft.Xna.Framework.Media
 		private bool _isLooped;
 		private Game _game;		
 		
-        public VideoPlayer(Game game)
+        public VideoPlayer()
         {
 			_state = MediaState.Stopped;
-			_game = game;
+			_game = Game.Instance;
         }
 
         public Texture2D GetTexture()


### PR DESCRIPTION
I am working on "porting" an XNA 4.0 game over to Mac OS X and Linux and am using MonoGame to accomplish this task.

Thus far MOSTLY everything is in there.. I found a few methods/properties missing here and there which I will send a pull-request for when done.

But the main issue right now I am having is the fact that the VideoPlayer implementation differs from the MS Documentation..  the Documentation states that the constructor takes no arguments, yet MonoGame's takes a single arg of a Game instance.

It looks like the primary reason it does this is ONLY to acquire access to the GraphicsDevice and Window objects.. So, my question is, how can this be refactored to NOT require passing the Game instance to the VideoPlayer constructor??
