### PR TITLE
Texture mapping and minor changes for primitives

### DIFF
--- a/MonoGame.Framework/MacOS/Graphics/Effect/BasicEffect.cs
+++ b/MonoGame.Framework/MacOS/Graphics/Effect/BasicEffect.cs
@@ -272,6 +272,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			get { return textureParam.GetValueTexture2D (); }
 			set {
 				_texture = value;
+				_texture.Apply();
 				textureParam.SetValue (value);
 			}
 		}

--- a/MonoGame.Framework/MacOS/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/MacOS/Graphics/GraphicsDevice.cs
@@ -718,15 +718,27 @@ namespace Microsoft.Xna.Framework.Graphics
 		public int GetElementCountArray (PrimitiveType primitiveType, int primitiveCount)
 		{
 			//TODO: Overview the calculation
+			// Please see comments made by kjpou1 below.  The samples would not work correctly so
+			//  modified the values below.  This is what got the samples working so if they
+			//  are not correct please modify but make sure samples are working.
+			//  TextureQuad and PrimitivesTest are the ones to check
 			switch (primitiveType) {
 			case PrimitiveType.LineList:
 				return primitiveCount * 2;
 			case PrimitiveType.LineStrip:
-				return 3 + (primitiveCount - 1); // ???
+				// Was causing extra lines
+				return primitiveCount + 1;//     3 + (primitiveCount - 1); // ???
 			case PrimitiveType.TriangleList:
-				return primitiveCount * 2;
+				// The primitiveCount * 2 was causing some lines not to show up
+				//  changing it to 3 activated those lines.  For a quad map only the first
+				//  triangle was showing instead of the full quad.
+				return primitiveCount * 3;  //primitiveCount * 2;
 			case PrimitiveType.TriangleStrip:
-				return 3 + (primitiveCount - 1); // ???
+				// This is a test --- changed by kjpou1 -- modified from what is below
+				// as I really did not understand it.
+				//   If the change does not work then please move back to what was below
+				//3 + (primitiveCount - 1); // ???
+				return primitiveCount + 2;
 			}
 
 			throw new NotSupportedException ();

--- a/MonoGame.Framework/MacOS/Graphics/Vertices/VertexDeclaration.cs
+++ b/MonoGame.Framework/MacOS/Graphics/Vertices/VertexDeclaration.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Xna.Framework.Graphics
             GLStateManager.VertexArray(true);
 
             bool normal = false;
-            bool texcoord = false;
+            bool texcoord = false; 
 			
             foreach (var ve in vd.GetVertexElements())
             {


### PR DESCRIPTION
Get Quad Texture mapping working.  

Modified the GetElementCountArray routine to fix TriangleList as it was being calculated incorrectly for the samples.  

Also Modified LineStrip as it was showing extraneous lines.  

TriangleStrip was also modified for the Samples as some lines were showing up and on other tests it was missing lines.
