### PR TITLE
SamplerState texture clamping fix

### DIFF
--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			switch(textureAddressMode)
 			{
 			case TextureAddressMode.Clamp:
-				return (int)TextureWrapMode.Clamp;
+				return (int)TextureWrapMode.ClampToEdge;
 			case TextureAddressMode.Wrap:
 				return (int)TextureWrapMode.Repeat;
 			case TextureAddressMode.Mirror:


### PR DESCRIPTION
GL_CLAMP_TO_EDGE rather than GL_CLAMP replicates DirectX's (and thus XNA's) texture clamping behavior, see http://www.opengl.org/resources/code/samples/sig99/advanced99/notes/node64.html
