### PR TITLE
Linux: new Sound.Rate property -- required by code

### DIFF
--- a/MonoGame.Framework/Linux/Audio/Sound.cs
+++ b/MonoGame.Framework/Linux/Audio/Sound.cs
@@ -60,6 +60,12 @@ namespace Microsoft.Xna.Framework.Audio
 			set;
 		}
 		
+		public float Rate
+		{
+			get;
+			set;
+		}
+		
 		public bool Playing
 		{
 			get


### PR DESCRIPTION
SoundEffectInstance.Pitch property were trying to access Sound.Rate member, but were not available in the Linux version. My fix however does not implement it in code, only adds a functioning property, that may needs to be further implement.
