### PR TITLE
Glyph misplaced in rare case

### DIFF
--- a/MonoGame.Framework/Linux/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Linux/Graphics/SpriteBatch.cs
@@ -631,7 +631,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				texCoordBR.X = spriteFont._texture.Image.GetTextureCoordX (g.Glyph.X + g.Glyph.Width);
 				texCoordBR.Y = spriteFont._texture.Image.GetTextureCoordY (g.Glyph.Y + g.Glyph.Height);
 
-				item.Set (p.X, 
+				item.Set (p.X + g.Cropping.X, 
 						p.Y + g.Cropping.Y, 
 						g.Glyph.Width, 
 						g.Glyph.Height, 
@@ -695,7 +695,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 				item.Set (position.X, 
 						position.Y, 
-						p.X * scale, 
+						(p.X + g.Cropping.X) * scale, 
 						(p.Y + g.Cropping.Y) * scale, 
 						g.Glyph.Width * scale, 
 						g.Glyph.Height * scale, 


### PR DESCRIPTION
When one uses a SpriteFont XNB file made from an image, it would improperly place the glyph if there are any space on the left hand side of a glyph.
Files demonstrating the situation can be found here: https://docs.google.com/open?id=0B5VJNChSb_NFOWY1NjUyZGQtMTQ5OC00MmRjLWFhYzEtMGUzMzM3NDA0NTRm
FontTester-4a.png – How XNA displays it
Sugar-MonoGame-cropped.png – How MonoGame used to display it.
Game1.cs – The sample program code.
fallback-font.xnb – The font that was used.
