### PR TITLE
Remove hack for pausing and stopping sounds

### DIFF
--- a/MonoGame.Framework/MacOS/Audio/Sound.cs
+++ b/MonoGame.Framework/MacOS/Audio/Sound.cs
@@ -146,9 +146,10 @@ namespace Microsoft.Xna.Framework.Audio
 		public void Pause()
 		{		
 			//HACK: Stopping or pausing NSSound is really slow (~200ms), don't if the sample is short :/
-			if (Duration > 2) {
+			//Uncomment the if clause if you have trouble pausing sounds.
+			//if (Duration > 2) {
 				_audioPlayer.Pause();
-			}
+			//}
 		}
 		
 		public void Play()
@@ -162,10 +163,13 @@ namespace Microsoft.Xna.Framework.Audio
 		}
 		
 		public void Stop()
-		{			
-			if (Duration > 2) { 
+		{
+			//HACK: Stopping or pausing NSSound is really slow (~200ms), don't if the sample is short :/
+			//Uncomment the if clause if you have trouble with stopping sounds.
+			//Note that with the if active it is impossible to stop looped sounds that are shorter than x seconds!
+			//if (Duration > 2) { 
 				_audioPlayer.Stop();
-			}
+			//}
 		}
 		
 		public float Volume


### PR DESCRIPTION
The previous hack made it impossible to pause or stop sounds shorter
than 2 seconds. This caused problems with short sound effects,
especially looped sounds.
