### PR TITLE
Changes to allow Portrait and upside-down portrait to render correctly.

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Android/AndroidGameWindow.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Xna.Framework
 		{	    
 			try
             {
-                // TODO  this.GLContextVersion = GLContextVersion.Gles2_0;
+                // TODO GLContextVersion = GLContextVersion.Gles2_0;
                 GLContextVersion = GLContextVersion.Gles1_1;
 				base.CreateFrameBuffer();
 		    } 
@@ -144,6 +144,8 @@ namespace Microsoft.Xna.Framework
                 GLContextVersion = GLContextVersion.Gles1_1;
 				base.CreateFrameBuffer();
 		    }
+			
+			GraphicsDevice.OpenGLESVersion = GLContextVersion;
 		}
 	
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -42,7 +42,11 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
+#if ANDROID
+using OpenTK.Graphics;
+#else
 using MonoTouch.OpenGLES;
+#endif
 
 using GL11 = OpenTK.Graphics.ES11.GL;
 using GL20 = OpenTK.Graphics.ES20.GL;
@@ -77,7 +81,12 @@ namespace Microsoft.Xna.Framework.Graphics
 		private RenderTargetBinding[] currentRenderTargets;
 		
 		//OpenGL Rendering API
+#if ANDROID
+		public static GLContextVersion OpenGLESVersion;
+#else
 		public static EAGLRenderingAPI OpenGLESVersion;
+#endif
+		
 		public static int FrameBufferScreen;
 		public static bool DefaultFrameBuffer = true;
 		
@@ -377,8 +386,12 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 		
 		public void SetRenderTarget (RenderTarget2D renderTarget)
-		{
+		{	
+#if ANDROID
+			if(OpenGLESVersion == GLContextVersion.Gles2_0)
+#else
 			if(OpenGLESVersion == EAGLRenderingAPI.OpenGLES2)
+#endif
 				SetRenderTargetGL20(renderTarget);
 			else
 				SetRenderTargetGL11(renderTarget);
@@ -415,7 +428,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 #if ANDROID
                 byte[] imageInfo = new byte[4];
-                GL.ReadPixels(0, 0, 1, 1, All.Rgba, All.UnsignedByte, imageInfo);
+                GL11.ReadPixels(0, 0, 1, 1, ALL11.Rgba, ALL11.UnsignedByte, imageInfo);
 #endif
 				// Detach the render buffers.
 				GL11.Oes.FramebufferRenderbuffer(ALL11.FramebufferOes, ALL11.DepthAttachmentOes,

--- a/MonoGame.Framework/Graphics/RenderTarget2D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.cs
@@ -74,7 +74,11 @@ namespace Microsoft.Xna.Framework.Graphics
 			SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
 			:base (graphicsDevice, width, height, mipMap, preferredFormat)
 		{
+#if ANDROID
+			if(GraphicsDevice.OpenGLESVersion == OpenTK.Graphics.GLContextVersion.Gles2_0)
+#else
 			if(GraphicsDevice.OpenGLESVersion == MonoTouch.OpenGLES.EAGLRenderingAPI.OpenGLES2)
+#endif
 			{
 				GL20.GenFramebuffers(1, ref frameBuffer);
 			}

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -83,8 +83,11 @@ namespace Microsoft.Xna.Framework.Graphics
 			this.graphicsDevice = graphicsDevice;
 			
 			_batcher = new SpriteBatcher();
-			
+#if ANDROID
+			if(GraphicsDevice.OpenGLESVersion == OpenTK.Graphics.GLContextVersion.Gles2_0)
+#else
 			if(GraphicsDevice.OpenGLESVersion == MonoTouch.OpenGLES.EAGLRenderingAPI.OpenGLES2)
+#endif
 				InitGL20();
 		}
 		
@@ -260,7 +263,11 @@ namespace Microsoft.Xna.Framework.Graphics
 		public void End()
 		{
 			// OpenGL ES Version 
+#if ANDROID
+			if(GraphicsDevice.OpenGLESVersion == OpenTK.Graphics.GLContextVersion.Gles2_0)
+#else
 			if(GraphicsDevice.OpenGLESVersion == MonoTouch.OpenGLES.EAGLRenderingAPI.OpenGLES2)
+#endif
 				EndGL20();
 			else
 				EndGL11();
@@ -352,8 +359,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 				case DisplayOrientation.LandscapeRight:
                 {
-					GL.Rotate(180, 0, 0, 1); 
-					GL.Ortho(0, this.graphicsDevice.Viewport.Width, this.graphicsDevice.Viewport.Height,  0, -1, 1);
+					GL11.Rotate(180, 0, 0, 1); 
+					GL11.Ortho(0, this.graphicsDevice.Viewport.Width, this.graphicsDevice.Viewport.Height,  0, -1, 1);
 					break;
 				}
 				
@@ -361,7 +368,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				case DisplayOrientation.PortraitUpsideDown:
                 default:
 				{
-					GL.Ortho(0, this.graphicsDevice.Viewport.Width, this.graphicsDevice.Viewport.Height, 0, -1, 1);
+					GL11.Ortho(0, this.graphicsDevice.Viewport.Width, this.graphicsDevice.Viewport.Height, 0, -1, 1);
 					break;
 				}
 			}					


### PR DESCRIPTION
Sorry for the delay in getting this fix out. But it turned out to be simpler than what I was trying to do a week ago. Basically don't call GL.Ortho twice in succession :S. I feel so thick for not spotting it ealier. But it did allow me to fix an issue in Unsidedown portrait to do with Scissor Rectangles. With this fix, I think 2.1 is ready. 

We need to talk first thing in the morning, if anyone is around.
