### PR TITLE
Fixed call to Initialize OpenGL states for iOS. Re-Enabled ES2.0 as default context on iOS.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -140,8 +140,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Init RasterizerState
             RasterizerState = new RasterizerState();
-
-            if (OpenGLESVersion == GLContextVersion.Gles1_1 || OpenGLESVersion == GLContextVersion.Gles1_0)
+#if IPHONE
+            if (OpenGLESVersion == EAGLRenderingAPI.OpenGLES1)
+#else
+			if (OpenGLESVersion == GLContextVersion.Gles1_1 || OpenGLESVersion == GLContextVersion.Gles1_0)
+#endif
             {
                 // Initialize OpenGL states
                 GL11.Disable(ALL11.DepthTest);

--- a/MonoGame.Framework/iOS/IOSGameWindow.cs
+++ b/MonoGame.Framework/iOS/IOSGameWindow.cs
@@ -165,7 +165,6 @@ namespace Microsoft.Xna.Framework
 			
 			try
 			{
-#if ES20
 				ContextRenderingApi = EAGLRenderingAPI.OpenGLES2;
 				base.CreateFrameBuffer();
 				
@@ -178,22 +177,6 @@ namespace Microsoft.Xna.Framework
 					renderbufferWidth = width;
 					renderbufferHeight = height;
 				}
-#else
-				ContextRenderingApi = EAGLRenderingAPI.OpenGLES1;
-				base.CreateFrameBuffer();
-				
-				// Determine actual render buffer size (due to possible Retina Display scaling)
-				// http://developer.apple.com/library/ios/#documentation/iphone/conceptual/iphoneosprogrammingguide/SupportingResolutionIndependence/SupportingResolutionIndependence.html#//apple_ref/doc/uid/TP40007072-CH10-SW11
-				unsafe
-				{
-					int width = 0, height = 0;
-					OpenTK.Graphics.ES11.GL.Oes.GetRenderbufferParameter(OpenTK.Graphics.ES11.All.RenderbufferOes, OpenTK.Graphics.ES11.All.RenderbufferWidthOes, &width);
-					OpenTK.Graphics.ES11.GL.Oes.GetRenderbufferParameter(OpenTK.Graphics.ES11.All.RenderbufferOes, OpenTK.Graphics.ES11.All.RenderbufferHeightOes, &height);
-	
-					renderbufferWidth = width;
-					renderbufferHeight = height;
-				}
-#endif
 		    } 
 			catch (Exception) 
 			{


### PR DESCRIPTION
It will fallback to 1.1 if 2.0 fails.
