### PR TITLE
Add vsync functionality to MacOS

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Xna.Framework
             // some problems on some Microsoft samples which we are not handling
             // correctly.
             graphicsDeviceManager.CreateDevice();
-            applyChanges(graphicsDeviceManager);
+            applyChanges();
 
             _platform.BeforeInitialize();
             Initialize();
@@ -416,7 +416,7 @@ namespace Microsoft.Xna.Framework
         //        break entirely the possibility that additional platforms could
         //        be added by third parties without changing MonoGame itself.
 
-        internal void applyChanges(GraphicsDeviceManager manager)
+        internal void applyChanges()
         {
             if (GraphicsDevice.PresentationParameters.IsFullScreen)
                 _platform.EnterFullScreen();
@@ -433,7 +433,9 @@ namespace Microsoft.Xna.Framework
             viewport.Height = GraphicsDevice.PresentationParameters.BackBufferHeight;
 
             GraphicsDevice.Viewport = viewport;
-        }
+			
+			_platform.Window.OpenGLContext.SwapInterval = graphicsDeviceManager.SynchronizeWithVerticalRetrace;
+         }
 
         internal void DoUpdate(GameTime gameTime)
         {

--- a/MonoGame.Framework/MacOS/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/MacOS/GraphicsDeviceManager.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Xna.Framework
 		private bool _preferMultiSampling;
 		private DisplayOrientation _supportedOrientations;
 		private bool wantFullScreen = false;
+		private bool _synchronizeWithVerticalRetrace = false;
 
 		public GraphicsDeviceManager (Game game)
 		{
@@ -163,7 +164,7 @@ namespace Microsoft.Xna.Framework
 				_graphicsDevice.PreferedFilter = All.Nearest;
 			}
 
-			_game.applyChanges(this);
+			_game.applyChanges();
 
 		}
 
@@ -257,9 +258,10 @@ namespace Microsoft.Xna.Framework
 
 		public bool SynchronizeWithVerticalRetrace {
 			get {
-				throw new NotImplementedException ();
+				return _synchronizeWithVerticalRetrace;
 			}
 			set {
+				_synchronizeWithVerticalRetrace = value;
 			}
 		}
 

--- a/MonoGame.Framework/MacOS/MacGamePlatform.cs
+++ b/MonoGame.Framework/MacOS/MacGamePlatform.cs
@@ -175,6 +175,10 @@ namespace Microsoft.Xna.Framework
         public override void StartRunLoop()
         {
             _gameWindow.Run(1 / Game.TargetElapsedTime.TotalSeconds);
+			
+			//The first call to MonoMacGameView.Run disables vsync for some reason, so  give
+			//the game a chance to re-enable it here
+			this.Game.applyChanges();
         }
 
         public override bool BeforeUpdate(GameTime gameTime)


### PR DESCRIPTION
Adds vsync functionality to MacOS by toggling the SwapInterval in the OpenGLContext of the game window.

Note that the MonoMacGameView forces vsync to false just before the first update (but after Game.Initialize() is called and the graphics are set up), so I force an update to the graphics setting in MacGamePlatform.StartRunLoop.

This is my first contribution to MonoGame (and my first pull request on Github), so please let me know if anything is horribly amiss!
