### PR TITLE
Flip Projection transform with rotation to keep aspect ratio correct in portrait mode.

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -378,28 +378,31 @@ namespace Microsoft.Xna.Framework.Graphics
 				case DisplayOrientation.LandscapeLeft:
                 {
 					GL11.Rotate(-90, 0, 0, 1);
+					GL11.Ortho(0, this.graphicsDevice.Viewport.Height, this.graphicsDevice.Viewport.Width, 0, -1, 1);
 					break;
 				}
 				
 				case DisplayOrientation.LandscapeRight:
                 {
 					GL11.Rotate(90, 0, 0, 1);					
+					GL11.Ortho(0, this.graphicsDevice.Viewport.Height, this.graphicsDevice.Viewport.Width, 0, -1, 1);
 					break;
 				}
 				
 				case DisplayOrientation.PortraitUpsideDown:
                 {
 					GL11.Rotate(180, 0, 0, 1); 
+					GL11.Ortho(0, this.graphicsDevice.Viewport.Width, this.graphicsDevice.Viewport.Height, 0, -1, 1);
 					break;
 				}
 				
 				default:
 				{
+					GL11.Ortho(0, this.graphicsDevice.Viewport.Width, this.graphicsDevice.Viewport.Height, 0, -1, 1);
 					break;
 				}
 			}
 			
-			GL11.Ortho(0, this.graphicsDevice.Viewport.Width, this.graphicsDevice.Viewport.Height, 0, -1, 1);
 #endif			
 			
 			// Enable Scissor Tests if necessary


### PR DESCRIPTION
I had to do this to prevent stretching in portrait mode. I see this is a subset of a change you have in the Ipad2_rotate branch already. That branch has other changes related gamecenter UI that don't seem related.

I'd like to receive feedback if someone thinks this will cause problems.
