### PR TITLE
Networking fixes and Game Logging

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -117,8 +117,8 @@ namespace Microsoft.Xna.Framework
 
         public Game()
         {
+            _instance = this;
 		    Exiting += OnExiting;
-
             _services = new GameServiceContainer();
             _components = new GameComponentCollection();
             _content = new ContentManager(_services);
@@ -176,6 +176,8 @@ namespace Microsoft.Xna.Framework
 #if ANDROID
         public static AndroidGameActivity Activity { get; set; }
 #endif
+        private static Game _instance = null;
+        internal static Game Instance { get { return Game._instance; } }
 
         public GameComponentCollection Components
         {

--- a/MonoGame.Framework/GamerServices/GamerCollection.cs
+++ b/MonoGame.Framework/GamerServices/GamerCollection.cs
@@ -43,7 +43,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-
+using System.Linq;
 #endregion Using clause
 
 namespace Microsoft.Xna.Framework.GamerServices
@@ -61,7 +61,20 @@ namespace Microsoft.Xna.Framework.GamerServices
 		}
  
 		internal void AddGamer (T item) {
-			base.Items.Add (item);
+            // need to add gamers at the correct index based on GamerTag           
+            if (base.Items.Count > 0)
+            {
+                for (int i = 0; i < base.Items.Count(); i++)
+                {
+                    if (item.Gamertag.CompareTo(base.Items[i].Gamertag) > 0)
+                    {
+                        base.Items.Insert(i, item);
+                        return;
+                    }
+                }
+            }
+            base.Items.Add(item);            
+            
 		}
 		
 		internal void RemoveGamer (T item) {
@@ -77,7 +90,7 @@ namespace Microsoft.Xna.Framework.GamerServices
 //            return this.GetEnumerator();
 //        }
 		
-	IEnumerator IEnumerable.GetEnumerator()
+	    IEnumerator IEnumerable.GetEnumerator()
         {
             return this.GetEnumerator();
         }

--- a/MonoGame.Framework/Net/MonoGamerPeer.cs
+++ b/MonoGame.Framework/Net/MonoGamerPeer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Xna.Framework.Net
 
 		void HandleSessionStateChanged (object sender, EventArgs e)
 		{
-			Console.WriteLine ("session state change");
+            Game.Instance.Log("session state change");
 			SendSessionStateChange ();
 
 			if (session.SessionState == NetworkSessionState.Ended)
@@ -87,6 +87,14 @@ namespace Microsoft.Xna.Framework.Net
 
 			IPAddress adr = IPAddress.Parse (myLocalAddress);
 			myLocalEndPoint = new IPEndPoint (adr, port);
+
+            // force a little wait until we have a LocalGamer otherwise things
+            // break. This is the first item in the queue so it shouldnt take long before we
+            // can continue.
+            while (session.LocalGamers.Count <= 0)
+            {
+                Thread.Sleep(10);
+            }
 
 			if (availableSession != null) {
 				if (!this.online) {
@@ -134,7 +142,7 @@ namespace Microsoft.Xna.Framework.Net
 					case NetIncomingMessageType.UnconnectedData :
 						break;
 					case NetIncomingMessageType.NatIntroductionSuccess:
-						Console.WriteLine ("NAT punch through OK " + msg.SenderEndpoint);                            
+                        Game.Instance.Log("NAT punch through OK " + msg.SenderEndpoint);                            
 						peer.Connect (msg.SenderEndpoint);                            
 						break;
 					case NetIncomingMessageType.DiscoveryRequest:
@@ -166,12 +174,12 @@ namespace Microsoft.Xna.Framework.Net
 						//
 						// Just print diagnostic messages to console
 						//
-						Console.WriteLine (msg.ReadString ());
+                        Game.Instance.Log(msg.ReadString());
 						break;
 					case NetIncomingMessageType.StatusChanged:
 						NetConnectionStatus status = (NetConnectionStatus)msg.ReadByte ();
 						if (status == NetConnectionStatus.Disconnected) {
-							Console.WriteLine (NetUtility.ToHexString (msg.SenderConnection.RemoteUniqueIdentifier) + " disconnected! from " + msg.SenderEndpoint);
+                            Game.Instance.Log(NetUtility.ToHexString(msg.SenderConnection.RemoteUniqueIdentifier) + " disconnected! from " + msg.SenderEndpoint);
 							CommandGamerLeft cgj = new CommandGamerLeft (msg.SenderConnection.RemoteUniqueIdentifier);
 							CommandEvent cmde = new CommandEvent (cgj);
 							session.commandQueue.Enqueue (cmde);					
@@ -181,11 +189,11 @@ namespace Microsoft.Xna.Framework.Net
 							// A new player just connected!
 							//
 							if (!pendingGamers.ContainsKey (msg.SenderConnection.RemoteUniqueIdentifier)) {
-								Console.WriteLine (NetUtility.ToHexString (msg.SenderConnection.RemoteUniqueIdentifier) + " connected! from " + msg.SenderEndpoint);
+                                Game.Instance.Log(NetUtility.ToHexString(msg.SenderConnection.RemoteUniqueIdentifier) + " connected! from " + msg.SenderEndpoint);
 								pendingGamers.Add (msg.SenderConnection.RemoteUniqueIdentifier, msg.SenderConnection);
 								SendProfileRequest (msg.SenderConnection);
 							} else {
-								Console.WriteLine ("Already have a connection for that user, this is probably due to both NAT intro requests working");
+                                Game.Instance.Log("Already have a connection for that user, this is probably due to both NAT intro requests working");
 							}
 						}
 
@@ -211,18 +219,18 @@ namespace Microsoft.Xna.Framework.Net
 
 								if (myLocalEndPoint.ToString () != endPoint.ToString () && !AlreadyConnected (endPoint)) {
 
-									Console.WriteLine ("Received Introduction for: " + introductionAddress + 
+                                    Game.Instance.Log("Received Introduction for: " + introductionAddress + 
 									" and I am: " + myLocalEndPoint + " from: " + msg.SenderEndpoint);
 
 									peer.Connect (endPoint);
 								}
 							} catch (Exception exc) {
-								Console.WriteLine ("Error parsing Introduction: " + introductionAddress + " : " + exc.Message);
+                                Game.Instance.Log("Error parsing Introduction: " + introductionAddress + " : " + exc.Message);
 							}
 
 							break;
 						case NetworkMessageType.GamerProfile:
-							//Console.WriteLine("Profile recieved from: " + NetUtility.ToHexString(msg.SenderConnection.RemoteUniqueIdentifier));
+                            Game.Instance.Log("Profile recieved from: " + NetUtility.ToHexString(msg.SenderConnection.RemoteUniqueIdentifier));
 							if (pendingGamers.ContainsKey (msg.SenderConnection.RemoteUniqueIdentifier)) {
 								pendingGamers.Remove (msg.SenderConnection.RemoteUniqueIdentifier);
 								msg.ReadInt32 ();
@@ -237,17 +245,17 @@ namespace Microsoft.Xna.Framework.Net
 								CommandEvent cmde = new CommandEvent (cgj);
 								session.commandQueue.Enqueue (cmde);					
 							} else {
-								Console.WriteLine ("We received a profile for an existing gamer.  Need to update it.");
+                                Game.Instance.Log("We received a profile for an existing gamer.  Need to update it.");
 							}
 							break;
 						case NetworkMessageType.RequestGamerProfile:
-							//Console.WriteLine("Profile Request recieved from: " + msg.SenderEndpoint);
+                            Game.Instance.Log("Profile Request recieved from: " + msg.SenderEndpoint);
 							SendProfile (msg.SenderConnection);
 							break;	
 						case NetworkMessageType.GamerStateChange:
 							GamerStates gamerstate = (GamerStates)msg.ReadInt32 ();
 							gamerstate &= ~GamerStates.Local;
-							Console.WriteLine ("State Change from: " + msg.SenderEndpoint + " new State: " + gamerstate);
+                            Game.Instance.Log("State Change from: " + msg.SenderEndpoint + " new State: " + gamerstate);
 							foreach (var gamer in session.RemoteGamers) {
 								if (gamer.RemoteUniqueIdentifier == msg.SenderConnection.RemoteUniqueIdentifier)
 									gamer.State = gamerstate;
@@ -258,7 +266,7 @@ namespace Microsoft.Xna.Framework.Net
 
 							foreach (var gamer in session.RemoteGamers) {
 								if (gamer.RemoteUniqueIdentifier == msg.SenderConnection.RemoteUniqueIdentifier) {
-									Console.WriteLine ("Session State change from: " + NetUtility.ToHexString (msg.SenderConnection.RemoteUniqueIdentifier) + 
+                                    Game.Instance.Log("Session State change from: " + NetUtility.ToHexString(msg.SenderConnection.RemoteUniqueIdentifier) + 
 										" session is now: " + sessionState);
 									if (gamer.IsHost && sessionState == NetworkSessionState.Playing) {
 										session.StartGame ();
@@ -279,7 +287,7 @@ namespace Microsoft.Xna.Framework.Net
 				Thread.Sleep (1);
 
 				if (worker.CancellationPending) {
-					Console.WriteLine ("worker CancellationPending");
+                    Game.Instance.Log("worker CancellationPending");
 					e.Cancel = true;
 					done = true;
 				}
@@ -300,12 +308,12 @@ namespace Microsoft.Xna.Framework.Net
 		private void MGServer_RunWorkerCompleted (object sender, RunWorkerCompletedEventArgs e)
 		{
 			if ((e.Cancelled == true)) {
-				Console.WriteLine ("Canceled");
+                Game.Instance.Log("Canceled");
 
 			} else if (!(e.Error == null)) {
-				Console.WriteLine ("Error: " + e.Error.Message);
-			} 
-			Console.WriteLine ("worker Completed");
+                Game.Instance.Log("Error: " + e.Error.Message);
+			}
+            Game.Instance.Log("worker Completed");
 
 			if (online && this.availableSession == null) {
 				// inform the master server we have closed
@@ -327,8 +335,8 @@ namespace Microsoft.Xna.Framework.Net
 			om.Write (session.LocalGamers [0].Gamertag);
 			om.Write (session.PrivateGamerSlots);
 			om.Write (session.MaxGamers);
-			om.Write ((int)session.LocalGamers [0].State);			
-			Console.WriteLine ("Sent profile to: " + NetUtility.ToHexString (player.RemoteUniqueIdentifier));
+			om.Write ((int)session.LocalGamers[0].State);
+            Game.Instance.Log("Sent profile to: " + NetUtility.ToHexString(player.RemoteUniqueIdentifier));
 			peer.SendMessage (om, player, NetDeliveryMethod.ReliableOrdered);			
 		}
 
@@ -336,7 +344,7 @@ namespace Microsoft.Xna.Framework.Net
 		{
 			NetOutgoingMessage om = peer.CreateMessage ();
 			om.Write ((byte)NetworkMessageType.RequestGamerProfile);
-			Console.WriteLine ("Sent profile request to: " + NetUtility.ToHexString (player.RemoteUniqueIdentifier));
+            Game.Instance.Log("Sent profile request to: " + NetUtility.ToHexString(player.RemoteUniqueIdentifier));
 			peer.SendMessage (om, player, NetDeliveryMethod.ReliableOrdered);			
 		}
 
@@ -357,7 +365,7 @@ namespace Microsoft.Xna.Framework.Net
 
 			foreach (NetConnection player in peer.Connections) {
 
-				Console.WriteLine ("Introduction sent to: " + player.RemoteEndpoint);
+                Game.Instance.Log("Introduction sent to: " + player.RemoteEndpoint);
 				NetOutgoingMessage om = peer.CreateMessage ();
 				om.Write ((byte)NetworkMessageType.Introduction);
 				om.Write (playerConnection.RemoteEndpoint.ToString ()); 
@@ -368,7 +376,7 @@ namespace Microsoft.Xna.Framework.Net
 
 		internal void SendGamerStateChange (NetworkGamer gamer)
 		{
-
+            Game.Instance.Log("SendGamerStateChange " + gamer.RemoteUniqueIdentifier);
 			NetOutgoingMessage om = peer.CreateMessage ();
 			om.Write ((byte)NetworkMessageType.GamerStateChange);
 			om.Write ((int)gamer.State);
@@ -378,7 +386,7 @@ namespace Microsoft.Xna.Framework.Net
 
 		internal void SendSessionStateChange ()
 		{
-
+            Game.Instance.Log("Send Session State Change");
 			NetOutgoingMessage om = peer.CreateMessage ();
 			om.Write ((byte)NetworkMessageType.SessionStateChange);
 			om.Write ((int)session.SessionState);

--- a/MonoGame.Framework/Windows/WindowsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WindowsGamePlatform.cs
@@ -156,5 +156,10 @@ namespace Microsoft.Xna.Framework
         {
             
         }
+
+        public override void Log(string Message)
+        {
+            Console.WriteLine(Message);
+        }
     }
 }


### PR DESCRIPTION
Fixed a couple of networking issues. the first is the LocalGamer array being empty when trying to send a profile. The second is the Gamers in the AllGamers array having different indexes on each machine which results in the Respawn in netrumble spawning the wrong player.

Added an internal Instance static property for the Game class to aide with Logging .
Added a windows implementation of the Log method to write to Console.
