### PR TITLE
Develop: Fixes to DrawUserIndexedPrimitive

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -912,7 +912,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 //Draw
                 GL20.DrawElements(PrimitiveTypeGL20(primitiveType), GetElementCountArray(primitiveType, primitiveCount),
-                                  ALL11.UnsignedShort, (IntPtr) (indexOffset*sizeof (ushort)));
+                                  ALL20.UnsignedShort, (IntPtr) (indexOffset*sizeof (ushort)));
 
 
                 // Free resources


### PR DESCRIPTION
Simple fixes to DrawUserIndexedPrimitive.
First one changed the method signature to match XNA
Second one passes in the right type for the index buffer.
