### PR TITLE
Develop: GlStateManager bug fix.

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/BasicEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/BasicEffect.cs
@@ -37,8 +37,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			OnApply();
 			
             GLStateManager.Projection(Projection);
-            GLStateManager.World(World);
-            GLStateManager.View(View);
+            GLStateManager.WorldView(World, View);
 
 			base.Apply();
 

--- a/MonoGame.Framework/Graphics/States/GLStateManager.cs
+++ b/MonoGame.Framework/Graphics/States/GLStateManager.cs
@@ -80,24 +80,15 @@ namespace Microsoft.Xna.Framework.Graphics
         public static void Projection(Matrix projection)
         {
             GL11.MatrixMode(All11.Projection);
-            GL11.LoadIdentity();
-            GL11.LoadMatrix(Matrix.ToFloatArray(projection));
+            GL11.LoadMatrix(ref projection.M11);
             //GL11.Ortho(0, _device.DisplayMode.Width, _device.DisplayMode.Height, 0, -1, 1);
         }
 
-        public static void View(Matrix view)
-        {
-            GL11.MatrixMode(All11.Viewport);
-            GL11.LoadIdentity();
-            GL11.LoadMatrix(Matrix.ToFloatArray(view));
-            //GL11.Ortho(0, _device.DisplayMode.Width, _device.DisplayMode.Height, 0, -1, 1);
-        }
-
-        public static void World(Matrix world)
+        public static void WorldView(Matrix world, Matrix view)
         {
             GL11.MatrixMode(All11.Modelview);
-            GL11.LoadIdentity();
-            GL11.LoadMatrix(Matrix.ToFloatArray(world));
+            GL11.LoadMatrix(ref view.M11);
+			GL11.MultMatrix(ref world.M11);
             //GL11.Ortho(0, _device.DisplayMode.Width, _device.DisplayMode.Height, 0, -1, 1);
         }
 

--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -749,7 +749,7 @@ namespace Microsoft.Xna.Framework
 
         public static Matrix CreateOrthographicOffCenter(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane)
         {
-			Matrix result = identity;
+            Matrix result = identity;
 
             float invRL = 1 / (right - left);
             float invTB = 1 / (top - bottom);
@@ -763,8 +763,7 @@ namespace Microsoft.Xna.Framework
             result.M42 = -(top + bottom) * invTB;
             result.M43 = -(zFarPlane + zNearPlane) * invFN;
             result.M44 = 1;
-			
-			return result;
+            return result;
         }
         
         public static void CreateOrthographicOffCenter(float left, float right, float bottom, float top,


### PR DESCRIPTION
Merge GLStateManager.World and View into WorldView, since GL needs it so

 GL11.MatrixMode(All11.Viewport); is not a valid GL Command!

Also, ToFloatArray is not necessary. I saw the proper use of ref somewhere else in the code. I threw that in too. One less allocation.
