### PR TITLE
GamepadState.Thumbsticks

### DIFF
--- a/MonoGame.Framework/iOS/Input/GamePad.cs
+++ b/MonoGame.Framework/iOS/Input/GamePad.cs
@@ -135,8 +135,10 @@
 	
 	        public static GamePadState GetState(PlayerIndex playerIndex)
 	        {		
-				return new GamePadState(); // Please fix
-				// TODO return new GamePadState((Buttons)GamePad.Instance._buttons,GamePad.Instance._leftStick,GamePad.Instance._rightStick);
+			//return new GamePadState(); // Please fix - Does not return triggers or buttons.
+		 	Buttons[] p = new Buttons[0];
+			 	
+			return new GamePadState(Instance._leftStick, Instance._rightStick, 0f, 0f, p);
 	        }
 	
 	        public static bool SetVibration(PlayerIndex playerIndex, float leftMotor, float rightMotor)


### PR DESCRIPTION
Hi,

I was having problems with reading the thumbstick input, it was always zero, it turns out that GamePade.GetState() was returning an empty GamePadState (It probably should have thrown Not Implemented Exception).

I have added thumbstick data into the new GamePadState that is returned.

Triggers and Buttons still need to be added. I cannot find triggers so I will leave that. I will look over buttons later.
