### PR TITLE
Added _matrix multiply to spritebatch in opengl2.0 codepath

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -503,7 +503,7 @@ namespace Microsoft.Xna.Framework.Graphics
 							Matrix4.CreateTranslation(-this.graphicsDevice.Viewport.Width/2,
 								this.graphicsDevice.Viewport.Height/2,
 								0);
-							matWVPScreen = matViewScreen * matProjection;
+							matWVPScreen =  _matrix.ToOpenTK() * matViewScreen * matProjection;
 		}
 #endif		
 		public void Draw 

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -399,6 +399,7 @@
     <Compile Include="Graphics\Effect\AlphaTestEffect.cs" />
     <Compile Include="Graphics\Effect\EffectHelpers.cs" />
     <Compile Include="Graphics\Effect\AlphaTestEffectCode.cs" />
+    <Compile Include="XnaToOpenTK.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/MonoGame.Framework/XnaToOpenTK.cs
+++ b/MonoGame.Framework/XnaToOpenTK.cs
@@ -1,0 +1,58 @@
+// #region License
+// /*
+// Microsoft Public License (Ms-PL)
+// MonoGame - Copyright © 2009 The MonoGame Team
+// 
+// All rights reserved.
+// 
+// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+// accept the license, do not use the software.
+// 
+// 1. Definitions
+// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+// U.S. copyright law.
+// 
+// A "contribution" is the original software, or any additions or changes to the software.
+// A "contributor" is any person that distributes its contribution under this license.
+// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
+// 
+// 2. Grant of Rights
+// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+// 
+// 3. Conditions and Limitations
+// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+// your patent license from such contributor to the software ends automatically.
+// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+// notices that are present in the software.
+// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+// code form, you may only do so under a license that complies with this license.
+// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+// purpose and non-infringement.
+// */
+// #endregion License
+// 
+using System;
+
+namespace Microsoft.Xna.Framework
+{
+	internal static class XnaToOpenTK
+	{
+		
+		public static OpenTK.Matrix4 ToOpenTK(this Matrix m)
+		{
+			return new OpenTK.Matrix4(m.M11, m.M12, m.M13, m.M14,
+			                          m.M21, m.M22, m.M23, m.M24,
+			                          m.M31, m.M32, m.M33, m.M34,
+			                          m.M41, m.M42, m.M43, m.M44);
+		}
+	}
+	
+}
+


### PR DESCRIPTION
Added this to make my calls to SpriteBatch that use the transform matrix to display in the right position (at least in portrait mode)

I added a static helper class to help with Xna Matrix to OpenTK matrix conversion.
