### PR TITLE
develop: Fix for issue #280: Return type of TouchCollection.FindById was incorrect.

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Android/AndroidGameWindow.cs
@@ -386,7 +386,7 @@ namespace Microsoft.Xna.Framework
                 // DOWN                
                 case 0:
                 case 5:
-                    index = collection.FindById(e.GetPointerId(e.ActionIndex), out tlocation);
+                    index = collection.FindIndexById(e.GetPointerId(e.ActionIndex), out tlocation);
                     if (index < 0)
                     {
                         tlocation = new TouchLocation(id, TouchLocationState.Pressed, position);
@@ -401,7 +401,7 @@ namespace Microsoft.Xna.Framework
                 // UP                
                 case 1:
                 case 6:
-                    index = collection.FindById(e.GetPointerId(e.ActionIndex), out tlocation);
+                    index = collection.FindIndexById(e.GetPointerId(e.ActionIndex), out tlocation);
                     if (index >= 0)
                     {
                         tlocation.State = TouchLocationState.Released;
@@ -416,7 +416,7 @@ namespace Microsoft.Xna.Framework
                         position.X = e.GetX(i);
                         position.Y = e.GetY(i);
                         UpdateTouchPosition(ref position);
-                        index = collection.FindById(id, out tlocation);
+                        index = collection.FindIndexById(id, out tlocation);
                         if (index >= 0)
                         {
                             tlocation.State = TouchLocationState.Moved;
@@ -428,7 +428,7 @@ namespace Microsoft.Xna.Framework
                 // CANCEL, OUTSIDE                
                 case 3:
                 case 4:
-                    index = collection.FindById(id, out tlocation);
+                    index = collection.FindIndexById(id, out tlocation);
                     if (index >= 0)
                     {
                         tlocation.State = TouchLocationState.Invalid;

--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -53,9 +53,6 @@ namespace Microsoft.Xna.Framework.Input.Touch
 		/// </summary>
 		private bool isConnected;
 		
-		//Helpers
-		private List<TouchLocation> aux;
-		
 		#region Properties
 		public bool IsConnected
 		{
@@ -75,7 +72,6 @@ namespace Microsoft.Xna.Framework.Input.Touch
 		
 		public TouchCollection()
 		{
-			aux = new List<TouchLocation>();
 		}
 		
 		internal TouchCollection(IEnumerable<TouchLocation> locations)	: base (locations)
@@ -83,16 +79,10 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			
 		}
 		
-		public bool Contains(TouchLocation item)
-		{
-			return (this.IndexOf(item) >= 0);
-		}
-		
 		internal void Update()
 		{ 
 			//Console.WriteLine("----------------"+this.Count+"--------------------");
-			aux.Clear();
-			for (int i = 0;  i <  this.Count; i++)
+			for (int i = this.Count - 1; i >= 0; --i)
 			{
 				TouchLocation t = this[i];
 				switch (t.State)
@@ -107,36 +97,25 @@ namespace Microsoft.Xna.Framework.Input.Touch
 						this[i] = t;
 					break;
 					case TouchLocationState.Released:
-						aux.Add(t);
+						this.RemoveAt(i);
 					break;
 				}
 			}
-			foreach(TouchLocation touch in aux)
-				this.Remove(touch);
 		}
-		
-		public void CopyTo (TouchLocation[] array, int arrayIndex)
+
+		public bool FindById(int id, out TouchLocation touchLocation)
 		{
-			if (array == null)
+			int index = this.FindIndex((t) => { return t.Id == id; });
+			if (index >= 0)
 			{
-				throw new ArgumentNullException("array");
+				touchLocation = this[index];
+				return true;
 			}
-			if (arrayIndex < 0)
-			{
-				throw new ArgumentOutOfRangeException("arrayIndex");
-			}
-			long num = arrayIndex + this.Count;
-			if (array.Length < num)
-			{
-				throw new ArgumentOutOfRangeException("arrayIndex");
-			}
-			for(int i = 0; i < this.Count; i++)
-			{
-				array[arrayIndex+i] = this[i];
-			}
+			touchLocation = default(TouchLocation);
+			return false;
 		}
-		
-		public int FindById(int id, out TouchLocation touchLocation)
+
+		internal int FindIndexById(int id, out TouchLocation touchLocation)
 		{
 			for (int i = 0; i < this.Count; i++)
 			{
@@ -147,22 +126,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
 					return i;
 				}
 			}
-			touchLocation = new TouchLocation();
+			touchLocation = default(TouchLocation);
 			return -1;
 		}
-		
-		
-		public int IndexOf(TouchLocation item)
-		{
-			for (int i = 0; i < this.Count; i++)
-			{
-				if (this[i] == item)
-				{
-					return i;
-				}
-			}
-			return -1;
-		}
-		
 	}
 }

--- a/MonoGame.Framework/iOS/IOSGameWindow.cs
+++ b/MonoGame.Framework/iOS/IOSGameWindow.cs
@@ -522,7 +522,7 @@ namespace Microsoft.Xna.Framework
 				{
 					case UITouchPhase.Stationary:
 					case UITouchPhase.Moved:
-						index = collection.FindById(touch.Handle.ToInt32(), out tlocation);
+						index = collection.FindIndexById(touch.Handle.ToInt32(), out tlocation);
 						if (index >= 0)
 					    {
 							tlocation.State = TouchLocationState.Moved;
@@ -547,7 +547,7 @@ namespace Microsoft.Xna.Framework
 						}
 						break;
 					case UITouchPhase.Ended	:
-						index = collection.FindById(touch.Handle.ToInt32(), out tlocation);
+						index = collection.FindIndexById(touch.Handle.ToInt32(), out tlocation);
 						if (index >= 0)
 						{
 							tlocation.State = TouchLocationState.Released;							
@@ -562,7 +562,7 @@ namespace Microsoft.Xna.Framework
 						}
 						break;
 					case UITouchPhase.Cancelled:
-						index = collection.FindById(touch.Handle.ToInt32(), out tlocation);
+						index = collection.FindIndexById(touch.Handle.ToInt32(), out tlocation);
 						if (index >= 0)
 						{
 							tlocation.State = TouchLocationState.Invalid;


### PR DESCRIPTION
Existing FindById returning an int was refactored to FindIndexById as iOSGameWindow and AndroidGameWindow used it for updating the touch state.
Added FindById that returned a bool to match XNA 4.0 API.
Removed internal List<> helper in TouchCollection that would have caused memory allocations per frame.
