### PR TITLE
update VideoPlayer constructor contract to match XNA 4

### DIFF
--- a/MonoGame.Framework/Android/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/Android/Media/VideoPlayer.cs
@@ -52,10 +52,10 @@ namespace Microsoft.Xna.Framework.Media
 		private bool _isLooped;
 		private Game _game;
 
-        public VideoPlayer(Game game)
+        public VideoPlayer()
         {
 			_state = MediaState.Stopped;
-			_game = game;
+			_game = Game.Instance;
         }
 
         public Texture2D GetTexture()

--- a/MonoGame.Framework/MacOS/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/MacOS/Media/VideoPlayer.cs
@@ -59,11 +59,11 @@ namespace Microsoft.Xna.Framework.Media
 		// TODO Needed to bind OpenGL to Quicktime private QTVisualContextRef  textureContext;
     	// TODO Needed to grab frame as a texture private CVOpenGLTextureRef  currentFrame;
 		
-        public VideoPlayer(Game game)
+        public VideoPlayer()
         {
 			_state = MediaState.Stopped;
-			_game = game;
-            _platform = (MacGamePlatform)game.Services.GetService(typeof(MacGamePlatform));
+			_game = Game.Instance;
+            _platform = (MacGamePlatform)_game.Services.GetService(typeof(MacGamePlatform));
         }
 
         public Texture2D GetTexture()

--- a/MonoGame.Framework/iOS/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/iOS/Media/VideoPlayer.cs
@@ -54,10 +54,10 @@ namespace Microsoft.Xna.Framework.Media
 		private Game _game;
         private iOSGamePlatform _platform;
 		
-        public VideoPlayer(Game game)
+        public VideoPlayer()
         {
 			_state = MediaState.Stopped;
-			_game = game;
+			_game = Game.Instance;
             _platform = (iOSGamePlatform)_game.Services.GetService(typeof(iOSGamePlatform));
             if (_platform == null)
                 throw new InvalidOperationException("No iOSGamePlatform instance was available");


### PR DESCRIPTION
- use Game.Instance to get the "game instance"

(this is from pull request #73 redone against current "develop" branch)
