### PR TITLE
Fix resolution change to properly scale and preserve aspect ratio.

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Android/AndroidGameWindow.cs
@@ -316,8 +316,14 @@ namespace Microsoft.Xna.Framework
                 position.X = this.Width - position.X;
                 position.Y = this.Height - position.Y;
             }
-            position.X = (position.X / Width) * _game.GraphicsDevice.Viewport.Width;
-            position.Y = (position.Y / Height) * _game.GraphicsDevice.Viewport.Height;
+
+            //Fix for ClientBounds
+            position.X -= ClientBounds.X;
+            position.Y -= ClientBounds.Y;
+
+            //Fix for Viewport
+            position.X = (position.X / ClientBounds.Width) * _game.GraphicsDevice.Viewport.Width;
+            position.Y = (position.Y / ClientBounds.Height) * _game.GraphicsDevice.Viewport.Height;
             //Android.Util.Log.Info("MonoGameInfo", String.Format("Touch {0}x{1}", position.X, position.Y));
         }
 
@@ -412,6 +418,12 @@ namespace Microsoft.Xna.Framework
 			{
 				return clientBounds;
 			}
+            internal set
+            {
+                clientBounds = value;
+                //if(ClientSizeChanged != null)
+                //    ClientSizeChanged(this, EventArgs.Empty);
+            }
 		}
 		
 		public bool AllowUserResizing 

--- a/MonoGame.Framework/Android/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Android/Graphics/DisplayMode.cs
@@ -38,8 +38,6 @@ purpose and non-infringement.
 */
 #endregion License
 
-using System;
-
 namespace Microsoft.Xna.Framework.Graphics
 {
     public struct DisplayMode
@@ -48,7 +46,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             get
             {
-                return Width  / Height;
+                return (float)Game.Activity.Resources.DisplayMetrics.WidthPixels / (float)Game.Activity.Resources.DisplayMetrics.HeightPixels;
             }
         }
 
@@ -56,7 +54,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             get
             {
-                return (int)Game.Activity.Resources.DisplayMetrics.WidthPixels;
+                return Game.Activity.Resources.DisplayMetrics.WidthPixels;
             }
         }
 
@@ -64,7 +62,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             get
             {
-                return (int)Game.Activity.Resources.DisplayMetrics.HeightPixels;
+                return Game.Activity.Resources.DisplayMetrics.HeightPixels;
             }
         }
 		

--- a/MonoGame.Framework/Android/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/Android/GraphicsDeviceManager.cs
@@ -239,6 +239,7 @@ namespace Microsoft.Xna.Framework
             set
             {
 				_preferredBackBufferHeight = value;
+                ResetClientBounds();
             }
         }
 
@@ -251,6 +252,39 @@ namespace Microsoft.Xna.Framework
             set
             {
 				_preferredBackBufferWidth = value;				
+                ResetClientBounds();
+            }
+        }
+
+        private void ResetClientBounds()
+        {
+            var clientBounds = Game.Instance.Window.ClientBounds;
+
+            var aspectRatio = (float)_preferredBackBufferWidth/_preferredBackBufferHeight;
+
+            if (GraphicsDevice.DisplayMode.AspectRatio > aspectRatio)
+            {
+                var newClientBounds = new Rectangle();
+
+                newClientBounds.Height = GraphicsDevice.DisplayMode.Height;
+                newClientBounds.Width = (int) (newClientBounds.Height*aspectRatio);
+                newClientBounds.X = (GraphicsDevice.DisplayMode.Width - newClientBounds.Width)/2;
+
+                Game.Instance.Window.ClientBounds = newClientBounds;
+            }
+            else if (GraphicsDevice.DisplayMode.AspectRatio < aspectRatio)
+            {
+                var newClientBounds = new Rectangle();
+
+                newClientBounds.Width = GraphicsDevice.DisplayMode.Width;
+                newClientBounds.Height = (int)(newClientBounds.Width / aspectRatio);
+                newClientBounds.Y = (GraphicsDevice.DisplayMode.Height - newClientBounds.Height) / 2;
+
+                Game.Instance.Window.ClientBounds = newClientBounds;
+            }
+            else
+            {
+                Game.Instance.Window.ClientBounds = new Rectangle(0, 0, _preferredBackBufferWidth, _preferredBackBufferHeight);
             }
         }
 

--- a/MonoGame.Framework/Graphics/Effect/BasicEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/BasicEffect.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			// May need to be moved elsewhere within this method
 			OnApply();
 			
+            GLStateManager.Viewport(Game.Instance.Window.ClientBounds);
             GLStateManager.Projection(Projection);
             GLStateManager.WorldView(World, View);
 

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -321,7 +321,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			UpdateWorldMatrixOrientation();
 			
 			// Configure ViewPort
-			GL20.Viewport(0, 0, this.graphicsDevice.Viewport.Width, this.graphicsDevice.Viewport.Height); 
+		    var client = Game.Instance.Window.ClientBounds;
+			GL20.Viewport(client.X, client.Y, client.Width, client.Height); 
 			GL20.UseProgram(program);
 			
             // Enable Scissor Tests if necessary
@@ -414,8 +415,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 			
 			GL11.MatrixMode(ALL11.Modelview);			
-			
-			//GL11.Viewport(0, 0, this.graphicsDevice.Viewport.Width, this.graphicsDevice.Viewport.Height);
+
+		    var viewClient = Game.Instance.Window.ClientBounds;
+			GL11.Viewport(viewClient.X, viewClient.Y, viewClient.Width, viewClient.Height);
 			
 			// Enable Scissor Tests if necessary
 			if ( this.graphicsDevice.RasterizerState.ScissorTestEnable )
@@ -466,7 +468,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				lastDisplayOrientation = graphicsDevice.PresentationParameters.DisplayOrientation;
 				
 				// make sure the viewport is correct
-				this.graphicsDevice.SetViewPort(graphicsDevice.DisplayMode.Width, graphicsDevice.DisplayMode.Height);
+				this.graphicsDevice.SetViewPort(Game.Instance.Window.ClientBounds.Width, Game.Instance.Window.ClientBounds.Height);
 				
 				matViewScreen = Matrix.CreateRotationZ((float)Math.PI)*
 							     	Matrix.CreateRotationY((float)Math.PI)*

--- a/MonoGame.Framework/Graphics/States/GLStateManager.cs
+++ b/MonoGame.Framework/Graphics/States/GLStateManager.cs
@@ -77,6 +77,11 @@ namespace Microsoft.Xna.Framework.Graphics
             GL11.Enable(All11.Blend);
         }
 
+        public static void Viewport(Rectangle viewport)
+        {
+            GL11.Viewport(viewport.X, viewport.Y, viewport.Width, viewport.Height);
+        }
+
         public static void Projection(Matrix projection)
         {
             GL11.MatrixMode(All11.Projection);


### PR DESCRIPTION
Note:  I use SpriteBatch very little so this might break some things in SpriteBatch.

This prevents the screen from stretching.  So, if the resolution set is 4:3 resolution and you are using landscape, there will be 2 black bars on each side and the picture will be centered while preserving the aspect ratio.  This should also work in portrait mode but have not tested it.  This is how WP7 works.
