### PR TITLE
Fix for SoundEffect on Windows

### DIFF
--- a/MonoGame.Framework/Desktop/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Desktop/Audio/SoundEffect.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Xna.Framework.Audio
             ALFormat format;
             int size;
             int freq;
-            byte[] data;
+            //byte[] data;
             Stream s;
 
             try
@@ -88,7 +88,7 @@ namespace Microsoft.Xna.Framework.Audio
                 throw new Content.ContentLoadException("Could not load audio data", e);
             }
 
-            data = LoadAudioStream(s, 1.0f, false);
+            _data = LoadAudioStream(s, 1.0f, false);
 
             s.Close();			
 		}


### PR DESCRIPTION
The SoundEffect constructor used by the standard ContentManager.Load<SoundEffect>() does not actually keep the sound data.
