### PR TITLE
Made per-letter position increment use Cropping X value

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Xna.Framework.Graphics {
 
 				if (flippedHorz)
 					p.X += PerThreadTypesetter.CurrentGlyph.BoundsInTexture.Width;
-				p.X += PerThreadTypesetter.CurrentGlyph.LeftSideBearing;
+				p.X += PerThreadTypesetter.CurrentGlyph.Cropping.X;
 
 				if (flippedVert)
 					p.Y += PerThreadTypesetter.CurrentGlyph.BoundsInTexture.Height - LineSpacing;


### PR DESCRIPTION
I tested this on the samples and their fonts look the same when run. On my texture based SpriteFont, this change fixes the X-alignment of the thin characters.
