### PR TITLE
iOS - Texture2D - Change FromFile so you can load from Documents folder

### DIFF
--- a/MonoGame.Framework/iOS/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/iOS/Graphics/Texture2D.cs
@@ -258,10 +258,26 @@ namespace Microsoft.Xna.Framework.Graphics
         public static Texture2D FromFile(GraphicsDevice graphicsDevice, string filename, int width, int height)
         {
 			UIImage image;
-			if(filename.Contains(".pdf"))
+
+			if (filename.Contains(".pdf"))
+			{
 				image = Extender.FromPdf(filename,width,height);
+			} 
 			else
-				image = UIImage.FromBundle(filename);
+			{
+				// If we are loading graphics from the Content folder then we can take advantage of the FromBundle methods ability
+				// to automatically cope with @2x graphics for high resolution devices.  If we are loading from somewhere else (e.g.
+				// the documents folder for our app) then FromBundle will not work and so we must call FromFile.
+				if (filename.StartsWith("Content/", StringComparison.OrdinalIgnoreCase) == true) 
+				{
+					image = UIImage.FromBundle(filename);
+				}
+				else 
+				{
+					image = UIImage.FromFile(filename);
+				}
+			}
+			
 			if (image == null)
 			{
 				throw new ContentLoadException("Error loading file: " + filename);
@@ -278,6 +294,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				var small = image.Scale (new SizeF (width, height));
 				theTexture = new ESImage(small, graphicsDevice.PreferedFilter);
 			}
+			
 			Texture2D result = new Texture2D(theTexture);
 			// result.Name = Path.GetFileNameWithoutExtension(filename);
 			result.Name = filename;


### PR DESCRIPTION
The FromFile method currently calls UIImage.FromBundle which takes advantage of automatically loading @2x images for high resolution retina devices.  However it can only load files from the Content folder.  The UIImage.FromFile method allows you to load graphics from the document folder as well as the Content folder, however it does not automatically cope with loading @2x images like the FromBundle method does.  Therefore this change will check the path we are trying to load - if it is from the Content folder then we continue to call UIImage.FromBundle, however if it is from anywhere else then we will call UIImage.FromFile.
