### PR TITLE
Develop3d - Added touch, mouse and stylus input for Metro

### DIFF
--- a/MonoGame.Framework/Input/MouseState.cs
+++ b/MonoGame.Framework/Input/MouseState.cs
@@ -150,6 +150,18 @@ namespace Microsoft.Xna.Framework.Input
 				return ButtonState.Released;
 			}
 		}
+
+#if WINRT
+        internal void Update(Windows.UI.Core.PointerEventArgs args)
+        {
+            _leftButton = args.CurrentPoint.Properties.IsLeftButtonPressed ? ButtonState.Pressed : ButtonState.Released;
+            _rightButton = args.CurrentPoint.Properties.IsRightButtonPressed ? ButtonState.Pressed : ButtonState.Released;
+            _middleButton = args.CurrentPoint.Properties.IsMiddleButtonPressed ? ButtonState.Pressed : ButtonState.Released;
+            _x = (int)args.CurrentPoint.Position.X;
+            _y = (int)args.CurrentPoint.Position.Y;
+            _scrollWheelValue += args.CurrentPoint.Properties.MouseWheelDelta;
+        }
+#endif
 	}
 }
 

--- a/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
@@ -63,7 +63,6 @@
     <Compile Include="Content\ContentReaders\TextureReader.cs" />
     <Compile Include="Content\ContentReaders\VertexBufferReader.cs" />
     <Compile Include="Content\ContentReaders\VertexDeclarationReader.cs" />
-    <Compile Include="Desktop\Input\Mouse.cs" />
     <Compile Include="Game.cs" />
     <Compile Include="GamePlatform.cs" />
     <Compile Include="GamerServices\MessageBoxIcon.cs">
@@ -131,6 +130,9 @@
     <Compile Include="Input\KeyboardState.cs" />
     <Compile Include="Input\Keys.cs" />
     <Compile Include="Input\KeyState.cs" />
+    <Compile Include="Input\Mouse.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Input\MouseState.cs" />
     <Compile Include="Input\ThumbStickDefinition.cs" />
     <Compile Include="Input\Touch\GestureSample.cs" />
@@ -354,6 +356,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="Desktop\Input\" />
     <Folder Include="Windows\Input\" />
   </ItemGroup>
   <ItemGroup>

--- a/MonoGame.Framework/Windows8/MetroGameWindow.cs
+++ b/MonoGame.Framework/Windows8/MetroGameWindow.cs
@@ -49,6 +49,7 @@ using Microsoft.Xna.Framework.Input;
 using Windows.UI.Core;
 using System.Runtime.InteropServices;
 using Windows.Graphics.Display;
+using Microsoft.Xna.Framework.Input.Touch;
 #endregion Using Statements
 
 namespace Microsoft.Xna.Framework
@@ -132,6 +133,54 @@ namespace Microsoft.Xna.Framework
                 _keys.Add(xnaKey);
         }
 
+        void _coreWindow_PointerMoved(CoreWindow sender, PointerEventArgs args)
+        {
+            Vector2 pos = new Vector2((float)args.CurrentPoint.Position.X, (float)args.CurrentPoint.Position.Y);
+            bool isTouch = args.CurrentPoint.PointerDevice.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Touch;
+            if (isTouch)
+            {
+                // Touch panel event
+                TouchPanel.Collection.Update((int)args.CurrentPoint.PointerId, TouchLocationState.Moved, pos);
+            }
+            if (!isTouch || args.CurrentPoint.Properties.IsPrimary)
+            {
+                // Mouse or stylus event or the primary touch event (simulated as mouse input)
+                Mouse.State.Update(args);
+            }
+        }
+
+        void _coreWindow_PointerReleased(CoreWindow sender, PointerEventArgs args)
+        {
+            Vector2 pos = new Vector2((float)args.CurrentPoint.Position.X, (float)args.CurrentPoint.Position.Y);
+            bool isTouch = args.CurrentPoint.PointerDevice.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Touch;
+            if (isTouch)
+            {
+                // Touch panel event
+                TouchPanel.Collection.Update((int)args.CurrentPoint.PointerId, TouchLocationState.Released, pos);
+            }
+            if (!isTouch || args.CurrentPoint.Properties.IsPrimary)
+            {
+                // Mouse or stylus event or the primary touch event (simulated as mouse input)
+                Mouse.State.Update(args);
+            }
+        }
+
+        void _coreWindow_PointerPressed(CoreWindow sender, PointerEventArgs args)
+        {
+            Vector2 pos = new Vector2((float)args.CurrentPoint.Position.X, (float)args.CurrentPoint.Position.Y);
+            bool isTouch = args.CurrentPoint.PointerDevice.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Touch;
+            if (isTouch)
+            {
+                // Touch panel event
+                TouchPanel.Collection.Add((int)args.CurrentPoint.PointerId, pos);
+            }
+            if (!isTouch || args.CurrentPoint.Properties.IsPrimary)
+            {
+                // Mouse or stylus event or the primary touch event (simulated as mouse input)
+                Mouse.State.Update(args);
+            }
+        }
+
         #endregion
 
         private void HandleInput()
@@ -162,15 +211,10 @@ namespace Microsoft.Xna.Framework
             // Set the window icon.
             //window.Icon = Icon.ExtractAssociatedIcon(Assembly.GetEntryAssembly().Location);
 
-            /*
-            // mouse
-            // TODO review this when opentk 1.1 is released
-#if !WINDOWS
-            Mouse.UpdateMouseInfo(window.Mouse);
-#else
-            Mouse.setWindows(window);
-#endif
-            */
+            // Receives mouse, touch and stylus input events
+            _coreWindow.PointerPressed += _coreWindow_PointerPressed;
+            _coreWindow.PointerReleased += _coreWindow_PointerReleased;
+            _coreWindow.PointerMoved += _coreWindow_PointerMoved;
         }
 
         private void Window_Closed(CoreWindow sender, CoreWindowEventArgs args)


### PR DESCRIPTION
Uses pointer events from CoreWindow.  Replaces previous mouse input in Desktop/Input/Mouse.cs.

Desktop/Input/Mouse.cs is no longer used. Uses Input/Mouse.cs as MouseState is updated from MetroGameWindow.
