### PR TITLE
SetRenderTarget saves Viewport when switching from Back Buffer

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -836,7 +836,10 @@ namespace Microsoft.Xna.Framework.Graphics
 		public void SetRenderTarget (RenderTarget2D renderTarget)
 		{
 			if (renderTarget == null)
-				this.SetRenderTargets(null);
+            {
+                SetRenderTargets(null);
+                Viewport = savedViewport;
+            }
 			else
 				this.SetRenderTargets(new RenderTargetBinding(renderTarget));
 		}
@@ -908,6 +911,9 @@ namespace Microsoft.Xna.Framework.Graphics
 					}
 					throw new InvalidOperationException(message);
 				}
+                
+                savedViewport = Viewport;
+                
 				this.Viewport = new Viewport(0, 0, renderTarget.Width, renderTarget.Height);
 #endif
             }


### PR DESCRIPTION
If `SetRenderTarget` was called in `GraphicsDevice`, it would overwrite `Viewport` (even if nothing was drawn). After switching back to the Back Buffer, it did not restore the original Viewport. This gave the impression that everything was drawn relative to a bottom-right origin after each window resize, which differs from XNA output.

This patch re-enables the `savedViewport` variable (previously removed) and the behaviour now matches XNA  (and the `develop` branch) during window `OnResize` events.

---

Comments in the code suggest that there might have been broader plans for `renderTarget` management, so this might not be the preferred solution.
