### PR TITLE
Develop3d - Fix null reference exception in effects other than BasicEffect

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/BasicEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/BasicEffect.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Xna.Framework.Graphics
         EffectParameter worldInverseTransposeParam;
         EffectParameter worldViewProjParam;
 
-        int _shaderIndex;
+        int _shaderIndex = -1;
 
         #endregion
 

--- a/MonoGame.Framework/Graphics/Effect/DualTextureEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/DualTextureEffect.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Xna.Framework.Graphics
         EffectParameter fogColorParam;
         EffectParameter fogVectorParam;
         EffectParameter worldViewProjParam;
-        EffectParameter shaderIndexParam;
+
+        int _shaderIndex = -1;
 
         #endregion
 
@@ -294,7 +295,6 @@ namespace Microsoft.Xna.Framework.Graphics
             fogColorParam       = Parameters["FogColor"];
             fogVectorParam      = Parameters["FogVector"];
             worldViewProjParam  = Parameters["WorldViewProj"];
-            shaderIndexParam    = Parameters["ShaderIndex"];
         }
 
 
@@ -325,9 +325,14 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (vertexColorEnabled)
                     shaderIndex += 2;
                 
-                shaderIndexParam.SetValue(shaderIndex);
-
                 dirtyFlags &= ~EffectDirtyFlags.ShaderIndex;
+
+                if (_shaderIndex != shaderIndex)
+                {
+                    _shaderIndex = shaderIndex;
+                    CurrentTechnique = Techniques[_shaderIndex];
+                    return true;
+                }
             }
 
             return false;

--- a/MonoGame.Framework/Graphics/Effect/EnvironmentMapEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/EnvironmentMapEffect.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Xna.Framework.Graphics
         EffectParameter worldParam;
         EffectParameter worldInverseTransposeParam;
         EffectParameter worldViewProjParam;
-        EffectParameter shaderIndexParam;
+
+        int _shaderIndex = -1;
 
         #endregion
 
@@ -444,7 +445,6 @@ namespace Microsoft.Xna.Framework.Graphics
             worldParam                  = Parameters["World"];
             worldInverseTransposeParam  = Parameters["WorldInverseTranspose"];
             worldViewProjParam          = Parameters["WorldViewProj"];
-            shaderIndexParam            = Parameters["ShaderIndex"];
 
             light0 = new DirectionalLight(Parameters["DirLight0Direction"],
                                           Parameters["DirLight0DiffuseColor"],
@@ -508,9 +508,14 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (oneLight)
                     shaderIndex += 8;
 
-                shaderIndexParam.SetValue(shaderIndex);
-
                 dirtyFlags &= ~EffectDirtyFlags.ShaderIndex;
+
+                if (_shaderIndex != shaderIndex)
+                {
+                    _shaderIndex = shaderIndex;
+                    CurrentTechnique = Techniques[_shaderIndex];
+                    return true;
+                }
             }
 
             return false;

--- a/MonoGame.Framework/Graphics/Effect/SkinnedEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/SkinnedEffect.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Xna.Framework.Graphics
         EffectParameter worldInverseTransposeParam;
         EffectParameter worldViewProjParam;
         EffectParameter bonesParam;
-        EffectParameter shaderIndexParam;
+
+        int _shaderIndex = -1;
 
         #endregion
 
@@ -471,7 +472,6 @@ namespace Microsoft.Xna.Framework.Graphics
             worldInverseTransposeParam  = Parameters["WorldInverseTranspose"];
             worldViewProjParam          = Parameters["WorldViewProj"];
             bonesParam                  = Parameters["Bones"];
-            shaderIndexParam            = Parameters["ShaderIndex"];
 
             light0 = new DirectionalLight(Parameters["DirLight0Direction"],
                                           Parameters["DirLight0DiffuseColor"],
@@ -536,9 +536,14 @@ namespace Microsoft.Xna.Framework.Graphics
                 else if (oneLight)
                     shaderIndex += 6;
 
-                shaderIndexParam.SetValue(shaderIndex);
-
                 dirtyFlags &= ~EffectDirtyFlags.ShaderIndex;
+
+                if (_shaderIndex != shaderIndex)
+                {
+                    _shaderIndex = shaderIndex;
+                    CurrentTechnique = Techniques[_shaderIndex];
+                    return true;
+                }
             }
 
             return false;


### PR DESCRIPTION
Shader index is no longer a shader parameter.  Fixes null reference exception.
