### PR TITLE
Fix AudioSession crash introduced with iOS 5.1.

### DIFF
--- a/MonoGame.Framework/MacOS/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/MacOS/Audio/OpenALSoundController.cs
@@ -34,10 +34,18 @@ namespace Microsoft.Xna.Framework.Audio
 #if IPHONE
 			AudioSession.Initialize();
 
-			if (AudioSession.OtherAudioIsPlaying)
-				AudioSession.Category = AudioSessionCategory.AmbientSound;
-			else
-				AudioSession.Category = AudioSessionCategory.SoloAmbientSound;
+			// NOTE: iOS 5.1 simulator throws an exception when setting the category
+			// to SoloAmbientSound.  This could be removed if that bug gets fixed.
+			try
+			{
+				if (AudioSession.OtherAudioIsPlaying)
+					AudioSession.Category = AudioSessionCategory.AmbientSound;
+				else
+				{
+					AudioSession.Category = AudioSessionCategory.SoloAmbientSound;
+				}
+			}
+			catch (AudioSessionException) { }
 #endif
 			alcMacOSXMixerOutputRate(PREFERRED_MIX_RATE);
 			_device = Alc.OpenDevice (string.Empty);


### PR DESCRIPTION
iOS 5.1 emulator crashes when setting the Category to SoloAmbientSound.  I added a try/catch which seems like the best solution for now.  Crash does not occur on actual hardware.  Could be a MonoTouch bug I suppose, but seems unlikely.
