### PR TITLE
Update Rectangle.Intersects to correct off-by-one error

### DIFF
--- a/MonoGame.Framework/Rectangle.cs
+++ b/MonoGame.Framework/Rectangle.cs
@@ -201,25 +201,21 @@ namespace Microsoft.Xna.Framework
             return (this.X ^ this.Y ^ this.Width ^ this.Height);
         }
 
-        public bool Intersects(Rectangle r2)
+        public bool Intersects(Rectangle value)
         {
-            return !(r2.Left >= Right
-                     || r2.Right <= Left
-                     || r2.Top >= Bottom
-                     || r2.Bottom <= Top
-                    );
-
+            return value.Left < Right       && 
+                   Left       < value.Right && 
+                   value.Top  < Bottom      &&
+                   Top        < value.Bottom;            
         }
 
 
         public void Intersects(ref Rectangle value, out bool result)
         {
-            result = !(value.Left >= Right
-                     || value.Right <= Left
-                     || value.Top >= Bottom
-                     || value.Bottom <= Top
-                    );
-
+            result = value.Left < Right       && 
+                     Left       < value.Right && 
+                     value.Top  < Bottom      &&
+                     Top        < value.Bottom;
         }
 
         public static Rectangle Intersect(Rectangle value1, Rectangle value2)


### PR DESCRIPTION
In XNA Rectangle.Intersects returns False for adjacent but non-overlapping rectangles, for example:

Rectangle rect1 = new Rectangle(0,0,32,32);
Rectangle rect2 = new Rectangle(32,0,32,32);
Console.WriteLine("Intersection : " + rect1.Intersects(rect2));

prints False. Monogame prints True.

I've update the definition in Rectangle.cs to use inclusive comparisons which I think fixes it.
