### PR TITLE
Update ClientBounds and PresentationParameters.Bounds on window resize (Desktop)

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -150,6 +150,10 @@ namespace Microsoft.Xna.Framework
             var winHeight = window.ClientRectangle.Height;
             var winRect = new Rectangle(0, 0, winWidth, winHeight);
             
+            // If window size is zero, leave bounds unchanged
+            if (winWidth == 0 || winHeight == 0)
+                return;
+            
             ChangeClientBounds(winRect);
             
             Game.GraphicsDevice.Viewport = new Viewport(0, 0, winWidth, winHeight);


### PR DESCRIPTION
This patch updates the major window bound parameters (ClientBounds, Viewport, PresentationParameters) on window resizing. Previously, only Viewport was updated after a window resize. This also indirectly resolves the renderTarget issue in #446 without the need to cache viewport size.
