### PR TITLE
MGSoundEffectProcessor Improvements

### DIFF
--- a/MonoGame.ContentPipeline/ContentProcessors/AudioConverter.cs
+++ b/MonoGame.ContentPipeline/ContentProcessors/AudioConverter.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Yeti.WMFSdk;
+using System.IO;
+//using Yeti.MMedia;
+//using WaveLib;
+//using Yeti.MMedia.Mp3;
+
+using NAudio;
+using NAudio.Wave;
+using NAudio.WindowsMediaFormat;
+using Microsoft.Xna.Framework.Content.Pipeline.Audio;
+
+namespace MonoGameContentProcessors.Utilities
+{
+    public static class AudioConverter
+    {
+        /// <summary>
+        /// Converts a WMA file to a WAV stream
+        /// </summary>
+        /// <param name="outputStream">Stream to store the converted wav.</param>
+        /// <param name="filePath">Path to a .wma file to convert</param>
+        /// <returns>The WaveFormat object of the converted wav</returns>
+        private static WaveFormat wmaToWav(string pathToWma, Stream outputStream, int sampleRate, int bitDepth, int numChannels)
+        {
+            if (!Path.GetExtension(pathToWma).ToLower().Contains("wma"))
+                throw new ArgumentException("Must be a .wma file!");
+
+            using (var reader = new WMAFileReader(pathToWma))
+            {
+                var targetFormat = new NAudio.Wave.WaveFormat(sampleRate, bitDepth, numChannels);
+                var pcmStream = new WaveFormatConversionStream(targetFormat, reader);
+                var buffer = new byte[pcmStream.Length];
+                pcmStream.Read(buffer, 0, (int)pcmStream.Length);
+                outputStream.Write(buffer, 0, buffer.Length);
+                outputStream.Position = 0;
+
+                pcmStream.Close();
+
+                return targetFormat;
+            }
+        }
+
+        /// <summary>
+        /// Converts one audio format into another.
+        /// </summary>
+        /// <param name="pathToFile">Path to the file to be converted</param>
+        /// <param name="outputStream">Stream where the converted sound will be.</param>
+        /// /// <param name="bitDepth">The target bit depth.</param>
+        /// <param name="sampleRate">The target sample rate.</param>
+        /// <param name="bitDepth">The target bit depth.</param>
+        /// <param name="numChannels">the number of channels.</param>
+        public static WaveFormat ConvertFile(string pathToFile, Stream outputStream, AudioFileType targetFileType, int sampleRate, int bitDepth, int numChannels)
+        {
+            if (targetFileType == AudioFileType.Wma)
+                throw new ArgumentException("WMA is not a vaid output type.");
+
+            string sourceFileType = pathToFile.Substring(pathToFile.Length - 3).ToLower();
+            switch (sourceFileType)
+            {
+                case "mp3":
+                    if (targetFileType != AudioFileType.Wav)
+                        throw new NotSupportedException("mp3's should only ever be converted to .wav.");
+
+                     return mp3ToWav(pathToFile, outputStream, sampleRate, bitDepth, numChannels);
+
+                case "wma":
+                     if (targetFileType == AudioFileType.Mp3)
+                     {
+                         wmaToMp3(pathToFile, outputStream, sampleRate, bitDepth, numChannels);
+                         return null;
+                     }
+                     else if (targetFileType == AudioFileType.Wav)
+                     {
+                         return wmaToWav(pathToFile, outputStream, sampleRate, bitDepth, numChannels);
+                     }
+
+                     break;
+
+                case "wav":
+                     if (targetFileType == AudioFileType.Mp3)
+                     {
+                         wavToMp3(pathToFile, outputStream, sampleRate, bitDepth, numChannels);
+                         return null;
+                     }
+                    else if (targetFileType == AudioFileType.Wav )
+                        return reencodeWav(pathToFile, outputStream, sampleRate, bitDepth, numChannels);
+
+                    break;
+
+            }
+
+            return null;
+        }
+
+        private static void wavToMp3(string pathToFile, Stream outputStream, int sampleRate, int bitDepth, int numChannels)
+        {
+            // wavStream gets closed in wavStreamToMP3();
+            wavToMp3(new WaveLib.WaveStream(pathToFile), outputStream, (uint)(sampleRate / 1000));
+        }
+
+        private static void wavToMp3(Stream streamToWav, Stream outputStream, uint desiredOutputBitRate)
+        {
+            var mp3Config = new Yeti.MMedia.Mp3.Mp3WriterConfig((streamToWav as WaveLib.WaveStream).Format, desiredOutputBitRate);
+
+            var mp3Writer = new Yeti.MMedia.Mp3.Mp3Writer(outputStream, mp3Config);
+            byte[] buff = new byte[mp3Writer.OptimalBufferSize];
+            int read = 0;
+            long total = streamToWav.Length;
+            streamToWav.Position = 0;
+            while ((read = streamToWav.Read(buff, 0, buff.Length)) > 0)
+                mp3Writer.Write(buff, 0, read);
+
+            mp3Writer.Close();
+            streamToWav.Close();
+        }
+
+        private static void wmaToMp3(string pathToFile, Stream outputStream, int sampleRate, int bitDepth, int numChannels)
+        {
+            var streamToWav = new WaveLib.WaveStream();
+            wmaToWav(pathToFile, streamToWav.BaseStream, sampleRate, bitDepth, numChannels);
+
+            streamToWav.ReadHeader();
+
+            // wavStream gets closed in wavStreamToMP3();
+            wavToMp3(streamToWav, outputStream, (uint)(sampleRate / 1000));
+        }
+
+        private static WaveFormat mp3ToWav(string pathToMp3, Stream outputStream, int sampleRate, int bitDepth, int numChannels)
+        {
+            using (var reader = new Mp3FileReader(pathToMp3))
+            {
+                var targetFormat = new NAudio.Wave.WaveFormat(sampleRate, bitDepth, numChannels);
+                var pcmStream = new WaveFormatConversionStream(targetFormat, reader);
+                var buffer = new byte[pcmStream.Length];
+                pcmStream.Read(buffer, 0, (int)pcmStream.Length);
+                outputStream.Write(buffer, 0, buffer.Length);
+                outputStream.Position = 0;
+
+                pcmStream.Close();
+
+                return targetFormat;
+            }
+        }
+
+        private static WaveFormat reencodeWav(string pathToWav, Stream outputStream, int sampleRate, int bitDepth, int numChannels)
+        {
+            using (var reader = new WaveFileReader(pathToWav))
+            {
+                var targetFormat = new NAudio.Wave.WaveFormat(sampleRate, bitDepth, numChannels);
+                var pcmStream = new WaveFormatConversionStream(targetFormat, reader);
+                var buffer = new byte[pcmStream.Length];
+                pcmStream.Read(buffer, 0, (int)pcmStream.Length);
+
+                outputStream.Write(buffer, 0, buffer.Length);
+                outputStream.Position = 0;
+
+                pcmStream.Close();
+
+                return targetFormat;
+            }
+        }
+    }
+}

--- a/MonoGame.ContentPipeline/ContentProcessors/MonoGameContentProcessors.csproj
+++ b/MonoGame.ContentPipeline/ContentProcessors/MonoGameContentProcessors.csproj
@@ -53,6 +53,13 @@
     <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86" />
     <Reference Include="Microsoft.Xna.Framework.Content.Pipeline, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86" />
     <Reference Include="Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86" />
+    <Reference Include="NAudio, Version=1.5.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\ThirdParty\Libs\NAudio\NAudio.dll</HintPath>
+    </Reference>
+    <Reference Include="NAudio.WindowsMediaFormat">
+      <HintPath>..\..\ThirdParty\Libs\NAudio\NAudio.WindowsMediaFormat.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -62,6 +69,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AudioConverter.cs" />
     <Compile Include="Content\MGBitmapContent.cs" />
     <Compile Include="Processors\MGMaterialProcessor.cs" />
     <Compile Include="Processors\MGSongProcessor.cs" />

--- a/MonoGame.ContentPipeline/ContentProcessors/MonoGameContentProcessors.sln
+++ b/MonoGame.ContentPipeline/ContentProcessors/MonoGameContentProcessors.sln
@@ -35,8 +35,8 @@ Global
 		{2C23E01D-DE2D-4671-85B0-1085857C6D25}.Debug|x86.Build.0 = Debug|x86
 		{2C23E01D-DE2D-4671-85B0-1085857C6D25}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2C23E01D-DE2D-4671-85B0-1085857C6D25}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2C23E01D-DE2D-4671-85B0-1085857C6D25}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{2C23E01D-DE2D-4671-85B0-1085857C6D25}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{2C23E01D-DE2D-4671-85B0-1085857C6D25}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{2C23E01D-DE2D-4671-85B0-1085857C6D25}.Release|Mixed Platforms.Build.0 = Release|x86
 		{2C23E01D-DE2D-4671-85B0-1085857C6D25}.Release|Win32.ActiveCfg = Release|x86
 		{2C23E01D-DE2D-4671-85B0-1085857C6D25}.Release|x86.ActiveCfg = Release|x86
 		{2C23E01D-DE2D-4671-85B0-1085857C6D25}.Release|x86.Build.0 = Release|x86

--- a/MonoGame.ContentPipeline/ContentProcessors/Processors/MGSoundEffectProcessor.cs
+++ b/MonoGame.ContentPipeline/ContentProcessors/Processors/MGSoundEffectProcessor.cs
@@ -4,6 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Reflection;
 using System.Collections.ObjectModel;
+using Microsoft.Xna.Framework.Content.Pipeline.Audio;
+using MonoGameContentProcessors.Utilities;
+using System.IO;
+
+using NAudio.Wave;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 {
@@ -15,15 +20,60 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             if (!context.BuildConfiguration.ToUpper().Contains("IOS"))
                 return base.Process(input, context);
 
+            var targetSampleRate = input.Format.SampleRate;
+
+            // XNA SoundEffects have their sample rate changed based on the quality setting on the processor.
+            //http://blogs.msdn.com/b/etayrien/archive/2008/09/22/audio-input-and-output-formats.aspx
+            switch(this.Quality)
+            {
+                case ConversionQuality.Best:
+                    break;
+
+                case ConversionQuality.Medium:
+                    targetSampleRate = (int)(targetSampleRate * 0.75f);
+                    break;
+
+                case ConversionQuality.Low:
+                    targetSampleRate = (int)(targetSampleRate * 0.5f);
+                    break;
+            }
+
+            targetSampleRate = Math.Max(8000, targetSampleRate);
+
+            var wavStream = new MemoryStream();
+            WaveFormat outputFormat = AudioConverter.ConvertFile(input.FileName, wavStream, AudioFileType.Wav, targetSampleRate, 
+                                                                 input.Format.BitsPerSample, input.Format.ChannelCount);
+
+            var outputData = new ReadOnlyCollection<byte>(wavStream.ToArray());
+            wavStream.Close();
+
+            var waveFormatHeader = writeWavHeader(outputFormat);
+
             // SoundEffectContent is a sealed class, construct it using reflection
             var type = typeof(SoundEffectContent);
             ConstructorInfo c = type.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance,
                     null, new Type[] { typeof(ReadOnlyCollection<byte>), typeof(ReadOnlyCollection<byte>), typeof(int), typeof(int), typeof(int) }, null);
 
-            var outputSoundEffectContent = (SoundEffectContent)c.Invoke(new Object[] { input.Format.NativeWaveFormat, input.Data, input.LoopStart, input.LoopLength, (int)input.Duration.TotalMilliseconds });
-
+            var outputSoundEffectContent = (SoundEffectContent)c.Invoke(new Object[] { waveFormatHeader, outputData, input.LoopStart, input.LoopLength, (int)input.Duration.TotalMilliseconds });
             return outputSoundEffectContent;
-        
+        }
+
+        private ReadOnlyCollection<byte> writeWavHeader(WaveFormat header)
+        {
+            using (var writer = new BinaryWriter(new MemoryStream()))
+            {
+                writer.Write((short)1);
+                writer.Write((short)header.Channels);
+                writer.Write(header.SampleRate);
+                writer.Write(header.AverageBytesPerSecond);
+                writer.Write((short)header.BlockAlign);
+                writer.Write((short)header.BitsPerSample);
+
+                writer.BaseStream.Position = 0;
+                var outputData = new byte[writer.BaseStream.Length];
+                writer.BaseStream.Read(outputData, 0, outputData.Length);
+                return new ReadOnlyCollection<byte>(outputData);
+            }
         }
 
     }

--- a/Tools/MP3Compression/yeti.mmedia/WaveStream.cs
+++ b/Tools/MP3Compression/yeti.mmedia/WaveStream.cs
@@ -23,6 +23,8 @@ namespace WaveLib
 
 		private WaveFormat m_Format;
 
+        public Stream BaseStream { get { return m_Stream; } }
+
 		public WaveFormat Format
 		{
 			get { return m_Format; }
@@ -35,8 +37,10 @@ namespace WaveLib
 			return System.Text.Encoding.ASCII.GetString(ch);
 		}
 
-		private void ReadHeader()
+		public void ReadHeader()
 		{
+            Position = 0;
+
 			BinaryReader Reader = new BinaryReader(m_Stream);
             var errorCaused = ReadChunk(Reader);
             if (errorCaused != "RIFF")
@@ -77,6 +81,11 @@ namespace WaveLib
 
 			Position = 0;
 		}
+
+        public WaveStream() : base()
+        {
+            m_Stream = new MemoryStream();
+        }
 
 		public WaveStream(string fileName) : this(new FileStream(fileName, FileMode.Open))
 		{

--- a/Tools/MP3Compression/yeti.mmedia/WaveWriter.cs
+++ b/Tools/MP3Compression/yeti.mmedia/WaveWriter.cs
@@ -96,7 +96,16 @@ namespace Yeti.MMedia
 		    }
 	    }
       closed = true;
+
       base.Close ();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (this.BaseStream is FileStream)
+            base.Dispose(disposing);
+        else
+            base.Dispose(false);
     }
   
     public override void Write(byte[] buffer, int index, int count)

--- a/Tools/MP3Compression/yeti.mp3/Mp3Writer.cs
+++ b/Tools/MP3Compression/yeti.mp3/Mp3Writer.cs
@@ -144,6 +144,14 @@ namespace Yeti.MMedia.Mp3
       closed = true;
       base.Close ();
     }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (BaseStream is FileStream)
+            base.Dispose(disposing);
+        else
+            base.Dispose(false);
+    }
   
   
     /// <summary>

--- a/Tools/MP3Compression/yeti.mp3/Mp3WriterConfig.cs
+++ b/Tools/MP3Compression/yeti.mp3/Mp3WriterConfig.cs
@@ -57,6 +57,11 @@ namespace Yeti.MMedia.Mp3
     {
     }
 
+    public Mp3WriterConfig(WaveFormat InFormat, uint outputBitRate)
+        : this(InFormat, new Lame.BE_CONFIG(InFormat, outputBitRate))
+    {
+    }
+
     public Mp3WriterConfig()
       :this(new WaveLib.WaveFormat(44100, 16, 2))
 		{


### PR DESCRIPTION
- The processor now adjusts the bitrate of it's input according to how XNA for Zune worked since it cannot compress them.
- We properly convert .wma and .mp3 files to uncompressed PCM sounds.

Note we started to test mp3 compressed sound effects on iOS.  This would give us a small file so package and load from disk, but we would quickly decompress them at load time to a PCM for playback via OpenAL.

Unfortunately it seems MonoTouch/iOS cannot decompress an MP3 and return the raw PCM data to us.  We would have to include a 3rd-party library to do that which isn't something we want to do at the moment.

The good news is this work will eventually help on Android where from what we understand can use mp3 sound effects natively.
