### PR TITLE
develop3d- Fixed incorrect backface culling

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -323,6 +323,13 @@ namespace Microsoft.Xna.Framework.Graphics
             DepthStencilState = DepthStencilState.Default;
             RasterizerState = RasterizerState.CullCounterClockwise;
 
+#if OPENGL
+            // Force the GLStateManager to set these render states
+            GLStateManager.SetRasterizerStates(RasterizerState, GetRenderTargets().Length > 0);
+            GLStateManager.SetBlendStates(BlendState);
+            GLStateManager.SetDepthStencilState(DepthStencilState);
+#endif
+
             // Set the default render target.
             SetRenderTarget(null);
 

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -159,10 +159,9 @@ namespace Microsoft.Xna.Framework
 		{			
 			// Set "full screen"  as default
 			_graphicsDevice.PresentationParameters.IsFullScreen = true;
-            //TODO: This is here on the Windows version, why is it not on the generic?
-#if PSS
+
             _graphicsDevice.Initialize();
-#endif
+
 #if !PSS
 			if (_preferMultiSampling)
 			{


### PR DESCRIPTION
- GraphicsDevice.Initialize was not being called.
- Force calls to GLStateManager in GraphicsDevice.Initialize to set initial render states.
