### PR TITLE
develop3d- Fix for work item 6883

### DIFF
--- a/MonoGame.Framework/iOS/GamerServices/SignedInGamer.cs
+++ b/MonoGame.Framework/iOS/GamerServices/SignedInGamer.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Xna.Framework.GamerServices
 					osVersion = parts[0] + "." + parts[1];
 				}
 				
-				if (double.Parse(osVersion) > 4.1)
+				if (double.Parse(osVersion, System.Globalization.CultureInfo.InvariantCulture) > 4.1)
 				{
 					
 					lp = GKLocalPlayer.LocalPlayer;


### PR DESCRIPTION
double.Parse() needs to be forced to work with the invariant culture when converting the system version to a number to avoid issues with cultures that use other decimal separators.
