### PR TITLE
Added functionality to load SpriteFonts from bitmap fonts stored in PNG ...

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -382,8 +382,26 @@ namespace Microsoft.Xna.Framework.Content
                 }
                 else if ((typeof(T) == typeof(SpriteFont)))
                 {
-                    //result = new SpriteFont(Texture2D.FromFile(graphicsDeviceService.GraphicsDevice,assetName), null, null, null, 0, 0.0f, null, null);
-                    throw new NotImplementedException();
+
+                    if (assetName.ToLower ().EndsWith (".png")) {
+
+                        // BITMAP FONT IN PNG FORMAT, LOAD TEXTURE USING ORIGINAL LOAD METHOD
+
+                        Texture2D fontTexture = Load<Texture2D> (originalAssetName); 
+
+                        result = new SpriteFontReader ().ReadFromTexture (fontTexture);
+
+                    }
+
+                    else {
+
+                        // RETAIN ORIGINAL EXCEPTION LOGIC 
+
+                        //result = new SpriteFont(Texture2D.FromFile(graphicsDeviceService.GraphicsDevice,assetName), null, null, null, 0, 0.0f, null, null);
+                        throw new NotImplementedException ();
+
+                    }
+
                 }
                 else if ((typeof(T) == typeof(Song)))
                 {

--- a/MonoGame.Framework/Windows/Content/ContentReaders/SpriteFontReader.cs
+++ b/MonoGame.Framework/Windows/Content/ContentReaders/SpriteFontReader.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Xna.Framework.Content
             // Concat the file name with valid extensions
             if (File.Exists(FileName + ".spritefont"))
                 return FileName + ".spritefont";
+
+
+            // ATTEMPT TO FIND THE FILE AS A BITMAP FONT STORED IN A PNG 
+
+            if (File.Exists (FileName + ".png")) { return FileName + ".png"; }
 			
 			return null;
 		}
@@ -81,5 +86,197 @@ namespace Microsoft.Xna.Framework.Content
             }
             return new SpriteFont(texture, glyphs, cropping, charMap, lineSpacing, spacing, kerning, defaultCharacter);
         }
+
+        /// <summary>
+        /// This reads a bitmap font from a texture. Allows for variable length lines and character boxes. 
+        ///   Assumes:
+        ///     The font is boxed by the standard Magenta color. 
+        ///     The characters start with the space (32) character and are contiguous.    
+        ///     All lines of characters have the same starting top offset. 
+        /// </summary>
+        /// <param name="fontTexture">The texture containing the font.</param>
+        /// <returns>A valid SpriteFont if successful or NULL.</returns>
+        /// <remarks>
+        ///     This is used to allow TTF font files to be converted to PNG format and loaded easily into the XNA environment.
+        ///     Make sure that you have your SpriteBatch blend state set to "NonPremultiplied" if you store alpha values in the font. 
+        ///     This has been tested with the SpriteFont 2.0 tool that converts TTF to PNG.
+        ///     The SpriteFontReader Normalize method was updated to check for "png" files. 
+        ///     The Content ReadAsset method was updated to support fonts in png format. 
+        ///     The only reason that the bmp format is not supported is because of a Access Violation Exception on GetPixel/GetData. 
+        /// </remarks>
+        protected internal SpriteFont ReadFromTexture (Texture2D fontTexture) {
+
+            SpriteFont font = null; // FONT TO RETURN 
+
+
+            Color magenta = new Color (255, 0, 255, 255); // MASK COLOR (STANDARD XNA)
+
+
+            List<Char> characters = new List<char> ();
+
+            List<Rectangle> glyphBounds = new List<Rectangle> ();
+
+            List<Rectangle> croppings = new List<Rectangle> ();
+
+            List<Vector3> kernings = new List<Vector3> ();
+
+
+            Byte currentCharacterCode = 32; // START CHARACTERS AT SPACE
+
+            Rectangle currentGlyphBounds = new Rectangle (0, 0, 1, 1);
+
+
+            Int32 currentPositionX = 0;
+
+            Int32 currentPositionY = 0;
+
+
+            Int32 leadingEdgeTop = 0;
+
+            Int32 leadingEdgeLeft = 0;
+
+
+            // DETERMINE LEADING EDGE (LEFT AND TOP)
+
+            while (fontTexture.GetPixel (currentPositionX, currentPositionY).Equals (magenta)) {
+
+                currentPositionX = currentPositionX + 1;
+
+                currentPositionY = currentPositionY + 1;
+
+
+                // CHECK FOR OUT BOUNDS 
+
+                if ((currentPositionX == fontTexture.Width) || (currentPositionY == fontTexture.Height)) {
+
+                    throw new InvalidDataException ("Unable to find starting position for bitmap font.");
+
+                }
+
+            }
+
+            // DETERMINE THE LEFT EDGE 
+
+            while (fontTexture.GetPixel (leadingEdgeLeft, currentPositionY).Equals (magenta)) {
+
+                leadingEdgeLeft = leadingEdgeLeft + 1;
+
+            }
+
+
+            while (leadingEdgeTop < fontTexture.Height) {
+
+                // DETERMINE LEAD TOP EDGE TO PROCESS CHARACTERS IN LINES 
+
+                while ((leadingEdgeTop < fontTexture.Height) && (fontTexture.GetPixel (leadingEdgeLeft, leadingEdgeTop).Equals (magenta))) {
+
+                    leadingEdgeTop = leadingEdgeTop + 1;
+
+                }
+
+                if (leadingEdgeTop < (fontTexture.Height - 1)) {
+
+                    // A LINE WAS FOUND, PROCESS ALL CHARACTERS IN THE LINE 
+
+                    currentPositionX = leadingEdgeLeft; // SET START OF CHARACTER BOX AT LEFT EDGE 
+
+                    while (currentPositionX < fontTexture.Width) {
+
+                        // FIND LEFT BOUNDARY OF CHARACTER BOX 
+
+                        while ((currentPositionX < fontTexture.Width) && (fontTexture.GetPixel (currentPositionX, leadingEdgeTop).Equals (magenta))) { // LOOKING FOR NON-MAGENTA PIXEL
+
+                            currentPositionX = currentPositionX + 1;
+
+                        }
+
+
+                        // CHECK TO ENSURE THAT WE DID RUN OUT OF TEXTURE FROM OUR BOX SEARCH 
+
+                        if (currentPositionX >= (fontTexture.Width - 1)) { 
+
+                            currentPositionX = leadingEdgeLeft;
+
+                            break; // EXIT THIS LINE LOOP
+
+                        }
+
+                        currentGlyphBounds.X = currentPositionX;
+
+                        currentGlyphBounds.Y = leadingEdgeTop;
+
+
+                        // FIND CHARACTER BOX HEIGHT 
+
+                        currentPositionY = leadingEdgeTop;
+
+                        while ((currentPositionY < fontTexture.Height) && (!fontTexture.GetPixel (currentPositionX, currentPositionY).Equals (magenta))) { // LOOKING FOR MAGENTA PIXEL
+
+                            currentPositionY = currentPositionY + 1;
+
+                        }
+
+                        currentGlyphBounds.Height = currentPositionY - currentGlyphBounds.Y;
+
+                        // FIND CHARACTER BOX WIDTH 
+
+                        while ((currentPositionX < fontTexture.Width) && (!fontTexture.GetPixel (currentPositionX, leadingEdgeTop).Equals (magenta))) { // LOOKING FOR MAGENTA PIXEL
+
+                            currentPositionX = currentPositionX + 1;
+
+                        }
+
+                        currentGlyphBounds.Width = currentPositionX - currentGlyphBounds.X;
+
+
+                        // ADD CHARACTER BOX AND CHARACTER TO FONT 
+
+                        characters.Add ((Char)currentCharacterCode);
+
+                        glyphBounds.Add (currentGlyphBounds);
+
+                        croppings.Add (new Rectangle (0, 0, currentGlyphBounds.Width, currentGlyphBounds.Height));
+
+                        kernings.Add (new Vector3 (0, currentGlyphBounds.Width, 0));
+
+                        currentCharacterCode += 1; // INCREMENT CHARACTER CODE TO PROCESS
+
+                    } // END OF LINE OF CHARACTERS 
+
+                } // END IF LINE FOUND
+
+
+                // INCREMENT LEADING TOP EDGE BY CHARACTER HEIGHT TO FIND THE NEXT LINE 
+
+                leadingEdgeTop = leadingEdgeTop + currentGlyphBounds.Height;
+
+            } // END OF FONT TEXTURE CHARACTER ROWS 
+
+
+            // REPLACE MAGENTA WITH TRANSPARENT BACKGROUND 
+
+            Color[] replaceColorData = new Color[fontTexture.Width * fontTexture.Height];
+
+            fontTexture.GetData (replaceColorData);
+
+            for (Int32 currentReplaceIndex = 0; currentReplaceIndex < replaceColorData.Length; currentReplaceIndex++) {
+
+                if (replaceColorData[currentReplaceIndex].Equals (magenta)) {
+
+                    replaceColorData[currentReplaceIndex] = Microsoft.Xna.Framework.Color.Transparent;
+
+                }
+
+            }
+
+            fontTexture.SetData (replaceColorData);
+
+
+            font = new SpriteFont (fontTexture, glyphBounds, croppings, characters, 0, 2.0f, kernings, null);
+
+            return font;
+
+        }
+
     }
 }

--- a/MonoGame.Framework/Windows/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Windows/Graphics/Texture2D.cs
@@ -397,6 +397,17 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
+
+                // CHECK TO ENSURE THAT THE textureData VARIABLE IS INITIALIZED 
+
+                if (textureData == null) {
+
+                    // COPIED INITIALIZATION FROM generateOpenGLTexture
+
+                    textureData = new Byte[_width * _height * 4];
+
+                }
+
                 // we now have a texture not based on an outside image source
                 // now we check what type was passed
                 if (typeof(T) == typeof(Color))


### PR DESCRIPTION
...files.

Added functionality to the SpriteFontReader to be able to parse a PNG file that has a rendered bitmap font into a SpriteFont. This allows developers to use third-party utilities to convert a TTF font into a bitmap font file and load it through the Content manager. Currently, I just added PNG support as GetPixel/GetData throws an exception when using a BMP file. 

Ultimately, it is just a cheap method of getting fonts into a game. The parsing algorithm is very basic. Please email any questions that you have. 
