### PR TITLE
Refactored the GamePad code

### DIFF
--- a/MonoGame.Framework/Desktop/Input/Axis.cs
+++ b/MonoGame.Framework/Desktop/Input/Axis.cs
@@ -1,0 +1,75 @@
+﻿#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    public class Axis
+    {
+        public Axis()
+        {
+            this.Negative = new Input();
+            this.Positive = new Input();            
+        }
+
+        public Input Negative { get; set; }
+        public Input Positive { get; set; }
+        public InputType Type { get; set; }
+
+        public float ReadAxis(IntPtr device)
+        {
+            return (this.Positive.ReadFloat(device) - this.Negative.ReadFloat(device));
+        }
+
+
+        internal void AssignAxis(int id, bool negative)
+        {
+            this.Negative.ID = id;
+            this.Negative.Negative = !negative;
+            this.Negative.Type = InputType.Axis;
+            this.Positive.ID = id;
+            this.Positive.Negative = negative;
+            this.Positive.Type = InputType.Axis;
+        }
+    }
+}

--- a/MonoGame.Framework/Desktop/Input/Capabilities.cs
+++ b/MonoGame.Framework/Desktop/Input/Capabilities.cs
@@ -1,0 +1,63 @@
+﻿#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    public class Capabilities
+    {
+        public Capabilities(IntPtr device)
+        {
+            // TODO: Complete member initialization            
+            this.NumberOfAxis = Tao.Sdl.Sdl.SDL_JoystickNumAxes(device);
+            this.NumberOfButtons = Tao.Sdl.Sdl.SDL_JoystickNumButtons(device);
+            this.NumberOfPovHats = Tao.Sdl.Sdl.SDL_JoystickNumHats(device);
+        }
+
+
+        public int NumberOfAxis { get; private set; }
+        public int NumberOfButtons { get; private set; }
+        public int NumberOfPovHats { get; private set; }
+
+    }
+}

--- a/MonoGame.Framework/Desktop/Input/DPad.cs
+++ b/MonoGame.Framework/Desktop/Input/DPad.cs
@@ -1,0 +1,79 @@
+﻿#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    public class DPad
+    {
+        public DPad()
+        {
+            this.Up = new Input();
+            this.Down = new Input();
+            this.Left = new Input();
+            this.Right = new Input();
+        }
+
+        public Input Up { get; set; }
+        public Input Down { get; set; }
+        public Input Left { get; set; }
+        public Input Right { get; set; }
+
+        internal void AssignPovHat(int id)
+        {
+            this.Up.ID = id;
+            this.Up.Negative = false;
+            this.Up.Type = InputType.PovUp;
+            this.Down.ID = id;
+            this.Down.Negative = false;
+            this.Down.Type = InputType.PovDown;
+            this.Left.ID = id;
+            this.Left.Negative = false;
+            this.Left.Type = InputType.PovLeft;
+            this.Right.ID = id;
+            this.Right.Negative = false;
+            this.Right.Type = InputType.PovRight;
+
+        }
+    }
+}

--- a/MonoGame.Framework/Desktop/Input/GamePad.cs
+++ b/MonoGame.Framework/Desktop/Input/GamePad.cs
@@ -1,9 +1,47 @@
-﻿using System;
+﻿#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.IO;
-using GamepadConfigLib;
 using Tao.Sdl;
 using System.Xml.Serialization;
 
@@ -16,8 +54,9 @@ namespace Microsoft.Xna.Framework.Input
     //     code samples.
     public static class GamePad
     {
-		static bool running;
-		static bool sdl;
+		static bool running;		
+        static bool sdl;
+
         static Settings settings;
         static Settings Settings
         {
@@ -27,16 +66,16 @@ namespace Microsoft.Xna.Framework.Input
             }
         }
 
-		static void AutoConfig () {
-						Init();
-				if (!sdl)
-					return;
+		static void AutoConfig () 
+        {
+		        Init();
+				if (!sdl) return;
 				Console.WriteLine("Number of joysticks: " + Sdl.SDL_NumJoysticks());
 					int numSticks = Sdl.SDL_NumJoysticks();
 					for (int x = 0; x < numSticks; x++) {
 
 						PadConfig pc = new PadConfig(Sdl.SDL_JoystickName(x), 0);
-						devices[x] = Sdl.SDL_JoystickOpen (pc.ID);
+						devices[x] = Sdl.SDL_JoystickOpen (pc.Index);
 
 						int numbuttons = Sdl.SDL_JoystickNumButtons(devices[x]);
 						Console.WriteLine("Number of buttons for joystick: " + x + " - " + numbuttons);
@@ -225,11 +264,8 @@ namespace Microsoft.Xna.Framework.Input
         {
             if (settings == null)
             {
-                settings = LoadConfigs("Settings.xml");
-                if (settings == null) {
                     settings = new Settings();
-					AutoConfig();
-		}
+					AutoConfig();		
             }
             else if (!running)
             {
@@ -240,48 +276,30 @@ namespace Microsoft.Xna.Framework.Input
                 Init();
             return settings;
         }
-        static Settings LoadConfigs(string filename)
-        {
-            Settings e;
-            try
-            {
-                using (Stream s = File.OpenRead(filename))
-                {
-                    XmlSerializer x = new XmlSerializer(typeof(Settings));
-                    e = (Settings)x.Deserialize(s);
-                }
-            }
-            catch
-            {
-                return null;
-            }
-            //for (int i = 0; i < 4; i++)
-              //  if (e[i] == null)
-                //    e[i] = new PadConfig(true);
-            return e;
-        }
+        
 
         static IntPtr[] devices = new IntPtr[4];
         //Inits SDL and grabs the sticks
         static void Init ()
         {
         	running = true;
-		try {
-        	Joystick.Init ();
+		    try 
+            {
+         	    Joystick.Init ();
 				sdl = true;
 			}
-			catch (Exception exc) {
+			catch (Exception) 
+            {
 
 			}
-
         	for (int i = 0; i < 4; i++)
-            	{
+            {
         		PadConfig pc = settings[i];
         		if (pc != null)
-                	{
-        			devices[i] = Sdl.SDL_JoystickOpen (pc.ID);
-			}
-		}
+                {
+        			devices[i] = Sdl.SDL_JoystickOpen (pc.Index);
+			    }
+		    }
 
 
         }
@@ -317,6 +335,7 @@ namespace Microsoft.Xna.Framework.Input
 
             return b;
         }
+
         static Buttons ReadButtons(IntPtr device, PadConfig c, float deadZoneSize)
         {
             short DeadZone = (short)(deadZoneSize * short.MaxValue);
@@ -366,7 +385,6 @@ namespace Microsoft.Xna.Framework.Input
 
             return b;
         }
-
         static GamePadState ReadState(PlayerIndex index, GamePadDeadZone deadZone)
         {
             const float DeadZoneSize = 0.27f;

--- a/MonoGame.Framework/Desktop/Input/Input.cs
+++ b/MonoGame.Framework/Desktop/Input/Input.cs
@@ -1,0 +1,101 @@
+﻿#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    public enum InputType { PovUp = 0, Button = 16, Axis = 32, PovDown = 4, PovLeft = 8, PovRight = 2, None = -1 };
+
+    public class Input
+    {
+        public int ID;
+        public InputType Type;
+        public bool Negative { get; set; }
+
+
+        internal bool ReadBool(IntPtr device, short DeadZone)
+        {
+            switch (Type)
+            {
+                case InputType.Axis:
+                    var axis = Tao.Sdl.Sdl.SDL_JoystickGetAxis(device, this.ID);
+                    if (this.Negative)
+                    {
+                        return (axis < -DeadZone);
+                    }
+                    return (axis > DeadZone);
+                case InputType.Button:
+                    return ((Tao.Sdl.Sdl.SDL_JoystickGetButton(device, this.ID) > 0) ^ this.Negative);
+                case InputType.PovUp:
+                case InputType.PovDown:
+                case InputType.PovLeft:
+                case InputType.PovRight:
+                    // Cast the type as an int to get the correct sdl mask for the hat
+                    return (((Tao.Sdl.Sdl.SDL_JoystickGetHat(device, this.ID) & (int)Type) > 0) ^ this.Negative);
+                case InputType.None:
+                default:
+                    return false;
+            }
+        }
+
+        internal float ReadFloat(IntPtr device)
+        {
+            float mask = this.Negative ? -1f : 1f;
+            switch (this.Type)
+            {
+                case InputType.Axis:
+                    float range = this.Negative ? ((float)(-32768)) : ((float)0x7fff);
+                    return (((float)Tao.Sdl.Sdl.SDL_JoystickGetAxis(device, this.ID)) / range);
+                case InputType.Button:
+                    return (Tao.Sdl.Sdl.SDL_JoystickGetButton(device, this.ID) * mask);
+                case InputType.PovUp:
+                case InputType.PovDown:
+                case InputType.PovLeft:
+                case InputType.PovRight:
+                    return ((Tao.Sdl.Sdl.SDL_JoystickGetHat(device, this.ID) & (int)Type) * mask);
+            }
+            return 0f;
+
+        }
+    }
+}

--- a/MonoGame.Framework/Desktop/Input/Joystick.cs
+++ b/MonoGame.Framework/Desktop/Input/Joystick.cs
@@ -1,0 +1,128 @@
+﻿#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Tao.Sdl;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    public class Joystick
+    {
+        private int id;
+        private IntPtr device;
+        public bool Open { get; private set; }
+        public string Name { get; private set; }
+        public PadConfig Config { get; private set; }
+        public Capabilities Details { get; private set; }
+
+        public Joystick(int id)
+        {
+            // TODO: Complete member initialization
+            this.id = id;
+            this.device = Tao.Sdl.Sdl.SDL_JoystickOpen(id);
+            this.Open = true;
+            this.Name = Tao.Sdl.Sdl.SDL_JoystickName(id);
+            this.Details = new Capabilities(this.device);
+            this.Config = new PadConfig(this.Name, id);
+            this.SetDefaults(this.Details);
+        }
+
+        private void SetDefaults(Capabilities capabilities)
+        {
+            if (capabilities != null)
+            {
+                if (capabilities.NumberOfAxis > 1)
+                {
+                    this.Config.LeftStick.X.AssignAxis(0, false);
+                    this.Config.LeftStick.Y.AssignAxis(1, false);
+                }
+                if (capabilities.NumberOfPovHats > 0)
+                {
+                    this.Config.Dpad.AssignPovHat(0);
+                }
+                if (capabilities.NumberOfButtons > 0)
+                {
+                    for (int i = 0; i < capabilities.NumberOfButtons; i++)
+                    {
+                        Input input = this.Config[i];
+                        if (input != null)
+                        {
+                            input.ID = i;
+                            input.Negative = false;
+                            input.Type = InputType.Button;
+                        }
+                    }
+                }
+            }
+
+        }
+
+        public int ID { get { return id; } }
+
+        public static bool Init()
+        {
+            // only initialise the Joystick part of SDL
+            return Sdl.SDL_Init(Sdl.SDL_INIT_JOYSTICK) == 0;
+        }
+
+        public static List<Joystick> GrabJoysticks()
+        {
+            int num = Tao.Sdl.Sdl.SDL_NumJoysticks();
+            List<Joystick> list = new List<Joystick>();
+            Tao.Sdl.Sdl.SDL_JoystickEventState(0);
+            for (int i = 0; i < num; i++)
+            {
+                list.Add(new Joystick(i));
+            }
+            return list;
+
+        }
+
+
+
+        internal static void Cleanup()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/MonoGame.Framework/Desktop/Input/PadConfig.cs
+++ b/MonoGame.Framework/Desktop/Input/PadConfig.cs
@@ -1,0 +1,126 @@
+﻿#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    public class PadConfig
+    {
+        private string name;
+        private int index;
+
+        public PadConfig(string name, int index)
+        {
+            // TODO: Complete member initialization
+            this.name = name;
+            this.index = index;
+            this.LeftStick = new Stick();
+            this.RightStick = new Stick();
+            this.Dpad = new DPad();
+            this.Button_A = new Input();
+            this.Button_B = new Input();
+            this.Button_X = new Input();
+            this.Button_Y = new Input();
+            this.Button_LB = new Input();
+            this.Button_RB = new Input();
+            this.Button_Start = new Input();
+            this.Button_Back = new Input();
+            this.LeftTrigger = new Input();
+            this.RightTrigger = new Input();
+
+        }
+
+        public int Index { get { return index; } }
+        public string JoystickName { get { return name; } }
+
+        public Input Button_A { get; set; }
+        public Input Button_B { get; set; }
+        public Input Button_X { get; set; }
+        public Input Button_Y { get; set; }
+        public Input Button_Back { get; set; }
+        public Input Button_Start { get; set; }
+        public Input Button_LB { get; set; }
+        public Input Button_RB { get; set; }
+        public Stick LeftStick { get; set; }
+        public Stick RightStick { get; set; }
+        public DPad Dpad { get; set; }
+        public Input LeftTrigger { get; set; }
+        public Input RightTrigger { get; set; }
+
+        public Input this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return this.Button_A;
+
+                    case 1:
+                        return this.Button_B;
+
+                    case 2:
+                        return this.Button_X;
+
+                    case 3:
+                        return this.Button_Y;
+
+                    case 4:
+                        return this.Button_LB;
+
+                    case 5:
+                        return this.Button_RB;
+
+                    case 6:
+                        return this.Button_Back;
+
+                    case 7:
+                        return this.Button_Start;
+                }
+                return null;
+
+            }
+        }
+    }
+
+}

--- a/MonoGame.Framework/Desktop/Input/Settings.cs
+++ b/MonoGame.Framework/Desktop/Input/Settings.cs
@@ -1,0 +1,75 @@
+﻿#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    public class Settings
+    {
+        // Fields
+        private List<PadConfig> players;
+
+        // Methods
+        public Settings()
+        {
+            this.players = new List<PadConfig>();
+            this.players.Add(null);
+            this.players.Add(null);
+            this.players.Add(null);
+            this.players.Add(null);            
+        }
+
+        // Properties
+        public PadConfig this[int index]
+        {
+            get { return this.players[index]; }
+            set { this.players[index] = value; }
+        }
+        public PadConfig Player1 { get; set; }
+        public PadConfig Player2 { get; set; }
+        public PadConfig Player3 { get; set; }
+        public PadConfig Player4 { get; set; }
+
+    }
+
+}

--- a/MonoGame.Framework/Desktop/Input/Stick.cs
+++ b/MonoGame.Framework/Desktop/Input/Stick.cs
@@ -1,0 +1,68 @@
+﻿#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    public class Stick
+    {
+
+        public Stick()
+        {
+            this.X = new Axis();
+            this.Y = new Axis();
+            this.Press = new Input();
+        }
+
+        public Input Press { get; set; }
+        public Axis X { get; set; }
+        public Axis Y { get; set; }
+
+
+        internal Vector2 ReadAxisPair(IntPtr device)
+        {
+            return new Vector2(this.X.ReadAxis(device), -this.Y.ReadAxis(device));
+        }
+
+    }
+}

--- a/MonoGame.Framework/MonoGame.Framework.Linux.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Linux.csproj
@@ -40,9 +40,6 @@
     <Reference Include="Tao.Sdl, Version=1.2.13.0, Culture=neutral, PublicKeyToken=9c7a200e36c0094e">
       <HintPath>..\ThirdParty\GamepadConfig\Tao.Sdl.dll</HintPath>
     </Reference>
-    <Reference Include="GamepadBridge, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\ThirdParty\GamepadConfig\GamepadBridge.dll</HintPath>
-    </Reference>
     <Reference Include="OpenTK">
       <HintPath>..\ThirdParty\Libs\OpenTK.dll</HintPath>
     </Reference>
@@ -328,9 +325,17 @@
     <Compile Include="Audio\XactClip.cs" />
     <Compile Include="Audio\XactSound.cs" />
     <Compile Include="Linux\Graphics\RenderTarget2D.cs" />
+    <Compile Include="Desktop\Input\Axis.cs" />
+    <Compile Include="Desktop\Input\Capabilities.cs" />
+    <Compile Include="Desktop\Input\DPad.cs" />
     <Compile Include="Desktop\Input\GamePad.cs" />
+    <Compile Include="Desktop\Input\Input.cs" />
+    <Compile Include="Desktop\Input\Joystick.cs" />
     <Compile Include="Desktop\Input\Mouse.cs" />
     <Compile Include="Desktop\Input\MouseState.cs" />
+    <Compile Include="Desktop\Input\PadConfig.cs" />
+    <Compile Include="Desktop\Input\Settings.cs" />
+    <Compile Include="Desktop\Input\Stick.cs" />
     <Compile Include="Desktop\Graphics\Vertices\VertexDeclaration.cs" />
     <Compile Include="LaunchParameters.cs" />
     <Compile Include="XnaToOpenTK.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
@@ -53,9 +53,6 @@
     <Reference Include="Tao.Sdl">
       <HintPath>..\ThirdParty\GamepadConfig\Tao.Sdl.dll</HintPath>
     </Reference>
-    <Reference Include="GamepadBridge">
-      <HintPath>..\ThirdParty\GamepadConfig\GamepadBridge.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Mono\MonoMac\v0.0\Mono.MonoMac.targets" />
@@ -247,7 +244,15 @@
     <Compile Include="MacOS\KeyUtil.cs" />
     <Compile Include="Graphics\States\TextureAddressMode.cs" />
     <Compile Include="Graphics\States\TextureFilter.cs" />
+    <Compile Include="Desktop\Input\Axis.cs" />
+    <Compile Include="Desktop\Input\Capabilities.cs" />
+    <Compile Include="Desktop\Input\DPad.cs" />
     <Compile Include="Desktop\Input\GamePad.cs" />
+    <Compile Include="Desktop\Input\Input.cs" />
+    <Compile Include="Desktop\Input\Joystick.cs" />
+    <Compile Include="Desktop\Input\PadConfig.cs" />
+    <Compile Include="Desktop\Input\Settings.cs" />
+    <Compile Include="Desktop\Input\Stick.cs" />
     <Compile Include="Desktop\Graphics\Vertices\VertexDeclaration.cs" />
     <Compile Include="Input\ButtonDefinition.cs" />
     <Compile Include="Input\ThumbStickDefinition.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.Windows.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows.csproj
@@ -80,12 +80,6 @@
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GamepadBridge">
-      <HintPath>..\ThirdParty\GamepadConfig\GamepadBridge.dll</HintPath>
-    </Reference>
-    <Reference Include="GamepadConfigControls">
-      <HintPath>..\ThirdParty\GamepadConfig\GamepadConfigControls.dll</HintPath>
-    </Reference>
     <Reference Include="OpenTK, Version=1.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <HintPath>..\ThirdParty\Libs\OpenTK.dll</HintPath>
     </Reference>
@@ -97,7 +91,8 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Drawing" />
-    <Reference Include="Tao.Sdl">
+    <Reference Include="Tao.Sdl, Version=1.2.13.0, Culture=neutral, PublicKeyToken=9c7a200e36c0094e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ThirdParty\GamepadConfig\Tao.Sdl.dll</HintPath>
     </Reference>
   </ItemGroup>
@@ -109,9 +104,17 @@
     <Compile Include="Content\ContentReaders\MatrixReader.cs" />
     <Compile Include="Content\ContentReaders\VertexBufferReader.cs" />
     <Compile Include="Desktop\Audio\SoundEffectInstance.cs" />
+    <Compile Include="Desktop\Input\Axis.cs" />
+    <Compile Include="Desktop\Input\Capabilities.cs" />
+    <Compile Include="Desktop\Input\DPad.cs" />
     <Compile Include="Desktop\Input\GamePad.cs" />
+    <Compile Include="Desktop\Input\Input.cs" />
+    <Compile Include="Desktop\Input\Joystick.cs" />
     <Compile Include="Desktop\Input\Mouse.cs" />
     <Compile Include="Desktop\Input\MouseState.cs" />
+    <Compile Include="Desktop\Input\PadConfig.cs" />
+    <Compile Include="Desktop\Input\Settings.cs" />
+    <Compile Include="Desktop\Input\Stick.cs" />
     <Compile Include="Game.cs" />
     <Compile Include="GamePlatform.cs" />
     <Compile Include="GamerServices\GamerServicesDispatcher.cs" />


### PR DESCRIPTION
Refactored the GamePad code for Windows , Linux and Mac to not rely on the thirdParty Gamepad dlls.

This means there is not GamePad config screen at the moment, only AutoConfig is working, but it will allow MonoGame to be included in the next debian release.

Needs testing on Linux and Mac. Works OK with a standard USB joystick on windows
