### PR TITLE
Texture2D: Initialize textureData array

### DIFF
--- a/MonoGame.Framework/Windows/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Windows/Graphics/Texture2D.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Xna.Framework.Graphics
             _height = texture.ImageHeight;
             _format = texture.Format;
             _textureId = (int)theImage.Name;
+
+            textureData = new byte[(_width * _height) * 4];
         }
 
         public Texture2D(GraphicsDevice graphicsDevice, int width, int height) :


### PR DESCRIPTION
I don't know if my patch is correct but without my changes this won't work:

```
var texture = Content.Load<Texture2D>("my_texture");
var data = new Color[texture.Width * texture.Height];

texture.GetData(data);
texture.SetData(data); // throws a null reference exeption
```
