### PR TITLE
Force build to use UTF-8 locale

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.Linux.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Linux.csproj
@@ -7,6 +7,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{35253CE1-C864-4CD3-8249-4D1319748E8F}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CodePage>65001</CodePage>
     <RootNamespace>MonoGame.Framework.Linux</RootNamespace>
     <AssemblyName>MonoGame.Framework.Linux</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
otherwise build fails when it encounters UTF-8 characters in source, when building on a non-UTF-8 locale.
