### PR TITLE
Fixed some sound issues

### DIFF
--- a/MonoGame.Framework/Desktop/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Desktop/Audio/SoundEffect.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         public bool Play()
         {
-            return Play(MasterVolume, 1.0f, 0.0f);
+            return Play(MasterVolume, 0.0f, 0.0f);
         }
 
         public bool Play(float volume, float pitch, float pan)

--- a/MonoGame.Framework/Desktop/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Desktop/Audio/SoundEffectInstance.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Xna.Framework.Audio
 		float _volume = 1.0f;
 		bool _looped = false;
 		float _pan = 0;
-		float _pitch = 1.0f;
+		float _pitch = 0f;
 
 		bool hasSourceId = false;
 		int sourceId;
@@ -146,6 +146,17 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 		}
 
+        private float XnaPitchToAlPitch(float pitch)
+        {
+            // pitch is different in XNA and OpenAL. XNA has a pitch between -1 and 1 for one octave down/up.
+            // openAL uses 0.5 to 2 for one octave down/up, while 1 is the default. The default value of 0 would make it completely silent.
+            float alPitch = 1;
+            if (pitch < 0)
+                alPitch = 1 + 0.5f * pitch;
+            else if (pitch > 0)
+                alPitch = 1 + pitch;
+            return alPitch;
+        }
 		private void ApplyState ()
 		{
 			if (!hasSourceId)
@@ -160,7 +171,7 @@ namespace Microsoft.Xna.Framework.Audio
 			// Looping
 			AL.Source (sourceId, ALSourceb.Looping, IsLooped);
 			// Pitch
-			AL.Source (sourceId, ALSourcef.Pitch, _pitch);
+			AL.Source (sourceId, ALSourcef.Pitch, XnaPitchToAlPitch(_pitch));
 		}
 
 		public void Play ()
@@ -243,7 +254,7 @@ namespace Microsoft.Xna.Framework.Audio
 				_pitch = value;
 				if (hasSourceId) {
 					// Pitch
-					AL.Source (sourceId, ALSourcef.Pitch, _pitch);
+					AL.Source (sourceId, ALSourcef.Pitch, XnaPitchToAlPitch(_pitch));
 				}
 
 			}


### PR DESCRIPTION
Hey there,
1: This will make the MGSongProcessor produce .wav songs when compiling content for Linux (because that's the only thing that's supported)
2: It fixes a problem when using the SoundEffect.Play() method with 3 parameters. The pitch was forwarded to openAL as is. However, a mapping from XNA's pitch to OpenAL's pitch should happen here.
I hope I diddn't forget to change any default values from 1 to 0.
