### PR TITLE
develop3d - Fix for Codeplex work item 6978

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/PrimitiveType.cs
+++ b/MonoGame.Framework/Graphics/Vertices/PrimitiveType.cs
@@ -1,4 +1,4 @@
-// #region License
+#region License
 // /*
 // Microsoft Public License (Ms-PL)
 // XnaTouch - Copyright © 2009 The XnaTouch Team
@@ -36,18 +36,33 @@
 // permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
 // purpose and non-infringement.
 // */
-// #endregion License
-// 
+#endregion License
 
-using System;
-
-namespace Microsoft.Xna.Framework
+namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines how vertex data is ordered.
+    /// </summary>
 	public enum PrimitiveType
 	{
-		LineList, // 	Renders the vertices as a list of isolated straight line segments; the count may be any positive integer.
-		LineStrip, //	Renders the vertices as a single polyline; the count may be any positive integer.
-		TriangleList, // 	Renders the specified vertices as a sequence of isolated triangles. Each group of three vertices defines a separate triangle. Back-face culling is affected by the current winding-order render state.
-		TriangleStrip //	Renders the vertices as a triangle strip. The back-face culling flag is flipped automatically on even-numbered triangles.
+        /// <summary>
+        /// Renders the specified vertices as a sequence of isolated triangles. Each group of three vertices defines a separate triangle. Back-face culling is affected by the current winding-order render state.
+        /// </summary>
+		TriangleList,
+
+        /// <summary>
+        /// Renders the vertices as a triangle strip. The back-face culling flag is flipped automatically on even-numbered triangles.
+        /// </summary>
+		TriangleStrip,
+
+        /// <summary>
+        /// Renders the vertices as a list of isolated straight line segments; the count may be any positive integer.
+        /// </summary>
+		LineList,
+
+        /// <summary>
+        /// Renders the vertices as a single polyline; the count may be any positive integer.
+        /// </summary>
+		LineStrip,
 	}
 }


### PR DESCRIPTION
PrimitiveType had the wrong namespace and in the process of fixing, I also found the order of enum members was incorrect.
Added region around license block and reformatted comments to XML doc standard for Intellisense.
