### PR TITLE
Fixes to Android platfrom not calling Exiting and handle screen locked

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameActivity.cs
+++ b/MonoGame.Framework/Android/AndroidGameActivity.cs
@@ -16,10 +16,18 @@ namespace Microsoft.Xna.Framework
 {
     public class AndroidGameActivity : Activity
     {
-        public static Game Game { get; set; }
+		public static Game Game { get; set; }
 		
 		private OrientationListener o;		
-		
+		private ScreenReceiver screenReceiver;
+
+		/// <summary>
+		/// OnCreate called when the activity is launched from cold or after the app
+		/// has been killed due to a higher priority app needing the memory
+		/// </summary>
+		/// <param name='savedInstanceState'>
+		/// Saved instance state.
+		/// </param>
 		protected override void OnCreate (Bundle savedInstanceState)
 		{
 			base.OnCreate (savedInstanceState);
@@ -28,6 +36,14 @@ namespace Microsoft.Xna.Framework
 			{
 				o.Enable();				
 			}					
+
+			IntentFilter filter = new IntentFilter();
+		    filter.AddAction(Intent.ActionScreenOff);
+		    filter.AddAction(Intent.ActionScreenOn);
+		    filter.AddAction(Intent.ActionUserPresent);
+		    
+		    screenReceiver = new ScreenReceiver();
+		    RegisterReceiver(screenReceiver, filter);
 
             RequestWindowFeature(WindowFeatures.NoTitle);
 		}
@@ -40,35 +56,65 @@ namespace Microsoft.Xna.Framework
 			base.OnConfigurationChanged (newConfig);
 		}
 
+		/// <summary>
+		/// Called when another app comes into the foreground or
+		/// if the screen is locked
+		/// </summary>
         protected override void OnPause()
         {
-            base.OnPause();
+		    base.OnPause();
             if (Paused != null)
                 Paused(this, EventArgs.Empty);
 
-            if (Game.GraphicsDevice != null)
-                Game.GraphicsDevice.ResourcesLost = true;
+            //if (Game.GraphicsDevice != null)
+             //   Game.GraphicsDevice.ResourcesLost = true;
 
-			if (Game.Window != null && Game.Window.Parent != null && (Game.Window.Parent is FrameLayout))
-			{				
-              ((FrameLayout)Game.Window.Parent).RemoveAllViews();
-			}
+			//if (Game.Window != null && Game.Window.Parent != null && (Game.Window.Parent is FrameLayout))
+			//{				
+            //  ((FrameLayout)Game.Window.Parent).RemoveAllViews();
+			//}
         }
 
         public static event EventHandler Resumed;
+
+		/// <summary>
+		/// Happens when the user returns to the activity
+		/// and when it first starts
+		/// </summary>
         protected override void OnResume()
         {
-            base.OnResume();
+			base.OnResume();
             if (Resumed != null)
                 Resumed(this, EventArgs.Empty);
 
             var deviceManager = (IGraphicsDeviceManager)Game.Services.GetService(typeof(IGraphicsDeviceManager));
             if (deviceManager == null)
                 return;
+
             (deviceManager as GraphicsDeviceManager).ForceSetFullScreen();
-            Game.Window.RequestFocus();
-            Game.GraphicsDevice.Initialize(Game.Platform);
+            //Game.Window.RequestFocus();
+            //Game.GraphicsDevice.Initialize(Game.Platform);		
         }
+
+		protected override void OnStart ()
+		{
+			base.OnStart ();
+		}
+
+		protected override void OnStop ()
+		{
+			base.OnStop ();
+		}
+
+		protected override void OnDestroy ()
+		{
+			base.OnDestroy ();
+		}
+
+		protected override void OnRestart ()
+		{
+			base.OnRestart ();
+		}
     }
 	
 	public static class ActivityExtensions

--- a/MonoGame.Framework/Android/AndroidGamePlatform.cs
+++ b/MonoGame.Framework/Android/AndroidGamePlatform.cs
@@ -198,11 +198,13 @@ namespace Microsoft.Xna.Framework
         {
             if (!IsActive)
             {
-                IsActive = true;
+				IsActive = true;
                 Window.Resume();
                 Accelerometer.Resume();
                 Sound.ResumeAll();
                 MediaPlayer.Resume();
+				if(!Window.IsFocused)
+		           Window.RequestFocus();
             }
         }
 
@@ -211,8 +213,9 @@ namespace Microsoft.Xna.Framework
         {
             if (IsActive)
             {
-                IsActive = false;
+				IsActive = false;
                 Window.Pause();
+				Window.ClearFocus();
                 Accelerometer.Pause();
                 Sound.PauseAll();
                 MediaPlayer.Pause();
@@ -226,7 +229,7 @@ namespace Microsoft.Xna.Framework
 		
 		public override void Log(string Message) 
 		{
-#if LOGGING
+#if !LOGGING
 			Android.Util.Log.Debug("MonoGameDebug", Message);
 #endif
 		}

--- a/MonoGame.Framework/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Android/AndroidGameWindow.cs
@@ -71,11 +71,12 @@ namespace Microsoft.Xna.Framework
         private DisplayOrientation supportedOrientations = DisplayOrientation.Default;
         private DisplayOrientation _currentOrientation;
 		private GestureDetector gesture = null;
+		private bool exiting = false;
 
         public AndroidGameWindow(Context context, Game game) : base(context)
         {
             _game = game;
-            Initialize();							
+            Initialize();	
         }		
 						
         private void Initialize()
@@ -97,15 +98,27 @@ namespace Microsoft.Xna.Framework
 		}
 		
 		void GameWindow_Closed(object sender,EventArgs e)
-        {        
-			try
+        {   
+			if (!exiting)
 			{
-        		_game.Exit();
+				exiting = true;
+				_game.DoExiting();
+			}
+			try
+			{					
+				_game.Exit();
 			}
 			catch(NullReferenceException)
 			{
 				// just in case the game is null
 			}
+
+		}
+
+		protected override void OnLoad (EventArgs e)
+		{
+			base.OnLoad (e);			
+			MakeCurrent();
 		}
 
         public override bool OnKeyDown(Keycode keyCode, KeyEvent e)
@@ -188,9 +201,17 @@ namespace Microsoft.Xna.Framework
             if (!GraphicsContext.IsCurrent)
                 MakeCurrent();
 
-            if (_game != null ) //Only call draw if an update has occured
+            if (_game != null)
             {
-                _game.Tick();
+				if ( _game.Platform.IsActive && !ScreenReceiver.ScreenLocked) //Only call draw if an update has occured
+				{
+					_game.Tick();
+				}
+				else
+				{ 
+					_game.GraphicsDevice.Clear(Color.Black);
+					_game.GraphicsDevice.Present();
+				}
             }
         }
 

--- a/MonoGame.Framework/Android/ScreenReciever.cs
+++ b/MonoGame.Framework/Android/ScreenReciever.cs
@@ -1,0 +1,33 @@
+using System;
+using Android.Content;
+using Microsoft.Xna.Framework.Media;
+
+namespace Microsoft.Xna.Framework
+{
+	internal class ScreenReceiver : BroadcastReceiver
+	{	
+		public static bool ScreenLocked;
+		
+		public override void OnReceive(Context context, Intent intent)
+		{
+			Android.Util.Log.Info("MonoGameInfo", intent.Action.ToString());
+			if(intent.Action == Intent.ActionScreenOff)
+			{
+				ScreenReceiver.ScreenLocked = true;     
+				
+				MediaPlayer.IsMuted = true;
+			}
+			else if(intent.Action == Intent.ActionScreenOn)
+			{
+				MediaPlayer.IsMuted = true;
+			}
+			else if(intent.Action == Intent.ActionUserPresent)
+			{
+				ScreenReceiver.ScreenLocked = false;
+				
+				MediaPlayer.IsMuted = false;
+			}
+		}
+	}
+}
+

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Xna.Framework
 
         public void Exit()
         {
-            Platform.Exit();
+			Platform.Exit();
         }
 
         public void ResetElapsedTime()
@@ -339,7 +339,7 @@ namespace Microsoft.Xna.Framework
             case GameRunBehavior.Synchronous:
                 Platform.RunLoop();
                 EndRun();
-                OnExiting(this, EventArgs.Empty);
+				DoExiting();
                 break;
             default:
                 throw new NotImplementedException(string.Format(
@@ -512,7 +512,7 @@ namespace Microsoft.Xna.Framework
             var platform = (GamePlatform)sender;
             platform.AsyncRunLoopEnded -= Platform_AsyncRunLoopEnded;
             EndRun();
-            OnExiting(this, EventArgs.Empty);
+			DoExiting();
         }
 
         private void Platform_Activated(object sender, EventArgs e)
@@ -587,6 +587,11 @@ namespace Microsoft.Xna.Framework
             Platform.BeforeInitialize();
             Initialize();
         }
+
+		internal void DoExiting()
+		{
+			OnExiting(this, EventArgs.Empty);
+		}
 
 #if LINUX
         internal void ResizeWindow(bool changed)

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -41,7 +41,7 @@
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AndroidLinkMode>SdkOnly</AndroidLinkMode>
-    <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />
@@ -368,6 +368,7 @@
     <Compile Include="Graphics\Effect\AlphaTestEffectCode.cs" />
     <Compile Include="Graphics\Effect\EffectHelpers.cs" />
     <Compile Include="XnaToOpenTK.cs" />
+    <Compile Include="Android\ScreenReciever.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />

--- a/ThirdParty/Lidgren.Network/Lidgren.Network.Android.csproj
+++ b/ThirdParty/Lidgren.Network/Lidgren.Network.Android.csproj
@@ -37,7 +37,7 @@
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <AndroidLinkMode>SdkOnly</AndroidLinkMode>
     <DefineConstants>ANDROID</DefineConstants>
-    <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Added a DoExiting method to allow the Android Platform to raise the Exiting event

Added ScreenReciever implementation
