### PR TITLE
Fixes for the Window Size on Windows (and linux?)

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -185,15 +185,28 @@ namespace Microsoft.Xna.Framework
 
             if (graphicsDeviceManager.IsFullScreen)
             {
-                bounds = new Rectangle(0, 0,
-                                       OpenTK.DisplayDevice.Default.Width,
-                                       OpenTK.DisplayDevice.Default.Height);
+                bounds = new Rectangle(0, 0,graphicsDeviceManager.PreferredBackBufferWidth,graphicsDeviceManager.PreferredBackBufferHeight);
+
+                if (OpenTK.DisplayDevice.Default.Width != graphicsDeviceManager.PreferredBackBufferWidth ||
+                    OpenTK.DisplayDevice.Default.Height != graphicsDeviceManager.PreferredBackBufferHeight)
+                {
+                    OpenTK.DisplayDevice.Default.ChangeResolution(graphicsDeviceManager.PreferredBackBufferWidth,
+                            graphicsDeviceManager.PreferredBackBufferHeight,
+                            OpenTK.DisplayDevice.Default.BitsPerPixel,
+                            OpenTK.DisplayDevice.Default.RefreshRate);
+                }
             }
             else
             {
+                
+                // switch back to the normal screen resolution
+                OpenTK.DisplayDevice.Default.RestoreResolution();
+                // now update the bounds 
                 bounds.Width = graphicsDeviceManager.PreferredBackBufferWidth;
                 bounds.Height = graphicsDeviceManager.PreferredBackBufferHeight;
             }
+
+            
 
             // Now we set our Presentation Parameters
             var device = (GraphicsDevice)graphicsDeviceManager.GraphicsDevice;

--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -142,21 +142,22 @@ namespace Microsoft.Xna.Framework
 
         private void OnResize(object sender, EventArgs e)
         {
-            var winWidth = window.ClientRectangle.Width;
-            var winHeight = window.ClientRectangle.Height;
+            var winWidth = ClientBounds.Width;
+            var winHeight = ClientBounds.Height;
             var winRect = new Rectangle(0, 0, winWidth, winHeight);
             
             // If window size is zero, leave bounds unchanged
             if (winWidth == 0 || winHeight == 0)
                 return;
-            
-            ChangeClientBounds(winRect);
-            
+
+
             Game.GraphicsDevice.Viewport = new Viewport(0, 0, winWidth, winHeight);
-            
+
             Game.GraphicsDevice.PresentationParameters.BackBufferWidth = winWidth;
             Game.GraphicsDevice.PresentationParameters.BackBufferHeight = winHeight;
-            
+
+            ChangeClientBounds(winRect);
+                                    
             OnClientSizeChanged();
         }
 

--- a/MonoGame.Framework/Graphics/DisplayModeCollection.cs
+++ b/MonoGame.Framework/Graphics/DisplayModeCollection.cs
@@ -33,28 +33,24 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-    public class DisplayModeCollection : IEnumerable<DisplayMode>
+    public class DisplayModeCollection : IEnumerable<DisplayMode>, IEnumerable
     {
         private List<DisplayMode> modes;
         
-        public static bool operator !=(DisplayModeCollection l, DisplayModeCollection r)
-        {
-            throw new NotImplementedException();
-        }
-
-        public static bool operator ==(DisplayModeCollection l, DisplayModeCollection r)
-        {
-            throw new NotImplementedException();
-        }
-
         public IEnumerable<DisplayMode> this[SurfaceFormat format]
         {
-            get { throw new NotImplementedException(); }
-        }
+            get {
+                List<DisplayMode> list = new List<DisplayMode>();
+                foreach (DisplayMode mode in this.modes)
+                {
+                    if (mode.Format == format)
+                    {
+                        list.Add(mode);
+                    }
+                }
+                return list;
 
-        public override bool Equals(object obj)
-        {
-            throw new NotImplementedException();
+            }
         }
 
         public IEnumerator<DisplayMode> GetEnumerator()


### PR DESCRIPTION
Added code to correctly report the DisplayMode rather than default to 800x600
Added code to correlty report the supported resolutions on windows/linux, note we only report 32 bit modes at this time.
Reworked the setting of the display so that when you switch from fullscreen to windowed the normal use displaymode is restored
