### PR TITLE
Save the framebuffer ID on the RenderTarget2D.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1044,7 +1044,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 lock (_d3dContext) 
                     _d3dContext.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);                
 #elif OPENGL
-				GL.BindFramebuffer(GLFramebuffer, 0);
+				GL.BindFramebuffer(GLFramebuffer, this.glFramebuffer);
 #endif
 
                 clearTarget = true;
@@ -1080,16 +1080,16 @@ namespace Microsoft.Xna.Framework.Graphics
                     _d3dContext.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
 
 #elif OPENGL
-				if (this.glFramebuffer == 0)
+				if (renderTarget.glFramebuffer == 0)
 				{
 #if GLES
-					GL.GenFramebuffers(1, ref this.glFramebuffer);
+					GL.GenFramebuffers(1, ref renderTarget.glFramebuffer);
 #else
-					GL.GenFramebuffers(1, out this.glFramebuffer);
+					GL.GenFramebuffers(1, out renderTarget.glFramebuffer);
 #endif
 				}
 
-				GL.BindFramebuffer(GLFramebuffer, this.glFramebuffer);
+				GL.BindFramebuffer(GLFramebuffer, renderTarget.glFramebuffer);
 				GL.FramebufferTexture2D(GLFramebuffer, GLColorAttachment0, TextureTarget.Texture2D, renderTarget.glTexture, 0);
 				if (renderTarget.DepthStencilFormat != DepthFormat.None)
 				{

--- a/MonoGame.Framework/Graphics/RenderTarget2D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Xna.Framework.Graphics
         internal SharpDX.Direct3D11.DepthStencilView _depthStencilView;
 #elif OPENGL
 		internal uint glDepthStencilBuffer;
+        internal uint glFramebuffer;
 #endif
 
 		public DepthFormat DepthStencilFormat { get; private set; }
@@ -171,6 +172,10 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 #elif OPENGL
 			GL.DeleteRenderbuffers(1, ref this.glDepthStencilBuffer);
+
+			if(this.glFramebuffer > 0)
+				GL.DeleteFramebuffers(1, ref this.glFramebuffer);
+
 #endif
             base.Dispose();
 		}


### PR DESCRIPTION
With this change the render target can be switched very often without frame rate drops.
