### PR TITLE
Game class now disposes all active components on exit, like XNA does

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -186,7 +186,19 @@ namespace Microsoft.Xna.Framework
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)
+            {
                 Platform.Dispose();
+
+                // Dispose loaded game components
+                var array = new IGameComponent[_components.Count];
+                _components.CopyTo(array, 0);
+                for (int i = 0; i < array.Length; i++)
+                {
+                    var disposable = array[i] as IDisposable;
+                    if (disposable != null)
+                        disposable.Dispose();
+                }
+            }
 
             _isDisposed = true;
         }


### PR DESCRIPTION
The code is adapted from a Reflector decompilation of the XNA Game.Dispose method.
Disposal of loaded components is desirable because components can own threads that won't exit until they are disposed, which prevents the game's process from exiting.
