### PR TITLE
Dispose active game components on exit

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -190,11 +190,9 @@ namespace Microsoft.Xna.Framework
                 Platform.Dispose();
 
                 // Dispose loaded game components
-                var array = new IGameComponent[_components.Count];
-                _components.CopyTo(array, 0);
-                for (int i = 0; i < array.Length; i++)
+                for (int i = 0; i < _components.Count; i++)
                 {
-                    var disposable = array[i] as IDisposable;
+                    var disposable = _components[i] as IDisposable;
                     if (disposable != null)
                         disposable.Dispose();
                 }


### PR DESCRIPTION
More intuitive version (although not much different) of pull request #597 to dispose active game components in the game's dispose method, to match XNA's behaviour.
