### PR TITLE
Fix mouse wheel delta to be consistent with XNA

### DIFF
--- a/MonoGame.Framework/Desktop/Input/Mouse.cs
+++ b/MonoGame.Framework/Desktop/Input/Mouse.cs
@@ -121,7 +121,10 @@ namespace Microsoft.Xna.Framework.Input
             ms.LeftButton = _mouse[OpenTK.Input.MouseButton.Left] ? ButtonState.Pressed : ButtonState.Released;
 			ms.RightButton = _mouse[OpenTK.Input.MouseButton.Right] ? ButtonState.Pressed : ButtonState.Released;
 			ms.MiddleButton = _mouse[OpenTK.Input.MouseButton.Middle] ? ButtonState.Pressed : ButtonState.Released;;
-			ms.ScrollWheelValue = _mouse.Wheel;
+
+			// WheelPrecise is divided by 120 (WHEEL_DELTA) in OpenTK (WinGLNative.cs)
+			// We need to counteract it to get the same value XNA provides
+			ms.ScrollWheelValue = (int)( _mouse.WheelPrecise * 120 );
 #endif			
 
 			return ms;


### PR DESCRIPTION
A little context: I'm porting CraftStudio (http://craftstud.io/) to MonoGame to make it run on Linux and MacOS X. It's a game-making platform so it touches a lot of stuff.

The user interface mostly runs on MonoGame but scrolling with the mouse wheel doesn't work because mouse wheel delta values in XNA and MonoGame are inconsistent.

XNA returns mouse wheel deltas in 120 increments whereas in MonoGame.Framework/Desktop/Input/Mouse.cs, the ScrollWheelValue is set to OpenTK's mouse.Wheel which has been divided by 120 (see line 307 at http://www.opentk.com/files/doc/_win_g_l_native_8cs_source.html)

My fix switches to "(int)(mouse.PreciseWheel \* 120);" which basically undoes OpenTK's division to get the original value back, just as XNA uses it.
