### PR TITLE
Fix default window title to use the entry assembly's name (fixes #592)

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Xna.Framework
             // Set the window title.
             // TODO: Get the title from the WindowsPhoneManifest.xml for WP7 projects.
             string windowTitle = string.Empty;
-            var assembly = Assembly.GetCallingAssembly();
+            var assembly = Assembly.GetEntryAssembly();
 
             //Use the Title attribute of the Assembly if possible.
             var assemblyTitleAtt = ((AssemblyTitleAttribute)AssemblyTitleAttribute.GetCustomAttribute(assembly, typeof(AssemblyTitleAttribute)));


### PR DESCRIPTION
The default window title was taken from the calling assembly which might be a library instead of the entry assembly which is the actual game running.

This only affects desktop platforms. I have tested that it works as expected on Windows and Linux. Pretty sure it's safe on MacOS X too.

(See https://github.com/mono/MonoGame/issues/592 for details)
