### PR TITLE
Resolution and IsMouseVisible fixes

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -74,6 +74,7 @@ using System.Text;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input.Touch;
+using Microsoft.Xna.Framework.Input;
 
 namespace Microsoft.Xna.Framework
 {
@@ -243,7 +244,16 @@ namespace Microsoft.Xna.Framework
         {
             
         }
-
+  
+        protected override void OnIsMouseVisibleChanged()
+        {
+            MouseState oldState = Mouse.GetState();
+            _view.Window.CursorVisible = IsMouseVisible;
+            // IsMouseVisible changes the location of the cursor on Linux (and Windows?) and we have to manually set it back to the correct position
+            System.Drawing.Point mousePos = _view.Window.PointToScreen(new System.Drawing.Point(oldState.X, oldState.Y));
+            OpenTK.Input.Mouse.SetPosition(mousePos.X, mousePos.Y);
+        }
+        
         public override void Log(string Message)
         {
             Console.WriteLine(Message);


### PR DESCRIPTION
Hey there,
a) This implements IsMouseVisible for Windows/Linux. However, this code only works with the SVN version of OpenTK and not with the version that is currently used by MonoGame. I would really recommend updating. The old OpenTK version doesn't support ChangeResolution() either, which means that it's currently impossible to change the screen resolution (which can result in really ugly behaviour from time to time)
b) When changing resolution, IsActive was sometimes set wrong. This pull request corrects the Game.IsActive property
c) The screen resolution will now be set back to the old resolution after exiting the game. There are still some multi-monitor issues on Linux, however.

-- only pull if the OpenTK version is upgraded
