### PR TITLE
develop3d- Async fix

### DIFF
--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -169,7 +169,9 @@ namespace Microsoft.Xna.Framework
                 GraphicsDevice.PresentationParameters.BackBufferHeight = isLandscape ? Math.Min(w, h) : Math.Max(w, h);
 
                 // Trigger a change in orientation in case the supported orientations have changed
+#if !IPHONE
                 _game.Window.SetOrientation(_game.Window.CurrentOrientation, false);
+#endif
             }
         }
 

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -325,11 +325,11 @@
     <Compile Include="iOS\iOSGamePlatform.cs" />
     <Compile Include="iOS\iOSGameViewController.cs" />
     <Compile Include="iOS\OrientationConverter.cs" />
-    <Compile Include="Desktop\Audio\OALSoundBuffer.cs"/>
-    <Compile Include="Desktop\Audio\OpenALSoundController.cs"/>
-    <Compile Include="MacOS\Audio\OpenALSupport.cs"/>
-    <Compile Include="MacOS\Audio\SoundEffect.cs"/>
-    <Compile Include="MacOS\Audio\SoundEffectInstance.cs"/>
+    <Compile Include="Desktop\Audio\OALSoundBuffer.cs" />
+    <Compile Include="Desktop\Audio\OpenALSoundController.cs" />
+    <Compile Include="MacOS\Audio\OpenALSupport.cs" />
+    <Compile Include="MacOS\Audio\SoundEffect.cs" />
+    <Compile Include="MacOS\Audio\SoundEffectInstance.cs" />
     <Compile Include="Graphics\Effect\AlphaTestEffect.cs" />
     <Compile Include="Graphics\Effect\DXShader.cs" />
     <Compile Include="Graphics\Effect\EffectAnnotation.cs" />
@@ -428,7 +428,6 @@
     <Compile Include="iOS\GamerServices\KeyboardInputAsyncResult.cs" />
     <Compile Include="iOS\iOSGameWindow.cs" />
     <Compile Include="Graphics\Effect\ConstantBuffer.cs" />
-    <Compile Include="Media\MediaQueue.cs" />
     <Compile Include="Input\Touch\TouchInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/MonoGame.Framework/Threading.cs
+++ b/MonoGame.Framework/Threading.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Xna.Framework
     internal class Threading
     {
         static int mainThreadId;
+        static int currentThreadId;
 #if ANDROID
         static List<Action> actions = new List<Action>();
         static Mutex actionsMutex = new Mutex();
@@ -99,9 +100,13 @@ namespace Microsoft.Xna.Framework
 #if IPHONE
             lock (BackgroundContext)
             {
-                if (EAGLContext.CurrentContext != BackgroundContext)
+                // Make the context current on this thread if it is not already
+                if (!Object.ReferenceEquals(EAGLContext.CurrentContext, BackgroundContext))
                     EAGLContext.SetCurrentContext(BackgroundContext);
+                // Execute the action
                 action();
+                // Must flush the GL calls so the GPU asset is ready for the main context to use it
+                GL.Flush();
             }
 #elif WINDOWS || LINUX
             lock (BackgroundContext)


### PR DESCRIPTION
Windows now works correctly with threaded texture loads.
Also added required call to GL.Flush() on iOS as well.
