### PR TITLE
Fixed crash bug for GraphicsDevice.SetVertexBuffer(null) in Windows 8.

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -74,8 +74,11 @@ namespace Microsoft.Xna.Framework.Audio
 #endif
 
         private string _name;
-		private string _filename = "";		
+#if !WINRT
+		private string _filename = "";
         private byte[] _data;
+#endif
+
 #if WINRT
         internal SoundEffect()
         {

--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -52,7 +52,9 @@ namespace Microsoft.Xna.Framework.Audio
 	public sealed class SoundEffectInstance : IDisposable
 	{
 		private bool isDisposed = false;
+#if !WINRT
 		private SoundState soundState = SoundState.Stopped;
+#endif
 
 #if WINRT        
         internal SourceVoice _voice { get; set; }

--- a/MonoGame.Framework/BoundingFrustum.cs
+++ b/MonoGame.Framework/BoundingFrustum.cs
@@ -450,7 +450,6 @@ namespace Microsoft.Xna.Framework
 
         #region Private Methods
 
-#warning Move this to the PlaneHelper class
         private void CreateCorners()
         {
             this.corners = new Vector3[8];

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -208,7 +208,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		List<string> extensions = new List<string>();
 
+#if OPENGL
         internal int glFramebuffer;
+#endif
 
 #if DIRECTX
 
@@ -1257,7 +1259,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (_vertexBuffer != null)
                     _d3dContext.InputAssembler.SetVertexBuffers(0, _vertexBuffer._binding);
                 else
-                    _d3dContext.InputAssembler.SetVertexBuffers(0, null);
+                    _d3dContext.InputAssembler.SetVertexBuffers(0);
             }
 #elif OPENGL
             if (_vertexBuffer != null)

--- a/MonoGame.Framework/Graphics/Model.cs
+++ b/MonoGame.Framework/Graphics/Model.cs
@@ -77,10 +77,6 @@ namespace Microsoft.Xna.Framework.Graphics
 			Debug.WriteLine("{0}:{1}", s, node.Name);
 		}
 		
-		float dt = 0;
-		float timer = 0;
-		int modelPart = 0;
-		
 		public void Draw(Matrix world, Matrix view, Matrix projection) 
 		{       			
 			// Look up combined bone matrices for the entire model.

--- a/MonoGame.Framework/Graphics/Vertices/DynamicIndexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/DynamicIndexBuffer.cs
@@ -55,12 +55,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void SetData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, SetDataOptions options) where T : struct
         {
-            base.SetData<T>(offsetInBytes, data, startIndex, elementCount, options);
+            base.SetDataInternal<T>(offsetInBytes, data, startIndex, elementCount, options);
         }
 
         public void SetData<T>(T[] data, int startIndex, int elementCount, SetDataOptions options) where T : struct
         {
-            base.SetData<T>(0, data, startIndex, elementCount, options);
+            base.SetDataInternal<T>(0, data, startIndex, elementCount, options);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.cs
@@ -170,20 +170,20 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void SetData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount) where T : struct
         {
-            SetData<T>(0, data, startIndex, elementCount, SetDataOptions.Discard);
+            SetDataInternal<T>(0, data, startIndex, elementCount, SetDataOptions.Discard);
         }
         		
 		public void SetData<T>(T[] data, int startIndex, int elementCount) where T : struct
         {
-            SetData<T>(0, data, startIndex, elementCount, SetDataOptions.Discard);
+            SetDataInternal<T>(0, data, startIndex, elementCount, SetDataOptions.Discard);
 		}
 		
         public void SetData<T>(T[] data) where T : struct
         {
-            SetData<T>(0, data, 0, data.Length, SetDataOptions.Discard);
+            SetDataInternal<T>(0, data, 0, data.Length, SetDataOptions.Discard);
         }
 
-        protected void SetData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, SetDataOptions options) where T : struct
+        protected void SetDataInternal<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, SetDataOptions options) where T : struct
         {
             if (data == null)
                 throw new ArgumentNullException("data");

--- a/MonoGame.Framework/Graphics/Vertices/VertexElement.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexElement.cs
@@ -123,6 +123,14 @@ namespace Microsoft.Xna.Framework.Graphics
                     element.SemanticName = "TEXCOORD";
                     break;
 
+                case Graphics.VertexElementUsage.BlendIndices:
+                    element.SemanticName = "BLENDINDICES";
+                    break;
+
+                case Graphics.VertexElementUsage.BlendWeight:
+                    element.SemanticName = "BLENDWEIGHT";
+                    break;
+
                 default:
                     throw new NotImplementedException("Unknown vertex element usage!");
             }

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -66,8 +66,9 @@ namespace Microsoft.Xna.Framework
         private bool _preferMultiSampling;
         private DisplayOrientation _supportedOrientations;
         private bool _synchronizedWithVerticalRetrace = true;
+#if !(WINDOWS || LINUX || WINRT)
         private bool _wantFullScreen = true;
-
+#endif
         public static readonly int DefaultBackBufferHeight = 480;
         public static readonly int DefaultBackBufferWidth = 800;
 

--- a/MonoGame.Framework/Input/MouseState.cs
+++ b/MonoGame.Framework/Input/MouseState.cs
@@ -93,6 +93,18 @@ namespace Microsoft.Xna.Framework.Input
 			return !(left == right);
 		}
 
+        public override bool Equals(object obj)
+        {
+            if (obj is MouseState)
+                return this == (MouseState)obj;
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
 		public int X {
 			get {
 				return _x;

--- a/MonoGame.Framework/Media/PlaylistCollection.cs
+++ b/MonoGame.Framework/Media/PlaylistCollection.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Xna.Framework.Media
     public sealed class PlaylistCollection : ICollection<Playlist>, IEnumerable<Playlist>, IEnumerable, IDisposable
     {
 		private bool isReadOnly = false;
-		private List<Playlist> innerlist;
+		private List<Playlist> innerlist = new List<Playlist>();
 		
         public void Dispose()
         {

--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Xna.Framework.Media
 #endif
 		
 		private string _name;
-		private int _playCount;   
+		private int _playCount = 0;   
 		
 		internal Song(string fileName)
 		{			

--- a/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
@@ -382,6 +382,81 @@
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' ">
     <VisualStudioVersion>11.0</VisualStudioVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;DEBUG;WINRT;NOMOJO;DIRECTX</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINRT;NOMOJO;DIRECTX</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;DEBUG;WINRT;NOMOJO;DIRECTX</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINRT;NOMOJO;DIRECTX</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;DEBUG;WINRT;NOMOJO;DIRECTX</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINRT;NOMOJO;DIRECTX</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Added some BlendWeights and BlendIndices support to VertexElement.cs for Windows 8.
Added x86, x64 and ARM platform configurations to Windows 8 project.  Xbox LIVE for Windows 8 can not use Any CPU.
Fixed several long-standing compiler warnings.
