### PR TITLE
Wrong namespace for BlendFunction (XNA compatibility)

### DIFF
--- a/MonoGame.Framework/Graphics/States/BlendFunction.cs
+++ b/MonoGame.Framework/Graphics/States/BlendFunction.cs
@@ -41,7 +41,7 @@
 
 using System;
 
-namespace Microsoft.Xna.Framework
+namespace Microsoft.Xna.Framework.Graphics
 {
 	public enum BlendFunction
 	{


### PR DESCRIPTION
Just found that while making my wrapper ;)
