### PR TITLE
Throw correct exceptions in SpriteBatch

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		SamplerState _samplerState;
 		DepthStencilState _depthStencilState; 
 		RasterizerState _rasterizerState;		
-		Effect _effect;	
+		Effect _effect;
+        bool beginCalled;
 
 		Effect spriteEffect;
 
@@ -45,6 +46,8 @@ namespace Microsoft.Xna.Framework.Graphics
             spriteEffect = new Effect(graphicsDevice, SpriteEffect.Bytecode);
 
             _batcher = new SpriteBatcher(graphicsDevice);
+
+            beginCalled = false;
 		}
 
 		public void Begin ()
@@ -71,6 +74,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				//setup things now so a user can chage them
 				Setup();
 			}
+
+            beginCalled = true;
 		}
 
 		public void Begin (SpriteSortMode sortMode, BlendState blendState)
@@ -89,7 +94,9 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		public void End ()
-		{	
+		{
+            beginCalled = false;
+
 			if (_sortMode != SpriteSortMode.Immediate) {
 				Setup ();
 			}
@@ -144,6 +151,34 @@ namespace Microsoft.Xna.Framework.Graphics
 			_batcher.DrawBatch (_sortMode, graphicsDevice.SamplerStates[0]);
 		}
 
+        void CheckValid(Texture2D texture)
+        {
+            if (texture == null)
+                throw new ArgumentNullException("texture");
+            if (!beginCalled)
+                throw new InvalidOperationException("Draw was called, but Begin has not yet been called. Begin must be called successfully before you can call Draw.");
+        }
+
+        void CheckValid(SpriteFont spriteFont, string text)
+        {
+            if (spriteFont == null)
+                throw new ArgumentNullException("spriteFont");
+            if (text == null)
+                throw new ArgumentNullException("text");
+            if (!beginCalled)
+                throw new InvalidOperationException("DrawString was called, but Begin has not yet been called. Begin must be called successfully before you can call DrawString.");
+        }
+
+        void CheckValid(SpriteFont spriteFont, StringBuilder text)
+        {
+            if (spriteFont == null)
+                throw new ArgumentNullException("spriteFont");
+            if (text == null)
+                throw new ArgumentNullException("text");
+            if (!beginCalled)
+                throw new InvalidOperationException("DrawString was called, but Begin has not yet been called. Begin must be called successfully before you can call DrawString.");
+        }
+
 		public void Draw (Texture2D texture,
 				Vector2 position,
 				Rectangle? sourceRectangle,
@@ -154,10 +189,9 @@ namespace Microsoft.Xna.Framework.Graphics
 				SpriteEffects effect,
 				float depth)
 		{
-			if (texture == null) {
-				throw new ArgumentException ("texture");
-			}
-			float w = texture.Width*scale.X;
+            CheckValid(texture);
+
+            float w = texture.Width*scale.X;
 			float h = texture.Height*scale.Y;
 			if (sourceRectangle.HasValue) {
 				w = sourceRectangle.Value.Width*scale.X;
@@ -225,9 +259,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			SpriteEffects effect,
 			float depth)
 		{
-			if (texture == null) {
-				throw new ArgumentException ("texture");
-			}
+            CheckValid(texture);
 
             // texture 0 is the texture beeing draw
             //
@@ -294,9 +326,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			Draw (texture, destinationRectangle, sourceRectangle, color, 0, Vector2.Zero, SpriteEffects.None, 0f);
 		}
 
-		public void Draw (Texture2D texture,
-				Vector2 position,
-				Color color)
+		public void Draw (Texture2D texture, Vector2 position, Color color)
 		{
 			Draw (texture, position, null, color);
 		}
@@ -308,8 +338,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void DrawString (SpriteFont spriteFont, string text, Vector2 position, Color color)
 		{
-			if (spriteFont == null)
-				throw new ArgumentNullException ("spriteFont");
+            CheckValid(spriteFont, text);
 
             var source = new SpriteFont.CharacterSource(text);
 			spriteFont.DrawInto (
@@ -320,8 +349,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			SpriteFont spriteFont, string text, Vector2 position, Color color,
 			float rotation, Vector2 origin, float scale, SpriteEffects effects, float depth)
 		{
-			if (spriteFont == null)
-				throw new ArgumentNullException ("spriteFont");
+            CheckValid(spriteFont, text);
 
 			var scaleVec = new Vector2(scale, scale);
             var source = new SpriteFont.CharacterSource(text);
@@ -332,8 +360,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			SpriteFont spriteFont, string text, Vector2 position, Color color,
 			float rotation, Vector2 origin, Vector2 scale, SpriteEffects effect, float depth)
 		{
-			if (spriteFont == null)
-				throw new ArgumentNullException ("spriteFont");
+            CheckValid(spriteFont, text);
 
             var source = new SpriteFont.CharacterSource(text);
             spriteFont.DrawInto(this, ref source, position, color, rotation, origin, scale, effect, depth);
@@ -341,8 +368,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void DrawString (SpriteFont spriteFont, StringBuilder text, Vector2 position, Color color)
 		{
-			if (spriteFont == null)
-				throw new ArgumentNullException ("spriteFont");
+            CheckValid(spriteFont, text);
 
             var source = new SpriteFont.CharacterSource(text);
 			spriteFont.DrawInto(this, ref source, position, color, 0, Vector2.Zero, Vector2.One, SpriteEffects.None, 0f);
@@ -352,8 +378,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			SpriteFont spriteFont, StringBuilder text, Vector2 position, Color color,
 			float rotation, Vector2 origin, float scale, SpriteEffects effects, float depth)
 		{
-			if (spriteFont == null)
-				throw new ArgumentNullException ("spriteFont");
+            CheckValid(spriteFont, text);
 
 			var scaleVec = new Vector2 (scale, scale);
             var source = new SpriteFont.CharacterSource(text);
@@ -364,8 +389,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			SpriteFont spriteFont, StringBuilder text, Vector2 position, Color color,
 			float rotation, Vector2 origin, Vector2 scale, SpriteEffects effect, float depth)
 		{
-			if (spriteFont == null)
-				throw new ArgumentNullException ("spriteFont");
+            CheckValid(spriteFont, text);
 
             var source = new SpriteFont.CharacterSource(text);
             spriteFont.DrawInto(this, ref source, position, color, rotation, origin, scale, effect, depth);


### PR DESCRIPTION
Fixes for issue #711
Added: Throw InvalidOperationException if SpriteBatch.Begin is not called prior to SpriteBatch.Draw or SpriteBatch.DrawString.
Fixed: Throw ArgumentNullException exception if texture parameter is null in calls to SpriteBatch.Draw. Was throwing ArgumentException.
Added: Throw ArgumentNullException if text parameter is null in calls to SpriteBatch.DrawString.
