### PR TITLE
Remove redundant check for valid asset

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -303,11 +303,6 @@ namespace Microsoft.Xna.Framework.Content
 					disposableAssets.Add(result as IDisposable);
 			}
 
-			if (result == null)
-			{
-				throw new ContentLoadException("Could not load " + originalAssetName + " asset!");
-			}
-		
 			CurrentAssetDirectory = null;
 			
 			return (T)result;


### PR DESCRIPTION
Fixes issue #708.
Fixed: Remove duplicate check for result not null.
