### PR TITLE
Fix use of ABC widths in SpriteFont rendering

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 if (hasCurrentGlyph)
-                    offset.X += Spacing + currentGlyph.WidthIncludingBearings;
+                    offset.X += Spacing + currentGlyph.Width + currentGlyph.RightSideBearing;
 
                 hasCurrentGlyph = _glyphs.TryGetValue(c, out currentGlyph);
                 if (!hasCurrentGlyph)
@@ -316,7 +316,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     currentGlyph = defaultGlyph.Value;
                     hasCurrentGlyph = true;
                 }
-
+                offset.X += currentGlyph.LeftSideBearing;
                 var p = offset;
 
 				if (flippedHorz)


### PR DESCRIPTION
Fixes issue #661
Fixed: Add left bearing (A) before rendering glyph, then add glyph width (B) and right bearing (C) after rendering the glyph. Now matches pixel-for-pixel the XNA rendering.
