### PR TITLE
Don't assume ushort indices, uint are also supported for index buffers

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1437,8 +1437,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 #elif OPENGL
 
-			var indexElementType = DrawElementsType.UnsignedShort;
-			var indexElementSize = 2;
+            var shortIndices = _indexBuffer.IndexElementSize == IndexElementSize.SixteenBits;
+
+			var indexElementType = shortIndices ? DrawElementsType.UnsignedShort : DrawElementsType.UnsignedInt;
+            var indexElementSize = shortIndices ? 2 : 4;
 			var indexOffsetInBytes = (IntPtr)(startIndex * indexElementSize);
 			var indexElementCount = GetElementCountArray(primitiveType, primitiveCount);
 			var target = PrimitiveTypeGL(primitiveType);


### PR DESCRIPTION
DrawIndexedPrimitives assumed that the index buffer used unsigned shorts. This fix makes it possible to use unsigned integers as well, as the rest of the system supports it.
This resolved a geometry corruption issue in my project.
