### PR TITLE
Added Windows 8 support for launching by protocol handler

### DIFF
--- a/MonoGame.Framework/Windows8/MetroFrameworkView.cs
+++ b/MonoGame.Framework/Windows8/MetroFrameworkView.cs
@@ -33,6 +33,16 @@ namespace Microsoft.Xna.Framework
                 // Construct the game.
                 _game = new T();
             }
+            else if (args.Kind == ActivationKind.Protocol)
+            {
+                // Save any protocol launch parameters to be parsed by the platform.
+                var protocolArgs = args as ProtocolActivatedEventArgs;
+                MetroGamePlatform.LaunchParameters = protocolArgs.Uri.AbsoluteUri;
+                MetroGamePlatform.PreviousExecutionState = protocolArgs.PreviousExecutionState;
+
+                // Construct the game.
+                _game = new T();
+            }
         }
 
         public void Load(string entryPoint)

--- a/MonoGame.Framework/Windows8/MetroGamePlatform.cs
+++ b/MonoGame.Framework/Windows8/MetroGamePlatform.cs
@@ -99,17 +99,59 @@ namespace Microsoft.Xna.Framework
             MetroGameWindow.Instance.Game = game;
 
             // Setup the launch parameters.
-            var arguments = LaunchParameters.Split(' ');
-            foreach (var arg in arguments)
+            // - Parameters can optionally start with a forward slash.
+            // - Keys can be separated from values by a colon.
+            // - Double quotes can be used to enclose spaces in a key or value.
+            int pos = 0;
+            int paramStart = 0;
+            bool inQuotes = false;
+            while (pos <= LaunchParameters.Length)
             {
-                if (arg.Contains("="))
+                string arg = string.Empty;
+                if (pos < LaunchParameters.Length)
                 {
-                    var keyVal = arg.Split('=');
-                    Game.LaunchParameters.Add(keyVal[0], keyVal[1]);
-
+                    char c = LaunchParameters[pos];
+                    if (c == '"')
+                        inQuotes = !inQuotes;
+                    else if ((c == ' ') && !inQuotes)
+                    {
+                        arg = LaunchParameters.Substring(paramStart, pos - paramStart).Replace("\"", "");
+                        paramStart = pos + 1;
+                    }
                 }
-                else if (arg != string.Empty)
-                    Game.LaunchParameters.Add(arg, string.Empty);
+                else
+                {
+                    arg = LaunchParameters.Substring(paramStart).Replace("\"", "");
+                }
+                ++pos;
+
+                if (string.IsNullOrWhiteSpace(arg))
+                    continue;
+
+                string key = string.Empty;
+                string value = string.Empty;
+                int keyStart = 0;
+
+                if (arg.StartsWith("/"))
+                    keyStart = 1;
+
+                if (arg.Length > keyStart)
+                {
+                    int keyEnd = arg.IndexOf(':', keyStart);
+                    if (keyEnd >= 0)
+                    {
+                        key = arg.Substring(keyStart, keyEnd - keyStart);
+                        int valueStart = keyEnd + 1;
+                        if (valueStart < arg.Length)
+                            value = arg.Substring(valueStart);
+                    }
+                    else
+                    {
+                        key = arg.Substring(keyStart);
+                    }
+
+                    Game.LaunchParameters.Add(key, value);
+                }
             }
 
             Game.PreviousExecutionState = PreviousExecutionState;


### PR DESCRIPTION
Xbox LIVE on Windows requires support for launching by protocol handler.  Add protocol URI to LaunchParameters.  URI gets split into schema (key) and path (value).
Re-worked population of Game.LaunchParameters to work the same as XNA 4 on Windows.
- Parameters can optionally start with a forward slash.
- Keys can be separated from values by a colon.
- Double quotes can be used to enclose spaces.
