### PR TITLE
GL DrawPrimXXX() Optimization (PLEASE TEST!)

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.cs
@@ -136,12 +136,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			// TODO: This is executed on every draw call... can we not
 			// allocate a vertex declaration once and just re-apply it?
 
-			bool[] enabledAttributes = new bool[16];
-			foreach (var ve in this.GetVertexElements()) {
-				IntPtr elementOffset = (IntPtr)(offset.ToInt64 () + ve.Offset);
-				int attributeLocation = -1;
+			var enabledAttributes = new bool[16];
+            foreach (var ve in _elements) 
+            {
+				var elementOffset = (IntPtr)(offset.ToInt64 () + ve.Offset);
+				var attributeLocation = -1;
 				
-				switch (ve.VertexElementUsage) {
+				switch (ve.VertexElementUsage) 
+                {
 				case VertexElementUsage.Position:
 					attributeLocation = GraphicsDevice.attributePosition + ve.UsageIndex;
 					break;


### PR DESCRIPTION
This pull request converts the GraphicsDevice.DrawUserXXX() methods to render directly from pinned index and vertex arrays.

This optimization is based on [feedback from the Infinite Flight team](https://github.com/mono/MonoGame/pull/761#issuecomment-8482636) and reports of [performance problems with SpriteBatch](https://github.com/mono/MonoGame/issues/765).

Please test it and let me know how it performs compared to Develop3D.
