### PR TITLE
Fixed the sampler state on sprite batches

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -194,7 +194,11 @@ namespace Microsoft.Xna.Framework.Graphics
 #if OPENGL
             // Activate the Texture before we draw. 
             // should this be to be moved into the GraphicsDevice?
-            if (_device.Textures[0] != null) _device.Textures[0].Activate();            
+            if (_device.Textures[0] != null)
+            {
+                _device.Textures[0].Activate();
+                _device.SamplerStates[0].Activate(_device.Textures[0].glTarget, _device.Textures[0].LevelCount > 1);
+            }
 #endif
 
             _device.DrawUserIndexedPrimitives<VertexPosition2ColorTexture>(


### PR DESCRIPTION
This is somewhat patchy, but I don't understand why the texture and the sampler state are not activated deeper down (when applying the fragment shader), and assume there is a good reason for it. 
Right now at least, the sampler states work for sprite batches.
