### PR TITLE
Fixed issue #672: Gamepad analogue sticks & Accelerator don't work (PSMobile)

### DIFF
--- a/MonoGame.Framework/PSSuite/Input/GamePad.cs
+++ b/MonoGame.Framework/PSSuite/Input/GamePad.cs
@@ -156,7 +156,7 @@ using Microsoft.Xna.Framework.Graphics;
         {
             var instance = GamePad.Instance;
 			instance.Update();
-            var state = new GamePadState(new GamePadThumbSticks(), new GamePadTriggers(), new GamePadButtons((Buttons)instance._buttons), new GamePadDPad((Buttons)instance._buttons));
+            var state = new GamePadState(new GamePadThumbSticks(instance._leftStick, instance._rightStick), new GamePadTriggers(), new GamePadButtons((Buttons)instance._buttons), new GamePadDPad((Buttons)instance._buttons));
             instance.Reset();
             return state;
         }


### PR DESCRIPTION
Initialize GamePadState with values (was initialized without the actual data from the gamepad).
