### PR TITLE
Removed call to Threading.EnsureUIThread() under WinRT

### DIFF
--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -57,7 +57,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void SetTextures(GraphicsDevice device)
         {
+#if !WINRT
             Threading.EnsureUIThread();
+#endif
 
             // Skip out if nothing has changed.
             if (_dirty == 0)


### PR DESCRIPTION
This fixes the build under WinRT.
