### PR TITLE
Fixed missing clamp from color multiply

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1222,10 +1222,10 @@ namespace Microsoft.Xna.Framework
 		
 		public static Color Multiply( Color value, float scale)
 		{
-			byte Red = (byte)(value.R * scale);
-			byte Green = (byte)(value.G * scale);
-			byte Blue = (byte)(value.B * scale);
-			byte Alpha = (byte)(value.A * scale);
+            byte Red = (byte)(MathHelper.Clamp(value.R * scale, Byte.MinValue, Byte.MaxValue));
+            byte Green = (byte)(MathHelper.Clamp(value.G * scale, Byte.MinValue, Byte.MaxValue));
+            byte Blue = (byte)(MathHelper.Clamp(value.B * scale, Byte.MinValue, Byte.MaxValue));
+            byte Alpha = (byte)(MathHelper.Clamp(value.A * scale, Byte.MinValue, Byte.MaxValue));
 			
 			return new Color( Red, Green, Blue, Alpha );
 		}


### PR DESCRIPTION
Color.White*1.000001f resulted in (0,0,0,0) instead of (255,255,255,255).
