### PR TITLE
SharpDX fixes to 2MGFX.

### DIFF
--- a/Tools/2MGFX/DXEffectObject.hlsl.cs
+++ b/Tools/2MGFX/DXEffectObject.hlsl.cs
@@ -190,9 +190,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw ex;
             }
 
-            // Get the shader bytecode.
-            var bytecode = new byte[shaderByteCode.Data.Length];
-            shaderByteCode.Data.Read(bytecode, 0, bytecode.Length);
+            // Get a copy of the shader bytecode.
+            var bytecode = shaderByteCode.Data.ToArray();
 
             // First look to see if we already created this same shader.
             DXShaderData dxShader = null;

--- a/Tools/2MGFX/DXShaderData.sharpdx.cs
+++ b/Tools/2MGFX/DXShaderData.sharpdx.cs
@@ -22,14 +22,12 @@ namespace Microsoft.Xna.Framework.Graphics
             using (var original = new SharpDX.D3DCompiler.ShaderBytecode(byteCode))
             {
                 // Strip the bytecode for saving to disk.
-                using (var stripped = original.Strip(stripFlags))
+                var stripped = original.Strip(stripFlags);
                 {
                     // Only SM4 and above works with strip... so this can return null!
                     if (stripped != null)
                     {
-                        var shaderCode = new byte[stripped.BufferSize];
-                        stripped.Data.Read(shaderCode, 0, shaderCode.Length);
-                        dxshader.ShaderCode = shaderCode;
+                        dxshader.ShaderCode = stripped;
                     }
                     else
                     {
@@ -46,7 +44,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 // Use reflection to get details of the shader.
-                using (var refelect = new SharpDX.D3DCompiler.ShaderReflection(original))
+                using (var refelect = new SharpDX.D3DCompiler.ShaderReflection(byteCode))
                 {
                     // Get the samplers.
                     var samplers = new List<Sampler>();


### PR DESCRIPTION
Small fixes to make the 2MGFX code compatible with SharpDX 2.3.0.

Requires merge of 3rd-party libs first....

https://github.com/kungfubanana/MonoGame-Dependencies/pull/16

... once that is merged let me know and i'll add the submodule reference to this pull and it can all be merged.
