### PR TITLE
Added missing #if OPENGL to fix Win8 build

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -377,8 +377,10 @@ namespace Microsoft.Xna.Framework.Graphics
             _vertexConstantBuffers.Clear();
             _pixelConstantBuffers.Clear();
 
+#if OPENGL
             // Ensure the vertex attributes are reset
             _enabledVertexAttributes.Clear();
+#endif
 
             // Force set the buffers and shaders on next ApplyState() call
             _indexBufferDirty = true;


### PR DESCRIPTION
Fix of PR 831

Added #if OPENGL for _enabledVertexAttributes.Clear(); to fix Win8 build.
