### PR TITLE
Fixs bug with IsMouseVisible.

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -105,6 +105,8 @@ namespace Microsoft.Xna.Framework
             _view = new OpenTKGameWindow();
             _view.Game = game;
             this.Window = _view;
+
+            this.IsMouseVisible = true;
 			
 			// Setup our OpenALSoundController to handle our SoundBuffer pools
 			soundControllerInstance = OpenALSoundController.GetInstance;


### PR DESCRIPTION
Setting Game.IsMouseVisible to false fails to hide the mouse cursor.
Setting it to true then false correctly hides the cursor. This commit
sets IsMouseVisible to true at startup so that endusers don't encounter
this behaviour.

This is on a Win7 machine so changes have been made to OpenTKPlatform not the base Platform type.
