### PR TITLE
Fix 'Shader Compilation Failed' on Linux

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -274,7 +274,11 @@ namespace Microsoft.Xna.Framework
             Threading.WindowInfo = window.WindowInfo;
 
             keys = new List<Keys>();
-
+   
+#if LINUX
+            Threading.BackgroundContext.MakeCurrent(Threading.WindowInfo);      
+#endif     
+            
             // mouse
             // TODO review this when opentk 1.1 is released
 #if WINDOWS || LINUX


### PR DESCRIPTION
Hi,

Currently when we launch a game with the latest Linux build of develop3d branch we have a Shader Compilation Failed message and the game doesn't launch.

This pull request fix this problem and MonoGame run now correctly. It's just one line who affect only the Linux build.

I've tested it with my games/experiments (2D/3D) and it work fine
