### PR TITLE
Fixed SpriteBatch Depth Under DX (TEST ME!)

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -98,12 +98,13 @@ namespace Microsoft.Xna.Framework.Graphics
 			
             // Setup the default sprite effect.
 			var vp = graphicsDevice.Viewport;
-            var projection = Matrix.CreateOrthographicOffCenter(0, vp.Width, vp.Height, 0, 0, 1);
 
             // GL requires a half pixel offset where as DirectX and PSS does not.
 #if PSS || DIRECTX
+            var projection = Matrix.CreateOrthographicOffCenter(0, vp.Width, vp.Height, 0, -1, 0);
             var transform = _matrix * projection;
 #else
+            var projection = Matrix.CreateOrthographicOffCenter(0, vp.Width, vp.Height, 0, 0, 1);
 			var halfPixelOffset = Matrix.CreateTranslation(-0.5f, -0.5f, 0);
 			var transform = _matrix * (halfPixelOffset * projection);
 #endif


### PR DESCRIPTION
I fixed the default SpriteBatch ortho projection under DirectX so that sprites with a depth > 0 render correctly.

There is still sort of a incompatibility.  Under OpenGL you can pass a depth of -1 and it still renders.  This is technically not the behavior under XNA4 which only renders if the depth is between 0 and 1.  I figure this is a fix for another day.

This fix only affects Windows 8 Metro... if you have a game that uses depth with SpriteBatch please test it.
