### PR TITLE
Make the GameCenter Integration work when building and running with iOS6

### DIFF
--- a/MonoGame.Framework/iOS/GamerServices/Guide.cs
+++ b/MonoGame.Framework/iOS/GamerServices/Guide.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Xna.Framework.GamerServices
         
         public override bool ShouldAutorotate ()
         {
-            return true;
+            return _parent.ShouldAutorotate();
         }
         
         public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation ()


### PR DESCRIPTION
I finally tried doing GameCenter integration using MonoGame and found it didn't work.
This fixes up the iOS Guide class to work.

Previously this.ParentViewController was always null, so we'd just crash when trying to present.
