### PR TITLE
Modified MetroHelper.AppDataFileExists to correctly work with files insi...

### DIFF
--- a/MonoGame.Framework/Windows8/MetroHelper.cs
+++ b/MonoGame.Framework/Windows8/MetroHelper.cs
@@ -16,16 +16,13 @@ namespace Microsoft.Xna.Framework
 
                 try
                 {
-                    var localFolder = ApplicationData.Current.LocalFolder;
-                    var storageFile = await localFolder.GetFileAsync(fileName);
+                    var file = await Windows.ApplicationModel.Package.Current.InstalledLocation.GetFileAsync(fileName);
+                    return file == null ? false : true;
                 }
                 catch (FileNotFoundException)
                 {
                     return false;
                 }
-
-                return true;
-
             }).Result;
 
             return result;


### PR DESCRIPTION
...de nested folders.

The current code doesn't handle cases where a the file is nested inside folders correctly. This methods handles that case and doesn't incorrectly throw a ContentLoadException.
