### PR TITLE
iOS Orientation fixes

### DIFF
--- a/MonoGame.Framework/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/iOS/iOSGamePlatform.cs
@@ -325,6 +325,7 @@ namespace Microsoft.Xna.Framework
 				presentParams.DisplayOrientation = orientation;
 
 				// Recalculate our views.
+                gdm.ApplyChanges();
 				ViewController.View.LayoutSubviews();
 			}
 			TouchPanel.DisplayOrientation = orientation;


### PR DESCRIPTION
After an orientation change we need to update TouchPanel DisplayHeight/Width or _touchScale will be incorrect.
This fixes Portrait games on iOS5.

@Nezz Since you touched this last could you please take a check, thanks :-)

You can install old simulators in xcode: XCode, Preferences, Downloads, Components, iOS 5.1 Simulator.
