### PR TITLE
SoundEffectInstance.State property getter returns a value in all #if conditionals

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -1,4 +1,4 @@
-#region License
+﻿#region License
 // /*
 // Microsoft Public License (Ms-PL)
 // MonoGame - Copyright © 2009 The MonoGame Team
@@ -487,6 +487,8 @@ namespace Microsoft.Xna.Framework.Audio
                 {
                     soundState = SoundState.Stopped;
                 }
+
+                return soundState;
 #endif
 			} 
 		}


### PR DESCRIPTION
In an attempt to fix the PSMobile project, this is a first fix.

The problem is that this property did not return a value in all different #if conditional branches (namely - in the last #elif, which PSMobile falls under since it is not Android or WinRT).

The fix is to simply return the private soundState field, as was before (i guess it was accidentally removed? )
