### PR TITLE
Make iOS6 portrait applications work properly

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Xna.Framework.Content
 		// If disposing is false, it was called by the finalizer.
 		protected virtual void Dispose(bool disposing)
 		{
-			if (disposing && !disposed)
+			if (!disposed)
 			{
 				Unload();
 				disposed = true;

--- a/MonoGame.Framework/iOS/iOSGameViewController.cs
+++ b/MonoGame.Framework/iOS/iOSGameViewController.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Xna.Framework {
         
         public override bool ShouldAutorotate ()
         {
-            return true;
+            return _platform.Game.Initialized;
         }
         
         public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation ()


### PR DESCRIPTION
Allow dispose to unload the ContentManager (discussed in #859, but not fixing the actual issue)

The iOS6 issue was that the mask was only retrieved once, when the application started. That happened because the autorotation was always enabled. That retrieving happened happened before the Game constructor was called, therefore the mask way always "Default" (Landscape left + right). This resulted in potrait apps crashing (no common orientation).
By only enabing the autorotation when the game is initialized, we have the time to set up the supported orientations. When the autorotation gets enabled (after initialize) we will have the correct mask and the application will work as intended.
