### PR TITLE
Fixes #861, let's discuss

### DIFF
--- a/MonoGame.Framework/iOS/GamerServices/SignedInGamer.cs
+++ b/MonoGame.Framework/iOS/GamerServices/SignedInGamer.cs
@@ -96,17 +96,11 @@ namespace Microsoft.Xna.Framework.GamerServices
     			        if (lp != null)
     					{
     						lp.Authenticate( delegate(NSError error) 
-    						                	{  							              
-    												try 
-    												{
-    													if ( error != null )
-    													{
-#if DEBUG									
-    														Console.WriteLine(error);
+    						                	{  	
+#if DEBUG
+    												if ( error != null )								
+    													Console.WriteLine(error);
 #endif
-                                                        }
-    												}
-                                                    catch { }
     											}
     						                );
     					}


### PR DESCRIPTION
The iOS authentication can take minutes with a bad connection and in the meantime, it was not possible to use the guide (which we use for starting a new game for example). I think that making the guide visible and blocking other guides is not needed.
Please test that this will not create any issues when the user needs to sign in by entering his credential.
