### PR TITLE
Remove the double attenuation on the volume of SFX in Android

### DIFF
--- a/MonoGame.Framework/Android/Audio/Sound.cs
+++ b/MonoGame.Framework/Android/Audio/Sound.cs
@@ -76,13 +76,8 @@ namespace Microsoft.Xna.Framework.Audio
             if (_soundId == 0)
                 return -1;
 
-            AudioManager audioManager = (AudioManager)Game.Activity.GetSystemService(Context.AudioService);
-
-            float streamVolumeCurrent = audioManager.GetStreamVolume(Stream.Music);
-            float streamVolumeMax = audioManager.GetStreamMaxVolume(Stream.Music);
-            float streamVolume = streamVolumeCurrent / streamVolumeMax;
             float panRatio = (this.Pan + 1.0f) / 2.0f;
-            float volumeTotal = SoundEffect.MasterVolume * Volume * streamVolume;
+            float volumeTotal = SoundEffect.MasterVolume * this.Volume;
             float volumeLeft = volumeTotal * (1.0f - panRatio);
             float volumeRight = volumeTotal * panRatio;
 


### PR DESCRIPTION
I'm not sure why the music stream volume was used to influence the SFX volume, but removing it fixes the issue where SoundEffects are played very quietly. At least on the devices I've tested, `audioManager.GetStreamVolume(Stream.Music);` returns the value you've set the device volume to using the hardware buttons. The end result was that sound effects had the device volume multiplied in again making them very quiet in comparison to the music, particularly when the device volume was low.

It's probably a good idea if some other people test this. Perhaps there was some reason the code was there, ie different behaviour in an old API or particular device. Note that change is in an Android only file.
