### PR TITLE
Adds support for XBox 360 wireless controller and fixes input

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.Windows.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows.csproj
@@ -81,7 +81,7 @@
     <DefineConstants>TRACE;WINDOWS;OPENGL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+    <Reference Include="OpenTK, Version=1.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ThirdParty\Libs\OpenTK.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Works on the XBox 360 Wireless Controller with dongle.  Fixes the right stick and right trigger.

Not 100% sure if this works the same way as the wired controller.  I don't have a wired controller to test with so if someone could do that before merging that might be a good idea.

Thanks,
John
