### PR TITLE
Fixed AccessViolationException on Texture.Dispose().

### DIFF
--- a/MonoGame.Framework/Graphics/Texture.cs
+++ b/MonoGame.Framework/Graphics/Texture.cs
@@ -174,7 +174,11 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
 #elif OPENGL
-            GL.DeleteTextures(1, ref glTexture);
+            if (glTexture != -1)
+            {
+                GL.DeleteTextures(1, ref glTexture);
+                glTexture = -1;
+            }
             GraphicsExtensions.CheckGLError();
 #endif
             base.Dispose();


### PR DESCRIPTION
You should be able to call Dispose() multiple times without causing an exception.
