### PR TITLE
Change vertex structs to have StructLayout(LayoutKind.Sequential, Pack=1)

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/VertexColorTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexColorTexture.cs
@@ -2,10 +2,11 @@ using System;
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	//[StructLayout(LayoutKind.Sequential)]
+	[StructLayout(LayoutKind.Sequential, Pack=1)]
 	internal struct VertexColorTexture
 	{
 		public Vector2 Vertex;

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
@@ -2,6 +2,7 @@ using System;
 #if WINRT
 using System.Runtime.Serialization;
 #endif
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -10,6 +11,7 @@ namespace Microsoft.Xna.Framework.Graphics
     #else
     [Serializable]
     #endif
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
 	public struct VertexPositionColor : IVertexType
 	{
 #if WINRT

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
@@ -1,5 +1,8 @@
+using System.Runtime.InteropServices;
+
 namespace Microsoft.Xna.Framework.Graphics
 {
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct VertexPositionColorTexture : IVertexType
     {
         public Vector3 Position;

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct VertexPositionNormalTexture : IVertexType
     {
         public Vector3 Position;

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
     public struct VertexPositionTexture : IVertexType
     {
         public Vector3 Position;


### PR DESCRIPTION
I believe all of the following structs ought to have a StructLayout(LayoutKind.Sequential, Pack=1) attribute added:
- VertexPositionColor
- VertexPositionColorTexture
- VertexPositionNormalTexture
- VertexPositionTexture

(I also added it to VertexColorTexture, although now that I look at the code that type doesn't even seem to be used anywhere...)

Without this attribute these structs could potentially be laid out in memory on some platforms in a way that doesn't match their vertex declarations (e.g. with gaps), which will lead to incorrect rendering.

Specifically, I ran into an issue on 64-bit Linux where the "natural" layout of VertexPositionTexture was not the "packed" layout expressed in the vertex declaration. Adding the StructLayout attribute fixes this problem.
