### PR TITLE
Enable window miniaturizing and zooming (if resizable) on Mac

### DIFF
--- a/MonoGame.Framework/MacOS/GameWindow.cs
+++ b/MonoGame.Framework/MacOS/GameWindow.cs
@@ -383,10 +383,12 @@ namespace Microsoft.Xna.Framework
 			set
             {
                 if (value)
-                    Window.StyleMask |= NSWindowStyle.Resizable;
+					Window.StyleMask |= NSWindowStyle.Resizable;
                 else
                     Window.StyleMask &= ~NSWindowStyle.Resizable;
-            }
+
+				Window.StandardWindowButton(NSWindowButton.ZoomButton).Enabled = value;
+			}
 		}	
 
 		private DisplayOrientation _currentOrientation;

--- a/MonoGame.Framework/MacOS/MacGamePlatform.cs
+++ b/MonoGame.Framework/MacOS/MacGamePlatform.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Xna.Framework
                 GraphicsDeviceManager.DefaultBackBufferHeight);
 
             _mainWindow = new MacGameNSWindow(
-                frame, NSWindowStyle.Titled | NSWindowStyle.Closable,
+				frame, NSWindowStyle.Titled | NSWindowStyle.Closable | NSWindowStyle.Miniaturizable,
                 NSBackingStore.Buffered, true);
 
             _mainWindow.WindowController = new NSWindowController(_mainWindow);
@@ -330,7 +330,7 @@ namespace Microsoft.Xna.Framework
                 string oldTitle = _gameWindow.Title;
 
                 NSMenu.MenuBarVisible = true;
-                _mainWindow.StyleMask = NSWindowStyle.Titled | NSWindowStyle.Closable;
+				_mainWindow.StyleMask = NSWindowStyle.Titled | NSWindowStyle.Closable | NSWindowStyle.Miniaturizable;
                 if (_wasResizeable)
                     _mainWindow.StyleMask |= NSWindowStyle.Resizable;
 
@@ -494,6 +494,11 @@ namespace Microsoft.Xna.Framework
                 NSApplication.SharedApplication.BeginInvokeOnMainThread(() =>
                     _owner.State = MacGamePlatform.RunState.Exited);
             }
+
+			public override bool ShouldZoom (NSWindow window, RectangleF newFrame)
+			{
+				return _owner.AllowUserResizing;
+			}
         }
     }
 }


### PR DESCRIPTION
This pull request enables miniaturizing and zooming (aka. maximizing) MonoGame windows on Mac with the yellow & green buttons located at the top-left of Cocoa windows, which were previously always disabled.

The zooming button is properly disabled when the window isn't set to be resizable.
