### PR TITLE
Added mouse wheel turns to == operator overload

### DIFF
--- a/MonoGame.Framework/Input/MouseState.cs
+++ b/MonoGame.Framework/Input/MouseState.cs
@@ -73,7 +73,8 @@ namespace Microsoft.Xna.Framework.Input
 				   left._y == right._y &&
 				   left._leftButton == right._leftButton &&
 				   left._middleButton == right._middleButton &&
-				   left._rightButton == right._rightButton;
+				   left._rightButton == right._rightButton &&
+                   left._scrollWheelValue == right._scrollWheelValue;
 		}
 		
 		public static bool operator !=(MouseState left, MouseState right)


### PR DESCRIPTION
I had a bug where the mouse state was seen as identical if you scrolled the mousewheel but did not move the cursor. This fixes that.
