### PR TITLE
Fix for Issue #917

### DIFF
--- a/MonoGame.Framework/DrawableGameComponent.cs
+++ b/MonoGame.Framework/DrawableGameComponent.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Xna.Framework
     {
         private bool _initialized;
         private int _drawOrder;
-        private bool _visible;
+        private bool _visible = true;
 
         public int DrawOrder
         {
@@ -84,7 +84,6 @@ namespace Microsoft.Xna.Framework
         public DrawableGameComponent(Game game)
             : base(game)
         {
-            this._visible = true;
         }
 
         public override void Initialize()

--- a/MonoGame.Framework/GameComponent.cs
+++ b/MonoGame.Framework/GameComponent.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Xna.Framework
 {   
     public class GameComponent : IGameComponent, IUpdateable, IComparable<GameComponent>, IDisposable
     {
-        bool _enabled;
+        bool _enabled = true;
         int _updateOrder;
 
         public Game Game { get; private set; }
@@ -90,7 +90,6 @@ namespace Microsoft.Xna.Framework
         public GameComponent(Game game)
         {
             this.Game = game;
-            this._enabled = true;
         }
 
         ~GameComponent()


### PR DESCRIPTION
Fix for https://github.com/mono/MonoGame/issues/917

Prevents the OnVisible and OnEnable changed constructors from firing during construction of GameComponents and Drawable game components.

This lines up to the behavior I have observed from other XNA implementations.
