### PR TITLE
Android - fixed memory usage in Texture2D

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -633,48 +633,52 @@ namespace Microsoft.Xna.Framework.Graphics
 				return texture;
 			}
 #elif ANDROID
-            // Work-around for "The program 'Mono' has exited with code 255 (0xff)."
-			// Based on http://stackoverflow.com/questions/7535503/mono-for-android-exit-code-255-on-bitmapfactory-decodestream
-            //Bitmap image = BitmapFactory.DecodeStream(stream);
-			Bitmap image = null;
-			using (MemoryStream memStream = new MemoryStream())
-			{
-				stream.CopyTo(memStream);
-				image = BitmapFactory.DecodeByteArray(memStream.GetBuffer(), 0, (int)memStream.Length);
-			}
-            var width = image.Width;
-            var height = image.Height;
-
-            int[] pixels = new int[width * height];
-            if ((width != image.Width) || (height != image.Height))
+            using (Bitmap image = BitmapFactory.DecodeStream(stream, null, new BitmapFactory.Options
             {
-                Bitmap imagePadded = Bitmap.CreateBitmap(width, height, Bitmap.Config.Argb8888);
-                Canvas canvas = new Canvas(imagePadded);
-                canvas.DrawARGB(0, 0, 0, 0);
-                canvas.DrawBitmap(image, 0, 0, null);
-                imagePadded.GetPixels(pixels, 0, width, 0, 0, width, height);
+                InScaled = false,
+                InDither = false,
+                InJustDecodeBounds = false,
+                InPurgeable = true,
+                InInputShareable = true,
+            }))
+            {
+                var width = image.Width;
+                var height = image.Height;
+
+                int[] pixels = new int[width * height];
+                if ((width != image.Width) || (height != image.Height))
+                {
+                    using (Bitmap imagePadded = Bitmap.CreateBitmap(width, height, Bitmap.Config.Argb8888))
+                    {
+                        Canvas canvas = new Canvas(imagePadded);
+                        canvas.DrawARGB(0, 0, 0, 0);
+                        canvas.DrawBitmap(image, 0, 0, null);
+                        imagePadded.GetPixels(pixels, 0, width, 0, 0, width, height);
+                        imagePadded.Recycle();
+                    }
+                }
+                else
+                {
+                    image.GetPixels(pixels, 0, width, 0, 0, width, height);
+                }
+                image.Recycle();
+
+                // Convert from ARGB to ABGR
+                for (int i = 0; i < width * height; ++i)
+                {
+                    uint pixel = (uint)pixels[i];
+                    pixels[i] = (int)((pixel & 0xFF00FF00) | ((pixel & 0x00FF0000) >> 16) | ((pixel & 0x000000FF) << 16));
+                }
+
+                Texture2D texture = null;
+                Threading.BlockOnUIThread(() =>
+                {
+                    texture = new Texture2D(graphicsDevice, width, height, false, SurfaceFormat.Color);
+                    texture.SetData<int>(pixels);
+                });
+
+                return texture;
             }
-            else
-            {
-                image.GetPixels(pixels, 0, width, 0, 0, width, height);
-            }
-
-			// Convert from ARGB to ABGR
-			for (int i = 0; i < width * height; ++i)
-			{
-				uint pixel = (uint)pixels[i];
-				pixels[i] = (int)((pixel & 0xFF00FF00) | ((pixel & 0x00FF0000) >> 16) | ((pixel & 0x000000FF) << 16));
-			}
-
-            Texture2D texture = null;
-            Threading.BlockOnUIThread(() =>
-            {
-                texture = new Texture2D(graphicsDevice, width, height, false, SurfaceFormat.Color);
-                texture.SetData<int>(pixels);
-            });
-
-            return texture;
- 
 #elif WINRT
             // For reference this implementation was ultimately found through this post:
             // http://stackoverflow.com/questions/9602102/loading-textures-with-sharpdx-in-metro 
@@ -721,29 +725,31 @@ namespace Microsoft.Xna.Framework.Graphics
         private void FillTextureFromStream(Stream stream)
         {
 #if ANDROID
-            // Work-around for "The program 'Mono' has exited with code 255 (0xff)."
-            // Based on http://stackoverflow.com/questions/7535503/mono-for-android-exit-code-255-on-bitmapfactory-decodestream
-            //Bitmap image = BitmapFactory.DecodeStream(stream);
-            Bitmap image = null;
-            using (MemoryStream memStream = new MemoryStream())
+            using (Bitmap image = BitmapFactory.DecodeStream(stream, null, new BitmapFactory.Options
             {
-                stream.CopyTo(memStream);
-                image = BitmapFactory.DecodeByteArray(memStream.GetBuffer(), 0, (int)memStream.Length);
-            }
-            var width = image.Width;
-            var height = image.Height;
-
-            int[] pixels = new int[width * height];
-            image.GetPixels(pixels, 0, width, 0, 0, width, height);
-
-            // Convert from ARGB to ABGR
-            for (int i = 0; i < width * height; ++i)
+                InScaled = false,
+                InDither = false,
+                InJustDecodeBounds = false,
+                InPurgeable = true,
+                InInputShareable = true,
+            }))
             {
-                uint pixel = (uint)pixels[i];
-                pixels[i] = (int)((pixel & 0xFF00FF00) | ((pixel & 0x00FF0000) >> 16) | ((pixel & 0x000000FF) << 16));
+                var width = image.Width;
+                var height = image.Height;
+
+                int[] pixels = new int[width * height];
+                image.GetPixels(pixels, 0, width, 0, 0, width, height);
+
+                // Convert from ARGB to ABGR
+                for (int i = 0; i < width * height; ++i)
+                {
+                    uint pixel = (uint)pixels[i];
+                    pixels[i] = (int)((pixel & 0xFF00FF00) | ((pixel & 0x00FF0000) >> 16) | ((pixel & 0x000000FF) << 16));
+                }
+
+                this.SetData<int>(pixels);
+                image.Recycle();
             }
-            
-            this.SetData<int>(pixels);
 #endif
         }
 


### PR DESCRIPTION
We were having lots of memory issues with our Android port, our game would get an OutOfMemoryException when loading textures.  It would happen on certain devices, and could sometimes get alleviated by calling GC.Collect() (which I didn't like).  It would always happen when trying to load my first 2048x2048 sprite sheet.

So to fix it, I added using statements and a call to Recycle() on any Bitmap object in Texture2D.  I removed the use of MemoryStream and read from the original Stream directly.  I also used the appropriate BitmapOptions we are using in other apps for better memory performance.

These changes are now working in our game (Draw a Stickman: EPIC http://epic.drawastickman.com), and I want to contribute back. 

Let's just make sure I didn't break something for someone else.

MonoGame is great, keep up the good work.
