### PR TITLE
Removed unnecessary update of previous location to fix issue #927

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchLocation.cs
+++ b/MonoGame.Framework/Input/Touch/TouchLocation.cs
@@ -174,11 +174,6 @@ namespace Microsoft.Xna.Framework.Input.Touch
         {
             var touch = this;
 
-            // Store the current state as the previous.
-            touch._previousState = touch._state;
-            touch._previousPosition = touch._position;
-            touch._previousPressure = touch._pressure;
-
             // Set the new state.
             touch._state = TouchLocationState.Moved;
             


### PR DESCRIPTION
Fix for issue https://github.com/mono/MonoGame/issues/927

Updating the touch's previous location within TouchLocation.AsMovedState results in doubly updating the previous location in each update loop, which means the previous location is always the same as the current one. 

To fix this, we removed the update within TouchLocation.AsMovedState. I have tested this on the Surface and it has fixed our issue. Also ran the TouchInput Sample (the one with the cat sprites) and it functions correctly after this change.
