### PR TITLE
Initial cut of a F# based project template for MonoGame on the Mac

### DIFF
--- a/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/MonoDevelop.MonoGame.Linux.csproj
+++ b/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/MonoDevelop.MonoGame.Linux.csproj
@@ -82,6 +82,9 @@
     <Content Include="templates\MonoGameApplication\Resource.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="templates\MonoGameMacFsharpProject.xpt.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -164,5 +167,9 @@
     <Content Include="templates\MonoGameApplication\Styles.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="templates\MonoGameApplication\MacGame.fs" />
+    <None Include="templates\MonoGameApplication\MacMain.fs" />
   </ItemGroup>
 </Project>

--- a/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/MonoDevelop.MonoGame.MacOS.csproj
+++ b/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/MonoDevelop.MonoGame.MacOS.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="MonoDevelop.Core">
-      <HintPath>..\..\..\..\..\..\..\..\..\Applications\MonoDevelop.app\Contents\MacOS\lib\monodevelop\bin\MonoDevelop.Core.dll</HintPath>
+      <HintPath>References\MonoDevelop.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
+++ b/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
@@ -10,6 +10,7 @@
 		<Import file="templates/MonoGameWindowsProject.xpt.xml" />
 		<Import file="templates/MonoGameLinuxProject.xpt.xml" />
 		<Import file="templates/MonoGameMacProject.xpt.xml" />
+        <Import file="templates/MonoGameMacFsharpProject.xpt.xml" />
 		<Import file="templates/MonoGameAndroidClass.xft.xml" />
 		<Import file="templates/MonoGameiOSClass.xft.xml" />
 		<Import file="templates/MonoGameMacClass.xft.xml" />
@@ -31,8 +32,10 @@
 		<Import file="templates/MonoGameApplication/iOSInfo.plist" />
 		<Import file="templates/MonoGameApplication/iOSMain.cs" />
 		<Import file="templates/MonoGameApplication/MacGame.cs" />
+        <Import file="templates/MonoGameApplication/MacGame.fs" />
 		<Import file="templates/MonoGameApplication/MacInfo.plist" />
 		<Import file="templates/MonoGameApplication/MacMain.cs" />
+        <Import file="templates/MonoGameApplication/MacMain.fs" />
 		<Import file="templates/MonoGameApplication/Program.cs" />
 		<Import file="templates/MonoGameApplication/Resource.cs" />
 		<Import file="templates/MonoGameApplication/Splash.png" />
@@ -63,6 +66,7 @@
 		<ProjectTemplate id="MonoGameForWindowsProject" file="templates/MonoGameWindowsProject.xpt.xml" />
 		<ProjectTemplate id="MonoGameForLinuxProject" file="templates/MonoGameLinuxProject.xpt.xml" />
 		<ProjectTemplate id="MonoGameForMacProject" file="templates/MonoGameMacProject.xpt.xml" />
+        <ProjectTemplate id="MonoGameForMacFSharpProject" file="templates/MonoGameMacFsharpProject.xpt.xml" />
 	</Extension>
 	<Extension path="/MonoDevelop/Ide/FileTemplates">
 		<FileTemplate id="MonoGameAndroidClass" resource="MonoGameAndroidClass.xft.xml" />

--- a/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/templates/MonoGameApplication/MacGame.fs
+++ b/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/templates/MonoGameApplication/MacGame.fs
@@ -1,0 +1,51 @@
+namespace ${Namespace}
+open System
+open Microsoft.Xna.Framework
+open Microsoft.Xna.Framework.Audio
+open Microsoft.Xna.Framework.Graphics
+open Microsoft.Xna.Framework.Input
+open Microsoft.Xna.Framework.Input.Touch
+open Microsoft.Xna.Framework.Storage
+open Microsoft.Xna.Framework.Content
+open Microsoft.Xna.Framework.Media
+
+    /// Default Project Template
+    type ${Namespace}Game() as x =
+        inherit Game()
+        let graphics = new GraphicsDeviceManager(x)
+        let mutable spriteBatch = Unchecked.defaultof<_>
+        let mutable logoTexture = Unchecked.defaultof<_>
+        do x.Content.RootDirectory <- "Content"
+           graphics.IsFullScreen <- false
+     
+        /// Overridden from the base Game.Initialize. Once the GraphicsDevice is setup,
+        /// we'll use the viewport to initialize some values.
+        override x.Initialize() = base.Initialize()
+
+        /// Load your graphics content.
+        override x.LoadContent() =
+            // Create a new SpriteBatch, which can be use to draw textures.
+            spriteBatch <- new SpriteBatch (graphics.GraphicsDevice)
+            
+            // TODO: use this.Content to load your game content here eg.
+            logoTexture <- x.Content.Load<_>("logo")
+
+        /// Allows the game to run logic such as updating the world,
+        /// checking for collisions, gathering input, and playing audio.
+        override x.Update ( gameTime:GameTime) =
+            // TODO: Add your update logic here                 
+            base.Update (gameTime)
+
+        /// This is called when the game should draw itself. 
+        override x.Draw (gameTime:GameTime) =
+            // Clear the backbuffer
+            graphics.GraphicsDevice.Clear (Color.CornflowerBlue)
+
+            spriteBatch.Begin()
+
+            // draw the logo
+            spriteBatch.Draw (logoTexture, new Vector2 (130.f, 200.f), Color.White);
+            spriteBatch.End()
+
+            //TODO: Add your drawing code here
+            base.Draw (gameTime)

--- a/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/templates/MonoGameApplication/MacMain.fs
+++ b/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/templates/MonoGameApplication/MacMain.fs
@@ -1,0 +1,22 @@
+namespace ${Namespace}
+open MonoMac.AppKit
+open MonoMac.Foundation
+
+type AppDelegate() = 
+    inherit NSApplicationDelegate()
+    
+    override x.FinishedLaunching(notification) =
+        let game = new ${ProjectName}Game()
+        game.Run()
+    
+    override x.ApplicationShouldTerminateAfterLastWindowClosed(sender) =
+        true
+ 
+module main =         
+    [<EntryPoint>]
+    let main args =
+        NSApplication.Init ()
+        using (new NSAutoreleasePool()) (fun n -> 
+            NSApplication.SharedApplication.Delegate <- new AppDelegate()
+            NSApplication.Main(args) )
+        0

--- a/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/templates/MonoGameMacFsharpProject.xpt.xml
+++ b/ProjectTemplates/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame/templates/MonoGameMacFsharpProject.xpt.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<Template>
+	<TemplateConfiguration>
+		<_Name>MonoGame Mac Application</_Name>
+		<_Category>F#/MonoGame</_Category>
+		<Icon>monogame-project</Icon>
+		<LanguageName>F#</LanguageName>
+		<_Description>Creates a MonoGame Application for Mac</_Description>
+	</TemplateConfiguration>
+	
+	<Actions>
+		<Open filename = "Game1.fs"/>
+	</Actions>
+	
+	<Combine name = "${ProjectName}" directory = ".">
+		<Options>
+			<StartupProject>${ProjectName}</StartupProject>
+		</Options>
+		
+		<Project name = "${ProjectName}" directory = "." type = "MonoMac">
+			<Options />
+			<References>
+				<Reference type="Gac" refto="System" />
+				<Reference type="Gac" refto="System.Xml" />
+				<Reference type="Gac" refto="System.Core" />
+				<Reference type="Gac" refto="System.Xml.Linq" />
+				<Reference type="Gac" refto="System.Drawing" />
+				<Reference type="Gac" refto="MonoMac" SpecificVersion="false" />
+
+				<Reference type="Gac" refto="MonoGame.Framework.MacOS" />
+				<Reference type="Gac" refto="Lidgren.Network.MacOS" />
+                
+			</References>
+			<Files>
+				<File name="Game1.fs" AddStandardHeader="True" src="MonoGameApplication/MacGame.fs" />
+				<File name="Main.fs" AddStandardHeader="True" src="MonoGameApplication/MacMain.fs" />
+				<File name="Info.plist" AddStandardHeader="False" src="MonoGameApplication/MacInfo.plist" />
+				<Directory name="Content">
+					<RawFile name="logo.png" src="MonoGameApplication/Icon-hd.png" />
+				</Directory>
+<!--		    <Directory name="Properties">
+					<File name="AssemblyInfo.cs" AddStandardHeader="True" src="MonoGameApplication/AssemblyInfo.cs" />
+				</Directory>-->
+			</Files>
+		</Project>
+	</Combine>
+</Template>


### PR DESCRIPTION
There is currently two caveats:
1) When a new project is created the logo.png file under the Content directory has no build action.  The build action for this file needs to be changed to copy to output
2) The References Lidgren.Network.dll and MonoGame.FrameWork.MacOS.dll are not referenced correctly, I think this is a issue because I have not installed MonoGame as a package.
