### PR TITLE
Fix reloading of graphics resources when device is resetting - Android

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/Effect.cs
+++ b/MonoGame.Framework/Graphics/Effect/Effect.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Xna.Framework.Graphics
             base.Dispose(disposing);
         }
 
-        internal protected virtual void GraphicsDeviceResetting()
+        internal protected override void GraphicsDeviceResetting()
         {
             for (var i = 0; i < ConstantBuffers.Length; i++)
                 ConstantBuffers[i].Clear();

--- a/MonoGame.Framework/Graphics/Shader/Shader.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #endif // OPENGL
 
-        internal protected virtual void GraphicsDeviceResetting()
+        internal protected override void GraphicsDeviceResetting()
         {
 #if OPENGL
             if (_shaderHandle != -1)

--- a/MonoGame.Framework/Graphics/Texture.cs
+++ b/MonoGame.Framework/Graphics/Texture.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #endif
 
-        internal protected virtual void GraphicsDeviceResetting()
+        internal protected override void GraphicsDeviceResetting()
         {
 #if OPENGL
             this.glTexture = -1;
@@ -191,6 +191,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         {
                             GL.DeleteTextures(1, ref glTexture);
                             GraphicsExtensions.CheckGLError();
+                            glTexture = -1;
                         });
                 }
 


### PR DESCRIPTION
This problem originated with https://github.com/mono/MonoGame/pull/905

The new approach with the GraphicsResource.GraphicsDeviceResetting() methods was good, except that the methods were never called due to not being overrides.

Also, it is necessary for this to be called in OnDeviceResetting, not OnDeviceReset.
