### PR TITLE
csproj had not been updated to reference GamePage*, instead of MainPage*

### DIFF
--- a/projecttemplates/VisualStudio2012/WindowsPhone/Application.csproj
+++ b/projecttemplates/VisualStudio2012/WindowsPhone/Application.csproj
@@ -94,8 +94,8 @@
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
     <Compile Include="LocalizedStrings.cs" />
-    <Compile Include="MainPage.xaml.cs">
-      <DependentUpon>MainPage.xaml</DependentUpon>
+    <Compile Include="GamePage.xaml.cs">
+      <DependentUpon>GamePage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\AppResources.Designer.cs">
@@ -109,7 +109,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </ApplicationDefinition>
-    <Page Include="MainPage.xaml">
+    <Page Include="GamePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
Basically the csproj was still referring to MainPage, when it should be referring to GamePage, as per a recent change. This PR fixes that, so that the template works correctly.
Just need the WindowsPhone8 assembly for it to work.
