### PR TITLE
Allow non-WINRT platforms to compile after changes in SoundEffect.cs

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -312,7 +312,8 @@ namespace Microsoft.Xna.Framework.Audio
                 voice = new SourceVoice(Device, _format, VoiceFlags.None, XAudio2.MaximumFrequencyRatio);
 
             var instance = new SoundEffectInstance(this, voice);
-#else			
+#else
+            var instance = new SoundEffectInstance();	
 			instance.Sound = _sound;			
 #endif
             return instance;


### PR DESCRIPTION
As the description states.

Note to self: In fixing this I noticed that `SoundEffect.CreateInstance()` is calling `new SoundEffectInstance()` every time. This should really be taken from a pool of SoundEffectInstance as it's going to be a significant source of garbage. That will be a change for another day.
