### PR TITLE
Fix GL related exception on Android after multiple resumes (988)

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsResource.cs
+++ b/MonoGame.Framework/Graphics/GraphicsResource.cs
@@ -74,6 +74,12 @@ namespace Microsoft.Xna.Framework.Graphics
             Dispose(false);
         }
 
+        /// <summary>
+        /// Called before the device is reset. Allows graphics resources to 
+        /// invalidate their state so they can be recreated after the device reset.
+        /// Warning: This may be called after a call to Dispose() up until
+        /// the resource is garbage collected.
+        /// </summary>
         internal protected virtual void GraphicsDeviceResetting()
         {
 
@@ -89,7 +95,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     if (target != null)
                         (target as GraphicsResource).GraphicsDeviceResetting();
                 }
-                resources.Clear();
+
+                // Remove references to resources that have been garbage collected.
+                resources.RemoveAll(wr => !wr.IsAlive);
             }
         }
 

--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -91,18 +91,18 @@ namespace Microsoft.Xna.Framework.Graphics
             GraphicsExtensions.CheckGLError();
 
             GL.AttachShader(program, vertexShader.GetShaderHandle());
-            GraphicsExtensions.LogGLError("VertexShaderCache.Link(), GL.AttachShader");
+            GraphicsExtensions.CheckGLError();
 
             GL.AttachShader(program, pixelShader.GetShaderHandle());
-            GraphicsExtensions.LogGLError("VertexShaderCache.Link(), GL.AttachShader");
+            GraphicsExtensions.CheckGLError();
 
             //vertexShader.BindVertexAttributes(program);
 
             GL.LinkProgram(program);
-            GraphicsExtensions.LogGLError("VertexShaderCache.Link(), GL.LinkProgram");
+            GraphicsExtensions.CheckGLError();
 
             GL.UseProgram(program);
-            GraphicsExtensions.LogGLError("VertexShaderCache.Link(), GL.UseProgram");
+            GraphicsExtensions.CheckGLError();
 
             vertexShader.GetVertexAttributeLocations(program);
 


### PR DESCRIPTION
This should resolve https://github.com/mono/MonoGame/issues/988

The issue arose from the static list `GraphicsResource.resources` being cleared when the devices was reset. During the second reset, the shader resources weren't in the list so they couldn't be invalidated. Since most of these resources would survive the reset, they shouldn't be cleared. Instead the list is pruned of expired (ie garbage collected) weak references.

Also improved a comment and tightened the GL error checking from logging to exceptions in ShaderProgramCache. It seems that if ever these errors were logged, the program could not recover and it would fail a subsequent error check anyway.
