### PR TITLE
Android: Fix black screen when turning screen on just after an auto screen off

### DIFF
--- a/MonoGame.Framework/Android/ScreenReciever.cs
+++ b/MonoGame.Framework/Android/ScreenReciever.cs
@@ -1,6 +1,7 @@
 using System;
 using Android.Content;
 using Microsoft.Xna.Framework.Media;
+using Android.App;
 
 namespace Microsoft.Xna.Framework
 {
@@ -10,21 +11,30 @@ namespace Microsoft.Xna.Framework
 		
 		public override void OnReceive(Context context, Intent intent)
 		{
-			Android.Util.Log.Info("MonoGameInfo", intent.Action.ToString());
+			Android.Util.Log.Info("MonoGame", intent.Action.ToString());
 			if(intent.Action == Intent.ActionScreenOff)
 			{
-				ScreenReceiver.ScreenLocked = true;     
-				
+				ScreenReceiver.ScreenLocked = true;
 				MediaPlayer.IsMuted = true;
 			}
 			else if(intent.Action == Intent.ActionScreenOn)
 			{
-				MediaPlayer.IsMuted = true;
+                // If the user turns the screen on just after it has automatically turned off, 
+                // the keyguard will not have had time to activate and the ActionUserPreset intent
+                // will not be broadcast. We need to check if the lock is currently active
+                // and if not re-enable the game related functions.
+                // http://stackoverflow.com/questions/4260794/how-to-tell-if-device-is-sleeping
+                KeyguardManager keyguard = (KeyguardManager)context.GetSystemService(Context.KeyguardService);
+                if (!keyguard.InKeyguardRestrictedInputMode())
+                {
+                    ScreenReceiver.ScreenLocked = false;
+                    MediaPlayer.IsMuted = false;
+                }
 			}
 			else if(intent.Action == Intent.ActionUserPresent)
 			{
+                // This intent is broadcast when the user unlocks the phone
 				ScreenReceiver.ScreenLocked = false;
-				
 				MediaPlayer.IsMuted = false;
 			}
 		}


### PR DESCRIPTION
If the user turns the screen on just after it has automatically turned off, the keyguard will not have had time to activate and the ActionUserPreset intent will not be broadcast. To fix the issue, I added a check for whether the lock is currently active when the screen is turned on and if not re-enable the game related functions.

There was some discussion about this issue here: https://github.com/mono/MonoGame/issues/792. I think this is the last of the Android lock / resume issues (for now!).

Reference: http://stackoverflow.com/questions/4260794/how-to-tell-if-device-is-sleeping
