### PR TITLE
Fixed stylus crash on Samsung Galaxy Note 2

### DIFF
--- a/MonoGame.Framework/Android/Input/Keyboard.cs
+++ b/MonoGame.Framework/Android/Input/Keyboard.cs
@@ -54,14 +54,22 @@ namespace Microsoft.Xna.Framework.Input
 
         public static void KeyDown(Keycode keyCode)
         {
-            Keys key = KeyMap[keyCode];
-            if (!keys.Contains(key)) keys.Add(key);            
+            Keys key;
+            if (KeyMap.TryGetValue(keyCode, out key))
+            {
+                if (!keys.Contains(key))
+                    keys.Add(key);
+            }
         }
 
         public static void KeyUp(Keycode keyCode)
         {
-            Keys key = KeyMap[keyCode];
-            if (keys.Contains(key)) keys.Remove(key);            
+            Keys key;
+            if (KeyMap.TryGetValue(keyCode, out key))
+            {
+                if (keys.Contains(key))
+                    keys.Remove(key);
+            }
         }
 
         private static IDictionary<Keycode, Keys> LoadKeyMap()


### PR DESCRIPTION
We were getting a lot of reviews on Draw a Stickman: EPIC where people were saying they couldn't use the S-Pen on a Samsung Galaxy Note.

So we went and borrowed a Note 1 off someone--everything worked fine.  So we finally had to go track down the brand new Galaxy Note II.

After plugging it in and debugging while using the stylus, it was a dictionary key exception in Keyboard.cs.  Pretty crazy Samsung, let's use keyboard events for the stylus!

Anyway this should fix crashes with extraneous KeyCode's on Android in general.
