### PR TITLE
Fix loading of compressed Xnb files in Android

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -459,7 +459,8 @@ namespace Microsoft.Xna.Framework.Content
                 memStream.Seek(0, SeekOrigin.Begin);
                 stream.Dispose();
                 stream = memStream;
-                pos = -14;
+                // Position is at the start of the MemoryStream as Stream.CopyTo copies from current position
+                pos = 0;
 #endif
 
                 while (pos - startPos < compressedSize)


### PR DESCRIPTION
Seems this was broken due to an incorrect starting position offset being applied. This caused an out of bounds access in the buffer during decompression.

This fixes https://github.com/mono/MonoGame/issues/640
