### PR TITLE
Set pixel unpacking alignment in Texture2D.SetData

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -538,6 +538,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     return 4;
                 case SurfaceFormat.Dxt3:
                     return 4;
+                case SurfaceFormat.Bgr565:
+                    return 2;
                 case SurfaceFormat.Bgra4444:
                     return 2;
                 case SurfaceFormat.Bgra5551:

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -347,6 +347,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
                 else
                 {
+                    // Set pixel alignment to match texel size in bytes
+                    GL.PixelStore(All.UnpackAlignment, GraphicsExtensions.Size(this.Format));
                     if (rect.HasValue)
                     {
                         GL.TexSubImage2D(TextureTarget.Texture2D, level,
@@ -365,7 +367,8 @@ namespace Microsoft.Xna.Framework.Graphics
                                   w, h, 0, glFormat, glType, dataPtr);
                         GraphicsExtensions.CheckGLError();
                     }
-
+                    // Return to default pixel alignment
+                    GL.PixelStore(All.UnpackAlignment, 4);
                 }
 
 #if !ANDROID


### PR DESCRIPTION
Fix attempt for issue #1028.
Set pixel unpacking alignment in Texture2D.SetData for uncompressed surface formats.  Should fix skewed textures when using 16-bit surface formats and an odd texture width.
Also added a missing SurfaceFormat.Bgr565 in GraphicsExtensions.Size().
