### PR TITLE
Corrected GL.PixelStore calls

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -72,7 +72,9 @@ using TextureParameterName = OpenTK.Graphics.ES20.All;
 using TextureMinFilter = OpenTK.Graphics.ES20.All;
 using PixelInternalFormat = OpenTK.Graphics.ES20.All;
 using PixelType = OpenTK.Graphics.ES20.All;
+using PixelStoreParameter = OpenTK.Graphics.ES20.All;
 using ErrorCode = OpenTK.Graphics.ES20.All;
+
 #endif
 
 using Microsoft.Xna.Framework.Content;
@@ -349,7 +351,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 {
                     // Set pixel alignment to match texel size in bytes
                     GL.PixelStore(PixelStoreParameter.UnpackAlignment, GraphicsExtensions.Size(this.Format));
-                    //GL.PixelStore(All.UnpackAlignment, GraphicsExtensions.Size(this.Format));
                     if (rect.HasValue)
                     {
                         GL.TexSubImage2D(TextureTarget.Texture2D, level,
@@ -370,7 +371,6 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
                     // Return to default pixel alignment
                     GL.PixelStore(PixelStoreParameter.UnpackAlignment, 4);
-                    //GL.PixelStore(All.UnpackAlignment, 4);
                 }
 
 #if !ANDROID


### PR DESCRIPTION
GL.PixelStore() calls in latest module used incorrect parameter types (All.UnpackAlignment instead of PixelStoreParameter.UnpackAlignment, for example), preventing the class library from compiling for Win7.
