### PR TITLE
Fixed thread deadlock on Windows 8

### DIFF
--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.cs
@@ -89,7 +89,8 @@ namespace Microsoft.Xna.Framework.Graphics
             desc.Usage = SharpDX.Direct3D11.ResourceUsage.Default;
             desc.BindFlags = SharpDX.Direct3D11.BindFlags.ConstantBuffer;
             desc.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.None;
-            _cbuffer = new SharpDX.Direct3D11.Buffer(GraphicsDevice._d3dDevice, desc);
+            lock (GraphicsDevice._d3dContext)
+                _cbuffer = new SharpDX.Direct3D11.Buffer(GraphicsDevice._d3dDevice, desc);
 
 #elif OPENGL 
 


### PR DESCRIPTION
when creating an Effect on a background thread. The deadlock happened between _swapChain.Present() and new Buffer().  Adding the lock(_d3dContext) around buffer creation solved it.
