### PR TITLE
Add missing ctor to DynamicIndexBuffer

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/DynamicIndexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/DynamicIndexBuffer.cs
@@ -51,10 +51,15 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public bool IsContentLost { get { return false; } }
 		
-		public DynamicIndexBuffer(GraphicsDevice graphicsDevice, IndexElementSize indexElementSize, int indexCount, BufferUsage bufferUsage) :
-			base(graphicsDevice, indexElementSize, indexCount, bufferUsage, true)
+		public DynamicIndexBuffer(GraphicsDevice graphicsDevice, IndexElementSize indexElementSize, int indexCount, BufferUsage usage) :
+			base(graphicsDevice, indexElementSize, indexCount, usage, true)
 		{
 		}
+
+   		public DynamicIndexBuffer(GraphicsDevice graphicsDevice, Type indexType, int indexCount, BufferUsage usage) :
+            base(graphicsDevice, indexType, indexCount, usage, true)
+        {
+        }
 
         public void SetData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, SetDataOptions options) where T : struct
         {

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.cs
@@ -37,16 +37,21 @@ namespace Microsoft.Xna.Framework.Graphics
         public int IndexCount { get; private set; }
         public IndexElementSize IndexElementSize { get; private set; }
 
-		protected IndexBuffer(GraphicsDevice graphicsDevice, IndexElementSize indexElementSize, int indexCount, BufferUsage bufferUsage, bool dynamic)
+   		protected IndexBuffer(GraphicsDevice graphicsDevice, Type indexType, int indexCount, BufferUsage usage, bool dynamic)
+            : this(graphicsDevice, SizeForType(graphicsDevice, indexType), indexCount, usage, dynamic)
+        {
+        }
+
+		protected IndexBuffer(GraphicsDevice graphicsDevice, IndexElementSize indexElementSize, int indexCount, BufferUsage usage, bool dynamic)
         {
 			if (graphicsDevice == null)
             {
-                throw new ArgumentNullException("Graphics Device Cannot Be Null");
+                throw new ArgumentNullException("GraphicsDevice is null");
             }
 			this.GraphicsDevice = graphicsDevice;
 			this.IndexElementSize = indexElementSize;	
             this.IndexCount = indexCount;
-            this.BufferUsage = bufferUsage;
+            this.BufferUsage = usage;
 			
 			var sizeInBytes = indexCount * (this.IndexElementSize == IndexElementSize.SixteenBits ? 2 : 4);
 
@@ -89,11 +94,29 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		public IndexBuffer(GraphicsDevice graphicsDevice, Type indexType, int indexCount, BufferUsage usage) :
-			this(graphicsDevice,
-			     (indexType == typeof(short) || indexType == typeof(ushort)) ? IndexElementSize.SixteenBits : IndexElementSize.ThirtyTwoBits,
-			     indexCount, usage)
+			this(graphicsDevice, SizeForType(graphicsDevice, indexType), indexCount, usage, false)
 		{
 		}
+
+        /// <summary>
+        /// Gets the relevant IndexElementSize enum value for the given type.
+        /// </summary>
+        /// <param name="type">The type to use for the index buffer</param>
+        /// <returns>The IndexElementSize enum value that matches the type</returns>
+        static IndexElementSize SizeForType(GraphicsDevice graphicsDevice, Type type)
+        {
+            switch (Marshal.SizeOf(type))
+            {
+                case 2:
+                    return IndexElementSize.SixteenBits;
+                case 4:
+                    if (graphicsDevice.GraphicsProfile == GraphicsProfile.Reach)
+                        throw new NotSupportedException("The profile does not support an elementSize of IndexElementSize.ThirtyTwoBits; use IndexElementSize.SixteenBits or a type that has a size of two bytes.");
+                    return IndexElementSize.ThirtyTwoBits;
+                default:
+                    throw new ArgumentOutOfRangeException("Index buffers can only be created for types that are sixteen or thirty two bits in length");
+            }
+        }
 
         /// <summary>
         /// The GraphicsDevice is resetting, so GPU resources must be recreated.


### PR DESCRIPTION
Add documented exceptions to IndexBuffer ctor.
Add support method to ensure 16 or 32 bit types are used.
