### PR TITLE
Fix minimizing Windows version

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -169,6 +169,7 @@ namespace Microsoft.Xna.Framework
             var winRect = new Rectangle(0, 0, winWidth, winHeight);
             
             // If window size is zero, leave bounds unchanged
+            // OpenTK appears to set the window client size to 1x1 when minimizing
             if (winWidth <= 1 || winHeight <= 1)
                 return;
 


### PR DESCRIPTION
To address issue #1056
The window state would be changed back to normal when the window was minimized due to the code in UpdateWindowState being run when it shouldn't have. OnResize was being called with a window client size of 1x1 when minimizing the window.  The fix is to early out if the new client size is 1x1 to prevent changing the back buffer to the new client size and incorrectly causing UpdateWindowState to bring the window back.
