### PR TITLE
Windows 8 Storage fixes

### DIFF
--- a/MonoGame.Framework/Storage/StorageContainer.cs
+++ b/MonoGame.Framework/Storage/StorageContainer.cs
@@ -129,9 +129,13 @@ namespace Microsoft.Xna.Framework.Storage
 			_playerIndex = playerIndex;
 			
 			// From the examples the root is based on MyDocuments folder
+#if WINDOWS_STOREAPP
+            var saved = "";
+#else
 			var root = StorageDevice.StorageRoot;
 			var saved = Path.Combine(root,"SavedGames");
-			_storagePath = Path.Combine(saved,name);
+#endif
+            _storagePath = Path.Combine(saved, name);
 			
 			var playerSave = string.Empty;
 			if (playerIndex.HasValue) {
@@ -144,7 +148,8 @@ namespace Microsoft.Xna.Framework.Storage
             // Create the "device" if need be
 #if WINDOWS_STOREAPP
             var folder = ApplicationData.Current.LocalFolder;
-            folder.CreateFolderAsync(_storagePath, CreationCollisionOption.OpenIfExists).GetResults();
+            var task = folder.CreateFolderAsync(_storagePath, CreationCollisionOption.OpenIfExists);
+            task.AsTask().Wait();
 #else
 			if (!Directory.Exists(_storagePath))
 				Directory.CreateDirectory(_storagePath);			
@@ -196,7 +201,8 @@ namespace Microsoft.Xna.Framework.Storage
             // Now let's try to create it
 #if WINDOWS_STOREAPP
             var folder = ApplicationData.Current.LocalFolder;
-            folder.CreateFolderAsync(dirPath, CreationCollisionOption.OpenIfExists).GetResults();
+            var task = folder.CreateFolderAsync(dirPath, CreationCollisionOption.OpenIfExists);
+            task.AsTask().Wait();
 #else
             Directory.CreateDirectory(dirPath);
 #endif			
@@ -246,8 +252,8 @@ namespace Microsoft.Xna.Framework.Storage
             // Now let's try to delete itd
 #if WINDOWS_STOREAPP
             var folder = ApplicationData.Current.LocalFolder;
-            var deleteFolder = folder.GetFolderAsync(dirPath).GetResults();
-            deleteFolder.DeleteAsync().GetResults();
+            var deleteFolder = folder.GetFolderAsync(dirPath).AsTask().GetAwaiter().GetResult();
+            deleteFolder.DeleteAsync().AsTask().Wait();
 #else
             Directory.Delete(dirPath);
 #endif
@@ -270,8 +276,8 @@ namespace Microsoft.Xna.Framework.Storage
 
 #if WINDOWS_STOREAPP
             var folder = ApplicationData.Current.LocalFolder;
-            var deleteFile = folder.GetFileAsync(filePath).GetResults();
-            deleteFile.DeleteAsync().GetResults();
+            var deleteFile = folder.GetFileAsync(filePath).AsTask().GetAwaiter().GetResult();
+            deleteFile.DeleteAsync().AsTask().Wait();
 #else
             // Now let's try to delete it
 			File.Delete(filePath);		
@@ -296,9 +302,17 @@ namespace Microsoft.Xna.Framework.Storage
 
 #if WINDOWS_STOREAPP
             var folder = ApplicationData.Current.LocalFolder;
-            var result = folder.GetFolderAsync(dirPath).GetResults();
+
+            try
+            {
+                var result = folder.GetFolderAsync(dirPath).GetResults();
             return result != null;
-#else
+            }
+            catch
+            {
+                return false;
+            }
+#else            
             return Directory.Exists(dirPath);
 #endif
 		}	
@@ -330,8 +344,16 @@ namespace Microsoft.Xna.Framework.Storage
 
 #if WINDOWS_STOREAPP
             var folder = ApplicationData.Current.LocalFolder;
-            var existsFile = folder.GetFileAsync(filePath).GetResults();
-            return existsFile != null;
+            // GetFile returns an exception if the file doesn't exist, so we catch it here and return the boolean.
+            try
+            {
+                var existsFile = folder.GetFileAsync(filePath).GetAwaiter().GetResult();
+                return existsFile != null;
+            }
+            catch
+            {
+                return false;
+            }
 #else
             // return A new file with read/write access.
 			return File.Exists(filePath);		
@@ -345,7 +367,7 @@ namespace Microsoft.Xna.Framework.Storage
         {
 #if WINDOWS_STOREAPP
             var folder = ApplicationData.Current.LocalFolder;
-            var results = folder.GetFoldersAsync().GetResults();
+            var results = folder.GetFoldersAsync().AsTask().GetAwaiter().GetResult();
             return results.Select<StorageFolder, string>(e => e.Name).ToArray();
 #else
             return Directory.GetDirectories(_storagePath);
@@ -372,7 +394,7 @@ namespace Microsoft.Xna.Framework.Storage
         {
 #if WINDOWS_STOREAPP
             var folder = ApplicationData.Current.LocalFolder;
-            var results = folder.GetFilesAsync().GetResults();
+            var results = folder.GetFilesAsync().AsTask().GetAwaiter().GetResult();
             return results.Select<StorageFile, string>(e => e.Name).ToArray();
 #else
             return Directory.GetFiles(_storagePath);
@@ -396,7 +418,7 @@ namespace Microsoft.Xna.Framework.Storage
             var folder = ApplicationData.Current.LocalFolder;
             var options = new QueryOptions( CommonFileQuery.DefaultQuery, new [] { searchPattern } );
             var query = folder.CreateFileQueryWithOptions(options);
-            var files = query.GetFilesAsync().GetResults();
+            var files = query.GetFilesAsync().AsTask().GetAwaiter().GetResult();
             return files.Select<StorageFile, string>(e => e.Name).ToArray();
 #else
             return Directory.GetFiles(_storagePath, searchPattern);
@@ -471,10 +493,14 @@ namespace Microsoft.Xna.Framework.Storage
             }
             else if (fileMode == FileMode.OpenOrCreate)
             {
-                if ( fileAccess == FileAccess.Read )
+                if (fileAccess == FileAccess.Read)
                     return folder.OpenStreamForReadAsync(filePath).GetAwaiter().GetResult();
                 else
-                    return folder.OpenStreamForWriteAsync(filePath, CreationCollisionOption.OpenIfExists).GetAwaiter().GetResult();
+                {
+                    // Not using OpenStreamForReadAsync because the stream position is placed at the end of the file, instead of the beginning
+                    var f = folder.CreateFileAsync(filePath, CreationCollisionOption.OpenIfExists).AsTask().GetAwaiter().GetResult();
+                    return f.OpenAsync(FileAccessMode.ReadWrite).AsTask().GetAwaiter().GetResult().AsStream();
+                }
             }
             else if (fileMode == FileMode.Truncate)
             {
@@ -483,7 +509,10 @@ namespace Microsoft.Xna.Framework.Storage
             else
             {
                 //if (fileMode == FileMode.Append)
-                return folder.OpenStreamForWriteAsync(filePath, CreationCollisionOption.OpenIfExists).GetAwaiter().GetResult();
+                // Not using OpenStreamForReadAsync because the stream position is placed at the end of the file, instead of the beginning
+                folder.CreateFileAsync(filePath, CreationCollisionOption.OpenIfExists).AsTask().GetAwaiter().GetResult().OpenAsync(FileAccessMode.ReadWrite).AsTask().GetAwaiter().GetResult().AsStream();
+                var f = folder.CreateFileAsync(filePath, CreationCollisionOption.OpenIfExists).AsTask().GetAwaiter().GetResult();
+                return f.OpenAsync(FileAccessMode.ReadWrite).AsTask().GetAwaiter().GetResult().AsStream();
             }
 #else
             return File.Open(filePath, fileMode, fileAccess, fileShare);

--- a/MonoGame.Framework/Storage/StorageDevice.cs
+++ b/MonoGame.Framework/Storage/StorageDevice.cs
@@ -194,6 +194,12 @@ namespace Microsoft.Xna.Framework.Storage
 		// TODO: Implement DeviceChanged when we having the graphical implementation
 		public static event EventHandler<EventArgs> DeviceChanged;
 
+#if WINRT
+        // Dirty trick to avoid the need to get the delegate from the IAsyncResult (can't be done in WinRT)
+        static Delegate showDelegate;
+        static Delegate containerDelegate;
+#endif
+
 		// Summary:
 		//     Begins the process for opening a StorageContainer containing any files for
 		//     the specified title.
@@ -218,7 +224,10 @@ namespace Microsoft.Xna.Framework.Storage
 		{
 			try {
 				OpenContainerAsynchronous AsynchronousOpen = new OpenContainerAsynchronous (Open);
-				return AsynchronousOpen.BeginInvoke (displayName, callback, state);
+#if WINRT
+                containerDelegate = AsynchronousOpen;
+#endif
+                return AsynchronousOpen.BeginInvoke (displayName, callback, state);
 			} finally {
 			}
 		}
@@ -291,8 +300,13 @@ namespace Microsoft.Xna.Framework.Storage
 		public static IAsyncResult BeginShowSelector (int sizeInBytes, int directoryCount, AsyncCallback callback, object state)
 		{
 			var del = new ShowSelectorAsynchronousShowNoPlayer (Show);
+
+#if WINRT
+            showDelegate = del;
+#endif
 			return del.BeginInvoke(sizeInBytes, directoryCount, callback, state);
 		}
+
 		
 		//
 		// Summary:
@@ -322,8 +336,11 @@ namespace Microsoft.Xna.Framework.Storage
 		public static IAsyncResult BeginShowSelector (PlayerIndex player, int sizeInBytes, int directoryCount, AsyncCallback callback, object state)
 		{
 			var del = new ShowSelectorAsynchronousShow (Show);
-			return del.BeginInvoke(player, sizeInBytes, directoryCount, callback, state);
-		}
+#if WINRT
+            showDelegate = del;
+#endif
+            return del.BeginInvoke(player, sizeInBytes, directoryCount, callback, state);
+        }
 	
 		// Private method to handle the creation of the StorageDevice
 		private static StorageDevice Show (PlayerIndex player, int sizeInBytes, int directoryCount)
@@ -360,7 +377,7 @@ namespace Microsoft.Xna.Framework.Storage
 			try {
 #if WINRT
                 // AsyncResult does not exist in WinRT
-                var asyncResult = result.AsyncState as OpenContainerAsynchronous;
+                var asyncResult = containerDelegate as OpenContainerAsynchronous;
 				if (asyncResult != null)
 				{
 					// Wait for the WaitHandle to become signaled.
@@ -369,6 +386,7 @@ namespace Microsoft.Xna.Framework.Storage
 					// Call EndInvoke to retrieve the results.
     				returnValue = asyncResult.EndInvoke(result);
 				}
+                containerDelegate = null;
 #else
 				// Retrieve the delegate.
 				AsyncResult asyncResult = result as AsyncResult;
@@ -404,24 +422,26 @@ namespace Microsoft.Xna.Framework.Storage
 		//     The IAsyncResult returned from BeginShowSelector.
 		public static StorageDevice EndShowSelector (IAsyncResult result) 
 		{
-#if WINRT
-            throw new NotImplementedException();
-#else
-
-
-			// Retrieve the delegate.
-			AsyncResult asyncResult = (AsyncResult)result;
 
 			if (!result.IsCompleted) {
 				// Wait for the WaitHandle to become signaled.
 				try {
 					result.AsyncWaitHandle.WaitOne ();
 				} finally {
+#if !WINRT
 					result.AsyncWaitHandle.Close ();
+#endif
 				}
 			}
+#if WINRT
+            var del = showDelegate;
+            showDelegate = null;
+#else
+			// Retrieve the delegate.
+			AsyncResult asyncResult = (AsyncResult)result;
 
-			var del = asyncResult.AsyncDelegate;
+            var del = asyncResult.AsyncDelegate;
+#endif
 
 			if (del is ShowSelectorAsynchronousShow)
 				return (del as ShowSelectorAsynchronousShow).EndInvoke (result);
@@ -429,7 +449,6 @@ namespace Microsoft.Xna.Framework.Storage
 				return (del as ShowSelectorAsynchronousShowNoPlayer).EndInvoke (result);
 			else
 				throw new ArgumentException ("result");
-#endif
 		}
 		
 		internal static string StorageRoot


### PR DESCRIPTION
- Fixed BeginShowSelector / EndShowSelector not working.
- Fixed BeginOpenContainer / EndOpenContainer not working.
  *\* Static variables added as a workaround for not being able to cast IAsyncResult to AsyncResult.
- Fixed StorageContainer methods throwing exceptions because there was no wait on the async methods.
- Fixed base path for StorageContainer
- Added a try/catch to StorageContainer.FileExists and StorageContainer.DirectoryExists
- Fixed OpenFile opening a Stream on the end of the file when the file existed.
