### PR TITLE
Fix PSMobile compilation.

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/Effect.cs
+++ b/MonoGame.Framework/Graphics/Effect/Effect.cs
@@ -470,7 +470,14 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			var effectPass = new EffectPass(this, "Pass", null, null, BlendState.AlphaBlend, DepthStencilState.Default, RasterizerState.CullNone, new EffectAnnotationCollection());
 			effectPass._shaderProgram = new ShaderProgram(reader.ReadBytes((int)reader.BaseStream.Length));
-			var shaderProgram = effectPass._shaderProgram;						Parameters = new EffectParameterCollection();			for (int i = 0; i < shaderProgram.UniformCount; i++)			{				Parameters.Add(EffectParameterForUniform(shaderProgram, i));			}#warning Hacks for BasicEffect as we don't have these parameters yet
+			var shaderProgram = effectPass._shaderProgram;
+			Parameters = new EffectParameterCollection();
+			for (int i = 0; i < shaderProgram.UniformCount; i++)
+			{	
+			    Parameters.Add(EffectParameterForUniform(shaderProgram, i));
+			}
+			
+			#warning Hacks for BasicEffect as we don't have these parameters yet
             Parameters.Add (new EffectParameter(
                 EffectParameterClass.Vector, EffectParameterType.Single, "SpecularColor",
                 3, 1, "float3",

--- a/MonoGame.Framework/MonoGame.Framework.PSMobile.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.PSMobile.csproj
@@ -121,6 +121,8 @@
     <Compile Include="Graphics\IGraphicsDeviceService.cs" />
     <Compile Include="Content\ContentTypeReader.cs" />
     <Compile Include="Content\ContentTypeReaderManager.cs" />
+	<Compile Include="Content\ContentReaders\EffectMaterialReader.cs" />
+	<Compile Include="Content\ContentReaders\ExternalReferenceReader.cs" />
     <Compile Include="Graphics\Viewport.cs" />
     <Compile Include="Graphics\DisplayMode.cs" />
     <Compile Include="Graphics\DisplayModeCollection.cs" />
@@ -161,6 +163,7 @@
     <Compile Include="Graphics\States\Blend.cs" />
     <Compile Include="Graphics\States\BlendFunction.cs" />
     <Compile Include="Graphics\States\BlendState.cs" />
+    <Compile Include="Graphics\Effect\EffectMaterial.cs" />
     <Compile Include="Graphics\Effect\EffectParameterCollection.cs" />
     <Compile Include="Graphics\Effect\EffectPassCollection.cs" />
     <Compile Include="Graphics\Effect\EffectTechnique.cs" />


### PR DESCRIPTION
1. Changed line breaks in Effect.cs (caused compilation errors).
2. Add missing files to PSMobile.csproj file:
- ContentReaders\EffectMaterialReader.cs
- ContentReaders\ExternalReferenceReader.cs
- Graphics\Effect\EffectMaterial.cs

I am not sure these changes are correct. Moreover, i have no real way (except for the simulator) to test these changes, as starting from the PSMobile 1.00 SDK, i cannot deploy to the Vita anymore (not without a publisher license).
