### PR TITLE
Removed PreserveFrameBuffer workaround

### DIFF
--- a/MonoGame.Framework/iOS/GamerServices/Guide.cs
+++ b/MonoGame.Framework/iOS/GamerServices/Guide.cs
@@ -245,8 +245,6 @@ namespace Microsoft.Xna.Framework.GamerServices
 			keyboardViewController = new KeyboardInputViewController(
 				title, description, defaultText, usePasswordMode);
 
-            (_gameViewController.View as iOSGameView).PreserveFrameBuffer = true;
-
 			_gameViewController.PresentModalViewController (keyboardViewController, true);
 
 			keyboardViewController.View.InputAccepted += (sender, e) => {
@@ -266,7 +264,6 @@ namespace Microsoft.Xna.Framework.GamerServices
 		{
 			AssertInitialised ();
 
-            (_gameViewController.View as iOSGameView).PreserveFrameBuffer = false;
             keyboardViewController = null;
 
 			if (!(result is KeyboardInputAsyncResult))

--- a/MonoGame.Framework/iOS/iOSGameView.cs
+++ b/MonoGame.Framework/iOS/iOSGameView.cs
@@ -91,8 +91,6 @@ namespace Microsoft.Xna.Framework {
 		private int _depthbuffer;
 		private int _framebuffer;
 
-        public bool PreserveFrameBuffer = false;
-
 		#region Construction/Destruction
 		public iOSGameView (iOSGamePlatform platform, RectangleF frame)
 			: base(frame)
@@ -198,9 +196,6 @@ namespace Microsoft.Xna.Framework {
 			AssertNotDisposed ();
 			AssertValidContext ();
 
-            if (PreserveFrameBuffer)
-                return;
-
 			__renderbuffergraphicsContext.MakeCurrent (null);
 			
 			// HACK:  GraphicsDevice itself should be calling
@@ -288,9 +283,6 @@ namespace Microsoft.Xna.Framework {
 
 		private void DestroyFramebuffer ()
 		{
-            if (PreserveFrameBuffer)
-                return;
-
 			AssertNotDisposed ();
 			AssertValidContext ();
 
@@ -361,25 +353,17 @@ namespace Microsoft.Xna.Framework {
 
 		#region UIWindow Notifications
 
-		public override void WillMoveToWindow (UIWindow window)
-		{
-			base.WillMoveToWindow (window);
-
-			if (_framebuffer + _colorbuffer + _depthbuffer != 0)
-				DestroyFramebuffer();
-		}
-
 		[Export ("didMoveToWindow")]
 		public virtual void DidMoveToWindow ()
 		{
 
-			if (Window != null) {
-				
-				if (__renderbuffergraphicsContext == null)
-					CreateContext ();
-				if (_framebuffer * _colorbuffer * _depthbuffer == 0)
-					CreateFramebuffer ();
-			}
+            if (Window != null) {
+                
+                if (__renderbuffergraphicsContext == null)
+                    CreateContext ();
+                if (_framebuffer * _colorbuffer * _depthbuffer == 0)
+                    CreateFramebuffer ();
+            }
 		}
 
 		#endregion UIWindow Notifications


### PR DESCRIPTION
First off, apologies about the name of the branch being pulled in. I originally thought the problem I was running into was related to poor handling of multiple views.

This PR removes the PreserveFrameBuffer workaround that was introduced a couple of months ago. WillMoveToWindow was destroying our framebuffer object. This gets called when the application starts, and when we present any kind of modal view, such as the keyboard or an advertisement. The whole implementation of WillMoveToWindow has been removed, as I don't believe we need it. LayoutSubviews destroys and recreates our framebuffer as the view's recalculated, but destroying the FBO when we present a modal view only leads to crashes as we yank the FBO from under the graphics device.

Test:
Remove the PreserveFrameBuffer bool from iOSGameView and all references to it.
Start the app/game up.
Use something like Guide.BeginShowKeyboardInput().
App will either crash or throw a GL exception.
