### PR TITLE
Not building on windows because "CursorVisible " was not available in Op...

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -251,13 +251,15 @@ namespace Microsoft.Xna.Framework
         }
   
         protected override void OnIsMouseVisibleChanged()
-        {
+		{
+#if LINUX
             MouseState oldState = Mouse.GetState();
             _view.Window.CursorVisible = IsMouseVisible;
             // IsMouseVisible changes the location of the cursor on Linux (and Windows?) and we have to manually set it back to the correct position
             System.Drawing.Point mousePos = _view.Window.PointToScreen(new System.Drawing.Point(oldState.X, oldState.Y));
             OpenTK.Input.Mouse.SetPosition(mousePos.X, mousePos.Y);
-        }
+#endif
+		}
         
         public override void Log(string Message)
         {


### PR DESCRIPTION
...enTKGameWindow

Not sure this is really the solution to this problem but a simple game works on my side with this build. Also I haven't tried to see if this has a negative impact on any of the other projects.
Cheers

Andrea
