### PR TITLE
Apply params correctly for effects using same shader

### DIFF
--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Xna.Framework.Graphics
         private int _program = -1;
         private int _location;
 
+        static ConstantBuffer _lastConstantBufferApplied = null;
+
         /// <summary>
         /// A hash value which can be used to compare constant buffers.
         /// </summary>
@@ -271,6 +273,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 _dirty = true;
             }
 
+            // If the shader program is the same, the effect may still be different and have different values in the buffer
+            if (!Object.ReferenceEquals(this, _lastConstantBufferApplied))
+                _dirty = true;
+
             // If the buffer content hasn't changed then we're
             // done... use the previously set uniform state.
             if (!_dirty)
@@ -288,6 +294,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Clear the dirty flag.
             _dirty = false;
+
+            _lastConstantBufferApplied = this;
 #endif
             
 #if PSM


### PR DESCRIPTION
Fix for issue #1116
If two effects were using the same shader, the constant buffer would not be applied when each effect was used.
