### PR TITLE
Fix OpenGL StencilOp mapping

### DIFF
--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -203,13 +203,13 @@ namespace Microsoft.Xna.Framework.Graphics
                 case StencilOperation.Keep:
                     return StencilOp.Keep;
                 case StencilOperation.Decrement:
-                    return StencilOp.Decr;
-                case StencilOperation.DecrementSaturation:
                     return StencilOp.DecrWrap;
+                case StencilOperation.DecrementSaturation:
+                    return StencilOp.Decr;
                 case StencilOperation.IncrementSaturation:
-                    return StencilOp.IncrWrap;
-                case StencilOperation.Increment:
                     return StencilOp.Incr;
+                case StencilOperation.Increment:
+                    return StencilOp.IncrWrap;
                 case StencilOperation.Invert:
                     return StencilOp.Invert;
                 case StencilOperation.Replace:


### PR DESCRIPTION
Fix OpenGL StencilOp mapping. GL_INCR / GL_DECR are clamped which correspond to StencilOperation.{Increment|Decrement}Saturation in XNA.
