### PR TITLE
Fix MonoGame.Framework.dll.config to be named properly on MacOS and Linux

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.Linux.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Linux.csproj
@@ -413,18 +413,6 @@
     <EmbeddedResource Include="Graphics\Effect\Resources\SpriteEffect.ogl.mgfxo" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="MonoGame.Framework.Linux.dll.config">
-      <Link>MonoGame.Framework.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\ThirdParty\Libs\libmojoshader_32.so">
-      <Link>libmojoshader_32.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\ThirdParty\Libs\libmojoshader_64.so">
-      <Link>libmojoshader_64.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Include="..\ThirdParty\GamepadConfig\Tao.Sdl.dll.config">
       <Link>Tao.Sdl.dll.config</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/MonoGame.Framework/MonoGame.Framework.Linux.dll.config
+++ b/MonoGame.Framework/MonoGame.Framework.Linux.dll.config
@@ -1,6 +1,0 @@
-<configuration>
-	<dllmap dll="libmojoshader.dll" os="linux" cpu="x86" target="libmojoshader_32.so" />
-	<dllmap dll="libmojoshader.dll" os="linux" cpu="x86-64,ia64" target="libmojoshader_64.so" />
-	<dllmap dll="libglsl_optimizer.dll" os="linux" cpu="x86" target="libglsl_optimizer_32.so" />
-	<dllmap dll="libglsl_optimizer.dll" os="linux" cpu="x86-64,ia64" target="libglsl_optimizer_64.so" />
-</configuration>

--- a/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
@@ -445,16 +445,6 @@
     <Folder Include="Desktop\Audio\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="MonoGame.Framework.MacOS.dll.config">
-      <Link>MonoGame.Framework.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\ThirdParty\Libs\libmojoshader.dylib">
-      <Link>libmojoshader.dylib</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Graphics\Effect\Resources\AlphaTestEffect.ogl.mgfxo" />
     <EmbeddedResource Include="Graphics\Effect\Resources\BasicEffect.ogl.mgfxo" />
     <EmbeddedResource Include="Graphics\Effect\Resources\DualTextureEffect.ogl.mgfxo" />

--- a/MonoGame.Framework/MonoGame.Framework.MacOS.dll.config
+++ b/MonoGame.Framework/MonoGame.Framework.MacOS.dll.config
@@ -1,4 +1,0 @@
-<configuration>
-    <dllmap dll="libmojoshader.dll" os="osx" target="libmojoshader.dylib" />
-	<dllmap dll="libglsl_optimizer.dll" os="osx" target="libglsl_optimizer.dylib" />
-</configuration>


### PR DESCRIPTION
The output DLLs for MacOS and Linux were [recently renamed](https://github.com/mono/MonoGame/commit/9a77339a68916dbc83b774bb0df495e58ac6fa41) to not include any suffix.

This commit updates the output names of the correspondig .dll.config files to match the new names. 

This is required for MonoGame to work at all on Mac and Linux.
