### PR TITLE
[Windows8] Fixing Compile Error on Debug (AllowUnsafeBlocks to true)

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
@@ -23,7 +23,7 @@
     <DefineConstants>TRACE;NETFX_CORE;DEBUG;WINRT;WINDOWS_STOREAPP;DIRECTX</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Need to AllowUnsafeBlocks on Debug Mode
The function float Convert(ushort value) - HalfTypeHelper
uses it
