### PR TITLE
Fix xnb loading bug in ContentManager

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -191,6 +191,9 @@ namespace Microsoft.Xna.Framework.Content
 			Stream stream;
 			try
             {
+                if (assetName[0] == '\\') {
+                    assetName = assetName.Substring(1);
+                }
                 string assetPath = Path.Combine(RootDirectoryFullPath, assetName) + ".xnb";
                 stream = TitleContainer.OpenStream(assetPath);
 


### PR DESCRIPTION
When loading a xnb file that has one or more subresources those subresources could not be loaded.

The bug results from the (unintuitive) behaviour of Path.Combine which ignores parameters that it thinks are absolute paths. In this case the submodel has a path that is prefixed with a '/' and path.combine assumes it is absolute.

This commit fixes it by checking if there is a '/' prefix and if there is removing it.
