### PR TITLE
Make OpenGL vertex shader dirty on viewport change

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1226,6 +1226,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 GL.DepthRange((double)value.MinDepth, (double)value.MaxDepth);
 #endif
                 GraphicsExtensions.LogGLError("GraphicsDevice.Viewport_set() GL.DepthRange");
+                
+                // In OpenGL we have to re-apply the special "posFixup"
+                // vertex shader uniform if the viewport changes.
+                _vertexShaderDirty = true;
 #endif
             }
         }
@@ -1292,12 +1296,6 @@ namespace Microsoft.Xna.Framework.Graphics
             _currentRenderTargetBindings = renderTargets;
 		
             var clearTarget = false;
-
-#if OPENGL
-            // In OpenGL we have to re-apply the special "posFixup"
-            // vertex shader uniform if the render target changes.
-            _vertexShaderDirty = true;
-#endif
 
             if (_currentRenderTargetBindings == null || _currentRenderTargetBindings.Length == 0)
 			{


### PR DESCRIPTION
This pull request fixes an offset bug on OpenGL platforms when changing the viewport size.

The OpenGL version of MonoGame uses an uniform named "posFixup" to offset any rendering by a fraction of the viewport size. This is required because DirectX coordinates refer to pixel centers while OpenGL coordinates refer to pixel corners.

Whenever the render target is changed, the vertex shader is marked dirty so that the posFixup uniform gets updated (the viewport changes whenever the render target is changed).

This change ensures the posFixup uniform is updated whenever the viewport changes, not only when it is changed through a render target change.

I wrote a testcase to reproduce & fix the bug, you can download it here: http://polyprograms.free.fr/tmp/BlurredSpriteBatch.zip

XNA version:
![BlurredSpriteBatch](https://f.cloud.github.com/assets/446986/61757/3fbbd092-5c7f-11e2-8dca-ab9a9ca4967c.png)

MonoGame version (without the fix) - text & sprite are offset / blurred:
![BlurredSpriteBatchMonoGame](https://f.cloud.github.com/assets/446986/61758/3fd2d440-5c7f-11e2-9101-436342885537.png)

MonoGame with fix version:
![BlurredSpriteBatchMonoGameWithFix](https://f.cloud.github.com/assets/446986/61759/3fe9b98a-5c7f-11e2-8962-0624f5e2ec7f.png)
