### PR TITLE
Fix disposing of ShaderProgramCache

### DIFF
--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -143,7 +143,8 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (!disposed)
             {
-                Clear();
+                if (disposing)
+                    Clear();
                 disposed = true;
             }
         }

--- a/ProjectTemplates/VisualStudio2010/Linux/Program.cs
+++ b/ProjectTemplates/VisualStudio2010/Linux/Program.cs
@@ -6,21 +6,21 @@ using System.Linq;
 
 namespace $safeprojectname$
 {
+#ifdef WINDOWS || LINUX
     /// <summary>
     /// The main class.
     /// </summary>
     public static class Program
     {
-        private static Game1 game;
-
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
         static void Main()
         {
-            game = new Game1();
-            game.Run();
+            using (var game = new Game1())
+                game.Run();
         }
     }
+#endif
 }

--- a/ProjectTemplates/VisualStudio2010/WindowsGL/Program.cs
+++ b/ProjectTemplates/VisualStudio2010/WindowsGL/Program.cs
@@ -6,21 +6,21 @@ using System.Linq;
 
 namespace $safeprojectname$
 {
+#ifdef WINDOWS || LINUX
     /// <summary>
     /// The main class.
     /// </summary>
     public static class Program
     {
-        private static Game1 game;
-
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
         static void Main()
         {
-            game = new Game1();
-            game.Run();
+            using (var game = new Game1())
+                game.Run();
         }
     }
+#endif
 }


### PR DESCRIPTION
Fixes issues #1071, #1181
Was trying to release managed objects in the finalizer.
Also fixes project templates for Windows and Linux to always properly dispose of the Game object.
