### PR TITLE
Reset Texture's cached GL SamplerState when device is reset

### DIFF
--- a/MonoGame.Framework/Graphics/Texture.cs
+++ b/MonoGame.Framework/Graphics/Texture.cs
@@ -162,6 +162,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
 #if OPENGL
             this.glTexture = -1;
+            this.glLastSamplerState = null;
 #endif
         }
 


### PR DESCRIPTION
The cached sampler state was being persisted between device resets. After a context lost event, the GL sampler states are reset to default but the cached state was not. This meant that if your game used a single non-default sampler state, after a device reset it would never get applied.

Reproducing the problem is simple. Create a default game for Android and load a single texture that is smaller than the screen size into a `Texture2D tex` member. Then add the following drawing code. After a resume (run app, hit Home button, switch back to app), you will notice that the PointClamp sampler state is no longer being applied (texture looks smooth instead of blocky).

```
        spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
        Rectangle rect =  new Rectangle(0, 0, Window.Width, Window.Height);
        spriteBatch.Draw(tex, rect, null, Color.White, 0.0f, Vector2.Zero, SpriteEffects.None, 0.0f);
        spriteBatch.End();
```

Codeplex discussion: http://monogame.codeplex.com/discussions/428652
