### PR TITLE
Use TimeSpan.FromTicks() to calculate default TargetElapsedTime

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Xna.Framework
         private bool _initialized = false;
         private bool _isFixedTimeStep = true;
 
-        private TimeSpan _targetElapsedTime = TimeSpan.FromSeconds(1 / DefaultTargetFramesPerSecond);
+        private TimeSpan _targetElapsedTime = TimeSpan.FromTicks((long)10000000 / (long)DefaultTargetFramesPerSecond);
         private TimeSpan _inactiveSleepTime = TimeSpan.FromSeconds(1);
 
         private readonly TimeSpan _maxElapsedTime = TimeSpan.FromMilliseconds(500);


### PR DESCRIPTION
Fixes issues #1184, #1085
TimeSpan.FromSeconds() has an accuracy of 3 decimal places only.  TimeSpan.FromTicks() is more accurate, resulting in the expected target elapsed time of 0.0166667 rather than 0.017.

Reference: http://msdn.microsoft.com/en-us/library/system.timespan.fromticks.aspx
