### PR TITLE
General re-write of window handling for Desktop platforms.

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -125,7 +125,6 @@ namespace Microsoft.Xna.Framework
 
         public override void RunLoop()
         {
-            ResetWindowBounds(false);
             _view.Window.Run(0);
         }
 
@@ -164,33 +163,38 @@ namespace Microsoft.Xna.Framework
 
         public override void EnterFullScreen()
         {
-            ResetWindowBounds(false);
+            //UpdateWindowBounds();
         }
 
         public override void ExitFullScreen()
         {
-            ResetWindowBounds(false);
+            //UpdateWindowBounds();
         }
 
-        internal void ResetWindowBounds(bool toggleFullScreen)
+        internal void UpdateWindowBounds()
         {
-            Rectangle bounds;
-
-            bounds = Window.ClientBounds;
-
             //Changing window style forces a redraw. Some games
             //have fail-logic and toggle fullscreen in their draw function,
             //so temporarily become inactive so it won't execute.
-
             bool wasActive = IsActive;
             IsActive = false;
 
-            var graphicsDeviceManager = (GraphicsDeviceManager)
-                Game.Services.GetService(typeof(IGraphicsDeviceManager));
+            var graphicsDeviceManager = (GraphicsDeviceManager)Game.Services.GetService(typeof(IGraphicsDeviceManager));
 
-            if (graphicsDeviceManager.IsFullScreen)
+            // If fullscreen has been toggled, we need to tell the window.
+            if (graphicsDeviceManager.IsFullScreen != isCurrentlyFullScreen)
             {
-                bounds = new Rectangle(0, 0,graphicsDeviceManager.PreferredBackBufferWidth,graphicsDeviceManager.PreferredBackBufferHeight);
+                _view.ToggleFullScreen();
+                
+                // Store the current fullscreen state.
+                isCurrentlyFullScreen = graphicsDeviceManager.IsFullScreen;
+            }
+
+            Rectangle clientBounds = _view.ClientBounds;
+
+            if (isCurrentlyFullScreen)
+            {
+                clientBounds = new Rectangle(0, 0, graphicsDeviceManager.PreferredBackBufferWidth, graphicsDeviceManager.PreferredBackBufferHeight);
 
                 if (OpenTK.DisplayDevice.Default.Width != graphicsDeviceManager.PreferredBackBufferWidth ||
                     OpenTK.DisplayDevice.Default.Height != graphicsDeviceManager.PreferredBackBufferHeight)
@@ -203,39 +207,14 @@ namespace Microsoft.Xna.Framework
             }
             else
             {
-                
-                // switch back to the normal screen resolution
-                OpenTK.DisplayDevice.Default.RestoreResolution();
+                _view.ChangeWindowSize(graphicsDeviceManager.PreferredBackBufferWidth, graphicsDeviceManager.PreferredBackBufferHeight);
+
                 // now update the bounds 
-                bounds.Width = graphicsDeviceManager.PreferredBackBufferWidth;
-                bounds.Height = graphicsDeviceManager.PreferredBackBufferHeight;
-            }
-            
-
-            // Now we set our Presentation Parameters
-            var device = (GraphicsDevice)graphicsDeviceManager.GraphicsDevice;
-            // FIXME: Eliminate the need for null checks by only calling
-            //        ResetWindowBounds after the device is ready.  Or,
-            //        possibly break this method into smaller methods.
-            if (device != null)
-            {
-                PresentationParameters parms = device.PresentationParameters;
-                parms.BackBufferHeight = (int)bounds.Height;
-                parms.BackBufferWidth = (int)bounds.Width;
+                clientBounds.Width = graphicsDeviceManager.PreferredBackBufferWidth;
+                clientBounds.Height = graphicsDeviceManager.PreferredBackBufferHeight;
             }
 
-            if (graphicsDeviceManager.IsFullScreen != isCurrentlyFullScreen)
-            {                
-                _view.ToggleFullScreen();
-            }
-
-            // we only change window bounds if we are not fullscreen
-            // or if fullscreen mode was just entered
-            if (!graphicsDeviceManager.IsFullScreen || (graphicsDeviceManager.IsFullScreen != isCurrentlyFullScreen))
-                _view.ChangeClientBounds(bounds);
-
-            // store the current fullscreen state
-            isCurrentlyFullScreen = graphicsDeviceManager.IsFullScreen;
+            _view.ChangeClientBounds(clientBounds);
 
             IsActive = wasActive;
         }

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -695,10 +695,10 @@ namespace Microsoft.Xna.Framework
 			UnloadContent();
 		}
 
-        internal void ResizeWindow(bool changed)
+        internal void UpdateWindowBounds()
         {
 #if LINUX || WINDOWS
-            ((OpenTKGamePlatform)Platform).ResetWindowBounds(changed);
+            ((OpenTKGamePlatform)Platform).UpdateWindowBounds();
 #endif
         }
 

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -249,7 +249,13 @@ namespace Microsoft.Xna.Framework
             _graphicsDevice.ApplyRenderTargets(null);
 
 #elif WINDOWS || LINUX
-            _game.ResizeWindow(false);
+            _graphicsDevice.PresentationParameters.BackBufferFormat = _preferredBackBufferFormat;
+            _graphicsDevice.PresentationParameters.BackBufferWidth = _preferredBackBufferWidth;
+            _graphicsDevice.PresentationParameters.BackBufferHeight = _preferredBackBufferHeight;
+            _graphicsDevice.PresentationParameters.DepthStencilFormat = _preferredDepthStencilFormat;
+            _graphicsDevice.GraphicsProfile = GraphicsProfile;
+
+            _game.UpdateWindowBounds();
 #elif MONOMAC
             _graphicsDevice.PresentationParameters.IsFullScreen = _wantFullScreen;
 

--- a/MonoGame.Framework/MonoGame.Framework.Windows.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows.csproj
@@ -42,7 +42,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\WindowsGL\Debug</OutputPath>
+    <OutputPath>..\..\..\Parapraxis-Foundations\Parapraxis Mono\Dependencies\Windows\</OutputPath>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>true</DebugSymbols>
@@ -55,7 +55,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\WindowsGL\Release</OutputPath>
+    <OutputPath>..\..\..\Parapraxis-Foundations\Parapraxis Mono\Dependencies\Windows\</OutputPath>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RegisterForComInterop>False</RegisterForComInterop>


### PR DESCRIPTION
Ok, finally got round to cleaning up my patch. 

This addresses Issue #669 and has been fully tested on my Windows machine. I've also got access to Linux for testing which I'll do ASAP. 

If there are too many unnecessary changes, let me know - I also did a little refactoring as I went a long and that could be reverted to make the logical differences more clear. 

On Windows, the behaviour outlined at MSDN for user resizing (http://msdn.microsoft.com/en-us/library/bb203876(v=xnagamestudio.40).aspx) now works as expected. In addition, a user may programatically change the window size by setting the GraphicsDeviceManager PreferredBackBufferWidth/Height and calling ApplyChanges() as is the behaviour in XNA. 

There's a lot of new stuff in this patch so it definitely needs to be tested thoroughly before merging.  
