### PR TITLE
Writing WMA and AAC/MP4 song files

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioHelper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
     class AudioHelper
     {
         // This array must remain in sync with the ConversionFormat enum.
-        static string[] conversionFormatExtensions = new[] { "wav", "wav", "wma", "xma", "mp4", "ogg" };
+        static string[] conversionFormatExtensions = new[] { "wav", "wav", "wma", "xma", "wav", "mp4", "ogg" };
 
         /// <summary>
         /// Gets the file extension for an audio format.

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.Windows.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.Windows.csproj
@@ -51,11 +51,8 @@
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NAudio">
+    <Reference Include="NAudio, Version=1.7.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\ThirdParty\Libs\NAudio\NAudio.dll</HintPath>
-    </Reference>
-    <Reference Include="NAudio.WindowsMediaFormat">
-      <HintPath>..\ThirdParty\Libs\NAudio\NAudio.WindowsMediaFormat.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/MonoGame.Framework.Content.Pipeline/Processors/SongProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/SongProcessor.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             }
 
             string songFileName = Path.ChangeExtension(context.OutputFilename, AudioHelper.GetExtension(targetFormat));
-            //input.ConvertFormat(targetFormat, quality, songFileName);
+            input.ConvertFormat(targetFormat, quality, songFileName);
             var song = new SongContent(PathHelper.GetRelativePath(Path.GetDirectoryName(context.OutputFilename) + Path.DirectorySeparatorChar, songFileName), input.Duration);
             return song;
         }


### PR DESCRIPTION
With NAudio 1.7-alpha03 and MediaFoundation support, we can now write WMA and AAC/MP4 encoded files.

Requires https://github.com/kungfubanana/MonoGame-Dependencies/pull/22
Once that is merged, I will add the submodule update to this PR.
