### PR TITLE
Added events for KeyUp and KeyDown

### DIFF
--- a/MonoGame.Framework/MacOS/GameWindow.cs
+++ b/MonoGame.Framework/MacOS/GameWindow.cs
@@ -488,6 +488,8 @@ namespace Microsoft.Xna.Framework
 
 		public override void KeyDown (NSEvent theEvent)
 		{
+			OnKeyDownEvent(new NSEventArgs(theEvent));
+
 			Keys kk = KeyUtil.GetKeys (theEvent); 
 
 			if (!_keys.Contains (kk))
@@ -496,14 +498,38 @@ namespace Microsoft.Xna.Framework
 			UpdateKeyboardState ();
 		}
 
+		protected virtual void OnKeyDownEvent (NSEventArgs e)
+		{
+			if (e == null)
+				throw new ArgumentNullException("e", "'e' cannot be null (Nothing in Visual Basic)");
+
+			if (KeyDownEvent != null)
+				KeyDownEvent(this, e);
+		}
+
+		public event EventHandler<NSEventArgs> KeyDownEvent;
+
 		public override void KeyUp (NSEvent theEvent)
 		{
+			OnKeyUpEvent(new NSEventArgs(theEvent));
+
 			Keys kk = KeyUtil.GetKeys (theEvent); 
 
 			_keys.Remove (kk);
 
 			UpdateKeyboardState ();
 		}
+
+		protected virtual void OnKeyUpEvent(NSEventArgs e)
+		{
+			if (e == null)
+				throw new ArgumentNullException("e", "'e' cannot be null (Nothing in Visual Basic)");
+
+			if (KeyUpEvent != null)
+				KeyUpEvent (this, e);
+		}
+
+		public event EventHandler<NSEventArgs> KeyUpEvent;
 
 		List<Keys> _flags = new List<Keys> ();
 

--- a/MonoGame.Framework/MacOS/NSEventArgs.cs
+++ b/MonoGame.Framework/MacOS/NSEventArgs.cs
@@ -1,0 +1,20 @@
+using System;
+using MonoMac.AppKit;
+
+namespace Microsoft.Xna.Framework
+{
+	public class NSEventArgs : EventArgs
+	{
+		public NSEventArgs (NSEvent theEvent)
+		{
+			TheEvent = theEvent;
+		}
+
+		public NSEvent TheEvent
+		{
+			get;
+			private set;
+		}
+	}
+}
+

--- a/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
@@ -12,45 +12,48 @@
     <AssemblyName>MonoGame.Framework</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>False</Optimize>
     <OutputPath>bin\MacOS\Debug</OutputPath>
     <DefineConstants>DEBUG;MONOMAC;OPENGL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <EnableCodeSigning>false</EnableCodeSigning>
-    <CreatePackage>false</CreatePackage>
-    <EnablePackageSigning>false</EnablePackageSigning>
-    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <ConsolePause>False</ConsolePause>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <EnableCodeSigning>False</EnableCodeSigning>
+    <CreatePackage>False</CreatePackage>
+    <EnablePackageSigning>False</EnablePackageSigning>
+    <IncludeMonoRuntime>False</IncludeMonoRuntime>
+    <UseSGen>False</UseSGen>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>False</Optimize>
     <OutputPath>bin\MacOS\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ConsolePause>False</ConsolePause>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>MONOMAC;OPENGL</DefineConstants>
-    <EnableCodeSigning>false</EnableCodeSigning>
-    <CreatePackage>false</CreatePackage>
-    <EnablePackageSigning>false</EnablePackageSigning>
-    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <EnableCodeSigning>False</EnableCodeSigning>
+    <CreatePackage>False</CreatePackage>
+    <EnablePackageSigning>False</EnablePackageSigning>
+    <IncludeMonoRuntime>False</IncludeMonoRuntime>
+    <UseSGen>False</UseSGen>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Distribution|AnyCPU' ">
     <DebugType>none</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>False</Optimize>
     <OutputPath>bin\MacOS\Distribution</OutputPath>
     <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>MONOMAC;OPENGL</DefineConstants>
-    <EnableCodeSigning>false</EnableCodeSigning>
-    <CreatePackage>false</CreatePackage>
-    <EnablePackageSigning>false</EnablePackageSigning>
-    <IncludeMonoRuntime>false</IncludeMonoRuntime>
+    <EnableCodeSigning>False</EnableCodeSigning>
+    <CreatePackage>False</CreatePackage>
+    <EnablePackageSigning>False</EnablePackageSigning>
+    <IncludeMonoRuntime>False</IncludeMonoRuntime>
+    <UseSGen>False</UseSGen>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -361,7 +364,7 @@
     <Compile Include="Content\ContentReaders\EffectReader.cs" />
     <Compile Include="Graphics\Effect\EffectAnnotation.cs" />
     <Compile Include="Graphics\Effect\EffectAnnotationCollection.cs" />
-	<Compile Include="Graphics\Shader\ConstantBufferCollection.cs" />
+    <Compile Include="Graphics\Shader\ConstantBufferCollection.cs" />
     <Compile Include="Graphics\Shader\ConstantBuffer.cs" />
     <Compile Include="Graphics\Shader\Shader.cs" />
     <Compile Include="Graphics\Shader\ShaderStage.cs" />
@@ -433,6 +436,7 @@
     <Compile Include="FrameworkDispatcher.cs" />
     <Compile Include="Graphics\Shader\ShaderProgramCache.cs" />
     <Compile Include="Utilities\Hash.cs" />
+    <Compile Include="MacOS\NSEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MacOS\" />


### PR DESCRIPTION
The KeyUp and KeyDown methods are very important for low level keyboard
access but in MonoGame the general solution of overriding the view
cannot be done so I expose both as events.
