### PR TITLE
Ignore mip maps for non power of two textures when device doesn't support them

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -84,6 +84,17 @@ namespace Microsoft.Xna.Framework.Content
 			int width = (reader.ReadInt32 ());
 			int height = (reader.ReadInt32 ());
 			int levelCount = (reader.ReadInt32 ());
+            int levelCountOutput = levelCount;
+
+            // If the system does not fully support Power of Two textures,
+            // skip any mip maps supplied with any non PoT textures.
+            if (levelCount > 1 && !GraphicsCapabilities.NonPowerOfTwo &&
+                (!MathHelper.IsPowerOfTwo(width) || !MathHelper.IsPowerOfTwo(height)))
+            {
+                levelCountOutput = 1;
+                System.Diagnostics.Debug.WriteLine(
+                    "Device does not support non Power of Two textures. Skipping mipmaps.");
+            }
 
 			SurfaceFormat convertedFormat = surfaceFormat;
 			switch (surfaceFormat)
@@ -112,7 +123,7 @@ namespace Microsoft.Xna.Framework.Content
 			}
 			
             if (existingInstance == null)
-			    texture = new Texture2D(reader.GraphicsDevice, width, height, levelCount > 1, convertedFormat);
+                texture = new Texture2D(reader.GraphicsDevice, width, height, levelCountOutput > 1, convertedFormat);
             else
                 texture = existingInstance;
 			
@@ -122,6 +133,12 @@ namespace Microsoft.Xna.Framework.Content
 				byte[] levelData = reader.ReadBytes (levelDataSizeInBytes);
                 int levelWidth = width >> level;
                 int levelHeight = height >> level;
+
+                if (level >= levelCountOutput)
+                {
+                    continue;
+                }
+
 				//Convert the image data if required
 				switch (surfaceFormat)
 				{

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -1,0 +1,89 @@
+#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+
+using System;
+using System.Collections.Generic;
+#if OPENGL
+using OpenTK.Graphics.ES20;
+#endif
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    /// <summary>
+    /// Provides information about the capabilities of the
+    /// current graphics device. A very useful thread for investigating GL extenion names
+    /// http://stackoverflow.com/questions/3881197/opengl-es-2-0-extensions-on-android-devices
+    /// </summary>
+    internal static class GraphicsCapabilities
+    {
+        /// <summary>
+        /// Whether the device fully supports non power-of-two textures, including
+        /// mip maps and wrap modes other than CLAMP_TO_EDGE
+        /// </summary>
+        internal static bool NonPowerOfTwo { get; private set; }
+
+        internal static void Initialize(GraphicsDevice device)
+        {
+            NonPowerOfTwo = GetNonPowerOfTwo(device);
+        }
+
+        static bool GetNonPowerOfTwo(GraphicsDevice device)
+        {
+#if OPENGL
+#if GLES
+            return device._extensions.Contains("GL_OES_texture_npot") ||
+                   device._extensions.Contains("GL_ARB_texture_non_power_of_two") ||
+                   device._extensions.Contains("GL_IMG_texture_npot") ||
+                   device._extensions.Contains("GL_NV_texture_npot_2D_mipmap");
+#else
+            // Unfortunately non PoT texture support is patchy even on desktop systems and we can't
+            // rely on the fact that GL2.0+ supposedly supports npot in the core.
+            // Reference: http://aras-p.info/blog/2012/10/17/non-power-of-two-textures/
+            int maxTextureSize = 0;
+            GL.GetInteger(GetPName.MaxTextureSize, out maxTextureSize);
+            return maxTextureSize >= 8192;
+#endif
+
+#else
+            return device.GraphicsProfile == GraphicsProfile.HiDef;
+#endif
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -239,11 +239,11 @@ namespace Microsoft.Xna.Framework.Graphics
 		public event EventHandler<ResourceDestroyedEventArgs> ResourceDestroyed;
         public event EventHandler<EventArgs> Disposing;
 
-        readonly List<string> _extensions = new List<string>();
 
 #if OPENGL
         internal int glFramebuffer;
         internal int MaxVertexAttributes;        
+        internal readonly List<string> _extensions = new List<string>();
 #endif
         
         internal int MaxTextureSlots;
@@ -376,6 +376,8 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
 #endif // OPENGL
+
+            GraphicsCapabilities.Initialize(this);
 
 #if DIRECTX
 

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Android\AndroidGamePlatform.cs" />
     <Compile Include="Android\Devices\Sensors\Accelerometer.cs" />
     <Compile Include="Android\Devices\Sensors\Compass.cs" />
+    <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Input\Mouse.cs" />
     <Compile Include="Android\Input\Touch\AndroidTouchEventManager.cs" />
     <Compile Include="Android\OrientationListener.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.Linux.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Linux.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Media\MediaState.cs" />
     <Compile Include="Media\MediaSourceType.cs" />
     <Compile Include="Content\ContentReader.cs" />
+    <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Graphics\IGraphicsDeviceService.cs" />
     <Compile Include="Content\ContentTypeReader.cs" />
     <Compile Include="Content\ContentTypeReaderManager.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Graphics\IGraphicsDeviceService.cs" />
     <Compile Include="Content\ContentTypeReader.cs" />
     <Compile Include="Content\ContentTypeReaderManager.cs" />
+    <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Graphics\Viewport.cs" />
     <Compile Include="Graphics\DisplayMode.cs" />
     <Compile Include="Graphics\DisplayModeCollection.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.Ouya.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Ouya.csproj
@@ -57,6 +57,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Graphics\ResourceCreatedEventArgs.cs" />
     <Compile Include="Graphics\ResourceDestroyedEventArgs.cs" />
     <Compile Include="Android\AndroidCompatibility.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.PSMobile.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.PSMobile.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Graphics\IGraphicsDeviceService.cs" />
     <Compile Include="Content\ContentTypeReader.cs" />
     <Compile Include="Content\ContentTypeReaderManager.cs" />
+    <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Content\ContentReaders\EffectMaterialReader.cs" />
     <Compile Include="Content\ContentReaders\ExternalReferenceReader.cs" />
     <Compile Include="Graphics\Viewport.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.Windows.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Content\ContentReaders\VertexDeclarationReader.cs" />
     <Compile Include="Content\ResourceContentManager.cs" />
     <Compile Include="Graphics\GraphicsExtensions.cs" />
+    <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Graphics\PackedVector\HalfVector4.cs" />
     <Compile Include="Graphics\PackedVector\Short4.cs" />
     <Compile Include="Graphics\ResourceCreatedEventArgs.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Graphics\Effect\EffectTechniqueCollection.cs" />
     <Compile Include="Graphics\Effect\SpriteEffect.cs" />
     <Compile Include="Graphics\ImageEx.cs" />
+    <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Graphics\PackedVector\IPackedVector.cs" />
     <Compile Include="Graphics\PackedVector\Short2.cs" />
     <Compile Include="Graphics\PackedVector\Short4.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.WindowsGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsGL.csproj
@@ -99,6 +99,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Graphics\ResourceCreatedEventArgs.cs" />
     <Compile Include="Graphics\ResourceDestroyedEventArgs.cs" />
     <Compile Include="Audio\AudioCategory.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.WindowsPhone.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsPhone.csproj
@@ -126,6 +126,7 @@
     <Compile Include="GamePlatform.cs" />
     <Compile Include="GamerServices\MessageBoxIcon.cs" />
     <Compile Include="GameTimerEventArgs.cs" />
+    <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Graphics\CubeMapFace.cs" />
     <Compile Include="Graphics\DisplayMode.cs" />
     <Compile Include="Graphics\Effect\AlphaTestEffect.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -90,6 +90,7 @@
     <Compile Include="GamerServices\GamerPrivileges.cs" />
     <Compile Include="GamerServices\GamerServicesComponent.cs" />
     <Compile Include="GamerServices\SignedInGamerCollection.cs" />
+    <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Graphics\ClearOptions.cs" />
     <Compile Include="Graphics\DisplayMode.cs" />
     <Compile Include="Graphics\DisplayModeCollection.cs" />


### PR DESCRIPTION
Added a GraphicsCapabilities class to test for non-power of two texture support. In the future this can be extended to test for other things.

This feature is important because when you supply non PoT mip maps and the device doesn't support them, you will GL errors. Also, on Android some devices support them and others don't, meaning you may test your game and have it work fine but once released it will crash on other devices.

The support for mip maps with non-PoT textures is patchy, but more and more devices have support so it'd be a shame to disable it outright.

So far I've tested on an iPad 1, Windows 7, Android 4.0 Samsung GalaxyS2, and a MacBook (not pro).

The only part I'm not confident about is the handling of OPENGL non-GLES platforms (ie desktop PC, Mac and Linux). I took the advice given here: http://aras-p.info/blog/2012/10/17/non-power-of-two-textures/ (OpenGL section), which suggests a more reliable way of deciding on PoT support is whether the card supports 8192 sized textures. This is pretty safe. The only risk is that certain older devices that don't support 8192 textures but do fully support non-PoT textures will have their non-PoT mip maps discarded. Not likely to be a problem IMO as non PoT textures are mostly for UI elements and not likely to have mip maps anyway.
