### PR TITLE
Fix for WinGL initialising GraphicsCapabilities

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -80,9 +80,7 @@ namespace Microsoft.Xna.Framework.Graphics
             // Unfortunately non PoT texture support is patchy even on desktop systems and we can't
             // rely on the fact that GL2.0+ supposedly supports npot in the core.
             // Reference: http://aras-p.info/blog/2012/10/17/non-power-of-two-textures/
-            int maxTextureSize = 0;
-            GL.GetInteger(GetPName.MaxTextureSize, out maxTextureSize);
-            return maxTextureSize >= 8192;
+            return device._maxTextureSize >= 8192;
 #endif
 
 #else

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -244,6 +244,7 @@ namespace Microsoft.Xna.Framework.Graphics
         internal int glFramebuffer;
         internal int MaxVertexAttributes;        
         internal readonly List<string> _extensions = new List<string>();
+        internal int _maxTextureSize = 0;
 #endif
         
         internal int MaxTextureSlots;
@@ -324,19 +325,29 @@ namespace Microsoft.Xna.Framework.Graphics
 			_viewport.MaxDepth = 1.0f;
 
             MaxTextureSlots = 16;
+#if OPENGL
 #if GLES
             GL.GetInteger(All.MaxTextureImageUnits, ref MaxTextureSlots);
             GraphicsExtensions.CheckGLError();
 
             GL.GetInteger(All.MaxVertexAttribs, ref MaxVertexAttributes);
-            GraphicsExtensions.CheckGLError();            
+            GraphicsExtensions.CheckGLError();
+
+            GL.GetInteger(All.MaxTextureSize, ref _maxTextureSize);
+            GraphicsExtensions.CheckGLError();
 #elif OPENGL
             GL.GetInteger(GetPName.MaxTextureImageUnits, out MaxTextureSlots);
             GraphicsExtensions.CheckGLError();
 
             GL.GetInteger(GetPName.MaxVertexAttribs, out MaxVertexAttributes);
-            GraphicsExtensions.CheckGLError();            
+            GraphicsExtensions.CheckGLError();
+            
+            GL.GetInteger(GetPName.MaxTextureSize, out _maxTextureSize);
+            GraphicsExtensions.CheckGLError();
 #endif
+            _extensions = GetGLExtensions();
+#endif // OPENGL
+
             Textures = new TextureCollection (MaxTextureSlots);
 			SamplerStates = new SamplerStateCollection (MaxTextureSlots);
 
@@ -349,25 +360,26 @@ namespace Microsoft.Xna.Framework.Graphics
             Dispose(false);
         }
 
-        internal void Initialize()
+#if OPENGL
+        List<string> GetGLExtensions()
         {
             // Setup extensions.
-#if OPENGL
+            List<string> extensions = new List<string>();
 #if GLES
             var extstring = GL.GetString(RenderbufferStorage.Extensions);            			
 #else
-            var extstring = GL.GetString(StringName.Extensions);	
+            var extstring = GL.GetString(StringName.Extensions);
 #endif
             GraphicsExtensions.CheckGLError();
             if (!string.IsNullOrEmpty(extstring))
             {
-                _extensions.AddRange(extstring.Split(' '));
+                extensions.AddRange(extstring.Split(' '));
 #if ANDROID
                 Android.Util.Log.Debug("MonoGame", "Supported extensions:");
 #else
                 System.Diagnostics.Debug.WriteLine("Supported extensions:");
 #endif
-                foreach (string extension in _extensions)
+                foreach (string extension in extensions)
 #if ANDROID
                     Android.Util.Log.Debug("MonoGame", extension);
 #else
@@ -375,8 +387,12 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
             }
 
+            return extensions;
+        }
 #endif // OPENGL
 
+        internal void Initialize()
+        {
             GraphicsCapabilities.Initialize(this);
 
 #if DIRECTX


### PR DESCRIPTION
Seems that my last pull request broke WindowsGL, and possibly Mac and Linux too. For some reason calling `GL.GetInteger(GetPName.MaxTextureSize, out maxTextureSize);` from a static method causes a null reference exception in OpenTK. I've worked around it by caching the _maxTextureSize in Graphics device. I've also move the parsing of GL extensions to their own method and moved it to constructor after the other 'GL.GetInteger' calls.
