### PR TITLE
Resuming a paused sound was not working correctly

### DIFF
--- a/MonoGame.Framework/Desktop/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Desktop/Audio/OpenALSoundController.cs
@@ -152,6 +152,11 @@ namespace Microsoft.Xna.Framework.Audio
 			AL.SourcePause (soundBuffer.SourceId);
 		}
 
+        public void ResumeSound(OALSoundBuffer soundBuffer)
+        {
+            AL.SourcePlay(soundBuffer.SourceId);
+        }
+
 		public bool IsState (OALSoundBuffer soundBuffer, int state)
 		{
 			int sourceState;

--- a/MonoGame.Framework/Desktop/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Desktop/Audio/SoundEffectInstance.cs
@@ -159,7 +159,8 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public void Pause ()
 		{
-			if (hasSourceId) {
+			if (hasSourceId && soundState == SoundState.Playing)
+            {
 				controller.PauseSound (soundBuffer);
 				soundState = SoundState.Paused;
 			}
@@ -191,15 +192,15 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public virtual void Play ()
 		{
-			int bufferId = soundBuffer.OpenALDataBuffer;
 			if (hasSourceId) {
 				return;
 			}
 			bool isSourceAvailable = controller.ReserveSource (soundBuffer);
-			if (!isSourceAvailable)
-				return;
+            if (!isSourceAvailable)
+                throw new InstancePlayLimitException();
 
-			AL.Source (soundBuffer.SourceId, ALSourcei.Buffer, bufferId);
+            int bufferId = soundBuffer.OpenALDataBuffer;
+            AL.Source(soundBuffer.SourceId, ALSourcei.Buffer, bufferId);
 			ApplyState ();
 
 			controller.PlaySound (soundBuffer);            
@@ -209,7 +210,18 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public void Resume ()
 		{
-			Play ();
+            if (hasSourceId)
+            {
+                if (soundState == SoundState.Paused)
+                {
+                    controller.ResumeSound(soundBuffer);
+                    soundState = SoundState.Playing;
+                }
+            }
+            else
+            {
+                Play();
+            }
 		}
 
 		public void Stop ()


### PR DESCRIPTION
in Desktop OpenAL due to a guard in Play that prevented the same instance being played twice. Now also protects against Resume and Pause being called many times.
Fixes issue #1263.
