### PR TITLE
Use sensor data on iOS

### DIFF
--- a/MonoGame.Framework/iOS/Devices/Sensors/Accelerometer.cs
+++ b/MonoGame.Framework/iOS/Devices/Sensors/Accelerometer.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Devices.Sensors
             if (this.IsDataValid)
             {
                 this.IsDataValid = true;
-                reading.Acceleration = new Vector3((float)motionManager.AccelerometerData.Acceleration.X, (float)motionManager.AccelerometerData.Acceleration.Y, (float)motionManager.AccelerometerData.Acceleration.Z);
+                reading.Acceleration = new Vector3((float)data.Acceleration.X, (float)data.Acceleration.Y, (float)data.Acceleration.Z);
                 reading.Timestamp = DateTime.Now;
                 this.CurrentValue = reading;
                 this.IsDataValid = error == null;

--- a/MonoGame.Framework/iOS/Devices/Sensors/Compass.cs
+++ b/MonoGame.Framework/iOS/Devices/Sensors/Compass.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Devices.Sensors
             this.IsDataValid = error == null;
             if (this.IsDataValid)
             {
-                reading.MagnetometerReading = new Vector3((float)motionManager.DeviceMotion.MagneticField.Field.Y, (float)-motionManager.DeviceMotion.MagneticField.Field.X, (float)motionManager.DeviceMotion.MagneticField.Field.Z);
+                reading.MagnetometerReading = new Vector3((float)data.MagneticField.Field.Y, (float)-data.MagneticField.Field.X, (float)data.MagneticField.Field.Z);
                 reading.TrueHeading = Math.Atan2(reading.MagnetometerReading.Y, reading.MagnetometerReading.X) / Math.PI * 180;
                 reading.MagneticHeading = reading.TrueHeading;
                 switch (data.MagneticField.Accuracy)


### PR DESCRIPTION
Since the MonoTouch bug was fixed with the sensor events, we can revert to using their data
