### PR TITLE
Fixes for Content Pipeline on Mac

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -63,7 +63,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
     public static class GraphicsUtil
     {
-
         public static byte[] GetData(this Bitmap bmp)
         {
             // Any bitmap using this function should use 32bpp ARGB pixel format, since we have to
@@ -262,10 +261,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         }
 
         internal static void Resize(this TextureContent content, int newWidth, int newHeight)
-        {   
-			var resizedBmp = new Bitmap(newWidth, newHeight);
-            
-			using (var graphics = System.Drawing.Graphics.FromImage(resizedBmp))
+        {
+            var resizedBmp = new Bitmap(newWidth, newHeight);
+
+            using (var graphics = System.Drawing.Graphics.FromImage(resizedBmp))
             {
                 graphics.DrawImage(content._bitmap, 0, 0, newWidth, newHeight);
 
@@ -273,10 +272,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 content._bitmap = resizedBmp;
             }
 
-			var imageData = content._bitmap.GetData();
-			
-			var bitmapContent = new PixelBitmapContent<Color>(content._bitmap.Width, content._bitmap.Height);
-			bitmapContent.SetPixelData(imageData);
+            var imageData = content._bitmap.GetData();
+
+            var bitmapContent = new PixelBitmapContent<Color>(content._bitmap.Width, content._bitmap.Height);
+            bitmapContent.SetPixelData(imageData);
 
             content.Faces.Clear();
             content.Faces.Add(new MipmapChain(bitmapContent));

--- a/MonoGame.Framework.Content.Pipeline/Graphics/PixelBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PixelBitmapContent.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 var dataHandle = GCHandle.Alloc(_pixelData[x], GCHandleType.Pinned);
                 var dataPtr = (IntPtr)dataHandle.AddrOfPinnedObject().ToInt64();
 
-				Marshal.Copy(sourceData, (x * Width * size), dataPtr, Width * size);
+                Marshal.Copy(sourceData, (x * Width * size), dataPtr, Width * size);
 
-				dataHandle.Free();
+                dataHandle.Free();
             }
         }
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/TextureContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/TextureContent.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         MipmapChainCollection faces;
         internal Bitmap _bitmap;
 
-		/// <summary>
+        /// <summary>
         /// Collection of image faces that hold a single mipmap chain for a regular 2D texture, six chains for a cube map, or an arbitrary number for volume and array textures.
         /// </summary>
         public MipmapChainCollection Faces

--- a/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
@@ -28,15 +28,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 
         public override TextureContent Process(TextureContent input, ContentProcessorContext context)
         {
-			var width = input._bitmap.Width;
-			var height = input._bitmap.Height;
-
-			if (ColorKeyEnabled)
+            if (ColorKeyEnabled)
             {
                 var replaceColor = System.Drawing.Color.FromArgb(0);
-                for (var x = 0; x < width; x++)
+                for (var x = 0; x < input._bitmap.Width; x++)
                 {
-                    for (var y = 0; y < height; y++)
+                    for (var y = 0; y < input._bitmap.Height; y++)
                     {
                         var col = input._bitmap.GetPixel(x, y);
 
@@ -57,9 +54,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 
             if (PremultiplyAlpha)
             {
-                for (var x = 0; x < width; x++)
+                for (var x = 0; x < input._bitmap.Width; x++)
                 {
-                    for (var y = 0; y < height; y++)
+                    for (var y = 0; y < input._bitmap.Height; y++)
                     {
                         var oldCol = input._bitmap.GetPixel(x, y);
                         var preMultipliedColor = Color.FromNonPremultiplied(oldCol.R, oldCol.G, oldCol.B, oldCol.A);

--- a/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
@@ -46,10 +46,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 				output._bitmap = bitmap;
 			}
 
-			if (output._bitmap.PixelFormat != System.Drawing.Imaging.PixelFormat.Format32bppArgb) {
-				throw new InvalidContentException("Bitmap is not ARGB32");
-			}
-            var imageData = output._bitmap.GetData();
+			var imageData = output._bitmap.GetData();
 
             var bitmapContent = new PixelBitmapContent<Color>(width, height);
             bitmapContent.SetPixelData(imageData);

--- a/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
@@ -366,7 +366,7 @@
     <Compile Include="Content\ContentReaders\EffectReader.cs" />
     <Compile Include="Graphics\Effect\EffectAnnotation.cs" />
     <Compile Include="Graphics\Effect\EffectAnnotationCollection.cs" />
-    <Compile Include="Graphics\Shader\ConstantBufferCollection.cs" />
+	<Compile Include="Graphics\Shader\ConstantBufferCollection.cs" />
     <Compile Include="Graphics\Shader\ConstantBuffer.cs" />
     <Compile Include="Graphics\Shader\Shader.cs" />
     <Compile Include="Graphics\Shader\ShaderStage.cs" />


### PR DESCRIPTION
Fixes a few compile issues under Mac.

The call to Bitmap.Clone does not work correctly on Mac, as it seems to ignore the PixelFormat and returns a bitmap with the same format as the origional, which causes crashes later on it the process. This has been swtiched over to use a new instance and a Graphics.Draw as this is more reliable.
