### PR TITLE
Fix For Leading Seperator In Song Path

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/SongReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SongReader.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Xna.Framework.Content
 
 		protected internal override Song Read(ContentReader input, Song existingInstance)
 		{
-			string path = input.ReadString();
+			var path = input.ReadString();
 			
 			if (!String.IsNullOrEmpty(path))
 			{
@@ -85,12 +85,12 @@ namespace Microsoft.Xna.Framework.Content
 				path = dst.LocalPath.Substring(1);
 				
 				// Adds the ContentManager's RootDirectory
-                path = input.ContentManager.RootDirectoryFullPath + separator + path;
+                path = Path.Combine(input.ContentManager.RootDirectoryFullPath, path);
 			}
 			
-			int durationMS = input.ReadObject<int>();
+			var durationMs = input.ReadObject<int>();
 
-            return new Song(path, durationMS); 
+            return new Song(path, durationMs); 
 		}
 	}
 }


### PR DESCRIPTION
A small fix which ensures we do not get paths with a leading separator when the content root directory is empty.

This only really occurs if a user uses an empty path for the Content folder.
