### PR TITLE
Fixed MGFX To Not Generate Default SampleState.

### DIFF
--- a/Tools/2MGFX/DXShaderData.mojo.cs
+++ b/Tools/2MGFX/DXShaderData.mojo.cs
@@ -141,8 +141,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 SamplerStateInfo state;
                 if (samplerStates.TryGetValue(originalSamplerName, out state))
                 {
-                    sampler.state = state.state;
-                    sampler.parameterName = state.textureName ?? originalSamplerName;
+                    sampler.state = state.State;
+                    sampler.parameterName = state.TextureName ?? originalSamplerName;
                 }
 
                 // Store the sampler.

--- a/Tools/2MGFX/DXShaderData.sharpdx.cs
+++ b/Tools/2MGFX/DXShaderData.sharpdx.cs
@@ -83,8 +83,8 @@ namespace Microsoft.Xna.Framework.Graphics
                             SamplerStateInfo state;
                             if (samplerStates.TryGetValue(rdesc.Name, out state))
                             {
-                                sampler.parameterName = state.textureName ?? rdesc.Name;
-                                sampler.state = state.state;
+                                sampler.parameterName = state.TextureName ?? rdesc.Name;
+                                sampler.state = state.State;
                             }
 
                             samplers.Add(sampler);

--- a/Tools/2MGFX/MGFX.tpg
+++ b/Tools/2MGFX/MGFX.tpg
@@ -187,47 +187,11 @@ PixelShader_Pass_Expression -> PixelShader Equals Compile ShaderModel Identifier
 
 Sampler_State_Expression -> Identifier Equals (LessThan Identifier GreaterThan | Identifier | Number) Semicolon
 {
-	var sampler = paramlist[0] as SamplerStateInfo;
 	var name = $Identifier[0] as string;
-	var value = ($Identifier[1] ?? ($Identifier[2] ?? $Number[0])) as string;
-	switch (name.ToLower())
-	{
-		case "texture":
-			sampler.textureName = value;
-			break;
-		case "minfilter":
-			sampler.MinFilter = ParseTreeTools.ParseTextureFilterType(value);
-			break;
-		case "magfilter":
-			sampler.MagFilter = ParseTreeTools.ParseTextureFilterType(value);
-			break;
-		case "mipfilter":
-			sampler.MipFilter = ParseTreeTools.ParseTextureFilterType(value);
-			break;
-		case "filter":
-			sampler.MinFilter = sampler.MagFilter = sampler.MipFilter = ParseTreeTools.ParseTextureFilterType(value);
-			break;
-		case "addressu":
-			sampler.state.AddressU = ParseTreeTools.ParseAddressMode(value);
-			break;
-		case "addressv":
-			sampler.state.AddressV = ParseTreeTools.ParseAddressMode(value);
-			break;
-		case "addressw":
-			sampler.state.AddressW = ParseTreeTools.ParseAddressMode(value);
-			break;
-		case "maxanisotropy":
-			sampler.state.MaxAnisotropy = int.Parse(value);
-			break;
-		case "maxlod":
-			sampler.state.MaxMipLevel = int.Parse(value);
-			break;
-		case "miplodbias":
-			sampler.state.MipMapLevelOfDetailBias = float.Parse(value);
-			break;
-		default:
-			break;
-	}
+	var value = ($Identifier[1] ?? ($Identifier[2] ?? $Number[0])) as string;	
+
+	var sampler = paramlist[0] as SamplerStateInfo;
+	sampler.Parse(name, value);
 
 	return null;
 };
@@ -243,34 +207,13 @@ Sampler_Declaration -> Sampler Identifier (Sampler_Register_Expression)* (Equals
 		return null;
 	
 	var sampler = new SamplerStateInfo();
-	sampler.name = $Identifier as string;
-	sampler.state = new Microsoft.Xna.Framework.Graphics.SamplerState();	
+	sampler.Name = $Identifier as string;
 	
 	foreach (ParseNode node in Nodes)
 		node.Eval(tree, sampler);
-	
-	// Figure out what kind of filter to set based on each individual min, mag, and mip filter
-	if (sampler.MinFilter == TextureFilterType.Anisotropic)
-		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.Anisotropic;
-	else if (sampler.MinFilter == TextureFilterType.Linear && sampler.MagFilter == TextureFilterType.Linear && sampler.MipFilter == TextureFilterType.Linear)
-		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.Linear;
-	else if (sampler.MinFilter == TextureFilterType.Linear && sampler.MagFilter == TextureFilterType.Linear && sampler.MipFilter == TextureFilterType.Point)
-		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.LinearMipPoint;
-	else if (sampler.MinFilter == TextureFilterType.Linear && sampler.MagFilter == TextureFilterType.Point && sampler.MipFilter == TextureFilterType.Linear)
-		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.MinLinearMagPointMipLinear;
-	else if (sampler.MinFilter == TextureFilterType.Linear && sampler.MagFilter == TextureFilterType.Point && sampler.MipFilter == TextureFilterType.Point)
-		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.MinLinearMagPointMipPoint;
-	else if (sampler.MinFilter == TextureFilterType.Point && sampler.MagFilter == TextureFilterType.Linear && sampler.MipFilter == TextureFilterType.Linear)
-		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.MinPointMagLinearMipLinear;
-	else if (sampler.MinFilter == TextureFilterType.Point && sampler.MagFilter == TextureFilterType.Linear && sampler.MipFilter == TextureFilterType.Point)
-		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.MinPointMagLinearMipPoint;
-	else if (sampler.MinFilter == TextureFilterType.Point && sampler.MagFilter == TextureFilterType.Point && sampler.MipFilter == TextureFilterType.Point)
-		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.Point;
-	else if (sampler.MinFilter == TextureFilterType.Point && sampler.MagFilter == TextureFilterType.Point && sampler.MipFilter == TextureFilterType.Linear)
-		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.PointMipLinear;
 
 	var shaderInfo = paramlist[0] as ShaderInfo;
-	shaderInfo.SamplerStates.Add(sampler.name, sampler);
+	shaderInfo.SamplerStates.Add(sampler.Name, sampler);
 
 	return null;
 };

--- a/Tools/2MGFX/ParseTree.cs
+++ b/Tools/2MGFX/ParseTree.cs
@@ -361,47 +361,11 @@ namespace TwoMGFX
 
         protected virtual object EvalSampler_State_Expression(ParseTree tree, params object[] paramlist)
         {
-            var sampler = paramlist[0] as SamplerStateInfo;
-        	var name = this.GetValue(tree, TokenType.Identifier, 0) as string;
-        	var value = (this.GetValue(tree, TokenType.Identifier, 1) ?? (this.GetValue(tree, TokenType.Identifier, 2) ?? this.GetValue(tree, TokenType.Number, 0))) as string;
-        	switch (name.ToLower())
-        	{
-        		case "texture":
-        			sampler.textureName = value;
-        			break;
-        		case "minfilter":
-        			sampler.MinFilter = ParseTreeTools.ParseTextureFilterType(value);
-        			break;
-        		case "magfilter":
-        			sampler.MagFilter = ParseTreeTools.ParseTextureFilterType(value);
-        			break;
-        		case "mipfilter":
-        			sampler.MipFilter = ParseTreeTools.ParseTextureFilterType(value);
-        			break;
-        		case "filter":
-        			sampler.MinFilter = sampler.MagFilter = sampler.MipFilter = ParseTreeTools.ParseTextureFilterType(value);
-        			break;
-        		case "addressu":
-        			sampler.state.AddressU = ParseTreeTools.ParseAddressMode(value);
-        			break;
-        		case "addressv":
-        			sampler.state.AddressV = ParseTreeTools.ParseAddressMode(value);
-        			break;
-        		case "addressw":
-        			sampler.state.AddressW = ParseTreeTools.ParseAddressMode(value);
-        			break;
-        		case "maxanisotropy":
-        			sampler.state.MaxAnisotropy = int.Parse(value);
-        			break;
-        		case "maxlod":
-        			sampler.state.MaxMipLevel = int.Parse(value);
-        			break;
-        		case "miplodbias":
-        			sampler.state.MipMapLevelOfDetailBias = float.Parse(value);
-        			break;
-        		default:
-        			break;
-        	}
+            var name = this.GetValue(tree, TokenType.Identifier, 0) as string;
+        	var value = (this.GetValue(tree, TokenType.Identifier, 1) ?? (this.GetValue(tree, TokenType.Identifier, 2) ?? this.GetValue(tree, TokenType.Number, 0))) as string;	
+        
+        	var sampler = paramlist[0] as SamplerStateInfo;
+        	sampler.Parse(name, value);
         
         	return null;
         }
@@ -417,34 +381,13 @@ namespace TwoMGFX
         		return null;
         	
         	var sampler = new SamplerStateInfo();
-        	sampler.name = this.GetValue(tree, TokenType.Identifier, 0) as string;
-        	sampler.state = new Microsoft.Xna.Framework.Graphics.SamplerState();	
+        	sampler.Name = this.GetValue(tree, TokenType.Identifier, 0) as string;
         	
         	foreach (ParseNode node in Nodes)
         		node.Eval(tree, sampler);
-        	
-        	// Figure out what kind of filter to set based on each individual min, mag, and mip filter
-        	if (sampler.MinFilter == TextureFilterType.Anisotropic)
-        		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.Anisotropic;
-        	else if (sampler.MinFilter == TextureFilterType.Linear && sampler.MagFilter == TextureFilterType.Linear && sampler.MipFilter == TextureFilterType.Linear)
-        		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.Linear;
-        	else if (sampler.MinFilter == TextureFilterType.Linear && sampler.MagFilter == TextureFilterType.Linear && sampler.MipFilter == TextureFilterType.Point)
-        		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.LinearMipPoint;
-        	else if (sampler.MinFilter == TextureFilterType.Linear && sampler.MagFilter == TextureFilterType.Point && sampler.MipFilter == TextureFilterType.Linear)
-        		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.MinLinearMagPointMipLinear;
-        	else if (sampler.MinFilter == TextureFilterType.Linear && sampler.MagFilter == TextureFilterType.Point && sampler.MipFilter == TextureFilterType.Point)
-        		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.MinLinearMagPointMipPoint;
-        	else if (sampler.MinFilter == TextureFilterType.Point && sampler.MagFilter == TextureFilterType.Linear && sampler.MipFilter == TextureFilterType.Linear)
-        		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.MinPointMagLinearMipLinear;
-        	else if (sampler.MinFilter == TextureFilterType.Point && sampler.MagFilter == TextureFilterType.Linear && sampler.MipFilter == TextureFilterType.Point)
-        		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.MinPointMagLinearMipPoint;
-        	else if (sampler.MinFilter == TextureFilterType.Point && sampler.MagFilter == TextureFilterType.Point && sampler.MipFilter == TextureFilterType.Point)
-        		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.Point;
-        	else if (sampler.MinFilter == TextureFilterType.Point && sampler.MagFilter == TextureFilterType.Point && sampler.MipFilter == TextureFilterType.Linear)
-        		sampler.state.Filter = Microsoft.Xna.Framework.Graphics.TextureFilter.PointMipLinear;
         
         	var shaderInfo = paramlist[0] as ShaderInfo;
-        	shaderInfo.SamplerStates.Add(sampler.name, sampler);
+        	shaderInfo.SamplerStates.Add(sampler.Name, sampler);
         
         	return null;
         }

--- a/Tools/2MGFX/ShaderInfo.cs
+++ b/Tools/2MGFX/ShaderInfo.cs
@@ -67,12 +67,213 @@ namespace TwoMGFX
 
 	public class SamplerStateInfo
 	{
-		public string name;
-        public string textureName;
-		public SamplerState state;
-		public TextureFilterType MinFilter;
-		public TextureFilterType MagFilter;
-		public TextureFilterType MipFilter;
+        private SamplerState _state;
+        
+        private bool _dirty;
+
+        private TextureFilterType _minFilter;
+        private TextureFilterType _magFilter;
+        private TextureFilterType _mipFilter;
+
+        private TextureAddressMode _addressU;
+        private TextureAddressMode _addressV;
+        private TextureAddressMode _addressW;
+
+	    private int _maxAnisotropy;
+        private int _maxMipLevel;
+	    private float _mipMapLevelOfDetailBias;
+
+        public string Name { get; set; }
+
+        public string TextureName { get; set; }
+
+	    public TextureFilterType MinFilter
+	    {
+            set
+            {
+                if (_minFilter == value) 
+                    return;
+                _minFilter = value;
+                _dirty = true;
+            }
+	    }
+
+        public TextureFilterType MagFilter
+        {
+            set
+            {
+                if (_magFilter == value) 
+                    return;
+                _magFilter = value;
+                _dirty = true;
+            }
+        }
+
+        public TextureFilterType MipFilter
+        {
+            set
+            {
+                if (_mipFilter == value) 
+                    return;
+                _mipFilter = value;
+                _dirty = true;
+            }
+        }
+
+        public TextureAddressMode AddressU
+        {
+            set
+            {
+                if (_addressU == value)
+                    return;
+                _addressU = value;
+                _dirty = true;
+            }
+        }
+
+        public TextureAddressMode AddressV
+        {
+            set
+            {
+                if (_addressV == value)
+                    return;
+                _addressV = value;
+                _dirty = true;
+            }
+        }
+
+        public TextureAddressMode AddressW
+        {
+            set
+            {
+                if (_addressW == value)
+                    return;
+                _addressW = value;
+                _dirty = true;
+            }
+        }
+
+        public int MaxAnisotropy
+        {
+            set
+            {
+                if (_maxAnisotropy == value)
+                    return;
+                _maxAnisotropy = value;
+                _dirty = true;
+            }
+        }
+
+        public int MaxMipLevel
+        {
+            set
+            {
+                if (_maxMipLevel == value)
+                    return;
+                _maxMipLevel = value;
+                _dirty = true;
+            }
+        }
+
+        public float MipMapLevelOfDetailBias
+        {
+            set
+            {
+                if (_mipMapLevelOfDetailBias == value)
+                    return;
+                _mipMapLevelOfDetailBias = value;
+                _dirty = true;
+            }
+        }
+
+        private void UpdateSamplerState()
+        {
+            // Get the existing state or create it.
+            if (_state == null)
+                _state = new SamplerState();
+
+            _state.AddressU = _addressU;
+            _state.AddressV = _addressV;
+            _state.AddressW = _addressW;
+
+            _state.MaxAnisotropy = _maxAnisotropy;
+            _state.MaxMipLevel = _maxMipLevel;
+            _state.MipMapLevelOfDetailBias = _mipMapLevelOfDetailBias;
+
+            // Figure out what kind of filter to set based on each
+            // individual min, mag, and mip filter settings.
+            if (_minFilter == TextureFilterType.Anisotropic)
+                _state.Filter = TextureFilter.Anisotropic;
+            else if (_minFilter == TextureFilterType.Linear && _magFilter == TextureFilterType.Linear && _mipFilter == TextureFilterType.Linear)
+                _state.Filter = TextureFilter.Linear;
+            else if (_minFilter == TextureFilterType.Linear && _magFilter == TextureFilterType.Linear && _mipFilter == TextureFilterType.Point)
+                _state.Filter = TextureFilter.LinearMipPoint;
+            else if (_minFilter == TextureFilterType.Linear && _magFilter == TextureFilterType.Point && _mipFilter == TextureFilterType.Linear)
+                _state.Filter = TextureFilter.MinLinearMagPointMipLinear;
+            else if (_minFilter == TextureFilterType.Linear && _magFilter == TextureFilterType.Point && _mipFilter == TextureFilterType.Point)
+                _state.Filter = TextureFilter.MinLinearMagPointMipPoint;
+            else if (_minFilter == TextureFilterType.Point && _magFilter == TextureFilterType.Linear && _mipFilter == TextureFilterType.Linear)
+                _state.Filter = TextureFilter.MinPointMagLinearMipLinear;
+            else if (_minFilter == TextureFilterType.Point && _magFilter == TextureFilterType.Linear && _mipFilter == TextureFilterType.Point)
+                _state.Filter = TextureFilter.MinPointMagLinearMipPoint;
+            else if (_minFilter == TextureFilterType.Point && _magFilter == TextureFilterType.Point && _mipFilter == TextureFilterType.Point)
+                _state.Filter = TextureFilter.Point;
+            else if (_minFilter == TextureFilterType.Point && _magFilter == TextureFilterType.Point && _mipFilter == TextureFilterType.Linear)
+                _state.Filter = TextureFilter.PointMipLinear;
+
+            _dirty = false;
+        }
+
+        public void Parse(string name, string value)
+        {
+            switch (name.ToLower())
+            {
+                case "texture":
+                    TextureName = value;
+                    break;
+                case "minfilter":
+                    MinFilter = ParseTreeTools.ParseTextureFilterType(value);
+                    break;
+                case "magfilter":
+                    MagFilter = ParseTreeTools.ParseTextureFilterType(value);
+                    break;
+                case "mipfilter":
+                    MipFilter = ParseTreeTools.ParseTextureFilterType(value);
+                    break;
+                case "filter":
+                    MinFilter = MagFilter = MipFilter = ParseTreeTools.ParseTextureFilterType(value);
+                    break;
+                case "addressu":
+                    AddressU = ParseTreeTools.ParseAddressMode(value);
+                    break;
+                case "addressv":
+                    AddressV = ParseTreeTools.ParseAddressMode(value);
+                    break;
+                case "addressw":
+                    AddressW = ParseTreeTools.ParseAddressMode(value);
+                    break;
+                case "maxanisotropy":
+                    MaxAnisotropy = int.Parse(value);
+                    break;
+                case "maxlod":
+                    MaxMipLevel = int.Parse(value);
+                    break;
+                case "miplodbias":
+                    MipMapLevelOfDetailBias = float.Parse(value);
+                    break;
+            }            
+        }
+
+        public SamplerState State
+	    {
+	        get
+	        {
+	            if (_dirty)
+                    UpdateSamplerState();
+
+	            return _state;
+	        }
+	    }
 	}
 
 	public class TechniqueInfo


### PR DESCRIPTION
The MGFX processor was generating a default SampleState when a user did not specify any SampleState parameters in his FX file.

This caused custom shaders to force LinearWrap even if the user sets it to something else.

See #1344 for an example.

This code change only affects the 2MGFX tool which currently only works on Windows.
