### PR TITLE
Removed minVertexIndex Exception

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -2078,6 +2078,16 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 #endif
 
+        /// <summary>
+        /// Draw geometry by indexing into the vertex buffer.
+        /// </summary>
+        /// <param name="primitiveType">The type of primitives in the index buffer.</param>
+        /// <param name="baseVertex">Used to offset the vertex range indexed from the vertex buffer.</param>
+        /// <param name="minVertexIndex">A hint of the lowest vertex indexed relative to baseVertex.</param>
+        /// <param name="numVertices">An hint of the maximum vertex indexed.</param>
+        /// <param name="startIndex">The index within the index buffer to start drawing from.</param>
+        /// <param name="primitiveCount">The number of primitives to render from the index buffer.</param>
+        /// <remarks>Note that minVertexIndex and numVertices are unused in MonoGame and will be ignored.</remarks>
         public void DrawIndexedPrimitives(PrimitiveType primitiveType, int baseVertex, int minVertexIndex, int numVertices, int startIndex, int primitiveCount)
         {
             Debug.Assert(_vertexBuffer != null, "The vertex buffer is null!");


### PR DESCRIPTION
This removes the exception on minVertexIndex in GraphicsDevice.DrawIndexedPrimitives().

minVertexIndex and numVertices are simply hints for software vertex processing.

 http://blogs.msdn.com/b/jsteed/archive/2004/07/16/drawindexedprimitive-demystified.aspx

> The MinIndex and NumVertices values are really just hints 
> to help Direct3D optimize memory access during software 
> vertex processing, and could simply be set to include the 
> entire vertex buffer at the price of performance.

Since DirectX11 and OpenGL do not support such hints these parameters are currently unused in MonoGame.  We leave them only for compatibility with XNA.
