### PR TITLE
TypeInitializationException Fix for WP8 MediaPlayer

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -96,8 +96,6 @@ namespace Microsoft.Xna.Framework.Media
         {
 #if WINDOWS_MEDIA_ENGINE
 
-            try
-            {
                 MediaManager.Startup(true);
                 using (var factory = new MediaEngineClassFactory())
                 using (var attributes = new MediaEngineAttributes { AudioCategory = AudioStreamCategory.GameMedia })
@@ -120,12 +118,6 @@ namespace Microsoft.Xna.Framework.Media
 #else
                 _dispatcher = CoreWindow.GetForCurrentThread().Dispatcher;
 #endif
-                
-            }
-            catch (Exception e)
-            {
-
-            }
 
 #elif WINDOWS_MEDIA_SESSION
 


### PR DESCRIPTION
WP8's construction of media player was failing for two reasons.

1) AudioOnly flag/mode is not supported on WP8: http://msdn.microsoft.com/en-us/library/windowsphone/develop/jj681688(v=vs.105).aspx

2) CoreWindow.GetForCurrentThread() on WP8 always returns NULL on WP8.
