### PR TITLE
Fix rendertarget rendering (OpenGL)

### DIFF
--- a/MonoGame.Framework/Graphics/RenderTarget2D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.cs
@@ -73,7 +73,6 @@ namespace Microsoft.Xna.Framework.Graphics
         internal SharpDX.Direct3D11.DepthStencilView _depthStencilView;
 #elif OPENGL
 		internal uint glDepthStencilBuffer;
-        internal uint glFramebuffer;
 #endif
 
 		public DepthFormat DepthStencilFormat { get; private set; }
@@ -187,12 +186,6 @@ namespace Microsoft.Xna.Framework.Graphics
                     {
                         GL.DeleteRenderbuffers(1, ref this.glDepthStencilBuffer);
                         GraphicsExtensions.CheckGLError();
-
-                        if (this.glFramebuffer > 0)
-                        {
-                            GL.DeleteFramebuffers(1, ref this.glFramebuffer);
-                            GraphicsExtensions.CheckGLError();
-                        }
                     });
 #endif
             }

--- a/MonoGame.Framework/iOS/iOSGameView.cs
+++ b/MonoGame.Framework/iOS/iOSGameView.cs
@@ -156,9 +156,12 @@ namespace Microsoft.Xna.Framework {
 		{
 			AssertNotDisposed ();
 
+            // RetainedBacking controls if the content of the colorbuffer should be preserved after being displayed
+            // This is the XNA equivalent to set PreserveContent when initializing the GraphicsDevice
+            // (should be false by default for better performance)
 			Layer.DrawableProperties = NSDictionary.FromObjectsAndKeys (
 				new NSObject [] {
-					NSNumber.FromBoolean (true),
+					NSNumber.FromBoolean (false), 
 					EAGLColorFormat.RGBA8
 				},
 				new NSObject [] {
@@ -214,21 +217,17 @@ namespace Microsoft.Xna.Framework {
             int viewportHeight = (int)Math.Round(Layer.Bounds.Size.Height * Layer.ContentsScale);
             int viewportWidth = (int)Math.Round(Layer.Bounds.Size.Width * Layer.ContentsScale);
 
-			int previousRenderbuffer = 0;
-			_glapi.GetInteger (All.RenderbufferBinding, ref previousRenderbuffer);
-			
 			_glapi.GenFramebuffers (1, ref _framebuffer);
 			_glapi.BindFramebuffer (All.Framebuffer, _framebuffer);
 			
 			// Create our Depth buffer. Color buffer must be the last one bound
 			GL.GenRenderbuffers(1, ref _depthbuffer);
 			GL.BindRenderbuffer(All.Renderbuffer, _depthbuffer);
-			GL.RenderbufferStorage(All.Renderbuffer, All.DepthComponent16, viewportWidth, viewportHeight);
-			
+            GL.RenderbufferStorage (All.Renderbuffer, All.DepthComponent16, viewportWidth, viewportHeight);
 			GL.FramebufferRenderbuffer(All.Framebuffer, All.DepthAttachment, All.Renderbuffer, _depthbuffer);
 
-			_glapi.GenRenderbuffers (2, ref _colorbuffer);
-			_glapi.BindRenderbuffer (All.Renderbuffer, _colorbuffer);
+			_glapi.GenRenderbuffers(1, ref _colorbuffer);
+			_glapi.BindRenderbuffer(All.Renderbuffer, _colorbuffer);
 
 			var ctx = ((IGraphicsContextInternal) __renderbuffergraphicsContext).Implementation as iPhoneOSGraphicsContext;
 
@@ -238,7 +237,7 @@ namespace Microsoft.Xna.Framework {
 			//       claims to have failed.
 			ctx.EAGLContext.RenderBufferStorage ((uint) All.Renderbuffer, Layer);
 			
-			_glapi.FramebufferRenderbuffer ( All.Framebuffer, All.ColorAttachment0, All.Renderbuffer, _colorbuffer);
+			_glapi.FramebufferRenderbuffer (All.Framebuffer, All.ColorAttachment0, All.Renderbuffer, _colorbuffer);
 			
 			var status = GL.CheckFramebufferStatus (All.Framebuffer);
 			if (status != All.FramebufferComplete)
@@ -327,9 +326,8 @@ namespace Microsoft.Xna.Framework {
 			AssertValidContext ();
 
 			__renderbuffergraphicsContext.MakeCurrent (null);
-
-			var ctx = ((IGraphicsContextInternal) __renderbuffergraphicsContext).Implementation as iPhoneOSGraphicsContext;
-			ctx.EAGLContext.PresentRenderBuffer ((uint) All.Renderbuffer);
+            GL.BindRenderbuffer (All.Renderbuffer, this._colorbuffer);
+            __renderbuffergraphicsContext.SwapBuffers();
 		}
 
 		// FIXME: This functionality belongs iMakeCurrentn GraphicsDevice.


### PR DESCRIPTION
This is a fix to make rendertarget work as expected in OpenGL. This is a followup to #1399.  Here is the gist of it:
- There is no need to create one FBO per rendertarget; we can simply swap attachments when we call GraphicsDevice.SetRenderTargets; also this paves the way to multiple rendertargets support
- The default color buffer needs to be reset before frame swap (iOSGameView.Present) to ensure the one that might be created in the RenderTarget constructor doesn't interfere.

Tested on Infinite Flight (iOS), we use rendertargets quite extensively.

Also changed the behavior for the default  colorbuffer after being displayed (discarded instead of preserved).
