### PR TITLE
Taking vertexOffset into account in WinGL DrawUserIndexedPrimitives

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.WindowsGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsGL.csproj
@@ -85,10 +85,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ThirdParty\Libs\OpenTK.dll</HintPath>
     </Reference>
-    <Reference Include="OpenTK.GLControl, Version=1.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ThirdParty\Libs\OpenTK.GLControl.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />


### PR DESCRIPTION
The WinGL version of DrawUserIndexedPrimitives ignores the vertexOffset parameter.  This patch recalculates the vertex address by taking the offset into account.
