### PR TITLE
Added MaxTextureSize to GraphicsDevice

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -2461,6 +2461,31 @@ namespace Microsoft.Xna.Framework.Graphics
 
             throw new NotSupportedException();
         }
-		
+
+		/// <summary>
+		/// 	Gets the size of the max texture.
+		/// </summary>
+		/// <value>
+		/// 	The size of the max texture.
+		/// </value>
+		/// <remarks>
+		/// 	On Windows with DirectX the limit is based on the <see cref="Microsoft.Xna.Framework.Graphics.GraphicsDevice.GraphicsProfile"/>. If it's set to <see cref="Microsoft.Xna.Framework.Graphics.GraphicsProfile.Reach"/> the value is 2024, if set to <see cref="Microsoft.Xna.Framework.Graphics.Graphics.GraphicsProfile.HiDef"/> then the value is 4096. On all other platforms it returns the lesser of the screen width or height.
+		/// </remarks>			
+		public int MaxTextureSize
+		{
+			get
+			{
+#if WINDOWS && DIRECTX
+				if (GraphicsProfile == GraphicsProfile.Reach)
+				{
+					return 2048;
+				}
+				return 4096;
+#else
+				return Math.Min(DisplayMode.Width, DisplayMode.Height);
+#endif
+			}
+		}
+
     }
 }


### PR DESCRIPTION
In XNA Textures can be larger than the screen (though there is a
maximum size) while in OpenGL they can't. This property returns the max
allowed. (for Windows DirectX it uses the XNA values to help porting)
