### PR TITLE
Fix: Mipmap levels of DXT textures were not loaded correctly in DirectX

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -295,6 +295,15 @@ namespace Microsoft.Xna.Framework.Graphics
                     y = 0;
                     w = Math.Max(width >> level, 1);
                     h = Math.Max(height >> level, 1);
+
+#if DIRECTX
+                    // For DXT textures the width and height of each level is a multiply of 4.
+                    if (format == SurfaceFormat.Dxt1 || format == SurfaceFormat.Dxt3 || format == SurfaceFormat.Dxt5)
+                    {
+                        w = ((w + 3) / 4) * 4;
+                        h = ((h + 3) / 4) * 4;
+                    }
+#endif
                 }
 
 #if DIRECTX

--- a/MonoGame.Framework/Graphics/TextureCube.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.cs
@@ -203,6 +203,15 @@ namespace Microsoft.Xna.Framework.Graphics
                 yOffset = 0;
                 width = Math.Max(1, this.size >> level);
                 height = Math.Max(1, this.size >> level);
+
+#if DIRECTX
+                // For DXT textures the width and height of each level is a multiply of 4.
+                if (format == SurfaceFormat.Dxt1 || format == SurfaceFormat.Dxt3 || format == SurfaceFormat.Dxt5)
+                {
+                    width = ((width + 3) / 4) * 4;
+                    height = ((height + 3) / 4) * 4;
+                }
+#endif
             }
 
 #if DIRECTX


### PR DESCRIPTION
This patch fixes following bug:
In DirectX, mipmap levels of DXTCompressed textures where the width/height is not a multiple of 4 where not loaded correctly. The width/height of each level must be a multiple of 4 because this is the DXT block size. For example, the last mipmap level which is usually 1x1 texels must be treated as 4x4 texels in UpdateSubresource().

This patch fixes the following issue: https://github.com/mono/MonoGame/issues/1415

The OpenGL implementation is unchanged and works. (GL.CompressedTexImage2D() works if we treat the last level as 1x1. It does not work if we treat the last level as 4x4.)
