### PR TITLE
GetShaderResourceView throws exception when called from TextureCollectio...

### DIFF
--- a/MonoGame.Framework/Graphics/Texture.cs
+++ b/MonoGame.Framework/Graphics/Texture.cs
@@ -162,7 +162,11 @@ namespace Microsoft.Xna.Framework.Graphics
         internal SharpDX.Direct3D11.ShaderResourceView GetShaderResourceView()
         {
             if (_resourceView == null)
-                _resourceView = new SharpDX.Direct3D11.ShaderResourceView(GraphicsDevice._d3dDevice, _texture);
+            {
+                if (_texture != null)
+                    _resourceView = new SharpDX.Direct3D11.ShaderResourceView(GraphicsDevice._d3dDevice, _texture);
+                else return null;
+            }
 
             return _resourceView;
         }


### PR DESCRIPTION
...n.SetTextures

Some effects like DualTextureEffect and EnvironmentMapEffect use two
textures.
Once used, the second texture stays at GraphicsDevice.Textures[1]
forever.

In case you later dispose the said texture, a NullReferenceException is
thrown.
