### PR TITLE
Develop3d - Cleanup Frame Render buffers for RenderTargets

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1508,6 +1508,33 @@ namespace Microsoft.Xna.Framework.Graphics
             if (_currentRenderTargetBindings == null && renderTargets == null)
                 return;
 
+#if OPENGL
+
+            // if there are render target bindings and we are asked to initialize the bindings
+            // we need to delete the Render Buffers if there were any attached.  If not then
+            // we may run into problems with render targets later being added with different 
+            // sizes which is not allowed.
+            if (_currentRenderTargetBindings != null && renderTargets == null) 
+            {
+                
+                for (var i = 0; i < _currentRenderTargetBindings.Length; i++)
+                {
+                    
+                    var renderTarget = _currentRenderTargetBindings[i].RenderTarget as RenderTarget2D;
+                    if (renderTarget != null && renderTarget.DepthStencilFormat != DepthFormat.None)
+                    {
+                        // Delete the render buffers
+                        GL.DeleteRenderbuffers(1, ref renderTarget.glDepthStencilBuffer);
+                        GraphicsExtensions.CheckGLError();
+                    }
+                }
+
+                _currentRenderTargetBindings = null;
+                
+            }
+
+#endif
+
             // If the bindings are the same then early out as well.
             if (    _currentRenderTargetBindings != null && renderTargets != null &&
                     _currentRenderTargetBindings.Length == renderTargets.Length )


### PR DESCRIPTION
Delete Render buffers for each Render Target binding in SetRenderTargets when the render target is passed as null which signifies resetting the Render Target bindings.

This fixes a problem with multiple render targets with DepthFormats other than None. FrameRenderBuffers are generated but are not cleaned up (GL.DeleteRenderBuffers) after they are no longer used. If this is not done and another RenderTarget is attached that does not have the same size then the FrameBufferStatus is invalid with FramebufferIncompleteDimensions.
