### PR TITLE
Allow Texture Name In Sampler Using Parenthesis

### DIFF
--- a/Tools/2MGFX/MGFX.tpg
+++ b/Tools/2MGFX/MGFX.tpg
@@ -114,7 +114,7 @@ PixelShader_Pass_Expression -> PixelShader Equals Compile ShaderModel Identifier
    return null;
 };
 
-Sampler_State_Expression -> Identifier Equals (LessThan Identifier GreaterThan | Identifier | Number) Semicolon
+Sampler_State_Expression -> Identifier Equals ((LessThan|OpenParenthesis) Identifier (GreaterThan|CloseParenthesis) | Identifier | Number) Semicolon
 {
 	var name = $Identifier[0] as string;
 	var value = ($Identifier[1] ?? ($Identifier[2] ?? $Number[0])) as string;	

--- a/Tools/2MGFX/Parser.cs
+++ b/Tools/2MGFX/Parser.cs
@@ -509,19 +509,39 @@ namespace TwoMGFX
             }
 
             
-            tok = scanner.LookAhead(TokenType.LessThan, TokenType.Identifier, TokenType.Number);
+            tok = scanner.LookAhead(TokenType.LessThan, TokenType.OpenParenthesis, TokenType.Identifier, TokenType.Number);
             switch (tok.Type)
             {
                 case TokenType.LessThan:
+                case TokenType.OpenParenthesis:
 
                     
-                    tok = scanner.Scan(TokenType.LessThan);
-                    n = node.CreateNode(tok, tok.ToString() );
-                    node.Token.UpdateRange(tok);
-                    node.Nodes.Add(n);
-                    if (tok.Type != TokenType.LessThan) {
-                        tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.LessThan.ToString(), 0x1001, tok));
-                        return;
+                    tok = scanner.LookAhead(TokenType.LessThan, TokenType.OpenParenthesis);
+                    switch (tok.Type)
+                    {
+                        case TokenType.LessThan:
+                            tok = scanner.Scan(TokenType.LessThan);
+                            n = node.CreateNode(tok, tok.ToString() );
+                            node.Token.UpdateRange(tok);
+                            node.Nodes.Add(n);
+                            if (tok.Type != TokenType.LessThan) {
+                                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.LessThan.ToString(), 0x1001, tok));
+                                return;
+                            }
+                            break;
+                        case TokenType.OpenParenthesis:
+                            tok = scanner.Scan(TokenType.OpenParenthesis);
+                            n = node.CreateNode(tok, tok.ToString() );
+                            node.Token.UpdateRange(tok);
+                            node.Nodes.Add(n);
+                            if (tok.Type != TokenType.OpenParenthesis) {
+                                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.OpenParenthesis.ToString(), 0x1001, tok));
+                                return;
+                            }
+                            break;
+                        default:
+                            tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found.", 0x0002, tok));
+                            break;
                     }
 
                     
@@ -535,13 +555,32 @@ namespace TwoMGFX
                     }
 
                     
-                    tok = scanner.Scan(TokenType.GreaterThan);
-                    n = node.CreateNode(tok, tok.ToString() );
-                    node.Token.UpdateRange(tok);
-                    node.Nodes.Add(n);
-                    if (tok.Type != TokenType.GreaterThan) {
-                        tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.GreaterThan.ToString(), 0x1001, tok));
-                        return;
+                    tok = scanner.LookAhead(TokenType.GreaterThan, TokenType.CloseParenthesis);
+                    switch (tok.Type)
+                    {
+                        case TokenType.GreaterThan:
+                            tok = scanner.Scan(TokenType.GreaterThan);
+                            n = node.CreateNode(tok, tok.ToString() );
+                            node.Token.UpdateRange(tok);
+                            node.Nodes.Add(n);
+                            if (tok.Type != TokenType.GreaterThan) {
+                                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.GreaterThan.ToString(), 0x1001, tok));
+                                return;
+                            }
+                            break;
+                        case TokenType.CloseParenthesis:
+                            tok = scanner.Scan(TokenType.CloseParenthesis);
+                            n = node.CreateNode(tok, tok.ToString() );
+                            node.Token.UpdateRange(tok);
+                            node.Nodes.Add(n);
+                            if (tok.Type != TokenType.CloseParenthesis) {
+                                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.CloseParenthesis.ToString(), 0x1001, tok));
+                                return;
+                            }
+                            break;
+                        default:
+                            tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found.", 0x0002, tok));
+                            break;
                     }
                     break;
                 case TokenType.Identifier:


### PR DESCRIPTION
We now support both:

```
samplerCUBE SkyBoxSampler = sampler_state 
{ 
   texture = (SkyBoxTexture); 
}
```

and

```
samplerCUBE SkyBoxSampler = sampler_state 
{ 
   texture = <SkyBoxTexture>; 
}
```

This is based on #1474, but it changes the input parser file and uses the parser generator.
