### PR TITLE
Mouse Cursor not hidden in XAML based apps. 

### DIFF
--- a/MonoGame.Framework/Windows8/MetroGameWindow.cs
+++ b/MonoGame.Framework/Windows8/MetroGameWindow.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Xna.Framework
             var bounds = _coreWindow.Bounds;
             SetClientBounds(bounds.Width, bounds.Height);
 
-            //SetCursor(false);
+            SetCursor(false);
         }
 
         private void Window_FocusChanged(CoreWindow sender, WindowActivatedEventArgs args)


### PR DESCRIPTION
In xaml, mouse must be actively turn off during initialization.

Setting Game.IsMouseVisible =false; has no effect because the code check
against current _isMouseVisible value, which is by false from the beginning.
Now, In order to hide the mouse cursor one must do:
IsMouseVisible = true;
IsMouseVisible = false;

Another thing: The execution path through
MetroGamePlatform.RunLoop()
MetroGameWindow.RunLoop()
which call SetCursor(false), doesn't seem to be active anymore.
