### PR TITLE
Fixing SoundEffect.Play so that it sends the default pitch in Xna, 0.0f....

### DIFF
--- a/MonoGame.Framework/MacOS/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/MacOS/Audio/SoundEffect.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public bool Play ()
 		{
-			return Play (MasterVolume, 1.0f, 0.0f);
+			return Play (MasterVolume, 0.0f, 0.0f);
 		}
 
 		public bool Play (float volume, float pitch, float pan)


### PR DESCRIPTION
...  The old value of 1, caused extremely high pitched sounds in Xna on iOS and SoundEffectInstance already uses 0 as the default.
