### PR TITLE
Fixing PowerOfTwo SpriteFont crash on iOS

### DIFF
--- a/MonoGame.ContentPipeline/ContentProcessors/Processors/MGSpriteFontDescriptionProcessor.cs
+++ b/MonoGame.ContentPipeline/ContentProcessors/Processors/MGSpriteFontDescriptionProcessor.cs
@@ -8,12 +8,22 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Processors;
 using MonoGameContentProcessors.Content;
+using System.Diagnostics;
 
 namespace MonoGameContentProcessors.Processors
 {
     [ContentProcessor(DisplayName = "MonoGame SpriteFont")]
     public class MGSpriteFontDescriptionProcessor : FontDescriptionProcessor
     {
+        int NearestSuperiorPowerOf2(int n)
+        {
+            int power = 1;
+            while (power < n)
+                power *= 2;
+
+            return power;
+        }
+
         public override SpriteFontContent Process(FontDescription input, ContentProcessorContext context)
         {
             // Fallback if we aren't buiding for iOS.
@@ -31,11 +41,11 @@ namespace MonoGameContentProcessors.Processors
             // or even Process is tricky. This works for now, but should be replaced when the content pipeline
             // moves a bit further
 
-            var texWidth = texture.Faces[0][0].Width;
-            var texHeight = texture.Faces[0][0].Height;
+            var texWidth = NearestSuperiorPowerOf2(texture.Faces[0][0].Width);
+            var texHeight = NearestSuperiorPowerOf2(texture.Faces[0][0].Height);
 
             // Resize to square, power of two if necessary.
-            if (texWidth != texHeight)
+            if (texWidth != texHeight || texture.Faces[0][0].Width != texture.Faces[0][0].Height)
             {
                 texHeight = texWidth = Math.Max(texHeight, texWidth);
                 var resizedBitmap = (BitmapContent)Activator.CreateInstance(typeof(PixelBitmapContent<Color>), new object[] { texWidth, texHeight });
@@ -44,9 +54,18 @@ namespace MonoGameContentProcessors.Processors
 
                 texture.Faces[0].Clear();
                 texture.Faces[0].Add(resizedBitmap);
+
+                context.Logger.LogImportantMessage("Resized Font Texture (" + resizedBitmap.Width + "x" + resizedBitmap.Height + ")");
             }
             else
+            {
                 texture.ConvertBitmapType(typeof(PixelBitmapContent<Color>));
+            }
+
+            texWidth = texture.Faces[0][0].Width;
+            texHeight = texture.Faces[0][0].Height;
+
+            context.Logger.LogImportantMessage("Processed Font Texture (" + texWidth + "x" + texHeight + ")");
 
             MGTextureProcessor.ConvertToPVRTC(texture, 1, true, MGCompressionMode.PVRTCFourBitsPerPixel);
 


### PR DESCRIPTION
Fixed a bug in the SpriteFont processor. For iOS the underlying texture has to be power of two and square, the content processor only checked if the texture was square.  This bug has been reported in the past, and people have been avoiding it by just playing with fonts and font sizes.  @see http://monogame.codeplex.com/discussions/404006 for an instance of how the bug shows itself when running on iOS.

Make sure when reproducing the problem you have to be running with a debug build of monogame or the opengl error wont be checked for.
