### PR TITLE
ReflectiveReader 'bug'

### DIFF
--- a/MonoGame.Framework/Content/ContentExtensions.cs
+++ b/MonoGame.Framework/Content/ContentExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Reflection;
+using System.Linq;
 
 #if WINRT
 using System.Reflection.Emit;
-using System.Linq;
 #endif
 
 namespace Microsoft.Xna.Framework.Content
@@ -24,15 +24,25 @@ namespace Microsoft.Xna.Framework.Content
 
         public static PropertyInfo[] GetAllProperties(this Type type)
         {
+
+            // Sometimes, overridden properties of abstract classes can show up even with 
+            // BindingFlags.DeclaredOnly is passed to GetProperties. Make sure that
+            // all properties in this list are defined in this class by comparing
+            // its get method with that of it's base class. If they're the same
+            // Then it's an overridden property.
 #if WINRT
             PropertyInfo[] infos= type.GetTypeInfo().DeclaredProperties.ToArray();
             var nonStaticPropertyInfos = from p in infos
-                                         where (p.GetMethod != null) && (!p.GetMethod.IsStatic)
+                                         where (p.GetMethod != null) && (!p.GetMethod.IsStatic) &&
+                                         (p.GetMethod == p.GetMethod.GetRuntimeBaseDefinition())
                                          select p;
             return nonStaticPropertyInfos.ToArray();
 #else
             var attrs = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            return type.GetProperties(attrs);
+            var allProps = type.GetProperties(attrs).ToList();
+
+            var props = allProps.FindAll(p => p.GetGetMethod() == p.GetGetMethod().GetBaseDefinition()).ToArray();
+            return props;
 #endif
         }
 

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -255,19 +255,7 @@ namespace Microsoft.Xna.Framework.Content
             var boxed = (object)obj;
 
             foreach (var property in properties)
-            {
-#if WINRT
-                var getter = property.GetMethod;
-                var baseDef = getter.GetRuntimeBaseDefinition();
-#else
-                var getter = property.GetGetMethod();
-                var baseDef = getter.GetBaseDefinition();
-#endif
-                if (baseDef != getter)
-                    continue;
-
                 Read(boxed, input, property);
-            }
 
             foreach (var field in fields)
                 Read(boxed, input, field);


### PR DESCRIPTION
First off, I know this PR is going to look crazy. It took me quite a while to figure out why our game wasn't working anymore.

This PR fixes a bug found in the reflective reader. It turns out that there's some odd behavior in .NET when it comes to using Type.GetAllProperties() with an abstract class, causing inherited properties to be pulled in anyway.

Suppose you have the following two classes:

```
    public class DerivedClass : BaseClass
    {
        public override string NameOfProperty { get; set; }
    }

    public abstract class BaseClass
    {
        public abstract string NameOfProperty { get; set; }
    }
```

For whatever reason, you override a property and didn't change it's implementation. Calling 

```
typeof(DerivedClass).GetAllProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
```

Will still return NameOfProperty as one of it's properties (Even with the DeclaredOnly binding flag). Because of this, an extra check is needed to make sure we the ContentReader isn't attempting to read in the same property twice. I ran this against our game on Windows 8 and iOS, seeing the problem fixed without any adverse affects.

I've also tested this against stock .NET to make sure I wasn't going crazy. But the setup above will still return the inherited property.
