### PR TITLE
Fixed byte order for Texture2D.GetData to ARGB on Android

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -457,10 +457,11 @@ namespace Microsoft.Xna.Framework.Graphics
 				{
 					final[i] = (uint)
 					(
-						colors[i].R << 24 |
-						colors[i].G << 16 |
-						colors[i].B << 8 |
-						colors[i].A
+						// use correct xna byte order (and remember to convert it yourself as needed)
+						colors[i].A << 24 |
+						colors[i].B << 16 |
+						colors[i].G << 8 |
+						colors[i].R
 					);
 				}
 			}


### PR DESCRIPTION
see http://developer.android.com/reference/android/graphics/Bitmap.html and http://developer.android.com/reference/android/graphics/Color.html

the latter states that the order should be ARGB:
(alpha << 24) | (red << 16) | (green << 8) | blue

Detected the wrong order when developing a screenshot (& mail) module for a current game project... 

NB: sorry for the (unnecessary) additional change on line 597, my VS converted the tabs to spaces...
