### PR TITLE
Fixed TextInput Crash

### DIFF
--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -120,7 +120,9 @@ namespace Microsoft.Xna.Framework {
 		public event EventHandler<EventArgs> ClientSizeChanged;
 		public event EventHandler<EventArgs> OrientationChanged;
 		public event EventHandler<EventArgs> ScreenDeviceNameChanged;
+
 #if WINDOWS || LINUX
+
 		/// <summary>
 		/// Use this event to retrieve text for objects like textbox's.
 		/// This event is not raised by noncharacter keys.
@@ -177,10 +179,11 @@ namespace Microsoft.Xna.Framework {
 		}
 
 #if WINDOWS || LINUX
-        	protected void OnTextInput(object sender, TextInputEventArgs e)
-        	{
-            		TextInput(sender, e);
-        	}
+		protected void OnTextInput(object sender, TextInputEventArgs e)
+		{
+			if (TextInput != null)
+				TextInput(sender, e);
+		}
 #endif
 
 		protected internal abstract void SetSupportedOrientations (DisplayOrientation orientations);


### PR DESCRIPTION
Simple crash fix on null TextInput event in GameWindow.
