### PR TITLE
Fix #if MACOS to be #if MONOMAC (fixes bugs with content loading & probably audio)

### DIFF
--- a/MonoGame.Framework/Desktop/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Desktop/Audio/OpenALSoundController.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// <returns>True if the sound controller was setup, and false if not.</returns>
         private bool OpenSoundController()
         {
-#if MACOSX || IOS
+#if MONOMAC || IOS
 			alcMacOSXMixerOutputRate(PREFERRED_MIX_RATE);
 #endif
             _device = Alc.OpenDevice(string.Empty);
@@ -282,7 +282,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         }
 
-#if MACOSX || IOS
+#if MONOMAC || IOS
 		public const string OpenALLibrary = "/System/Library/Frameworks/OpenAL.framework/OpenAL";
 
 		[DllImport(OpenALLibrary, EntryPoint = "alcMacOSXMixerOutputRate")]

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -46,7 +46,7 @@ using System.Threading.Tasks;
 #elif IOS
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
-#elif MACOS
+#elif MONOMAC
 using MonoMac.Foundation;
 #elif PSM
 using Sce.PlayStation.Core;
@@ -62,15 +62,18 @@ namespace Microsoft.Xna.Framework
             Location = AppDomain.CurrentDomain.BaseDirectory;
 #elif WINRT
             Location = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
-#elif IOS || MACOS
+#elif IOS || MONOMAC
 			Location = NSBundle.MainBundle.ResourcePath;
-            SupportRetina = UIScreen.MainScreen.Scale == 2.0f;
 #elif PSM
 			Location = "/Application";
 #else
             Location = string.Empty;
-#endif                    
-        }
+#endif
+
+#if IOS
+			SupportRetina = UIScreen.MainScreen.Scale == 2.0f;
+#endif
+		}
 
         static internal string Location { get; private set; }
 #if IOS


### PR DESCRIPTION
There were a couple "#if MACOS" directives in TitleOpenContainer.cs and OpenALSoundController.cs, but MACOS isn't a valid define symbol for any platform. The proper symbol to check against is MONOMAC. The attached commit fixes that.

The bug made all content loading on Mac be relative to the current working directory so I suppose it went undetected because few people are changing the current working directory.

It also made the call to alcMacOSXMixerOutputRate in OpenALSoundController never happen on Mac. Not sure what are the implications of that but I guess it's a good thing it's not ignored anymore.
