### PR TITLE
A better error message when a ContentTypeReader can no be found using Type.GetType

### DIFF
--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -158,7 +158,9 @@ namespace Microsoft.Xna.Framework.Content
                         }
                     }
                     else
-                        throw new ContentLoadException("Could not find matching content reader of type " + originalReaderTypeString + " (" + readerTypeString + ")");
+                        throw new ContentLoadException(
+                                "Could not find ContentTypeReader Type. Please ensure the name of the Assembly that contains the Type matches the assembly in the full type name: " + 
+                                originalReaderTypeString + " (" + readerTypeString + ")");
                 }
 
 				// I think the next 4 bytes refer to the "Version" of the type reader,


### PR DESCRIPTION
This change has been made in response to a common problem when porting projects. If you suffix your project with the platform name, eg MyGameTypes.Android, this defaults the Assembly name and resulting dll to MyGameTypes.Android.dll. Content types in this assembly can then not be reflected as the Xnb files were build against the project MyGameTypes.dll and hence have a mis-matched full type name.

Reference: http://monogame.codeplex.com/discussions/435819
