### PR TITLE
Fix for iOS Song's Play/Stop

### DIFF
--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -278,6 +278,8 @@ namespace Microsoft.Xna.Framework.Media
 				return;
 
 #if IOS
+            // AVAudioPlayer sound.Stop() does not reset the playback position as XNA does.
+            // Set Play's currentTime to 0 to ensure playback at the start.
             _sound.CurrentTime = 0.0;
 #endif
 			_sound.Play();


### PR DESCRIPTION
In XNA, calling MediaPlayer.Play() should start a song from it's beginning. AVAudioPlayer does not have the same behavior, and needs it's CurrentTime property set to 0 to emulate this behavior.

Replication steps:
Play a song using MediaPlayer.Play().
Play a second song using MediaPlayer.Play().
Call MediaPlayer.Play() again on the first song played
Bug: First song starts at where it left off, rather than the start.
