### PR TITLE
Fixed SamplerStateCollection to reset to SamplerState.LinearWrap

### DIFF
--- a/MonoGame.Framework/Graphics/SamplerStateCollection.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.cs
@@ -70,13 +70,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		internal SamplerStateCollection( int maxSamplers )
         {
             _samplers = new SamplerState[maxSamplers];
-
-            for (var i = 0; i < maxSamplers; i++)
-                _samplers[i] = SamplerState.LinearWrap;
-            
-#if DIRECTX
-            _d3dDirty = int.MaxValue;
-#endif
+		    Clear();
         }
 		
 		public SamplerState this [int index] 


### PR DESCRIPTION
This fixes the issue where the SamplerState is null after the device state is reset.
