### PR TITLE
Fixing Gesture Infinite Loop

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchPanel.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanel.cs
@@ -109,6 +109,11 @@ namespace Microsoft.Xna.Framework.Input.Touch
         private static int _nextTouchId = 2;
 
         /// <summary>
+        /// The currently enabled gestures.
+        /// </summary>
+        private static GestureType _enabledGestures;
+
+        /// <summary>
         /// The mapping between platform specific touch ids
         /// and the touch ids we assign to touch locations.
         /// </summary>
@@ -391,20 +396,18 @@ namespace Microsoft.Xna.Framework.Input.Touch
                 UpdateTouchScale();
             }
         }
-		
-        private static GestureType m_enabledGestures;
         
         /// <summary>
         /// Gets or sets enabled gestures.
         /// </summary>
         public static GestureType EnabledGestures
         {
-            get { return m_enabledGestures; }
+            get { return _enabledGestures; }
             set
             {
-                if (m_enabledGestures != value)
+                if (_enabledGestures != value)
                 {
-                    m_enabledGestures = value;
+                    _enabledGestures = value;
                     ReleaseAllTouches();
                 }
             }


### PR DESCRIPTION
When the enabled gestures is changed we need to call ReleaseAllTouches(). While testing on iOS I found that changing the EnabledGestures while a drag is occurring on the hardware will result in an infinite loop due to partial state being recorded - the IsGestureAvailable call will loop forever.
