### PR TITLE
Allow scaling for METRO/DX/XAML

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -701,12 +701,14 @@ namespace Microsoft.Xna.Framework.Graphics
                                             format, 
                                             SwapChainFlags.None);
                 
-                //Update SwapChainBackgroundPanel to force scale/resolution change.
-                if ((PresentationParameters.BackBufferWidth != this.DisplayMode.Width || PresentationParameters.BackBufferHeight != this.DisplayMode.Height)
-                    && PresentationParameters.DeviceWindowHandle == IntPtr.Zero)
+                //Update SwapChainBackgroundPanel to force scale/resolution change.                
+                if (PresentationParameters.DeviceWindowHandle == IntPtr.Zero)
                 {
-                    using (var nativePanel = ComObject.As<SharpDX.DXGI.ISwapChainBackgroundPanelNative>(PresentationParameters.SwapChainPanel))
-                        nativePanel.SwapChain = _swapChain;                    
+                    if (PresentationParameters.BackBufferWidth != _viewport.Width || PresentationParameters.BackBufferHeight != _viewport.Height)
+                    {
+                        using (var nativePanel = ComObject.As<SharpDX.DXGI.ISwapChainBackgroundPanelNative>(PresentationParameters.SwapChainPanel))
+                            nativePanel.SwapChain = _swapChain;
+                    }
                 }
             }
 


### PR DESCRIPTION
https://github.com/mono/MonoGame/issues/1487

When setting the backbuffer/swapChain to other than the native
 resolution
 SwapChainBackgroundPanel doesn't get notified.
 One way to force it to update and change the resolution (scaling) is to
 set again the SwapChain.
