### PR TITLE
Fixed missing keyboard mapping for Linux

### DIFF
--- a/MonoGame.Framework/Linux/Input/KeyboardUtil.cs
+++ b/MonoGame.Framework/Linux/Input/KeyboardUtil.cs
@@ -350,6 +350,12 @@ namespace Microsoft.Xna.Framework.Input
 				case OpenTK.Input.Key.Right:
 					return Keys.Right;
 	                    
+				case OpenTK.Input.Key.RShift:
+					return Keys.RightShift;
+	                    
+				case OpenTK.Input.Key.RWin:
+					return Keys.RightWindows;
+	                    
 				case OpenTK.Input.Key.S:
 					return Keys.S;
 	                    
@@ -360,7 +366,7 @@ namespace Microsoft.Xna.Framework.Input
 					return Keys.OemSemicolon;
 	                    
 				case OpenTK.Input.Key.Slash:
-					return Keys.None;
+					return Keys.OemQuestion;
 	                    
 				case OpenTK.Input.Key.Sleep:
 					return Keys.Sleep;


### PR DESCRIPTION
The Linux version is missing keyboard mappings for the right shift key, right windows key, and the forward slash key is assigned to Keys.None rather than Keys.OemQuestion.
