### PR TITLE
Fix SamplerState in EffectPass

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/EffectPass.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectPass.cs
@@ -120,11 +120,11 @@ namespace Microsoft.Xna.Framework.Graphics
 					// If there is no texture assigned then skip it
 					// and leave whatever set directly on the device.
 					if (texture != null)
-					{
 						device.Textures[sampler.textureSlot] = texture;
-						if (sampler.state != null)
-							device.SamplerStates[sampler.samplerSlot] = sampler.state;
-					}
+
+                    // If there is a sampler state set it.
+                    if (sampler.state != null)
+                        device.SamplerStates[sampler.samplerSlot] = sampler.state;
                 }
                 
                 // Update the constant buffers.


### PR DESCRIPTION
This small fix makes it so that the SamplerState defined in an EffectPass is set even if there is no texture assigned to the EffectParameter.
