### PR TITLE
Added Wrap methods to MathHelper.

### DIFF
--- a/MonoGame.Framework/MathHelper.cs
+++ b/MonoGame.Framework/MathHelper.cs
@@ -302,34 +302,16 @@ namespace Microsoft.Xna.Framework
         public static int Wrap(int value, int min, int max)
         {
             if (min == max) return min;
-
-            int r = Math.Abs(min) + Math.Abs(max);
-
-            if (value >= max)
-            { 
-                int temp = value;
-                while (temp >= max)
-                {
-                    temp -= r;
-                }
-                return temp;
+            int v = (((value - min)%(max - min))); 
+            if (value > max)
+            {
+                return min + v;
             }
-            else
-            { 
-                if (value < min)
-                {
-                    int temp = value;
-                    while (temp < min)
-                    {
-                        temp += r;
-                    }
-                    return temp;
-                }
-                else
-                { 
-                    return value;
-                }
-            } 
+            if (value < min)
+            {
+                return max + v;
+            }
+            return value;
         }
 
         /// <summary>


### PR DESCRIPTION
These methods are not exist in XNA but I found them very useful in many cases. Also im introduced them to SharpDX and this is fine. WrapAngle is too limited. 

eg value = Wrap(value+1,0,10); // the value will constantly cycled between min and max.
