### PR TITLE
Issue #1123 - Fix for song and sound effect being lost

### DIFF
--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -110,6 +110,8 @@ namespace Microsoft.Xna.Framework.Content
                 var hNullableRectReader = new NullableReader<Rectangle>();
 				var hEffectMaterialReader = new EffectMaterialReader();
 				var hExternalReferenceReader = new ExternalReferenceReader();
+                var hSoundEffectReader = new SoundEffectReader();
+                var hSongReader = new SongReader();
             }
 #pragma warning restore 0219, 0649
 


### PR DESCRIPTION
Part of the infamous shameless hack to keep the SongReader and SoundEffectReader in the library during AOT optimization on iOS. Tested in debug and release modes with full linking and the sound effects did not get lost. Did not test songs (mp3 content).
