### PR TITLE
This fixes the missing content loader exception for a null AV player

### DIFF
--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -82,6 +82,10 @@ namespace Microsoft.Xna.Framework.Media
 			
 #if IOS
 			_sound = AVAudioPlayer.FromUrl(NSUrl.FromFilename(fileName));
+            if (_sound == null)
+            {
+                throw (new Content.ContentLoadException("Failed to load Song at " + fileName));
+            }
 			_sound.NumberOfLoops = 0;
             _sound.FinishedPlaying += OnFinishedPlaying;
 #elif PSM


### PR DESCRIPTION
This is just the missing content loader exception. The reason for the null AV player is unknown yet.
