### PR TITLE
Handle to Device property for GraphicsDevice.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -313,7 +313,23 @@ namespace Microsoft.Xna.Framework.Graphics
 				return IsDisposed;
 			}
 		}
-
+	
+	/// <summary>
+        /// Returns a handle to internal device object. Valid only on DirectX platforms.
+        /// For usage, convert this to SharpDX.Direct3D11.Device.
+        /// </summary>
+        public object Handle
+        {
+            get
+            {
+#if DIRECTX
+                return _d3dDevice;
+#else
+                return null;
+#endif
+            }
+        }
+	
         internal bool IsRenderTargetBound
         {
             get


### PR DESCRIPTION
This small change gives developers on microsoft platforms new hard layer of developing by adding possibility of using directx calls from SharpDX Device(eg for implementing missing features like compute shaders). The XNA does not have this feature, but why not extending programmers life by this small change ? The other platforms will not be wound.
