### PR TITLE
Fixed Guide exception on WP8

### DIFF
--- a/MonoGame.Framework/Windows/GamerServices/Guide.cs
+++ b/MonoGame.Framework/Windows/GamerServices/Guide.cs
@@ -95,10 +95,14 @@ namespace Microsoft.Xna.Framework.GamerServices
             Deployment.Current.Dispatcher.BeginInvoke(() =>
             {
 #endif
+
+#if WINRT
                 var licenseInformation = CurrentApp.LicenseInformation;
                 licenseInformation.LicenseChanged += () => isTrialMode = !licenseInformation.IsActive || licenseInformation.IsTrial;
 
                 isTrialMode = !licenseInformation.IsActive || licenseInformation.IsTrial;
+#endif
+
 #if WINDOWS_PHONE
             });
 #endif


### PR DESCRIPTION
Fixed initialization exception when Guide is called on WP8 from non-UI thread

Tested on Windows 8 and WP8.
