### PR TITLE
Fixes disappearing SoundEffects on iOS

### DIFF
--- a/MonoGame.Framework/Desktop/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Desktop/Audio/OALSoundBuffer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Xna.Framework.Audio
             ALError alError = AL.GetError();
             if (alError != ALError.NoError)
             {
-                Console.WriteLine("Failed to get buffer bits: ", AL.GetErrorString(alError) + ", format=" + format + ", size=" + size + ", sampleRate=" + sampleRate);
+                Console.WriteLine("Failed to get buffer bits: {0}, format={1}, size={2}, sampleRate={3}", AL.GetErrorString(alError), format, size, sampleRate);
                 Duration = -1;
             }
             else
@@ -65,7 +65,7 @@ namespace Microsoft.Xna.Framework.Audio
                 alError = AL.GetError();
                 if (alError != ALError.NoError)
                 {
-                    Console.WriteLine("Failed to get buffer channels: ", AL.GetErrorString(alError) + ", format=" + format + ", size=" + size + ", sampleRate=" + sampleRate);
+                    Console.WriteLine("Failed to get buffer bits: {0}, format={1}, size={2}, sampleRate={3}", AL.GetErrorString(alError), format, size, sampleRate);
                     Duration = -1;
                 }
                 else


### PR DESCRIPTION
Fixes disappearing SoundEffects on iOS (#1123)
This is accomplished by manually setting the buffer properties if the packet does not decode (MonoTouch bug)

Fixed broken sound buffer debug output
