### PR TITLE
WP8 TouchPanel hacking removed

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchPanel.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanel.cs
@@ -329,8 +329,6 @@ namespace Microsoft.Xna.Framework.Input.Touch
                     windowSize = new Vector2(   (float)Window.Current.CoreWindow.Bounds.Width * dipFactor,
                                                 (float)Window.Current.CoreWindow.Bounds.Height * dipFactor);
                 }
-#elif WINDOWS_PHONE
-            windowSize *= 96.0f / DisplayProperties.LogicalDpi;
 #endif
 
                 // Recalculate the touch scale.

--- a/MonoGame.Framework/WindowsPhone/WPGameWindow.cs
+++ b/MonoGame.Framework/WindowsPhone/WPGameWindow.cs
@@ -126,16 +126,13 @@ namespace MonoGame.Framework.WindowsPhone
 
         private void SetClientBounds(double width, double height)
         {
-            var dpi = DisplayProperties.LogicalDpi;
-            var pwidth = width * dpi / 96.0;
-            var pheight = height * dpi / 96.0;
-
-            _clientBounds = new Rectangle(0, 0, (int)pwidth, (int)pheight);
+            _clientBounds = new Rectangle(0, 0, (int)width, (int)height);
         }
 
         public override void EndScreenDeviceChange(string screenDeviceName, int clientWidth, int clientHeight)
         {
             SetClientBounds(clientWidth, clientHeight);
+            _game.graphicsDeviceManager.ApplyChanges();
         }
 
         /*


### PR DESCRIPTION
Until now, touchpanel display size was set to the client size instead of the resolution (and the GraphicsDeviceManager's ApplyChanges wasn't called so it won't be changed back to the resolution). With the window size scaling applied, this is no longer needed.

Update: removed the pointless scale of client size. Tested on all resolutions.
