### PR TITLE
Color Fix

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1861,13 +1861,11 @@ namespace Microsoft.Xna.Framework
         /// <param name="amount">Interpolation factor.</param>
         /// <returns>Interpolated <see cref="Color"/>.</returns>
         public static Color Lerp(Color value1, Color value2, Single amount)
-        {
-            byte Red   = (byte)MathHelper.Clamp(MathHelper.Lerp(value1.R, value2.R, amount), Byte.MinValue, Byte.MaxValue);   
-			byte Green = (byte)MathHelper.Clamp(MathHelper.Lerp(value1.G, value2.G, amount), Byte.MinValue, Byte.MaxValue);
-			byte Blue  = (byte)MathHelper.Clamp(MathHelper.Lerp(value1.B, value2.B, amount), Byte.MinValue, Byte.MaxValue);
-			byte Alpha = (byte)MathHelper.Clamp(MathHelper.Lerp(value1.A, value2.A, amount), Byte.MinValue, Byte.MaxValue);
-			
-            return new Color( Red, Green, Blue, Alpha );
+        {		
+            return new Color(   (int)MathHelper.Lerp(value1.R, value2.R, amount), 
+                                (int)MathHelper.Lerp(value1.G, value2.G, amount), 
+                                (int)MathHelper.Lerp(value1.B, value2.B, amount), 
+                                (int)MathHelper.Lerp(value1.A, value2.A, amount) );
         }
 		
 	/// <summary>
@@ -1876,13 +1874,9 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Color"/>.</param>
         /// <param name="scale">Multiplicator.</param>
         /// <returns>Multiplication result.</returns>
-	public static Color Multiply( Color value, float scale)
+	public static Color Multiply(Color value, float scale)
 	{
-	    byte Red = (byte)(MathHelper.Clamp(value.R * scale, Byte.MinValue, Byte.MaxValue));
-	    byte Green = (byte)(MathHelper.Clamp(value.G * scale, Byte.MinValue, Byte.MaxValue));
-	    byte Blue = (byte)(MathHelper.Clamp(value.B * scale, Byte.MinValue, Byte.MaxValue));
-	    byte Alpha = (byte)(MathHelper.Clamp(value.A * scale, Byte.MinValue, Byte.MaxValue)); 
-	    return new Color( Red, Green, Blue, Alpha );
+	    return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
 	}
 	
 	/// <summary>
@@ -1893,7 +1887,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>Multiplication result.</returns>
 	public static Color operator *(Color value, float scale)
         {
-            return Multiply(value, scale);
+            return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
         }		
 
 	/// <summary>

--- a/Test/Framework/ColorTest.cs
+++ b/Test/Framework/ColorTest.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.Xna.Framework;
+using NUnit.Framework;
+
+namespace MonoGame.Tests.Framework
+{
+    class ColorTest
+    {
+        [Test]
+        public void Multiply()
+        {
+            var color = new Color(1, 2, 3, 4);
+
+            // Test 1.0 scale.
+            Assert.AreEqual(color, color * 1.0f);
+            Assert.AreEqual(color, Color.Multiply(color, 1.0f));
+            Assert.AreEqual(color * 1.0f, Color.Multiply(color, 1.0f));
+
+            // Test 0.999 scale.
+            var almostOne = new Color(0, 1, 2, 3);
+            Assert.AreEqual(almostOne, color * 0.999f);
+            Assert.AreEqual(almostOne, Color.Multiply(color, 0.999f));
+            Assert.AreEqual(color * 0.999f, Color.Multiply(color, 0.999f));
+
+            // Test 1.001 scale.
+            Assert.AreEqual(color, color * 1.001f);
+            Assert.AreEqual(color, Color.Multiply(color, 1.001f));
+            Assert.AreEqual(color * 1.001f, Color.Multiply(color, 1.001f));
+
+            // Test 0.0 scale.
+            Assert.AreEqual(Color.Transparent, color * 0.0f);
+            Assert.AreEqual(Color.Transparent, Color.Multiply(color, 0.0f));
+            Assert.AreEqual(color * 0.0f, Color.Multiply(color, 0.0f));
+
+            // Test 0.001 scale.
+            Assert.AreEqual(Color.Transparent, color * 0.001f);
+            Assert.AreEqual(Color.Transparent, Color.Multiply(color, 0.001f));
+            Assert.AreEqual(color * 0.001f, Color.Multiply(color, 0.001f));
+
+            // Test -0.001 scale.
+            Assert.AreEqual(Color.Transparent, color * -0.001f);
+            Assert.AreEqual(Color.Transparent, Color.Multiply(color, -0.001f));
+            Assert.AreEqual(color * -0.001f, Color.Multiply(color, -0.001f));
+
+            // Test for overflow.
+            Assert.AreEqual(Color.White, color * 300.0f);
+            Assert.AreEqual(Color.White, Color.Multiply(color, 300.0f));
+            Assert.AreEqual(color * 300.0f, Color.Multiply(color, 300.0f));
+
+            // Test for underflow.
+            Assert.AreEqual(Color.Transparent, color * -1.0f);
+            Assert.AreEqual(Color.Transparent, Color.Multiply(color, -1.0f));
+            Assert.AreEqual(color * -1.0f, Color.Multiply(color, -1.0f));
+        }
+
+        [Test]
+        public void Lerp()
+        {
+            // Test zero and underflow.
+            Assert.AreEqual(Color.Transparent, Color.Lerp(Color.Transparent, Color.White, 0.0f));
+            Assert.AreEqual(Color.Transparent, Color.Lerp(Color.Transparent, Color.White, 0.001f));
+            Assert.AreEqual(Color.Transparent, Color.Lerp(Color.Transparent, Color.White, -0.001f));
+            Assert.AreEqual(Color.Transparent, Color.Lerp(Color.Transparent, Color.White, -1.0f));
+
+            // Test one scale and overflows.
+            Assert.AreEqual(Color.White, Color.Lerp(Color.Transparent, Color.White, 1.0f));
+            Assert.AreEqual(Color.White, Color.Lerp(Color.Transparent, Color.White, 1.001f));
+            Assert.AreEqual(new Color(254, 254, 254, 254), Color.Lerp(Color.Transparent, Color.White, 0.999f));
+            Assert.AreEqual(Color.White, Color.Lerp(Color.Transparent, Color.White, 2.0f));
+
+            // Test half scale.
+            var half = new Color(127, 127, 127, 127);
+            Assert.AreEqual(half, Color.Lerp(Color.Transparent, Color.White, 0.5f));
+            Assert.AreEqual(half, Color.Lerp(Color.Transparent, Color.White, 0.501f));
+            Assert.AreEqual(half, Color.Lerp(Color.Transparent, Color.White, 0.499f));
+
+            // Test backwards lerp.
+            Assert.AreEqual(Color.White, Color.Lerp(Color.White, Color.Transparent, 0.0f));
+            Assert.AreEqual(Color.Transparent, Color.Lerp(Color.White, Color.Transparent, 1.0f));
+            Assert.AreEqual(half, Color.Lerp(Color.White, Color.Transparent, 0.5f));
+        }
+    }
+}

--- a/Test/MonoGame.Tests.Linux.csproj
+++ b/Test/MonoGame.Tests.Linux.csproj
@@ -77,6 +77,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Framework\ColorTest.cs" />
     <Compile Include="Framework\GameTest+Properties.cs" />
     <Compile Include="Framework\GameTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Test/MonoGame.Tests.MacOS.csproj
+++ b/Test/MonoGame.Tests.MacOS.csproj
@@ -61,6 +61,7 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Mono\MonoMac\v0.0\Mono.MonoMac.targets" />
   <ItemGroup>
+    <Compile Include="Framework\ColorTest.cs" />
     <Compile Include="Framework\GameTest.cs" />
     <Compile Include="Framework\GameTest+Properties.cs" />
     <Compile Include="Runner\MacOS\Program.cs" />

--- a/Test/MonoGame.Tests.Windows.csproj
+++ b/Test/MonoGame.Tests.Windows.csproj
@@ -76,6 +76,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Framework\ColorTest.cs" />
     <Compile Include="Framework\Components\DrawFrameNumberComponent.cs" />
     <Compile Include="Framework\Components\FlexibleGameComponent.cs" />
     <Compile Include="Framework\Components\FrameCompareComponent.cs" />

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -82,6 +82,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Framework\ColorTest.cs" />
     <Compile Include="Framework\Components\DrawFrameNumberComponent.cs" />
     <Compile Include="Framework\Components\FlexibleGameComponent.cs" />
     <Compile Include="Framework\Components\ImplicitDrawOrderComponent.cs" />

--- a/Test/MonoGame.Tests.iOS.csproj
+++ b/Test/MonoGame.Tests.iOS.csproj
@@ -103,6 +103,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Framework\ColorTest.cs" />
     <Compile Include="Framework\Components\DrawFrameNumberComponent.cs" />
     <Compile Include="Framework\Components\FrameCompareComponent.cs" />
     <Compile Include="Framework\Components\ImplicitDrawOrderComponent.cs" />


### PR DESCRIPTION
Some bug fixes and/or optimizations to Color.

The basic issue was that the constructors do clamping... so clamping in Lerp/Multiply is pointless.  Worse Color.Multiply was doing a floating point clamp instead of integer.
- Fixed Color.Lerp() to not double clamp.
- Fixed Color.Multipy() to not double clamp.
- Added Color to unit tests.

The unit test verifies that XNA and MonoGame behave the same with Lerp and Multiply.
