### PR TITLE
Support For Signed Numbers in MGFX

### DIFF
--- a/Tools/2MGFX/MGFX.tpg
+++ b/Tools/2MGFX/MGFX.tpg
@@ -20,6 +20,7 @@
 [IgnoreCase] PixelShader -> @"PixelShader";
 [IgnoreCase] Register -> @"register";
 Number -> @"[0-9]?\.?[0-9]+";
+Sign -> @"-|\+";
 Identifier -> @"[A-Za-z_][A-Za-z0-9_]*";
 OpenBracket -> @"{";
 CloseBracket -> @"}";
@@ -69,10 +70,10 @@ Technique_Declaration -> Technique Identifier? OpenBracket Pass_Declaration+ Clo
    return null;
 };
 
-Render_State_Expression -> Identifier Equals (Identifier | Number) Semicolon
+Render_State_Expression -> Identifier Equals (Identifier | Sign? Number) Semicolon
 {
 	var name = $Identifier[0] as string;
-	var value = ($Identifier[1] ?? $Number) as string;
+	var value = (string)($Sign ?? "") + (string)($Identifier[1] ?? $Number);
 	
 	var pass = paramlist[0] as PassInfo;
 	pass.ParseRenderState(name, value);
@@ -114,10 +115,10 @@ PixelShader_Pass_Expression -> PixelShader Equals Compile ShaderModel Identifier
    return null;
 };
 
-Sampler_State_Expression -> Identifier Equals ((LessThan|OpenParenthesis) Identifier (GreaterThan|CloseParenthesis) | Identifier | Number) Semicolon
+Sampler_State_Expression -> Identifier Equals ((LessThan|OpenParenthesis) Identifier (GreaterThan|CloseParenthesis) | Identifier | Sign? Number) Semicolon
 {
 	var name = $Identifier[0] as string;
-	var value = ($Identifier[1] ?? ($Identifier[2] ?? $Number[0])) as string;	
+	var value = (string)($Sign ?? "") + (string)($Identifier[1] ?? ($Identifier[2] ?? $Number[0]));	
 
 	var sampler = paramlist[0] as SamplerStateInfo;
 	sampler.Parse(name, value);

--- a/Tools/2MGFX/ParseTree.cs
+++ b/Tools/2MGFX/ParseTree.cs
@@ -246,7 +246,7 @@ namespace TwoMGFX
         protected virtual object EvalRender_State_Expression(ParseTree tree, params object[] paramlist)
         {
             var name = this.GetValue(tree, TokenType.Identifier, 0) as string;
-        	var value = (this.GetValue(tree, TokenType.Identifier, 1) ?? this.GetValue(tree, TokenType.Number, 0)) as string;
+        	var value = (string)(this.GetValue(tree, TokenType.Sign, 0) ?? "") + (string)(this.GetValue(tree, TokenType.Identifier, 1) ?? this.GetValue(tree, TokenType.Number, 0));
         	
         	var pass = paramlist[0] as PassInfo;
         	pass.ParseRenderState(name, value);
@@ -291,7 +291,7 @@ namespace TwoMGFX
         protected virtual object EvalSampler_State_Expression(ParseTree tree, params object[] paramlist)
         {
             var name = this.GetValue(tree, TokenType.Identifier, 0) as string;
-        	var value = (this.GetValue(tree, TokenType.Identifier, 1) ?? (this.GetValue(tree, TokenType.Identifier, 2) ?? this.GetValue(tree, TokenType.Number, 0))) as string;	
+        	var value = (string)(this.GetValue(tree, TokenType.Sign, 0) ?? "") + (string)(this.GetValue(tree, TokenType.Identifier, 1) ?? (this.GetValue(tree, TokenType.Identifier, 2) ?? this.GetValue(tree, TokenType.Number, 0)));	
         
         	var sampler = paramlist[0] as SamplerStateInfo;
         	sampler.Parse(name, value);

--- a/Tools/2MGFX/Parser.cs
+++ b/Tools/2MGFX/Parser.cs
@@ -177,7 +177,7 @@ namespace TwoMGFX
             }
 
             
-            tok = scanner.LookAhead(TokenType.Identifier, TokenType.Number);
+            tok = scanner.LookAhead(TokenType.Identifier, TokenType.Sign, TokenType.Number);
             switch (tok.Type)
             {
                 case TokenType.Identifier:
@@ -190,7 +190,24 @@ namespace TwoMGFX
                         return;
                     }
                     break;
+                case TokenType.Sign:
                 case TokenType.Number:
+
+                    
+                    tok = scanner.LookAhead(TokenType.Sign);
+                    if (tok.Type == TokenType.Sign)
+                    {
+                        tok = scanner.Scan(TokenType.Sign);
+                        n = node.CreateNode(tok, tok.ToString() );
+                        node.Token.UpdateRange(tok);
+                        node.Nodes.Add(n);
+                        if (tok.Type != TokenType.Sign) {
+                            tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Sign.ToString(), 0x1001, tok));
+                            return;
+                        }
+                    }
+
+                    
                     tok = scanner.Scan(TokenType.Number);
                     n = node.CreateNode(tok, tok.ToString() );
                     node.Token.UpdateRange(tok);
@@ -509,7 +526,7 @@ namespace TwoMGFX
             }
 
             
-            tok = scanner.LookAhead(TokenType.LessThan, TokenType.OpenParenthesis, TokenType.Identifier, TokenType.Number);
+            tok = scanner.LookAhead(TokenType.LessThan, TokenType.OpenParenthesis, TokenType.Identifier, TokenType.Sign, TokenType.Number);
             switch (tok.Type)
             {
                 case TokenType.LessThan:
@@ -593,7 +610,24 @@ namespace TwoMGFX
                         return;
                     }
                     break;
+                case TokenType.Sign:
                 case TokenType.Number:
+
+                    
+                    tok = scanner.LookAhead(TokenType.Sign);
+                    if (tok.Type == TokenType.Sign)
+                    {
+                        tok = scanner.Scan(TokenType.Sign);
+                        n = node.CreateNode(tok, tok.ToString() );
+                        node.Token.UpdateRange(tok);
+                        node.Nodes.Add(n);
+                        if (tok.Type != TokenType.Sign) {
+                            tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Sign.ToString(), 0x1001, tok));
+                            return;
+                        }
+                    }
+
+                    
                     tok = scanner.Scan(TokenType.Number);
                     n = node.CreateNode(tok, tok.ToString() );
                     node.Token.UpdateRange(tok);

--- a/Tools/2MGFX/Scanner.cs
+++ b/Tools/2MGFX/Scanner.cs
@@ -89,6 +89,10 @@ namespace TwoMGFX
             Patterns.Add(TokenType.Number, regex);
             Tokens.Add(TokenType.Number);
 
+            regex = new Regex(@"-|\+", RegexOptions.Compiled);
+            Patterns.Add(TokenType.Sign, regex);
+            Tokens.Add(TokenType.Sign);
+
             regex = new Regex(@"[A-Za-z_][A-Za-z0-9_]*", RegexOptions.Compiled);
             Patterns.Add(TokenType.Identifier, regex);
             Tokens.Add(TokenType.Identifier);
@@ -332,23 +336,24 @@ namespace TwoMGFX
             PixelShader= 20,
             Register= 21,
             Number  = 22,
-            Identifier= 23,
-            OpenBracket= 24,
-            CloseBracket= 25,
-            Equals  = 26,
-            Colon   = 27,
-            Comma   = 28,
-            Semicolon= 29,
-            OpenParenthesis= 30,
-            CloseParenthesis= 31,
-            OpenSquareBracket= 32,
-            CloseSquareBracket= 33,
-            LessThan= 34,
-            GreaterThan= 35,
-            Compile = 36,
-            ShaderModel= 37,
-            Code    = 38,
-            EndOfFile= 39
+            Sign    = 23,
+            Identifier= 24,
+            OpenBracket= 25,
+            CloseBracket= 26,
+            Equals  = 27,
+            Colon   = 28,
+            Comma   = 29,
+            Semicolon= 30,
+            OpenParenthesis= 31,
+            CloseParenthesis= 32,
+            OpenSquareBracket= 33,
+            CloseSquareBracket= 34,
+            LessThan= 35,
+            GreaterThan= 36,
+            Compile = 37,
+            ShaderModel= 38,
+            Code    = 39,
+            EndOfFile= 40
     }
 
     public class Token


### PR DESCRIPTION
This adds support for signed numbers in both render states and sampler states in an MGFX file.

It is a fix for #1653.
