### PR TITLE
Adds the default constructor for TouchCollection.

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 
         public TouchCollection()
         {
-            _collection = new TouchLocation[8];
+            _collection = new TouchLocation[0];
             _isConnected = false;
         }
 


### PR DESCRIPTION
Without this constructor the TouchCollection class, since is a struct and don't need to be instantiated, can throw some exceptions when you call, for example, the Count method. This assures full XNA compatibility.
