### PR TITLE
Adds the default constructor for TouchCollection.

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -57,6 +57,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
 
         private bool _isConnected;
 
+        private static readonly TouchLocation[] emptyCollection = new TouchLocation[0];
+
 		#region Properties
 
         /// <summary>
@@ -65,12 +67,6 @@ namespace Microsoft.Xna.Framework.Input.Touch
 		public bool IsConnected { get { return _isConnected; } }
 
 		#endregion
-
-        public TouchCollection()
-        {
-            _collection = new TouchLocation[0];
-            _isConnected = false;
-        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TouchCollection"/> with a pre-determined set of touch locations.
@@ -90,6 +86,11 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <returns></returns>
         public bool FindById(int id, out TouchLocation touchLocation)
 		{
+            if (_collection == null)
+            {
+                touchLocation = default(TouchLocation);
+                return false;
+            }
             for (var i = 0; i < _collection.Length; i++)
             {
                 var location = _collection[i];
@@ -121,6 +122,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <returns></returns>
         public int IndexOf(TouchLocation item)
         {
+            if (_collection == null)
+                return -1;
             for (var i = 0; i < _collection.Length; i++)
             {
                 if (item == _collection[i])
@@ -156,7 +159,12 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <returns><see cref="TouchLocation"/></returns>
         public TouchLocation this[int index]
         {
-            get { return _collection[index]; }
+            get
+            {
+                if (_collection == null)
+                    throw new ArgumentOutOfRangeException("index");
+                return _collection[index];
+            }
             set
             {
                 throw new NotSupportedException();
@@ -187,6 +195,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <returns>Returns true if queried item is found, false otherwise.</returns>
         public bool Contains(TouchLocation item)
         {
+            if (_collection == null)
+                return false;
             for (var i = 0; i < _collection.Length; i++)
             {
                 if (item == _collection[i])
@@ -203,7 +213,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <param name="arrayIndex">The starting index of the copy operation.</param>
         public void CopyTo(TouchLocation[] array, int arrayIndex)
         {
-            _collection.CopyTo(array, arrayIndex);
+            if (_collection != null)
+                _collection.CopyTo(array, arrayIndex);
         }
 
         /// <summary>
@@ -211,7 +222,12 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// </summary>
         public int Count
         {
-            get { return _collection.Length; }
+            get
+            {
+                if (_collection == null)
+                    return 0;
+                return _collection.Length;
+            }
         }
 
         /// <summary>
@@ -230,6 +246,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <returns>Enumerable list of <see cref="TouchLocation"/> objects.</returns>
         public IEnumerator<TouchLocation> GetEnumerator()
         {
+            if (_collection == null)
+                return emptyCollection.AsEnumerable().GetEnumerator();
             return _collection.AsEnumerable().GetEnumerator();
         }
 
@@ -240,6 +258,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <returns>Enumerable list of objects.</returns>
         IEnumerator IEnumerable.GetEnumerator()
         {
+            if (_collection == null)
+                return emptyCollection.GetEnumerator();
             return _collection.GetEnumerator();
         }
 


### PR DESCRIPTION
Without this constructor the TouchCollection class, since is a struct and don't need to be instantiated, can throw some exceptions when you call, for example, the Count method. This assures full XNA compatibility.
