### PR TITLE
Added support for all remaining SurfaceFormat values in OpenGL

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -504,6 +504,68 @@ namespace Microsoft.Xna.Framework.Graphics
 				glFormat = PixelFormat.Red;
 				glType = PixelType.Float;
 				break;
+
+            case SurfaceFormat.HalfVector2:
+                glInternalFormat = PixelInternalFormat.Rg16f;
+				glFormat = PixelFormat.Rg;
+				glType = PixelType.HalfFloat;
+                break;
+
+            // HdrBlendable implemented as HalfVector4 (see http://blogs.msdn.com/b/shawnhar/archive/2010/07/09/surfaceformat-hdrblendable.aspx)
+            case SurfaceFormat.HdrBlendable:
+            case SurfaceFormat.HalfVector4:
+                glInternalFormat = PixelInternalFormat.Rgba16f;
+                glFormat = PixelFormat.Rgba;
+                glType = PixelType.HalfFloat;
+                break;
+
+            case SurfaceFormat.HalfSingle:
+                glInternalFormat = PixelInternalFormat.R16f;
+                glFormat = PixelFormat.Red;
+                glType = PixelType.HalfFloat;
+                break;
+
+            case SurfaceFormat.Vector2:
+                glInternalFormat = PixelInternalFormat.Rg32f;
+                glFormat = PixelFormat.Rg;
+                glType = PixelType.Float;
+                break;
+
+            case SurfaceFormat.Vector4:
+                glInternalFormat = PixelInternalFormat.Rgba32f;
+                glFormat = PixelFormat.Rgba;
+                glType = PixelType.Float;
+                break;
+
+            case SurfaceFormat.NormalizedByte2:
+                glInternalFormat = PixelInternalFormat.Rg8i;
+                glFormat = PixelFormat.Rg;
+                glType = PixelType.Byte;
+                break;
+
+            case SurfaceFormat.NormalizedByte4:
+                glInternalFormat = PixelInternalFormat.Rgba8i;
+                glFormat = PixelFormat.Rgba;
+                glType = PixelType.Byte;
+                break;
+
+            case SurfaceFormat.Rg32:
+                glInternalFormat = PixelInternalFormat.Rg16ui;
+                glFormat = PixelFormat.Rg;
+                glType = PixelType.UnsignedShort;
+                break;
+
+            case SurfaceFormat.Rgba64:
+                glInternalFormat = PixelInternalFormat.Rgba16ui;
+                glFormat = PixelFormat.Rgba;
+                glType = PixelType.UnsignedShort;
+                break;
+
+            case SurfaceFormat.Rgba1010102:
+                glInternalFormat = PixelInternalFormat.Rgb10A2ui;
+                glFormat = PixelFormat.Rgba;
+                glType = PixelType.UnsignedInt1010102;
+                break;
 #endif
 				
 #if OUYA
@@ -565,6 +627,28 @@ namespace Microsoft.Xna.Framework.Graphics
                     return 1;
 				case SurfaceFormat.NormalizedByte4:
                     return 4;
+                case SurfaceFormat.HalfSingle:
+                    return 2;
+                case SurfaceFormat.HalfVector2:
+                    return 4;
+                case SurfaceFormat.HalfVector4:
+                    return 8;
+                case SurfaceFormat.HdrBlendable:
+                    return 8;
+                case SurfaceFormat.NormalizedByte2:
+                    return 2;
+                case SurfaceFormat.Rg32:
+                    return 4;
+                case SurfaceFormat.Rgba1010102:
+                    return 4;
+                case SurfaceFormat.Rgba64:
+                    return 8;
+                case SurfaceFormat.Single:
+                    return 4;
+                case SurfaceFormat.Vector2:
+                    return 8;
+                case SurfaceFormat.Vector4:
+                    return 16;
                 default:
                     throw new NotImplementedException();
             }
@@ -584,7 +668,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     return 12;
 
                 case VertexElementFormat.Vector4:
-                    return 0x10;
+                    return 16;
 
                 case VertexElementFormat.Color:
                     return 4;


### PR DESCRIPTION
Adds support for HalfVector2, HalfVector4, Rg32, Rgba64, Rgba1010102, Vector2, Vector4, HdrBlendable, NormalizedByte2, NormalizedByte4.

Supported for OpenGL, not OpenGL ES 2.0.
