### PR TITLE
Fixes for Mouse class

### DIFF
--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Xna.Framework.Input
 #endif
         }
 
-        #endregion // Public interface
+        #endregion Public methods
     
         private static void UpdateStatePosition(int x, int y)
         {


### PR DESCRIPTION
This should clarify this class for XNA users. Methods such GetCursorPos are not good for this class in my opinion(probably need an extension)(I did not delete them just hide through internal modifier). And WindowHandle now will return window handle on future WindowsDirectX platform. Also added missing compatibility property set accessor in WindowHandle and normalizing code a bit.
