### PR TITLE
Remove File extension check that only causes failure.

### DIFF
--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -114,12 +114,6 @@ namespace Microsoft.Xna.Framework.Content
             if (files.Any(s => s == file))
                 return fileName;
 
-            // Check the file extension
-            if (!string.IsNullOrEmpty(Path.GetExtension(fileName)))
-            {
-                return null;
-            }
-
 			// FirstOrDefault returns null as the default if the file is not found. This crashed Path.Combine so check
 			// for it first.
 			string file2 = files.FirstOrDefault(s => extensions.Any(ext => s.ToLower() == (file.ToLower() + ext)));
@@ -137,9 +131,6 @@ namespace Microsoft.Xna.Framework.Content
             if (File.Exists(fileName))
 				return fileName;
 #endif
-			// Check the file extension
-			if (!string.IsNullOrEmpty(Path.GetExtension(fileName)))
-				return null;
 			
             foreach (string ext in extensions)
             {


### PR DESCRIPTION
If you have a file named something like "button.down.png" and try load it with `content.Load<Texture2D>("button.down")` then we fail to load it as we detect it has an extension in the file name.

This check appears to be unnecessary as there is a check for the file existing a few lines above, also it differs from XNA behaviour, where files named like this work fine.
