### PR TITLE
Add DebuggerHidden attribute to CheckGLError

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
 
 #if OPENGL
 #if MONOMAC
@@ -22,7 +20,6 @@ using ColorPointerType = OpenTK.Graphics.ES20.All;
 using NormalPointerType = OpenTK.Graphics.ES20.All;
 using TexCoordPointerType = OpenTK.Graphics.ES20.All;
 using GetPName = OpenTK.Graphics.ES20.All;
-using System.Diagnostics;
 #endif
 #endif
 


### PR DESCRIPTION
The DebuggerHidden attribute makes the debugger break at the caller of CheckGLError if an exception is thrown, not inside CheckGLError.  This is much more helpful to devs as they do not have to manually navigate up the callstack.
