### PR TITLE
Fix for clearing of forground framebuffer when un-setting RenderTargets.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1623,6 +1623,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #elif PSM
                 _graphics.SetFrameBuffer(_graphics.Screen);
 #endif
+                clearTarget = PresentationParameters.RenderTargetUsage == RenderTargetUsage.DiscardContents;
 
                 Viewport = new Viewport(0, 0,
 					PresentationParameters.BackBufferWidth, 


### PR DESCRIPTION
This fixes an ongoing problem with some of our Transitions.  What was happening is that our background graphics were being cleared.

Draw a graphic and then using a RenderTarget we would draw over that graphic.  During the unsetting of the RenderTarget it looks like the foreground framebuffer is being cleared.  

This now works like the XNA implementation.

Tested on Android, iOS and Mac.
