### PR TITLE
Moved the 'WINDOWS || WINRT' endif that was preventing the graphics device from being created

### DIFF
--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -346,6 +346,8 @@ namespace Microsoft.Xna.Framework
             presentationParameters.IsFullScreen = true;
 #endif // MONOMAC
 
+#endif // WINDOWS || WINRT
+
             // TODO: Implement multisampling (aka anti-alising) for all platforms!
             if (PreparingDeviceSettings != null)
             {
@@ -365,8 +367,6 @@ namespace Microsoft.Xna.Framework
 #if !MONOMAC
             ApplyChanges();
 #endif
-
-#endif // WINDOWS || WINRT
 
             // Set the new display size on the touch panel.
             //


### PR DESCRIPTION
Explained in issue #1756
