### PR TITLE
Fix for issue #1758 - Drawing SpriteFonts to multiple RenderTarget2Ds consecutively leads to all but the first render target missing the text (WindowsGL)

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1751,6 +1751,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			// Reset the raster state because we flip vertices
             // when rendering offscreen and hence the cull direction.
             _rasterizerStateDirty = true;
+
+            // Textures will need to be rebound to render correctly in the new render target.
+            Textures.Dirty();
 #endif
         }
 


### PR DESCRIPTION
Added a call to Textures.Dirty() in GraphicsDevice.ApplyRenderTargets(...). 

Fixes a bug in OpenGL versions where drawing a texture to multiple render targets one after the other would only produce visible results in the first render target drawn to.

Issue: https://github.com/mono/MonoGame/issues/1758
