### PR TITLE
Place cursor at end in Android KeyboardInput

### DIFF
--- a/MonoGame.Framework/Android/GamerServices/Guide.cs
+++ b/MonoGame.Framework/Android/GamerServices/Guide.cs
@@ -103,6 +103,10 @@ namespace Microsoft.Xna.Framework.GamerServices
                     alert.SetMessage(description);
 
                     var input = new EditText(Game.Activity) { Text = defaultText };
+                    if (defaultText != null)
+                    {
+                        input.SetSelection(defaultText.Length);
+                    }
                     alert.SetView(input);
 
                     alert.SetPositiveButton("Ok", (dialog, whichButton) =>


### PR DESCRIPTION
When using Guide.ShowKeyboardInput on Android, the cursor was placed at the beginning of the default text in the input field. This patch puts it at the end of the input, which is more user-friendly.
