### PR TITLE
Fix for iOS Orientation on iOS6+

### DIFF
--- a/MonoGame.Framework/iOS/iOSGameViewController.cs
+++ b/MonoGame.Framework/iOS/iOSGameViewController.cs
@@ -132,7 +132,9 @@ namespace Microsoft.Xna.Framework {
         public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation ()
         {
             DisplayOrientation supportedOrientations = OrientationConverter.Normalize(SupportedOrientations);
-            if ((supportedOrientations & DisplayOrientation.LandscapeRight) != 0)
+            if ((supportedOrientations & OrientationConverter.ToDisplayOrientation(this.InterfaceOrientation)) != 0)
+                return this.InterfaceOrientation;
+            else if ((supportedOrientations & DisplayOrientation.LandscapeRight) != 0)
                 return UIInterfaceOrientation.LandscapeRight;
             else if ((supportedOrientations & DisplayOrientation.LandscapeLeft) != 0)
                 return UIInterfaceOrientation.LandscapeLeft;


### PR DESCRIPTION
When using Guide.BeginShowKeyboardInput and having both Landscape Left
and Right orientations enabled, this method was forcing the orientation
of the presented KeyboardInputViewController to be LandscapeRight, even
if the current orientation was different. Now the code tries to keep the
current orientation. If this is not possible, only then it will try to
force Right, then Left and then Portrait.
