### PR TITLE
HalfTypeHelper no longer uses unsafe.

### DIFF
--- a/MonoGame.Framework/Graphics/PackedVector/HalfTypeHelper.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfTypeHelper.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             public float f;
             [FieldOffset(0)]
             public int i;
+            [FieldOffset(0)]
+            public uint u;
         }
 
         internal static UInt16 Convert(float f)
@@ -79,7 +81,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             }
         }
 
-        internal static unsafe float Convert(ushort value)
+        internal static float Convert(ushort value)
         {
             uint rst;
             uint mantissa = (uint)(value & 1023);
@@ -107,7 +109,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
                 rst = (uint)(((((uint)value & 0x8000) << 16) | ((((((uint)value >> 10) & 0x1f) - 15) + 127) << 23)) | (mantissa << 13));
             }
 
-            return *(((float*)&rst));
+            var uif = new uif();
+            uif.u = rst;
+            return uif.f;
         }
     }
 }

--- a/MonoGame.Framework/MonoGame.Framework.WindowsPhone.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsPhone.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -92,6 +92,11 @@
   <ItemGroup>
     <Compile Include="Content\ContentReaders\Texture3DReader.cs" />
     <Compile Include="Graphics\IRenderTarget.cs" />
+    <Compile Include="Graphics\PackedVector\HalfSingle.cs" />
+    <Compile Include="Graphics\PackedVector\HalfTypeHelper.cs" />
+    <Compile Include="Graphics\PackedVector\HalfVector2.cs" />
+    <Compile Include="Graphics\PackedVector\HalfVector4.cs" />
+    <Compile Include="Graphics\PackedVector\Short4.cs" />
     <Compile Include="Graphics\RenderTargetCube.cs" />
     <Compile Include="Graphics\RenderTarget3D.cs" />
     <Compile Include="Graphics\ResourceCreatedEventArgs.cs" />


### PR DESCRIPTION
Added HalfSingle, HalfVector2, HalfVector4 and Short4 to WindowsPhone project.
