### PR TITLE
MediaPlayer: ActiveSongChanged

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -85,6 +85,8 @@ namespace Microsoft.Xna.Framework.Media
 		private static bool _isMuted = false;
 		private static readonly MediaQueue _queue = new MediaQueue();
 
+		public static event EventHandler<EventArgs> ActiveSongChanged;
+
 #if WINDOWS_MEDIA_ENGINE
         private static readonly MediaEngine _mediaEngineEx;
 #if WINDOWS_PHONE
@@ -440,6 +442,12 @@ namespace Microsoft.Xna.Framework.Media
 				if (!IsRepeating)
 				{
 					State = MediaState.Stopped;
+
+					if (ActiveSongChanged != null)
+					{
+						ActiveSongChanged.Invoke(null, null);
+					}
+
 					return;
 				}
 			}
@@ -523,6 +531,11 @@ namespace Microsoft.Xna.Framework.Media
                 Stop();
             else            
                 Play(nextSong);                            
+
+            if (ActiveSongChanged != null)
+            {
+                ActiveSongChanged.Invoke(null, null);
+            }
 		}
     }
 }


### PR DESCRIPTION
This adds MediaPlayer.ActiveSongChanged to the MonoGame MediaPlayer.

MSDN Documentation: http://msdn.microsoft.com/en-us/library/microsoft.xna.framework.media.mediaplayer.activesongchanged.aspx

As you can see, there is no real documentation aside from the statement that this variable exists. You'll notice that both Invoke() calls pass `null` for both parameters; since the MediaPlayer itself is static, and there are no documented EventArgs for this EventHandler, I can only assume that neither are actually used (and to date, no XNA game I've ported so far as used either parameter).

If someone has more information on this that'd be great, but as far as I know this is XNA4-compliant.
