### PR TITLE
Fix comparison of null DisplayModes.

### DIFF
--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -95,13 +95,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public static bool operator ==(DisplayMode left, DisplayMode right)
         {
-            object leftMode = (object) left;
-            object rightMode = (object) right;
-            if (leftMode == null && rightMode == null)
+            if (left == null && right == null)
             {
                 return true;
             }
-            if (leftMode == null || rightMode == null)
+            if (left == null || right == null)
             {
                 return false;
             }


### PR DESCRIPTION
This fixes a bug where comparing with one or more null DisplayModes would cause a NullReferenceException.

This also allows us to do deliberate null checks like `if (myMode == null)`.
