### PR TITLE
Texture2D FromStream works fine w/o the DX specific version.

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -808,8 +808,6 @@ namespace Microsoft.Xna.Framework.Graphics
 				toReturn._texture = sharpDxTexture;
 			}
             return toReturn;
-#elif DIRECTX
-            throw new NotImplementedException(); 
 #elif PSM
             return new Texture2D(graphicsDevice, stream);
 #else


### PR DESCRIPTION
 Texture2D FromStream(GraphicsDevice graphicsDevice, Stream stream)

the DirectX version crashes with "Not Implemented".  But it works fine if you allow it to goto the "#else".
