### PR TITLE
Texture2D: Fix OpenGL GetData with null Rect

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -667,28 +667,27 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
 #else
-			var temp = new T[this.width*this.height];
 
 			GL.BindTexture(TextureTarget.Texture2D, this.glTexture);
 
 			if (glFormat == (GLPixelFormat)All.CompressedTextureFormats) {
 				throw new NotImplementedException();
 			} else {
-				GL.GetTexImage(TextureTarget.Texture2D, level, this.glFormat, this.glType, temp);
-			}
+				if (rect.HasValue) {
+					var temp = new T[this.width*this.height];
+					GL.GetTexImage(TextureTarget.Texture2D, level, this.glFormat, this.glType, temp);
+					int z = 0, w = 0;
 
-			if (rect.HasValue) {
-				int z = 0, w = 0;
-
-				for(int y= rect.Value.Y; y < rect.Value.Y+ rect.Value.Height; y++) {
-					for(int x=rect.Value.X; x < rect.Value.X + rect.Value.Width; x++) {
-						data[z*rect.Value.Width+w] = temp[(y*width)+x];
-						w++;
+					for(int y= rect.Value.Y; y < rect.Value.Y+ rect.Value.Height; y++) {
+						for(int x=rect.Value.X; x < rect.Value.X + rect.Value.Width; x++) {
+							data[z*rect.Value.Width+w] = temp[(y*width)+x];
+							w++;
+						}
+						z++;
 					}
-					z++;
+				} else {
+					GL.GetTexImage(TextureTarget.Texture2D, level, this.glFormat, this.glType, data);
 				}
-			} else {
-				data = temp;
 			}
 
 #endif


### PR DESCRIPTION
In the current Texture2D.GetData, we create a temp array for the texture data even when we do not need to. In the case where we don't need to, the `data` value is reassigned to the temp reference. This isn't entirely efficient, and can cause problems in certain cases (Capsized crashes after attempting to pass the newly obtained Texture2D data to FarseerPhysicsXNA's PolygonCreationAssistance class).

This revision adjusts the GetTexImage call to use `data` directly if `rect` has no value, so we always write our result to the original array.
