### PR TITLE
Fixed GameWindow Crash

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -244,6 +244,9 @@ namespace MonoGame.Framework
 
         private void OnRawKeyEvent(object sender, KeyboardInputEventArgs args)
         {
+            if (KeyState == null)
+                return;
+
             XnaKey xnaKey;
 
             switch (args.MakeCode)


### PR DESCRIPTION
Small fix for when a secondary WinFormsGameWindow gets a keyboard event, but it doesn't have a `KeyState` to capture it.
