### PR TITLE
Added an overload to SpriteBatch.Draw()

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -205,15 +205,15 @@ namespace Microsoft.Xna.Framework.Graphics
         {
 
             // Assign default values to null parameters here, as they are not compile-time constants
-            if(color == null)
+            if(!color.HasValue)
                 color = Color.White;
-            if(origin == null)
+            if(!origin.HasValue)
                 origin = Vector2.Zero;
-            if(scale == null)
+            if(!scale.HasValue)
                 scale = Vector2.One;
 
-            // If it's unclear where the the texture should be drawn, raise an error
-            if((drawRectangle == null) == (position == null))
+            // If both drawRectangle and position are null, or if both have been assigned a value, raise an error
+            if((drawRectangle.HasValue) == (position.HasValue))
             {
                 throw new InvalidOperationException("Expected drawRectangle or position, but received neither or both.");
             }


### PR DESCRIPTION
While it's a small change, I've added a new overload to SpriteBatch.Draw() that wraps the two "large" Draw methods and makes all arguments following the Texture2D optional.  The intention is to simplify the process of invoking SpriteBatch.Draw() by allowing the user to call the method using named parameters instead of feeding in a long list of what are essentially default or null values in order to change a single property. 

This allows verbose draw calls such as:

``` csharp
spriteBatch.Draw(texture, playerRectangle, null, Color.White, 0f, Vector2.Zero, SpriteEffects.FlipHorizontally, 0f);
```

To be written more concisely and clearly:

``` csharp
spriteBatch.Draw(texture, drawRectangle: playerRectangle, effect: SpriteEffects.FlipHorizontally);
```

Another example, simply changing the rotation of a drawn sprite:

``` csharp
spriteBatch.Draw(texture, position: playerPosition, rotation: playRotation);
```

You can see where this is going.  I added this because I've always hated having to fill extraneous parameters in XNA just to add a rotation to a texture, for example.  Feedback appreciated.  
