### PR TITLE
Fixes for Android Depth/Stencil buffer problems.

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Android/AndroidGameWindow.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Xna.Framework
         public AndroidGameWindow(Context context, Game game) : base(context)
         {
             _game = game;
-            Initialize();
+			Initialize();
         }		
 						
         private void Initialize()
@@ -170,7 +170,7 @@ namespace Microsoft.Xna.Framework
 						case DepthFormat.Depth16: 
 						depth = 16;
 						break;
-						case DepthFormat.Depth24: 
+						case DepthFormat.Depth24:
 						depth = 24;
 						break;
 						case DepthFormat.Depth24Stencil8: 
@@ -179,18 +179,24 @@ namespace Microsoft.Xna.Framework
 						break;
 						case DepthFormat.None: break;
 					}
-					Android.Util.Log.Debug("MonoGame", string.Format("Creating Color:RGBA8 Depth:{0} Stencil:{1}", depth, stencil));
+					Android.Util.Log.Debug("MonoGame", string.Format("Creating Color:Default Depth:{0} Stencil:{1}", depth, stencil));
 					GraphicsMode = new AndroidGraphicsMode(new ColorFormat(8,8,8,8), depth,stencil, 0, 0, false);
 					base.CreateFrameBuffer();
-					Android.Util.Log.Debug("MonoGame", "Created desired format");
 				}
 				catch(Exception)
 				{
 					Android.Util.Log.Debug("MonoGame", "Failed to create desired format, falling back to defaults");
-					// try again using a more basic mode which hopefully the device will support
-					GraphicsMode = new AndroidGraphicsMode(0, 0, 0, 0, 0, false);
-					base.CreateFrameBuffer();
+					// try again using a more basic mode with a 16 bit depth buffer which hopefully the device will support 
+					GraphicsMode = new AndroidGraphicsMode(new ColorFormat(0, 0, 0, 0), 16, 0, 0, 0, false);
+					try {
+						base.CreateFrameBuffer();
+					} catch (Exception) {
+						// ok we are right back to getting the default
+						GraphicsMode = new AndroidGraphicsMode(0, 0, 0, 0, 0, false);
+						base.CreateFrameBuffer();
+					}
 				}
+				Android.Util.Log.Debug("MonoGame", "Created format {0}", this.GraphicsContext.GraphicsMode);
                 All status = GL.CheckFramebufferStatus(All.Framebuffer);
                 Android.Util.Log.Debug("MonoGame", "Framebuffer Status: " + status.ToString());
             } 


### PR DESCRIPTION
It appears on some newer devices (Nexus 4) the defaults used by the AndroidGameView result in a surface without a depth or stencil buffer. This PR corrects the issue by attempting to use the PreferredDepthStencilFormat to pass in the correct parameters that the user wants. 

 Fixed an issue in AddSpecular where on certain android gpu's applying

the color.a to the specular wipes out the texture.

The fix is to apply it in two operations.

This has been tested on 4 different devices and emulator and works ok. 

If we had the xamarin test cloud we could know for sure but hey ho ;)
