### PR TITLE
Issue #1850 - Moved init of color bank to a static constructor

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1710,7 +1710,11 @@ namespace Microsoft.Xna.Framework
         /// <returns>Interpolated <see cref="Color"/>.</returns>
         public static Color Lerp(Color value1, Color value2, Single amount)
         {		
-            return new Color(   (int)MathHelper.Lerp(value1.R, value2.R, amount),               (int)MathHelper.Lerp(value1.G, value2.G, amount),               (int)MathHelper.Lerp(value1.B, value2.B, amount),               (int)MathHelper.Lerp(value1.A, value2.A, amount) );
+            return new Color(   
+                (int)MathHelper.Lerp(value1.R, value2.R, amount),
+                (int)MathHelper.Lerp(value1.G, value2.G, amount),
+                (int)MathHelper.Lerp(value1.B, value2.B, amount),
+                (int)MathHelper.Lerp(value1.A, value2.A, amount) );
         }
 		
 	/// <summary>


### PR DESCRIPTION
This moves the initialization of the static color bank to a static constructor. The repeated new() of the prior version's color bank has a small but noticeable affect when repeatedly called from a draw or update method. This change will abate some of the mysterious overhead associated with new() on structs.

There is no change to the serialization signature of this class. Furthermore, this does not change the XNA compatibility of this class.
