### PR TITLE
Add a Try/Catch around creating a debug XAudio2 Device 

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -467,18 +467,23 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal static void InitializeSoundEffect()
         {
-            var flags = XAudio2Flags.None;
-
-#if !WINRT && DEBUG
-            flags |= XAudio2Flags.DebugEngine;
-#endif
             try
             {
                 if (Device == null)
                 {
-                    // This cannot fail.
-                    Device = new XAudio2(flags, ProcessorSpecifier.DefaultProcessor);
-                    Device.StartEngine();
+#if !WINRT && DEBUG
+                    try
+                    {
+                        //Fails if the XAudio2 SDK is not installed
+                        Device = new XAudio2(XAudio2Flags.DebugEngine, ProcessorSpecifier.DefaultProcessor);
+                        Device.StartEngine();
+                    }
+                    catch
+#endif
+                    {
+                        Device = new XAudio2(XAudio2Flags.None, ProcessorSpecifier.DefaultProcessor);
+                        Device.StartEngine();
+                    }
                 }
 
                 // Just use the default device.


### PR DESCRIPTION
As it fails if the XAudio2 SDK is not installed. Fixes #1877

Discussion in related issue.
