### PR TITLE
Various Updates to get the Content Pipleine working on Mac

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineBuildLogger.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineBuildLogger.cs
@@ -11,20 +11,22 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
     {
         public override void LogMessage(string message, params object[] messageArgs)
         {
-            Console.WriteLine(message, messageArgs);
+			System.Diagnostics.Trace.WriteLine(string.Format(message, messageArgs));
         }
 
         public override void LogImportantMessage(string message, params object[] messageArgs)
         {
             // TODO: How do i make it high importance?
-            Console.WriteLine(message, messageArgs);
+			System.Diagnostics.Trace.WriteLine(string.Format(message, messageArgs));
         }
 
         public override void LogWarning(string helpLink, ContentIdentity contentIdentity, string message, params object[] messageArgs)
         {
             var msg = string.Format(message, messageArgs);
             var fileName = GetCurrentFilename(contentIdentity);
-            Console.WriteLine("{0}: {1}", fileName, msg);
+			System.Diagnostics.Trace.WriteLine(string.Format("{0}: {1}", fileName, msg));
         }
+
     }
+
 }

--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -42,7 +42,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         private ContentCompiler _compiler;
         private MethodInfo _compileMethod;
 
-        public ContentBuildLogger Logger { get; private set; }
+        public ContentBuildLogger Logger { get; set; }
 
         public List<string> Assemblies { get; private set; }
 
@@ -161,6 +161,30 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 }
             }
         }
+
+		public Type[] GetProcessorTypes()
+		{
+			if (_processors == null)
+				ResolveAssemblies ();
+
+			List <Type> types = new List<Type> ();
+			foreach (var item in _processors) {
+				types.Add (item.type);
+			}
+			return types.ToArray ();
+		}
+
+		public Type[] GetImporterTypes()
+		{
+			if (_importers == null)
+				ResolveAssemblies ();
+
+			List <Type> types = new List<Type> ();
+			foreach (var item in _importers) {
+				types.Add (item.type);
+			}
+			return types.ToArray ();
+		}
 
         public IContentImporter CreateImporter(string name)
         {

--- a/MonoGame.Framework.Content.Pipeline/Graphics/FontHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/FontHelper.cs
@@ -5,40 +5,209 @@ using System.Text;
 using System.Runtime.InteropServices;
 using System.Drawing;
 
+#if MACOS
+using MonoMac.CoreGraphics;
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+using MonoMac.CoreText;
+using MonoMac.ImageIO;
+#endif
+
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
-    static class FontHelper
-    {
-        [StructLayout(LayoutKind.Sequential)]
-        public struct ABC
-        {
-            public int abcA;
-            public uint abcB;
-            public int abcC;
-        }
+	static class FontHelper
+	{
+		[StructLayout(LayoutKind.Sequential)]
+		public struct ABC
+		{
+			public int abcA;
+			public uint abcB;
+			public int abcC;
+		}
 
-        [DllImport("gdi32.dll", ExactSpelling = true)]
-        public static extern IntPtr SelectObject(IntPtr hDC, IntPtr hObj);
+		[DllImport("gdi32.dll", ExactSpelling = true)]
+		public static extern IntPtr SelectObject(IntPtr hDC, IntPtr hObj);
 
-        [DllImport("gdi32.dll", ExactSpelling = true, SetLastError = true)]
-        public static extern int DeleteObject(IntPtr hObj);
+		[DllImport("gdi32.dll", ExactSpelling = true, SetLastError = true)]
+		public static extern int DeleteObject(IntPtr hObj);
 
-        [DllImport("gdi32.dll", ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern bool GetCharABCWidthsW(IntPtr hdc, uint uFirstChar, uint uLastChar, [Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStruct, SizeConst = 1)] ABC[] lpabc);
+		[DllImport("gdi32.dll", ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+		public static extern bool GetCharABCWidthsW(IntPtr hdc, uint uFirstChar, uint uLastChar, [Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStruct, SizeConst = 1)] ABC[] lpabc);
+		#if MACOS
 
-        public static ABC GetCharWidthABC(char ch, Font font, System.Drawing.Graphics gr)
-        {
-            ABC[] _temp = new ABC[1];
-            IntPtr hDC = gr.GetHdc();
-            Font ft = (Font)font.Clone();
-            IntPtr hFt = ft.ToHfont();
-            SelectObject(hDC, hFt);
-            GetCharABCWidthsW(hDC, ch, ch, _temp);
-            DeleteObject(hFt);
-            gr.ReleaseHdc();
+		static CTFont nativeFont;
 
-            return _temp[0];
-        }
+		public static ABC GetCharWidthABC(char ch, Font font, System.Drawing.Graphics gr)
+		{
+			ABC[] _temp = new ABC[1];
+			var nativFont = CreateFont (font.Name, font.Size, font.Style, font.GdiCharSet, font.GdiVerticalFont);
+			var atts = buildAttributedString(ch.ToString(), nativFont);
 
-    }
+			// for now just a line not sure if this is going to work
+			CTLine line = new CTLine(atts);
+
+			float ascent;
+			float descent;
+			float leading;
+			_temp[0].abcB = (uint)line.GetTypographicBounds(out ascent, out descent, out leading);
+
+
+			return _temp[0];
+		}
+
+		const byte DefaultCharSet = 1;
+		static bool underLine = false;
+		static bool strikeThrough = false;
+
+		static float dpiScale = 96f / 72f;
+
+
+		static internal CTFont CreateFont (string familyName, float emSize)
+		{
+			return CreateFont (familyName, emSize, FontStyle.Regular, DefaultCharSet, false);
+		}
+
+		static internal CTFont CreateFont (string familyName, float emSize, FontStyle style)
+		{
+			return CreateFont (familyName, emSize, style, DefaultCharSet, false);
+		}
+
+		static internal CTFont CreateFont (string familyName, float emSize, FontStyle style, byte gdiCharSet)
+		{
+			return CreateFont (familyName, emSize, style, gdiCharSet, false);
+		}
+
+		static internal CTFont CreateFont (string familyName, float emSize, FontStyle style,
+		                                   byte gdiCharSet, bool  gdiVerticalFont )
+		{
+			if (emSize <= 0)
+				throw new ArgumentException("emSize is less than or equal to 0, evaluates to infinity, or is not a valid number.","emSize");
+
+			CTFont nativeFont;
+
+			// convert to 96 Dpi to be consistent with Windows
+			var dpiSize = emSize * dpiScale;
+
+			try {
+				nativeFont = new CTFont(familyName,dpiSize);
+			}
+			catch
+			{
+				nativeFont = new CTFont("Helvetica",dpiSize);
+			}
+
+			CTFontSymbolicTraits tMask = CTFontSymbolicTraits.None;
+
+			if ((style & FontStyle.Bold) == FontStyle.Bold)
+				tMask |= CTFontSymbolicTraits.Bold;
+			if ((style & FontStyle.Italic) == FontStyle.Italic)
+				tMask |= CTFontSymbolicTraits.Italic;
+			strikeThrough = (style & FontStyle.Strikeout) == FontStyle.Strikeout;
+			underLine = (style & FontStyle.Underline) == FontStyle.Underline;
+
+			var nativeFont2 = nativeFont.WithSymbolicTraits(dpiSize,tMask,tMask);
+
+			if (nativeFont2 != null)
+				nativeFont = nativeFont2;
+
+			return nativeFont;
+		}
+
+		static NSString FontAttributedName = (NSString)"NSFont";
+		static NSString ForegroundColorAttributedName = (NSString)"NSColor";
+		static NSString UnderlineStyleAttributeName = (NSString)"NSUnderline";
+		static NSString ParagraphStyleAttributeName = (NSString)"NSParagraphStyle";
+		//NSAttributedString.ParagraphStyleAttributeName
+		static NSString StrikethroughStyleAttributeName = (NSString)"NSStrikethrough";
+
+		private static NSMutableAttributedString buildAttributedString(string text, CTFont font, 
+		                                                               Color? fontColor=null) 
+		{
+
+
+			// Create a new attributed string from text
+			NSMutableAttributedString atts = 
+				new NSMutableAttributedString(text);
+
+			var attRange = new NSRange(0, atts.Length);
+			var attsDic = new NSMutableDictionary();
+
+			// Font attribute
+			NSObject fontObject = new NSObject(font.Handle);
+			attsDic.Add(FontAttributedName, fontObject);
+			// -- end font 
+
+			if (fontColor.HasValue) {
+
+				// Font color
+				var fc = fontColor.Value;
+				NSColor color = NSColor.FromDeviceRgba(fc.R / 255f, 
+				                                       fc.G / 255f,
+				                                       fc.B / 255f,
+				                                       fc.A / 255f);
+				NSObject colorObject = new NSObject(color.Handle);
+				attsDic.Add(ForegroundColorAttributedName, colorObject);
+				// -- end font Color
+			}
+
+			if (underLine) {
+				// Underline
+				int single = (int)MonoMac.AppKit.NSUnderlineStyle.Single;
+				int solid = (int)MonoMac.AppKit.NSUnderlinePattern.Solid;
+				var attss = single | solid;
+				var underlineObject = NSNumber.FromInt32(attss);
+				//var under = NSAttributedString.UnderlineStyleAttributeName.ToString();
+				attsDic.Add(UnderlineStyleAttributeName, underlineObject);
+				// --- end underline
+			}
+
+
+			if (strikeThrough) {
+				// StrikeThrough
+				//				NSColor bcolor = NSColor.Blue;
+				//				NSObject bcolorObject = new NSObject(bcolor.Handle);
+				//				attsDic.Add(NSAttributedString.StrikethroughColorAttributeName, bcolorObject);
+				int stsingle = (int)MonoMac.AppKit.NSUnderlineStyle.Single;
+				int stsolid = (int)MonoMac.AppKit.NSUnderlinePattern.Solid;
+				var stattss = stsingle | stsolid;
+				var stunderlineObject = NSNumber.FromInt32(stattss);
+
+				attsDic.Add(StrikethroughStyleAttributeName, stunderlineObject);
+				// --- end underline
+			}
+
+
+			// Text alignment
+			var alignment = CTTextAlignment.Left;
+			var alignmentSettings = new CTParagraphStyleSettings();
+			alignmentSettings.Alignment = alignment;
+			var paragraphStyle = new CTParagraphStyle(alignmentSettings);
+			NSObject psObject = new NSObject(paragraphStyle.Handle);
+
+			// end text alignment
+
+			attsDic.Add(ParagraphStyleAttributeName, psObject);
+
+			atts.SetAttributes(attsDic, attRange);
+
+			return atts;
+
+		}
+
+		#else
+		public static ABC GetCharWidthABC(char ch, Font font, System.Drawing.Graphics gr)
+		{
+			ABC[] _temp = new ABC[1];
+			IntPtr hDC = gr.GetHdc();
+			Font ft = (Font)font.Clone();
+			IntPtr hFt = ft.ToHfont();
+			SelectObject(hDC, hFt);
+			GetCharABCWidthsW(hDC, ch, ch, _temp);
+			DeleteObject(hFt);
+			gr.ReleaseHdc();
+
+			return _temp[0];
+		}
+		#endif
+	}
 }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -143,31 +143,33 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         /// <summary>
         /// Compresses TextureContent in a format appropriate to the platform
         /// </summary>
-        public static void CompressTexture(TextureContent content, TargetPlatform platform, bool premultipliedAlpha)
+		public static void CompressTexture(TextureContent content, ContentProcessorContext context, bool premultipliedAlpha)
         {
             // TODO: At the moment, only DXT compression from windows machine is supported
             // Add more here as they become available.
-            switch (platform)
+            switch (context.TargetPlatform)
             {
-                case TargetPlatform.Windows:
-                case TargetPlatform.WindowsPhone:
-                case TargetPlatform.WindowsPhone8:
-                case TargetPlatform.WindowsStoreApp:
-                case TargetPlatform.Ouya:
-                case TargetPlatform.Android:
-                case TargetPlatform.Linux: 
-                case TargetPlatform.MacOSX:
-                case TargetPlatform.NativeClient:
-                case TargetPlatform.Xbox360:
-                    CompressDXT(content);
-                    break;
+				case TargetPlatform.Windows:
+				case TargetPlatform.WindowsPhone:
+				case TargetPlatform.WindowsPhone8:
+				case TargetPlatform.WindowsStoreApp:
+				case TargetPlatform.Ouya:
+				case TargetPlatform.Android:
+				case TargetPlatform.Linux: 
+				case TargetPlatform.MacOSX:
+				case TargetPlatform.NativeClient:
+				case TargetPlatform.Xbox360:
+					context.Logger.LogMessage ("Detected {0} using DXT Compression", context.TargetPlatform);
+				    CompressDXT(content);
+				    break;
 
                 case TargetPlatform.iOS:
+					context.Logger.LogMessage ("Detected {0} using PVRTC Compression", context.TargetPlatform);
                     CompressPVRTC(content, premultipliedAlpha);
                     break;
 
                 default:
-                    throw new NotImplementedException(string.Format("Texture Compression it not implemented for {0}", platform));
+                    throw new NotImplementedException(string.Format("Texture Compression it not implemented for {0}", context.TargetPlatform));
             }
         }
 

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.MacOS.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.MacOS.csproj
@@ -47,6 +47,12 @@
     <Reference Include="MonoMac, Version=0.0.0.0, Culture=neutral">
       <Private>False</Private>
     </Reference>
+    <Reference Include="AssimpNet">
+      <HintPath>..\ThirdParty\Libs\assimp\AssimpNet.dll</HintPath>
+    </Reference>
+    <Reference Include="ManagedPVRTC">
+      <HintPath>..\ThirdParty\Libs\ManagedPVRTC\ManagedPVRTC.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Audio\AudioContent.cs" />
@@ -191,6 +197,9 @@
     <Compile Include="Serialization\Compiler\Vector4Writer.cs" />
     <Compile Include="Graphics\DXTBitmapContent.cs" />
     <Compile Include="Graphics\PVRTCBitmapContent.cs" />
+    <Compile Include="Graphics\FontHelper.cs" />
+    <Compile Include="Graphics\BasicMaterialContent.cs" />
+    <Compile Include="Serialization\Compiler\SpriteFontContentWriter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -133,9 +133,15 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                     }
                 }
 
-                var bitmapContent = new PixelBitmapContent<Color>(texBounds.X, texBounds.Y);
+				output.Texture._bitmap = outputBitmap;
+
+				var bitmapContent = new PixelBitmapContent<Color>(texBounds.X, texBounds.Y);
                 bitmapContent.SetPixelData(outputBitmap.GetData());
                 output.Texture.Faces.Add(new MipmapChain(bitmapContent));
+
+				TextureProcessor p = new TextureProcessor ();
+				p.TextureFormat = TextureProcessorOutputFormat.Compressed;
+				output.Texture =  (Texture2DContent)p.Process (output.Texture, context);
             }
 
             return output;

--- a/MonoGame.Framework.Content.Pipeline/Processors/SpriteFontContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/SpriteFontContent.cs
@@ -4,10 +4,11 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
-    public class SpriteFontContent
+	public class SpriteFontContent
     {
         public SpriteFontContent() { }
 

--- a/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
@@ -76,10 +76,27 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 
             if (TextureFormat == TextureProcessorOutputFormat.NoChange)
                 return input;
-
-            if (TextureFormat == TextureProcessorOutputFormat.DXTCompressed || 
+			try 
+			{
+			if (TextureFormat == TextureProcessorOutputFormat.DXTCompressed || 
                 TextureFormat == TextureProcessorOutputFormat.Compressed )
-                GraphicsUtil.CompressTexture(input, context.TargetPlatform, PremultiplyAlpha);
+				context.Logger.LogMessage("Compressing using {0}",TextureFormat);
+                GraphicsUtil.CompressTexture(input, context, PremultiplyAlpha);
+				context.Logger.LogMessage("Compression {0} Suceeded", TextureFormat);
+			}
+			catch(EntryPointNotFoundException ex) {
+				context.Logger.LogImportantMessage ("Could not find the entry point to compress the texture", ex.ToString());
+				TextureFormat = TextureProcessorOutputFormat.Color;
+			}
+			catch(DllNotFoundException ex) {
+				context.Logger.LogImportantMessage ("Could not compress texture. Required shared lib is missing. {0}", ex.ToString());
+				TextureFormat = TextureProcessorOutputFormat.Color;
+			}
+			catch(Exception ex)
+			{
+				context.Logger.LogImportantMessage ("Could not compress texture {0}", ex.ToString());
+				TextureFormat = TextureProcessorOutputFormat.Color;
+			}
 
             return input;
         }

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentCompiler.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentCompiler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
                 var contentTypeWriterType = typeof(ContentTypeWriter<>);
                 foreach (var type in exportedTypes)
                 {
-                    if (type.IsAbstract)
+					if (type.IsAbstract)
                         continue;
                     if (Attribute.IsDefined(type, typeof(ContentTypeWriterAttribute)))
                     {
@@ -74,7 +74,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
             Type typeWriterType;
             if (!typeWriterMap.TryGetValue(contentTypeWriterType, out typeWriterType))
             {
-                var inputTypeDef = type.GetGenericTypeDefinition();
+				var inputTypeDef = type.GetGenericTypeDefinition ();
 
                 Type chosen = null;
                 foreach (var kvp in typeWriterMap)
@@ -108,6 +108,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
                 {
                     throw new InvalidContentException(String.Format("Could not find ContentTypeWriter for type '{0}'", type.Name));
                 }
+				
             }
             else
             {

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentTypeWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentTypeWriter.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
         /// <returns>The qualified name.</returns>
         public virtual string GetRuntimeType(TargetPlatform targetPlatform)
         {
-            return targetType.FullName + ", " + targetType.Assembly.FullName;
+			return targetType.FullName + ", Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral";// + targetType.Assembly.FullName;
         }
 
         /// <summary>

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/SpriteFontContentWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/SpriteFontContentWriter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
         {
             // Base the reader type string from a known public class in the same namespace in the same assembly
             Type type = typeof(ContentReader);
-            string readerType = type.Namespace + ".SpriteFontReader, " + type.Assembly.FullName;
+			string readerType = type.Namespace + ".SpriteFontReader, Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral";// + type.Assembly.FullName;
             return readerType;
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
         {
             // Base the reader type string from a known public class in the same namespace in the same assembly
             Type type = typeof(ContentReader);
-            string readerType = type.Namespace + ".SpriteFontReader, " + type.AssemblyQualifiedName;
+			string readerType = type.Namespace + ".SpriteFontReader, Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral";// + type.AssemblyQualifiedName;
             return readerType;
         }
 


### PR DESCRIPTION
Slight changes to the API to allow custom Loggers to be assigned,
This is useful for the Addins and any custom UI.
Changed the ContentTypeWriter to emit XNA style assembly
references for backward compatability (for now)
Updated the SpriteFont processor to attempt to write
compressed textures
Added Core.Graphics support for the FontHelper (thanks kjpou1)

Sorry about the line endings/tabbing not sure what is going on there.
