### PR TITLE
iOS *.csproj <Import> is out of date

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -460,7 +460,7 @@
     <Compile Include="GameUpdateRequiredException.cs" />
     <Compile Include="Audio\MSADPCMToPCM.cs" />
   </ItemGroup>
-  <Import Project="$(ProgramFiles)\MSBuild\MonoTouch\Novell.MonoTouch.Common.targets" Condition="'$(windir)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <MonoDevelop>

--- a/ThirdParty/Lidgren.Network/Lidgren.Network.iOS.csproj
+++ b/ThirdParty/Lidgren.Network/Lidgren.Network.iOS.csproj
@@ -38,7 +38,7 @@
     <Reference Include="System.Core" />
     <Reference Include="monotouch" />
   </ItemGroup>
-  <Import Project="$(ProgramFiles)\MSBuild\MonoTouch\Novell.MonoTouch.Common.targets" Condition="'$(windir)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Compile Include="Encryption\INetEncryption.cs" />


### PR DESCRIPTION
I switched to using the latest <Import> statements for the latest
Xamarin.iOS

Originally this was failing in Visual Studio on Windows, these changes resolve the issue. I tested on my Mac as well, and everything is still working.

I'm using Xamarin.iOS 6.4.1 on both platforms.
