### PR TITLE
issue #1920: Song always loops on Android

### DIFF
--- a/MonoGame.Framework/Android/Media/Song.cs
+++ b/MonoGame.Framework/Android/Media/Song.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Xna.Framework.Media
                     _androidPlayer.Reset();
                     _androidPlayer.SetDataSource(afd.FileDescriptor, afd.StartOffset, afd.Length);
                     _androidPlayer.Prepare();
-                    _androidPlayer.Looping = true;
+                    _androidPlayer.Looping = MediaPlayer.IsRepeating;
                 }
             }
         }


### PR DESCRIPTION
This is a pretty simple fix for issue #1920: Song always loops on Android
Sets the looping value to the correct value
