### PR TITLE
PremultiplyAlpha should be set true by default

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
@@ -11,7 +11,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
     [ContentProcessor(DisplayName="Texture - MonoGame")]
     public class TextureProcessor : ContentProcessor<TextureContent, TextureContent>
     {
-        public TextureProcessor() { }
+        public TextureProcessor()
+        {
+            PremultiplyAlpha = true;
+        }
 
         public virtual Color ColorKeyColor { get; set; }
 


### PR DESCRIPTION
DefaultValueAttribute does not set the value, just hints it.
http://stackoverflow.com/questions/1980520/defaultvalue-attribute-is-not-working-with-my-auto-property

This change means when building texture content with mgcb it will be premultiplied by default, matching the XNA default.
