### PR TITLE
Pass the current Platform/Profile down when building content. 

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -543,7 +543,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
             // Write the XNB.
             using (var stream = new FileStream(pipelineEvent.DestFile, FileMode.Create, FileAccess.Write, FileShare.None))
-                _compiler.Compile(stream, content, TargetPlatform.Windows, GraphicsProfile.Reach, false, OutputDirectory, outputFileDir);
+                _compiler.Compile(stream, content, Platform, Profile, false, OutputDirectory, outputFileDir);
 
             // Store the last write time of the output XNB here
             // so we can verify it hasn't been tampered with.


### PR DESCRIPTION
This allows content writers to save things different for different platforms.

I'm using this to work aroun WP8 not supporting Texture2D.FromStream in my own project where I save a PNG for all  platforms that support it, or raw PARGB32 on WP8.
