### PR TITLE
Enabled BlendFunction Max and Min in Windows and Linux

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				return BlendEquationMode.MaxExt;
 			case BlendFunction.Min:
 				return BlendEquationMode.MinExt;
-#elif MONOMAC
+#elif MONOMAC || WINDOWS || LINUX
 			case BlendFunction.Max:
 				return BlendEquationMode.Max;
 			case BlendFunction.Min:


### PR DESCRIPTION
BlendFunction.Min and BlendFunction.Max does not work in Windows.
The exception NotImplementedException is thrown when used.
Tested with WindowsGL on Windows 8
