### PR TITLE
Fix XACT IsPlaying properties.

### DIFF
--- a/MonoGame.Framework/Audio/XactClip.cs
+++ b/MonoGame.Framework/Audio/XactClip.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			public override bool Playing {
 				get {
-					return wave.State == SoundState.Playing;
+					return wave.State != SoundState.Stopped;
 				}
 			}
 			public override bool IsPaused

--- a/MonoGame.Framework/Audio/XactSound.cs
+++ b/MonoGame.Framework/Audio/XactSound.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Xna.Framework.Audio
 					}
 					return false;
 				} else {
-					return wave.State == SoundState.Playing;
+					return wave.State != SoundState.Stopped;
 				}
 			}
 		}


### PR DESCRIPTION
Currently, XactClip and XactSound assume that `IsPlaying` is only true when SoundState == Playing. However, the wave is technically playing when it is either Playing or Paused, since pausing is still in the middle of playback (as opposied to stopping, which resets the playback position).

So, the expected behavior should be:

`SoundState.Stopped`: `Playing == false`, `IsPaused == false`
`SoundState.Playing`: `Playing == true`, `IsPaused == false`
`SoundState.Paused`: `Playing == true`, `IsPaused == true`

And there should never be a case where `Playing == false` and `IsPaused == true`.
