### PR TITLE
Removed PreferredInterfaceOrientationForPresentation() for iOS

### DIFF
--- a/MonoGame.Framework/iOS/iOSGameViewController.cs
+++ b/MonoGame.Framework/iOS/iOSGameViewController.cs
@@ -128,19 +128,6 @@ namespace Microsoft.Xna.Framework {
         {
             return _platform.Game.Initialized;
         }
-        
-        public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation ()
-        {
-            DisplayOrientation supportedOrientations = OrientationConverter.Normalize(SupportedOrientations);
-            if ((supportedOrientations & OrientationConverter.ToDisplayOrientation(this.InterfaceOrientation)) != 0)
-                return this.InterfaceOrientation;
-            else if ((supportedOrientations & DisplayOrientation.LandscapeRight) != 0)
-                return UIInterfaceOrientation.LandscapeRight;
-            else if ((supportedOrientations & DisplayOrientation.LandscapeLeft) != 0)
-                return UIInterfaceOrientation.LandscapeLeft;
-            else
-                return UIInterfaceOrientation.Portrait;
-        }
         #endregion
 
 		public override void DidRotate (UIInterfaceOrientation fromInterfaceOrientation)


### PR DESCRIPTION
Overriding this method is not something that is commonly required on iOS.

It also causes the following bug:
- Create a MonoGame game that runs in `LandscapeLeft` or `LandscapeRight`
- Play the game in `LandscapeLeft`
- Pull out the underlying `UIViewController` and present a native iOS controller via `PresentViewController`
- Dimiss the modal controller
- The MonoGame controller will return `LandscapeRight` for `PreferredInterfaceOrientationForPresentation()`
- Your game will be upside down.

Removing the method completely fixes the issue in our game.

I have not tested it, but I presume the same would happen with a portrait game when it is oriented `PortraitUpsideDown`.

Does anyone know if this method was overridden for a specific purpose? It is not commonly used in standard iOS apps. Apple doc here (might need to scroll down): http://developer.apple.com/library/ios/documentation/UIKit/Reference/UIViewController_Class/Reference/Reference.html#//apple_ref/occ/instm/UIViewController/preferredInterfaceOrientationForPresentation
