### PR TITLE
Fixed strange sound loading issue on MacOS

### DIFF
--- a/MonoGame.ContentPipeline/ContentProcessors/Processors/MGSongProcessor.cs
+++ b/MonoGame.ContentPipeline/ContentProcessors/Processors/MGSongProcessor.cs
@@ -18,11 +18,11 @@ namespace MonoGameContentProcessors.Processors
         {
             // Fallback if we aren't buiding for iOS.
             var platform = ContentHelper.GetMonoGamePlatform();
-            if (platform != MonoGamePlatform.iOS && platform != MonoGamePlatform.Linux)
+            if (platform != MonoGamePlatform.iOS && platform != MonoGamePlatform.Linux && platform != MonoGamePlatform.OSX)
                 return base.Process(input, context);
 
             //TODO: If quality isn't best and it's a .wma, don't compress to MP3. Leave it as a .wav instead
-            string outputType = (platform == MonoGamePlatform.iOS) ? "mp3" : "wav";
+            string outputType = (platform == MonoGamePlatform.iOS || platform == MonoGamePlatform.OSX) ? "mp3" : "wav";
             string outputFilename = Path.ChangeExtension(context.OutputFilename, outputType);
             string directoryName = Path.GetDirectoryName(outputFilename);
             if (!Directory.Exists(directoryName))
@@ -49,7 +49,7 @@ namespace MonoGameContentProcessors.Processors
                     break;
             }
 
-            AudioFileType target = (platform == MonoGamePlatform.iOS) ? AudioFileType.Mp3 : AudioFileType.Wav;
+            AudioFileType target = (platform == MonoGamePlatform.iOS || platform == MonoGamePlatform.OSX) ? AudioFileType.Mp3 : AudioFileType.Wav;
             // Create a new file if we need to.
             FileStream outputStream = input.FileType != target ? new FileStream(outputFilename, FileMode.Create) : null;
             

--- a/MonoGame.ContentPipeline/ContentProcessors/Processors/MGSongProcessor.cs
+++ b/MonoGame.ContentPipeline/ContentProcessors/Processors/MGSongProcessor.cs
@@ -18,11 +18,11 @@ namespace MonoGameContentProcessors.Processors
         {
             // Fallback if we aren't buiding for iOS.
             var platform = ContentHelper.GetMonoGamePlatform();
-            if (platform != MonoGamePlatform.iOS && platform != MonoGamePlatform.Linux && platform != MonoGamePlatform.OSX)
+            if (platform != MonoGamePlatform.iOS && platform != MonoGamePlatform.Linux)
                 return base.Process(input, context);
 
             //TODO: If quality isn't best and it's a .wma, don't compress to MP3. Leave it as a .wav instead
-            string outputType = (platform == MonoGamePlatform.iOS || platform == MonoGamePlatform.OSX) ? "mp3" : "wav";
+            string outputType = (platform == MonoGamePlatform.iOS) ? "mp3" : "wav";
             string outputFilename = Path.ChangeExtension(context.OutputFilename, outputType);
             string directoryName = Path.GetDirectoryName(outputFilename);
             if (!Directory.Exists(directoryName))
@@ -49,7 +49,7 @@ namespace MonoGameContentProcessors.Processors
                     break;
             }
 
-            AudioFileType target = (platform == MonoGamePlatform.iOS || platform == MonoGamePlatform.OSX) ? AudioFileType.Mp3 : AudioFileType.Wav;
+            AudioFileType target = (platform == MonoGamePlatform.iOS) ? AudioFileType.Mp3 : AudioFileType.Wav;
             // Create a new file if we need to.
             FileStream outputStream = input.FileType != target ? new FileStream(outputFilename, FileMode.Create) : null;
             

--- a/MonoGame.Framework/MacOS/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/MacOS/Audio/SoundEffect.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Xna.Framework.Audio
             Rate = (float)asbd.SampleRate;
             Size = (int)afs.DataByteCount;
             
-            if (asbd.ChannelsPerFrame == 1)
+            if (asbd.ChannelsPerFrame <= 1)
                 Format = asbd.BitsPerChannel == 8 ? ALFormat.Mono8 : ALFormat.Mono16;
             else
                 Format = asbd.BitsPerChannel == 8 ? ALFormat.Stereo8 : ALFormat.Stereo16;


### PR DESCRIPTION
Sometimes (Not sure why!) SoundEffect buffer reports -1 ChannelsPerFrame, and treats it as stereo even being a mono sound. This results in a sound played at twice the speed, very high pitched.

It can happen to different sounds on two consecutive runs of the game, so it's pretty random right now.

Since on XNA all sounds had to be Mono (Or so I think), treating this case as Mono "fixes" the issue.
