### PR TITLE
Fixed crash when the output directory does not exist for SongProcessor

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
@@ -178,6 +178,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
 
                 case ConversionFormat.WindowsMedia:
 #if WINDOWS
+                    //Ensure the directory is there so the wma file can be saved in it
+                    Directory.CreateDirectory(Path.GetDirectoryName(targetFileName) + Path.DirectorySeparatorChar);
                     reader.Position = 0;
                     MediaFoundationEncoder.EncodeToWma(reader, targetFileName, QualityToBitRate(quality));
                     break;


### PR DESCRIPTION
Ensure the output directory exists for WMA files otherwise we crash.
We ensure the output directory exists in PipelineBuildEvent.Save but WMA files are saved early
