### PR TITLE
Fix for game init when running under unit test runner

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -341,7 +341,9 @@ namespace Microsoft.Xna.Framework
             window.KeyPress += OnKeyPress;
             
             // Set the window icon.
-            window.Icon = Icon.ExtractAssociatedIcon(Assembly.GetEntryAssembly().Location);
+            var assembly = Assembly.GetEntryAssembly();
+            if(assembly != null)
+                window.Icon = Icon.ExtractAssociatedIcon(assembly.Location);
 
             updateClientBounds = false;
             clientBounds = new Rectangle(window.ClientRectangle.X, window.ClientRectangle.Y,


### PR DESCRIPTION
I was trying to run some tests on a class inheriting Game and was encountering NullReferenceExceptions. The class worked fine when being run directly. After some debugging I found this use of Assembly.GetExecutingAssembly() and added a null check.

It turns out this was already fixed in a few other files in:
Unit Test Fixes by tomspilman · Pull Request #1530 · mono/MonoGame
