### PR TITLE
Fix RenderTarget creation if called from non UI thread

### DIFF
--- a/MonoGame.Framework/Graphics/RenderTarget2D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.cs
@@ -190,8 +190,9 @@ namespace Microsoft.Xna.Framework.Graphics
 				GL.RenderbufferStorage(GLRenderbuffer, glDepthFormat, this.width, this.height);
 				GraphicsExtensions.CheckGLError();
 			}
+
+            });
 #endif
-        });
 
         }
 		


### PR DESCRIPTION
Reloading resources after resume on Android (and probably other GL platforms with device reset on resume) could cause rendertargets to turn black (invalid). This simple change should fix that.
