### PR TITLE
Kill Process On Exit

### DIFF
--- a/MonoGame.Framework/Android/AndroidGamePlatform.cs
+++ b/MonoGame.Framework/Android/AndroidGamePlatform.cs
@@ -115,6 +115,7 @@ namespace Microsoft.Xna.Framework
                     Net.NetworkSession.Exit();
                	    Game.Activity.Finish();
 				    Window.Close();
+					Process.KillProcess(Process.MyPid());
 				}
             }
             catch


### PR DESCRIPTION
Kill process on exit for consistency with other platforms (killing process clears its memory, preventing static data persisting between runs - potentially dangerous with complex games)
