### PR TITLE
Improving BlendState/RasterizerState/DepthStencilState.ToString()

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsResource.cs
+++ b/MonoGame.Framework/Graphics/GraphicsResource.cs
@@ -185,6 +185,11 @@ namespace Microsoft.Xna.Framework.Graphics
 		public string Name { get; set; }
 		
 		public Object Tag { get; set; }
+
+        public override string ToString()
+        {
+            return string.IsNullOrEmpty(Name) ? base.ToString() : Name;
+        }
 	}
 }
 

--- a/MonoGame.Framework/Graphics/States/BlendState.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.cs
@@ -213,6 +213,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             _additive = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState
             {
+                Name = "BlendState.Additive",
                 ColorSourceBlend = Blend.SourceAlpha,
                 AlphaSourceBlend = Blend.SourceAlpha,
                 ColorDestinationBlend = Blend.One,
@@ -221,6 +222,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 			_alphaBlend = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState()
             {
+                Name = "BlendState.AlphaBlend",
 				ColorSourceBlend = Blend.One,
 				AlphaSourceBlend = Blend.One,
 				ColorDestinationBlend = Blend.InverseSourceAlpha,
@@ -229,6 +231,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 			_nonPremultiplied = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState() 
             {
+                Name = "BlendState.NonPremultiplied",
 				ColorSourceBlend = Blend.SourceAlpha,
 				AlphaSourceBlend = Blend.SourceAlpha,
 				ColorDestinationBlend = Blend.InverseSourceAlpha,
@@ -237,31 +240,13 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 			_opaque = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState()
             {
+                Name = "BlendState.Opaque",
 				ColorSourceBlend = Blend.One,
 				AlphaSourceBlend = Blend.One,			    
 				ColorDestinationBlend = Blend.Zero,
 				AlphaDestinationBlend = Blend.Zero
 			});
 		}
-
-        public override string ToString ()
-        {
-            string blendStateName;
-
-            if (this == BlendState.Additive)
-                blendStateName = "Additive";
-            else if (this == BlendState.AlphaBlend)
-                blendStateName = "AlphaBlend";
-            else if (this == BlendState.NonPremultiplied)
-                blendStateName = "NonPremultiplied";
-            else if (this == BlendState.Opaque)
-                blendStateName = "Opaque";
-            else
-                blendStateName = "Custom";
-
-            return string.Format("BlendState.{0}", blendStateName);
-        }
-
 
 #if OPENGL
         internal void ApplyState(GraphicsDevice device)

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -82,19 +82,22 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			_default = new Utilities.ObjectFactoryWithReset<DepthStencilState>(() => new DepthStencilState
             {
+                Name = "DepthStencilState.Default",
 				DepthBufferEnable = true,
 				DepthBufferWriteEnable = true
 			});
 			
 			_depthRead = new Utilities.ObjectFactoryWithReset<DepthStencilState>(() => new DepthStencilState
             {
-				DepthBufferEnable = true,
+                Name = "DepthStencilState.DepthRead",
+                DepthBufferEnable = true,
 				DepthBufferWriteEnable = false
 			});
 			
 			_none = new Utilities.ObjectFactoryWithReset<DepthStencilState>(() => new DepthStencilState
             {
-				DepthBufferEnable = false,
+                Name = "DepthStencilState.None",
+                DepthBufferEnable = false,
 				DepthBufferWriteEnable = false
 			});
 		}
@@ -439,22 +442,6 @@ namespace Microsoft.Xna.Framework.Graphics
             g.Enable(EnableMode.StencilTest, StencilEnable);
         }
 #endif
-
-        public override string ToString()
-        {
-            string name;
-
-            if (this == DepthStencilState.Default)
-                name = "Default";
-            else if (this == DepthStencilState.DepthRead)
-                name = "DepthRead";
-            else if (this == DepthStencilState.None)
-                name = "None";            
-            else
-                name = "Custom";
-
-            return string.Format("DepthStencilState.{0}", name);
-        }
 	}
 }
 

--- a/MonoGame.Framework/Graphics/States/RasterizerState.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.cs
@@ -57,16 +57,19 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			_cullClockwise = new Utilities.ObjectFactoryWithReset<RasterizerState>(() => new RasterizerState
             {
+                Name = "RasterizerState.CullClockwise",
 				CullMode = CullMode.CullClockwiseFace
 			});
 
 			_cullCounterClockwise = new Utilities.ObjectFactoryWithReset<RasterizerState>(() => new RasterizerState
             {
+                Name = "RasterizerState.CullCounterClockwise",
 				CullMode = CullMode.CullCounterClockwiseFace
 			});
 
 			_cullNone = new Utilities.ObjectFactoryWithReset<RasterizerState>(() => new RasterizerState
             {
+                Name = "RasterizerState.CullNone",
 				CullMode = CullMode.None
 			});
 		}
@@ -228,21 +231,5 @@ namespace Microsoft.Xna.Framework.Graphics
             // FIXME: Everything else
         }
 #endif
-
-        public override string ToString()
-        {
-            string name;
-
-            if (this == RasterizerState.CullClockwise)
-                name = "CullClockwise";
-            else if (this == RasterizerState.CullCounterClockwise)
-                name = "CullCounterClockwise";
-            else if (this == RasterizerState.CullNone)
-                name = "CullNone";
-            else
-                name = "Custom";
-
-            return string.Format("RasterizerState.{0}", name);
-        }
     }
 }

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -87,11 +87,10 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
             GraphicsExtensions.CheckGLError();
 #endif
-
-
 	
 			_anisotropicClamp = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
             {
+                Name = "SamplerState.AnisotropicClamp",
 				Filter = TextureFilter.Anisotropic,
 				AddressU = TextureAddressMode.Clamp,
 				AddressV = TextureAddressMode.Clamp,
@@ -100,6 +99,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 			_anisotropicWrap = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
             {
+                Name = "SamplerState.AnisotropicWrap",
 				Filter = TextureFilter.Anisotropic,
 				AddressU = TextureAddressMode.Wrap,
 				AddressV = TextureAddressMode.Wrap,
@@ -108,6 +108,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 			_linearClamp = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
             {
+                Name = "SamplerState.LinearClamp",
 				Filter = TextureFilter.Linear,
 				AddressU = TextureAddressMode.Clamp,
 				AddressV = TextureAddressMode.Clamp,
@@ -116,6 +117,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 			_linearWrap = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
             {
+                Name = "SamplerState.LinearWrap",
 				Filter = TextureFilter.Linear,
 				AddressU = TextureAddressMode.Wrap,
 				AddressV = TextureAddressMode.Wrap,
@@ -124,6 +126,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 			_pointClamp = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
             {
+                Name = "SamplerState.PointClamp",
 				Filter = TextureFilter.Point,
 				AddressU = TextureAddressMode.Clamp,
 				AddressV = TextureAddressMode.Clamp,
@@ -132,6 +135,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 			_pointWrap = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
             {
+                Name = "SamplerState.PointWrap",
 				Filter = TextureFilter.Point,
 				AddressU = TextureAddressMode.Wrap,
 				AddressV = TextureAddressMode.Wrap,


### PR DESCRIPTION
Fix: BlendState.ToString() to not display "Opaque" for all custom states.
Improvement: BlendState.ToString() now displays the short type name instead of the namespace-qualified type name.
Improvement: Added ToString() to DepthStencilState and RasterizerState, mirroring the implementation of BlendState.ToString().

Note that these methods are primarily for improving workflow while debugging, since these objects are displayed in the watch window by the evaluation of their ToString() method.
