### PR TITLE
Fixed XAudio Shutdown

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -79,7 +79,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Activation;
 #endif
-
+using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework;
@@ -235,11 +235,16 @@ namespace Microsoft.Xna.Framework
                     ContentTypeReaderManager.ClearTypeCreators();
 
 #if WINDOWS_PHONE
-                    TouchPanel.ResetState();
-                    Microsoft.Xna.Framework.Audio.SoundEffect.Shutdown();
+                    TouchPanel.ResetState();                    
+#endif
+
+#if WINDOWS_MEDIA_SESSION
+                    Media.MediaManagerState.CheckShutdown();
 #endif
 
 #if DIRECTX
+                    SoundEffect.Shutdown();
+
                     BlendState.ResetStates();
                     DepthStencilState.ResetStates();
                     RasterizerState.ResetStates();
@@ -738,6 +743,10 @@ namespace Microsoft.Xna.Framework
 		{
 			OnExiting(this, EventArgs.Empty);
 			UnloadContent();
+
+#if DIRECTX
+		    SoundEffect.Shutdown();
+#endif
 
 #if WINDOWS_MEDIA_SESSION
             Media.MediaManagerState.CheckShutdown();


### PR DESCRIPTION
Turns out that on the DirectX desktop builds which actually exit the game the XAudio system wasn't being correctly shutdown causing periodic crashes.

This didn't affect WP or WinStore because they don't exit the game.  The game is disposed when their task is killed off.

This shouldn't affect anything but the WinDX platform, but it wouldn't hurt for someone to test on WP and WinStore.
