### PR TITLE
Fixes orientation changes for Android Tablets.

### DIFF
--- a/MonoGame.Framework/Android/OrientationListener.cs
+++ b/MonoGame.Framework/Android/OrientationListener.cs
@@ -70,7 +70,8 @@ namespace Microsoft.Xna.Framework
                 }
 
                 // Only auto-rotate if target orientation is supported and not current
-                if ((AndroidGameActivity.Game.Window.GetEffectiveSupportedOrientations() & disporientation) != 0 &&
+                if (AndroidGameActivity.Game != null &&
+                    (AndroidGameActivity.Game.Window.GetEffectiveSupportedOrientations() & disporientation) != 0 &&
                      disporientation != AndroidGameActivity.Game.Window.CurrentOrientation)
                 {
                     AndroidGameActivity.Game.Window.SetOrientation(disporientation, true);


### PR DESCRIPTION
This fixes the orientation changed event for Android Tablet.
This solution was found on MonoGame's CodePlex discussions.
I only adapted the solution to work on the actual MonoGame's version. All the credit goes to JohnHolmes.
I found the bug and, coincidentally, found the solution on the discussion board.
The error report:
https://monogame.codeplex.com/discussions/452578
And the fix, by JohnHolmes:
https://monogame.codeplex.com/discussions/444056
I just packet it all together, made a PR and submitted.
I've also tested this on a Samsung Galaxy Tab 2. Works flawlessly.
