### PR TITLE
Critial Crash Fix

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/Effect.cs
+++ b/MonoGame.Framework/Graphics/Effect/Effect.cs
@@ -479,8 +479,16 @@ namespace Microsoft.Xna.Framework.Graphics
                                 break;							
                             }
 
-						default:
+                        case EffectParameterType.String:
+                            // TODO: We have not investigated what a string
+                            // type should do in the parameter list.  Till then
+                            // throw to let the user know.
 							throw new NotSupportedException();
+
+                        default:
+                            // NOTE: We skip over all other types as they 
+                            // don't get added to the constant buffer.
+					        break;
 					}
                 }
 


### PR DESCRIPTION
My cleanup of `NotImplementedExceptions' in #1985 introduced a critical bug.  

This restores the previous behavior and adds comments to make it clear why it works like it does.
