### PR TITLE
Fixed DX SetRenderTarget Bug

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1681,6 +1681,11 @@ namespace Microsoft.Xna.Framework.Graphics
                 Array.Clear(_currentRenderTargets, 0, _currentRenderTargets.Length);
                 _currentDepthStencilView = null;
 
+                // Make sure none of the new targets are bound
+                // to the device as a texture resource.
+                lock (_d3dContext)
+                    Textures.ClearTargets(this, _currentRenderTargetBindings);
+
                 for (var i = 0; i < _currentRenderTargetCount; i++)
                 {
                     var binding = _currentRenderTargetBindings[i];

--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -49,6 +49,38 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+#if DIRECTX
+
+        internal void ClearTargets(GraphicsDevice device, RenderTargetBinding[] targets)
+        {
+            // NOTE: We make the assumption here that the caller has
+            // locked the d3dContext for us to use.
+            var pixelShaderStage = device._d3dContext.PixelShader;
+
+            // We assume 4 targets to avoid a loop within a loop below.
+            var target0 = targets[0].RenderTarget;
+            var target1 = targets[1].RenderTarget;
+            var target2 = targets[2].RenderTarget;
+            var target3 = targets[3].RenderTarget;
+
+            // Make one pass across all the texture slots.
+            for (var i = 0; i < _textures.Length; i++)
+            {
+                if (_textures[i] != target0 &&
+                    _textures[i] != target1 &&
+                    _textures[i] != target2 &&
+                    _textures[i] != target3)
+                    continue;
+
+                // Immediately clear the texture from the device.
+                _dirty &= ~(1 << i);
+                _textures[i] = null;
+                pixelShaderStage.SetShaderResource(i, null);
+            }
+        }
+
+#endif
+
         internal void Clear()
         {
             for (var i = 0; i < _textures.Length; i++)


### PR DESCRIPTION
This fix ensures that a render target cannot be bound as a render target and as a texture at the same time.

This is disallowed by DirectX and when you manage to do it would cause the render target apply to fail.  I don't think this same issue can occur on OpenGL because of how the API works, so I limited the fix to DirectX only until someone reports otherwise.

See #1868 for a sample that causes this to occur.
