### PR TITLE
Fix potential framebuffer corruption on iOS

### DIFF
--- a/MonoGame.Framework/iOS/iOSGameView.cs
+++ b/MonoGame.Framework/iOS/iOSGameView.cs
@@ -295,15 +295,6 @@ namespace Microsoft.Xna.Framework {
 
 			__renderbuffergraphicsContext.MakeCurrent (null);
 
-			var ctx = ((IGraphicsContextInternal)__renderbuffergraphicsContext).Implementation as iPhoneOSGraphicsContext;
-			// FIXME: MonoTouch needs to allow null arguments to
-			//        RenderBufferStorage, but it doesn't right now.
-			//        So we call it manually.
-			//ctx.EAGLContext.RenderBufferStorage((uint)All.Renderbuffer, null);
-			var selector = new Selector("renderbufferStorage:fromDrawable:");
-			Messaging.bool_objc_msgSend_UInt32_IntPtr(
-				ctx.EAGLContext.Handle, selector.Handle, (uint)All.Renderbuffer, IntPtr.Zero);
-
 			_glapi.DeleteFramebuffers (1, ref _framebuffer);
 			_framebuffer = 0;
 


### PR DESCRIPTION
Remove unnecessary call in DestroyFramebuffer that can cause framebuffer corruption if a user framebuffer is bound when called.

This condition can happen when creating and using a separate RenderTarget at startup (for UI rendering for example). It causes an error to be reported in Instruments (Zero Sized Framebuffer Attachment) on all devices except iPhone 5S where it just fail to render anything on the separate RenderTarget (drivers must be a bit more strict).

This fix has been tested on iPad Mini, iPhone 5 and iPhone 5S 
