### PR TITLE
VertexElementColor R,G,B,A properties must be public.

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/VertexElementColor.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexElementColor.cs
@@ -7,16 +7,16 @@ namespace Microsoft.Xna.Framework.Graphics
 	public struct VertexElementColor
 	{
         [DataMember]
-		byte R;
+        public byte R;
 
         [DataMember]
-		byte G;
+        public byte G;
         
         [DataMember]
-		byte B;
+        public byte B;
         
         [DataMember]
-		byte A;
+        public byte A;
 
 		public VertexElementColor (Color color)
 		{


### PR DESCRIPTION
I am not really sure what is the purpose of VertexElementColor in
VertexPositionColor.
XNA documentation states that it should have been a 'Color'. Also one
should be able to define it's own IVertex structure and they would
normally use a 'Color' to do so.

What I see is that Color defines Getter/Setter for storing those values
into a packed int. Is this really necessary? A struct is a struct after
all. Same effect could have been achieved with StructLayout/FieldOffset
attributes.

Anyways. For now R/B/G/A properties must be publicly accessible as they
are on 'Color'.
