### PR TITLE
Polishing framework.

### DIFF
--- a/MonoGame.Framework.sln
+++ b/MonoGame.Framework.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.WindowsG
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.WindowsPhone", "MonoGame.Framework\MonoGame.Framework.WindowsPhone.csproj", "{BAA9A6E4-7690-4DE0-9531-DE0EAEEC9739}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.Linux", "MonoGame.Framework\MonoGame.Framework.Linux.csproj", "{35253CE1-C864-4CD3-8249-4D1319748E8F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,24 +31,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Release|ARM.ActiveCfg = Release|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Release|x64.ActiveCfg = Release|Any CPU
-		{AEA9E92A-C99E-4161-8D54-7AC1AE4B3601}.Release|x86.ActiveCfg = Release|Any CPU
 		{AE483C29-042E-4226-BA52-D247CE7676DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AE483C29-042E-4226-BA52-D247CE7676DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AE483C29-042E-4226-BA52-D247CE7676DA}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -149,6 +133,24 @@ Global
 		{BAA9A6E4-7690-4DE0-9531-DE0EAEEC9739}.Release|x64.ActiveCfg = Release|Any CPU
 		{BAA9A6E4-7690-4DE0-9531-DE0EAEEC9739}.Release|x86.ActiveCfg = Release|x86
 		{BAA9A6E4-7690-4DE0-9531-DE0EAEEC9739}.Release|x86.Build.0 = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|ARM.ActiveCfg = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|iPhone.ActiveCfg = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|iPhoneSimulator.ActiveCfg = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x64.ActiveCfg = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.ActiveCfg = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Debug|x86.Build.0 = Debug|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|Any CPU.ActiveCfg = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|ARM.ActiveCfg = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|iPhone.ActiveCfg = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|iPhoneSimulator.ActiveCfg = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|Mixed Platforms.Build.0 = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x64.ActiveCfg = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x86.ActiveCfg = Release|x86
+		{35253CE1-C864-4CD3-8249-4D1319748E8F}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MonoGame.Framework/MonoGame.Framework.Linux.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Linux.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -101,7 +101,6 @@
     <Compile Include="GamerServices\GamerPresenceMode.cs" />
     <Compile Include="GamerServices\GamerPrivileges.cs" />
     <Compile Include="GamerServices\GamerPrivilegeSetting.cs" />
-    <Compile Include="Input\AccelerometerState.cs" />
     <Compile Include="Input\ButtonState.cs" />
     <Compile Include="Input\GamePadState.cs" />
     <Compile Include="Input\KeyboardState.cs" />
@@ -182,7 +181,7 @@
     <Compile Include="Graphics\States\Blend.cs" />
     <Compile Include="Graphics\States\BlendFunction.cs" />
     <Compile Include="Graphics\States\BlendState.cs" />
-	<Compile Include="Graphics\States\TargetBlendState.cs" />
+    <Compile Include="Graphics\States\TargetBlendState.cs" />
     <Compile Include="Graphics\Effect\EffectParameterCollection.cs" />
     <Compile Include="Graphics\Effect\EffectPassCollection.cs" />
     <Compile Include="Graphics\Effect\EffectTechnique.cs" />
@@ -219,8 +218,6 @@
     <Compile Include="Graphics\DirectionalLight.cs" />
     <Compile Include="Graphics\States\TextureAddressMode.cs" />
     <Compile Include="Graphics\States\TextureFilter.cs" />
-    <Compile Include="Input\ButtonDefinition.cs" />
-    <Compile Include="Input\ThumbStickDefinition.cs" />
     <Compile Include="Linux\GamerServices\SignedInGamer.cs" />
     <Compile Include="GamerServices\Gamer.cs" />
     <Compile Include="GamerServices\SignedInGamerCollection.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.Windows.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows.csproj
@@ -293,7 +293,6 @@
     <Compile Include="IDrawable.cs" />
     <Compile Include="IGameComponent.cs" />
     <Compile Include="IGraphicsDeviceManager.cs" />
-    <Compile Include="Input\ButtonDefinition.cs" />
     <Compile Include="Input\Buttons.cs" />
     <Compile Include="Input\ButtonState.cs" />
     <Compile Include="Input\GamePadButtons.cs" />
@@ -306,7 +305,6 @@
     <Compile Include="Input\KeyboardState.cs" />
     <Compile Include="Input\Keys.cs" />
     <Compile Include="Input\KeyState.cs" />
-    <Compile Include="Input\ThumbStickDefinition.cs" />
     <Compile Include="IUpdateable.cs" />
     <Compile Include="MathHelper.cs" />
     <Compile Include="Matrix.cs" />
@@ -338,7 +336,7 @@
     <Compile Include="Graphics\States\Blend.cs" />
     <Compile Include="Graphics\States\BlendFunction.cs" />
     <Compile Include="Graphics\States\BlendState.cs" />
-	<Compile Include="Graphics\States\TargetBlendState.cs" />
+    <Compile Include="Graphics\States\TargetBlendState.cs" />
     <Compile Include="Graphics\ClearOptions.cs" />
     <Compile Include="Graphics\DeviceType.cs" />
     <Compile Include="Graphics\GraphicsDeviceStatus.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
@@ -170,9 +170,6 @@
     <Compile Include="Graphics\Vertices\VertexDeclaration.cs" />
     <Compile Include="Graphics\Vertices\VertexDeclarationCache.cs" />
     <Compile Include="Graphics\Vertices\VertexPositionColorTexture.cs" />
-    <Compile Include="Input\AccelerometerCapabilities.cs" />
-    <Compile Include="Input\AccelerometerState.cs" />
-    <Compile Include="Input\ButtonDefinition.cs" />
     <Compile Include="Input\Buttons.cs" />
     <Compile Include="Input\ButtonState.cs" />
     <Compile Include="Input\GamePadButtons.cs" />
@@ -191,7 +188,6 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Input\MouseState.cs" />
-    <Compile Include="Input\ThumbStickDefinition.cs" />
     <Compile Include="Input\Touch\GestureSample.cs" />
     <Compile Include="Input\Touch\GestureType.cs" />
     <Compile Include="Input\Touch\TouchCollection.cs" />
@@ -370,7 +366,7 @@
     <Compile Include="Graphics\States\Blend.cs" />
     <Compile Include="Graphics\States\BlendFunction.cs" />
     <Compile Include="Graphics\States\BlendState.cs" />
-	<Compile Include="Graphics\States\TargetBlendState.cs" />
+    <Compile Include="Graphics\States\TargetBlendState.cs" />
     <Compile Include="Graphics\ClearOptions.cs" />
     <Compile Include="Graphics\DeviceType.cs" />
     <Compile Include="Graphics\GraphicsDeviceStatus.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.WindowsGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsGL.csproj
@@ -166,11 +166,8 @@
     <Compile Include="Graphics\ModelMeshPart.cs" />
     <Compile Include="Graphics\ModelMeshPartCollection.cs" />
     <Compile Include="Graphics\PackedVector\Bgr565.cs" />
-	
     <Compile Include="Graphics\PackedVector\Bgra4444.cs" />
-	
     <Compile Include="Graphics\PackedVector\Byte4.cs" />
-	
     <Compile Include="Graphics\PackedVector\HalfSingle.cs" />
     <Compile Include="Graphics\PackedVector\HalfTypeHelper.cs" />
     <Compile Include="Graphics\PackedVector\HalfVector2.cs" />
@@ -375,7 +372,6 @@
     <Compile Include="IDrawable.cs" />
     <Compile Include="IGameComponent.cs" />
     <Compile Include="IGraphicsDeviceManager.cs" />
-    <Compile Include="Input\ButtonDefinition.cs" />
     <Compile Include="Input\Buttons.cs" />
     <Compile Include="Input\ButtonState.cs" />
     <Compile Include="Input\GamePadButtons.cs" />
@@ -388,7 +384,6 @@
     <Compile Include="Input\KeyboardState.cs" />
     <Compile Include="Input\Keys.cs" />
     <Compile Include="Input\KeyState.cs" />
-    <Compile Include="Input\ThumbStickDefinition.cs" />
     <Compile Include="IUpdateable.cs" />
     <Compile Include="MathHelper.cs" />
     <Compile Include="Matrix.cs" />
@@ -421,7 +416,7 @@
     <Compile Include="Graphics\States\Blend.cs" />
     <Compile Include="Graphics\States\BlendFunction.cs" />
     <Compile Include="Graphics\States\BlendState.cs" />
-	<Compile Include="Graphics\States\TargetBlendState.cs" />
+    <Compile Include="Graphics\States\TargetBlendState.cs" />
     <Compile Include="Graphics\ClearOptions.cs" />
     <Compile Include="Graphics\DeviceType.cs" />
     <Compile Include="Graphics\GraphicsDeviceStatus.cs" />
@@ -470,8 +465,7 @@
     <Compile Include="Media\MediaSource.cs" />
     <Compile Include="FrameworkDispatcher.cs" />
     <Compile Include="Audio\MSADPCMToPCM.cs" />
-	<Compile Include="Utilities\ObjectFactoryWithReset.cs" />
-    
+    <Compile Include="Utilities\ObjectFactoryWithReset.cs" />
     <Compile Include="GamerServices\LeaderboardEntry.cs" />
     <Compile Include="GamerServices\LeaderboardIdentity.cs" />
     <Compile Include="GamerServices\LeaderboardKey.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.WindowsPhone.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsPhone.csproj
@@ -189,9 +189,6 @@
     <Compile Include="Graphics\Vertices\VertexDeclaration.cs" />
     <Compile Include="Graphics\Vertices\VertexDeclarationCache.cs" />
     <Compile Include="Graphics\Vertices\VertexPositionColorTexture.cs" />
-    <Compile Include="Input\AccelerometerCapabilities.cs" />
-    <Compile Include="Input\AccelerometerState.cs" />
-    <Compile Include="Input\ButtonDefinition.cs" />
     <Compile Include="Input\Buttons.cs" />
     <Compile Include="Input\ButtonState.cs" />
     <Compile Include="Input\GamePadButtons.cs" />
@@ -210,7 +207,6 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Input\MouseState.cs" />
-    <Compile Include="Input\ThumbStickDefinition.cs" />
     <Compile Include="Input\Touch\GestureSample.cs" />
     <Compile Include="Input\Touch\GestureType.cs" />
     <Compile Include="Input\Touch\TouchCollection.cs" />


### PR DESCRIPTION
I found this strange - that linux framework project can be readed and compiled within VS but did not included by default to the solution. - And I includes it. Also I removes(but not actually delete) few useless(with 0 references) classes and structs from popular project types(winGL,winDX,win8,winphone,linux) which will reduce the redistributed size. Now, Input folder of all of these projects contains 16 files(exclude GamePad.cs), like XNA.

Excluded:
AccelerometerCapabilities.cs
AccelerometerState.cs
ButtonDefinition.cs
ThumbStickDefinition.cs

moreover - These classes/structs in these files is declared public and could distract and confuse users from XNA.
