### PR TITLE
Move GraphicsDevice property from GameComponent to DrawableGameComponent

### DIFF
--- a/MonoGame.Framework/DrawableGameComponent.cs
+++ b/MonoGame.Framework/DrawableGameComponent.cs
@@ -48,6 +48,18 @@ namespace Microsoft.Xna.Framework
         private int _drawOrder;
         private bool _visible = true;
 
+        public Graphics.GraphicsDevice GraphicsDevice
+        {
+            get 
+            {
+                if (!_initialized)
+                {
+                    throw new InvalidOperationException("The GraphicsDevice property cannot be used before Initialize has been called.");
+                }
+                return this.Game.GraphicsDevice; 
+            }
+        }
+
         public int DrawOrder
         {
             get { return _drawOrder; }

--- a/MonoGame.Framework/GameComponent.cs
+++ b/MonoGame.Framework/GameComponent.cs
@@ -49,11 +49,6 @@ namespace Microsoft.Xna.Framework
 
         public Game Game { get; private set; }
 
-        public Graphics.GraphicsDevice GraphicsDevice
-        {
-            get { return this.Game.GraphicsDevice; }
-        }
-
         public bool Enabled
         {
             get { return _enabled; }


### PR DESCRIPTION
GameComponent exposes a public GraphicsDevice property which is not
available on XNA. This property belong to DrawableGameComponent.

https://github.com/mono/MonoGame/issues/1807#issuecomment-19672898

This fix was posted by @Aztherion together with a
DynamicSoundEffectInstance  implementation but merge has been postponed
since then. I am posting a clean fix to this issue.
