### PR TITLE
Corrected color bug with SaveAsJpeg on Windows Phone 8

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -909,14 +909,10 @@ namespace Microsoft.Xna.Framework.Graphics
                     offset = (row * (int)pixelWidth * 4) + (col * 4);
 
                     byte B = pixels[offset];
-                    byte G = pixels[offset + 1];
                     byte R = pixels[offset + 2];
-                    byte A = pixels[offset + 3];
 
                     pixels[offset] = R;
-                    pixels[offset + 1] = G;
                     pixels[offset + 2] = B;
-                    pixels[offset + 3] = A;
                 }
             }
         }


### PR DESCRIPTION
Adjusted the Windows Phone 8 version of Texture2D's SaveAsJpeg class to
switch the pixels RGBA/BGRA values so that Writeablebitmap will read the
data correctly.  Added helper function in Texture2D called ConvertToRGBA
to convert the pixel data.  Images now save as properly colored JPEGs.

Note:  This function will block permanently if called from the Main/UI thread.  This happens because WriteableBitmap needs to be called from the UI thread and ManualResetEventSlim will pause the UI thread, called the dispatcher to invoke the UI thread when it ready...but the UI thread will never be ready because you just paused it!  Therefore, this function can currently only be called from a background thread. (It was setup this way when I found it, and I couldn't think of a better solution so I left it).  Also, this is my first commit to this project so if I did anything wrong/silly please let me know!
