### PR TITLE
Add a few missing equality operators to Input structs.

### DIFF
--- a/MonoGame.Framework/Input/GamePadButtons.cs
+++ b/MonoGame.Framework/Input/GamePadButtons.cs
@@ -134,6 +134,38 @@ namespace Microsoft.Xna.Framework.Input
             foreach (Buttons b in buttons)
                 this.buttons |= b;
         }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="GamePadButtons"/> are equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are equal; otherwise, false.</returns>
+        public static bool operator ==(GamePadButtons left, GamePadButtons right)
+        {
+            return left.buttons == right.buttons;
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="GamePadButtons"/> are not equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are not equal; otherwise, false.</returns>
+        public static bool operator !=(GamePadButtons left, GamePadButtons right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">An object to compare to this instance.</param>
+        /// <returns>true if <paramref name="obj"/> is a <see cref="GamePadButtons"/> and has the same value as this instance; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            return (obj is GamePadButtons) && (this == (GamePadButtons)obj);
+        }
     }
 }
 

--- a/MonoGame.Framework/Input/GamePadDPad.cs
+++ b/MonoGame.Framework/Input/GamePadDPad.cs
@@ -85,5 +85,40 @@ namespace Microsoft.Xna.Framework.Input
             if ((b & Buttons.DPadUp) == Buttons.DPadUp)
                 Up = ButtonState.Pressed;
         }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="GamePadDPad"/> are equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are equal; otherwise, false.</returns>
+        public static bool operator ==(GamePadDPad left, GamePadDPad right)
+        {
+            return (left.Down == right.Down)
+                && (left.Left == right.Left)
+                && (left.Right == right.Right)
+                && (left.Up == right.Up);
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="GamePadDPad"/> are not equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are not equal; otherwise, false.</returns>
+        public static bool operator !=(GamePadDPad left, GamePadDPad right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">An object to compare to this instance.</param>
+        /// <returns>true if <paramref name="obj"/> is a <see cref="GamePadDPad"/> and has the same value as this instance; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            return (obj is GamePadDPad) && (this == (GamePadDPad)obj);
+        }
 	}
 }

--- a/MonoGame.Framework/Input/GamePadThumbSticks.cs
+++ b/MonoGame.Framework/Input/GamePadThumbSticks.cs
@@ -143,5 +143,38 @@ namespace Microsoft.Xna.Framework.Input
                     break;
             }
         }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="GamePadThumbSticks"/> are equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are equal; otherwise, false.</returns>
+        public static bool operator ==(GamePadThumbSticks left, GamePadThumbSticks right)
+        {
+            return (left.left == right.left)
+                && (left.right == right.right);
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="GamePadThumbSticks"/> are not equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are not equal; otherwise, false.</returns>
+        public static bool operator !=(GamePadThumbSticks left, GamePadThumbSticks right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">An object to compare to this instance.</param>
+        /// <returns>true if <paramref name="obj"/> is a <see cref="GamePadThumbSticks"/> and has the same value as this instance; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            return (obj is GamePadThumbSticks) && (this == (GamePadThumbSticks)obj);
+        }
     }
 }

--- a/MonoGame.Framework/Input/GamePadTriggers.cs
+++ b/MonoGame.Framework/Input/GamePadTriggers.cs
@@ -62,5 +62,38 @@ namespace Microsoft.Xna.Framework.Input
             Left = leftTrigger;
             Right = rightTrigger;
         }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="GamePadTriggers"/> are equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are equal; otherwise, false.</returns>
+        public static bool operator ==(GamePadTriggers left, GamePadTriggers right)
+        {
+            return (left.left == right.left)
+                && (left.right == right.right);
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="GamePadTriggers"/> are not equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are not equal; otherwise, false.</returns>
+        public static bool operator !=(GamePadTriggers left, GamePadTriggers right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">An object to compare to this instance.</param>
+        /// <returns>true if <paramref name="obj"/> is a <see cref="GamePadTriggers"/> and has the same value as this instance; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            return (obj is GamePadTriggers) && (this == (GamePadTriggers)obj);
+        }
 	}
 }


### PR DESCRIPTION
Adds equality operators and Object.Equals() overrides to the GamePadButtons, GamePadDPad, GamePadThumbSticks, and GamePadTriggers structs in the MonoGame.Framework.Input namespace.
