### PR TITLE
Fix a NRE in Mouse.GetState() when used to initialize a static field.

### DIFF
--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Xna.Framework.Input
     {
         internal static GameWindow PrimaryWindow;
 
-        private static MouseState _defaultState = new MouseState();
+        private static readonly MouseState _defaultState = new MouseState();
 
 #if (WINDOWS && OPENGL) || LINUX
 	private static OpenTK.Input.MouseDevice _mouse = null;			


### PR DESCRIPTION
A project I'm porting from XNA to MonoGame initializes a static field using Mouse.GetState(). The fix returns a default MouseState if Mouse.PrimaryWindow hasn't been initialized. A more correct implementation would be to forward to a platform-specific (or GameWindow-specific) static method that decided whether to poll hardware (XNA queries the mouse directly, always) or return a default state if hardware isn't ready yet.
