### PR TITLE
Fix playing multiple music tracks from a collection

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -545,8 +545,8 @@ namespace Microsoft.Xna.Framework.Media
 
             if (nextSong == null)
                 Stop();
-            else            
-                Play(nextSong);                            
+            else
+                PlaySong(nextSong);
 
             if (ActiveSongChanged != null)
             {


### PR DESCRIPTION
``` c#
MediaPlayer.Play(new SongCollection() { song1, song2, song3 });
```

Previously when the first one finished we'd play the second one which would reset the queue, so the 3rd would never play.
