### PR TITLE
Correctly set the ProductID to a new GUID

### DIFF
--- a/ProjectTemplates/VisualStudio2012/WindowsPhone/WMAppManifest.xml
+++ b/ProjectTemplates/VisualStudio2012/WindowsPhone/WMAppManifest.xml
@@ -2,7 +2,7 @@
 
 <Deployment xmlns="http://schemas.microsoft.com/windowsphone/2012/deployment" AppPlatformVersion="8.0">
   <DefaultLanguage xmlns="" code="en-US"/>
-  <App xmlns="" ProductID="{f13744ce-a3b0-426b-8a4a-cf6f482b80cd}" Title="$safeprojectname$" RuntimeType="Silverlight" Version="1.0.0.0" Genre="apps.normal"  Author="$safeprojectname$ author" Description="Sample description" Publisher="$safeprojectname$" PublisherID="{0df4bf76-7146-42eb-ba7c-83daa7249a23}">
+  <App xmlns="" ProductID="$guid2$" Title="$safeprojectname$" RuntimeType="Silverlight" Version="1.0.0.0" Genre="apps.normal"  Author="$safeprojectname$ author" Description="Sample description" Publisher="$safeprojectname$" PublisherID="{0df4bf76-7146-42eb-ba7c-83daa7249a23}">
     <IconPath IsRelative="true" IsResource="false">Assets\ApplicationIcon.png</IconPath>
     <Capabilities>
       <Capability Name="ID_CAP_NETWORKING"/>


### PR DESCRIPTION
The ProductID in WMAppManifest.xml was explicitly set, resulting in deployment overwriting previously deployed apps. This ProductID should match that in AssemblyInfo.cs.
