### PR TITLE
Make SpriteBatch.DrawString() an atomic operation.

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -257,7 +257,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				rotation,
 				origin * scale,
 				effect,
-				depth);
+				depth,
+				true);
 		}
 
 		public void Draw (Texture2D texture,
@@ -287,7 +288,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				rotation,
 				origin * scale,
 				effect,
-				depth);
+				depth,
+				true);
 		}
 
 		public void Draw (Texture2D texture,
@@ -312,7 +314,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			      new Vector2(origin.X * ((float)destinationRectangle.Width / (float)( (sourceRectangle.HasValue && sourceRectangle.Value.Width != 0) ? sourceRectangle.Value.Width : texture.Width)),
                         			origin.Y * ((float)destinationRectangle.Height) / (float)( (sourceRectangle.HasValue && sourceRectangle.Value.Height != 0) ? sourceRectangle.Value.Height : texture.Height)),
 			      effect,
-			      depth);
+			      depth,
+			      true);
 		}
 
 		internal void DrawInternal (Texture2D texture,
@@ -322,7 +325,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			float rotation,
 			Vector2 origin,
 			SpriteEffects effect,
-			float depth)
+			float depth,
+			bool autoFlush)
 		{
 			var item = _batcher.CreateBatchItem();
 
@@ -366,8 +370,19 @@ namespace Microsoft.Xna.Framework.Graphics
 					_texCoordTL, 
 					_texCoordBR);			
 			
+			if (autoFlush)
+			{
+				FlushIfNeeded();
+			}
+		}
+
+		// Mark the end of a draw operation for Immediate SpriteSortMode.
+		internal void FlushIfNeeded()
+		{
 			if (_sortMode == SpriteSortMode.Immediate)
-                _batcher.DrawBatch(_sortMode);
+			{
+				_batcher.DrawBatch(_sortMode);
+			}
 		}
 
 		public void Draw (Texture2D texture, Vector2 position, Rectangle? sourceRectangle, Color color)

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -363,8 +363,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
 				spriteBatch.DrawInternal(
                     _texture, destRect, currentGlyph.BoundsInTexture,
-					color, rotation, Vector2.Zero, effect, depth);
+					color, rotation, Vector2.Zero, effect, depth, false);
 			}
+
+			// We need to flush if we're using Immediate sort mode.
+			spriteBatch.FlushIfNeeded();
 		}
 
         internal struct CharacterSource 


### PR DESCRIPTION
SpriteBatch.DrawString() is _really_ slow when SpriteSortMode is "Immediate", as it flushes after every character. If we treat DrawString as a single Draw call, and flush after all characters are drawn, we can reduce the number of GL calls drastically and get a significant performance improvement.

This reduces number of draw calls by ~90% in some text-heavy scenes, without (as far as I can tell) diverging from the Xna spec. Doesn't seem to break anything in the MonoGame tests, either!

-- David
