### PR TITLE
Make Texture2D.Reload(Stream) public -- again

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -1081,7 +1081,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         // This method allows games that use Texture2D.FromStream 
         // to reload their textures after the GL context is lost.
-        internal void Reload(Stream textureStream)
+        public void Reload(Stream textureStream)
         {
 #if OPENGL
             GenerateGLTextureIfRequired();


### PR DESCRIPTION
Someone already did this in a previous commit ( https://github.com/mono/MonoGame/commit/06f6c2fe65201fd3552af1261711af07fbc51cf3 ) but I think it inadvertently got lost in a merge...
I'm not sure why nobody missed it, but my team and I are using this method on Android, to recover from the GraphicsDevice.DeviceReset event. To quote the original commit message:

"The ContentManager class handles texture reloading of all its loaded textures, but if you're using Texture2D.FromStream() to load textures, this change will allow you to reload them without updating their references everywhere."
