### PR TITLE
RenderTarget improvements

### DIFF
--- a/MonoGame.Framework/Graphics/RenderTargetBinding.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetBinding.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Xna.Framework.Graphics
             get { return _arraySlice; }
         }
 
+        public CubeMapFace CubeMapFace
+        {
+            get { return (CubeMapFace)_arraySlice; }
+        }
+
 		public RenderTargetBinding(RenderTarget2D renderTarget)
 		{
 			if (renderTarget == null) 

--- a/MonoGame.Framework/Graphics/RenderTargetCube.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.cs
@@ -167,7 +167,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 _depthStencilView = new DepthStencilView(graphicsDevice._d3dDevice, depthBuffer, depthStencilViewDescription);
             }
 #else
-            throw new NotImplementedException();
+            Threading.BlockOnUIThread(() =>
+            {
+                this.GraphicsDevice.CreateGLRenderTarget(this, size, size, preferredDepthFormat, preferredMultiSampleCount, this.RenderTargetUsage);
+            });   
 #endif            
         }
 
@@ -199,6 +202,8 @@ namespace Microsoft.Xna.Framework.Graphics
                         _depthStencilView = null;
                     }
                 }
+#elif OPENGL
+                Threading.BlockOnUIThread(() => { this.GraphicsDevice.DeleteGLRenderTarget(this); });
 #endif
 
                 base.Dispose(disposing);


### PR DESCRIPTION
- Add MSAA support when available (WindowsGL, iOS and Android)
- Add render to cubemap support
- Better Framebuffer object management

This is a big change that add proper RenderTarget support (MSAA + Cubmap + MRT) on all GL platforms. Due to the complexity supporting RenderTarget on mobile platforms, I moved all the GL calls inside the GraphicsDevice class; this makes it a lot easier to maintain a clean code. I would strongly advise that we do this for all graphics resources and separate each API in its own GraphicsDevice implementation (will be necessary to support GLES3.0 along with GLES2.0).

This PR might have a few issue due to other changes in the GraphicsDevice that I couldn't test but I wanted to send this to have ppl review it, discuss it, test it and eventually improve it.
