### PR TITLE
Finally a fix for the WP8 debug bug

### DIFF
--- a/MonoGame.Framework/WindowsPhone/XamlGame.cs
+++ b/MonoGame.Framework/WindowsPhone/XamlGame.cs
@@ -30,7 +30,7 @@ namespace MonoGame.Framework.WindowsPhone
                 manipulationHost.PointerReleased += OnPointerReleased;
             }
 
-            private static void OnPointerPressed(DrawingSurfaceManipulationHost sender, PointerEventArgs args)
+            private void OnPointerPressed(DrawingSurfaceManipulationHost sender, PointerEventArgs args)
             {
                 var pointerPoint = args.CurrentPoint;
 
@@ -40,7 +40,7 @@ namespace MonoGame.Framework.WindowsPhone
                 TouchPanel.AddEvent((int)pointerPoint.PointerId, TouchLocationState.Pressed, pos);
             }
 
-            private static void OnPointerMoved(DrawingSurfaceManipulationHost sender, PointerEventArgs args)
+            private void OnPointerMoved(DrawingSurfaceManipulationHost sender, PointerEventArgs args)
             {
                 var pointerPoint = args.CurrentPoint;
 
@@ -50,7 +50,7 @@ namespace MonoGame.Framework.WindowsPhone
                 TouchPanel.AddEvent((int)pointerPoint.PointerId, TouchLocationState.Moved, pos);
             }
 
-            private static void OnPointerReleased(DrawingSurfaceManipulationHost sender, PointerEventArgs args)
+            private void OnPointerReleased(DrawingSurfaceManipulationHost sender, PointerEventArgs args)
             {
                 var pointerPoint = args.CurrentPoint;
 


### PR DESCRIPTION
Fixed the slowdowns that occur when debugging WP8 and dragging the screen. If anyone has any idea why this was the cause, let me know.
