### PR TITLE
Fix DictionaryReader.Read when existing instance supplied

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
@@ -73,7 +73,11 @@ namespace Microsoft.Xna.Framework.Content
         {
             int count = input.ReadInt32();
             Dictionary<TKey, TValue> dictionary = existingInstance;
-            if (dictionary == null) dictionary = new Dictionary<TKey, TValue>();
+            if (dictionary == null)
+                dictionary = new Dictionary<TKey, TValue>();
+            else
+                dictionary.Clear();
+
             for (int i = 0; i < count; i++)
             {
 				TKey key;


### PR DESCRIPTION
This can occur on Android when reloading subclassed Texture2D sprite sheets (ie when a dictionary is used to store named texture regions)
