### PR TITLE
GameFrameworkViewSource supports the Activated event from the CoreApplic...

### DIFF
--- a/MonoGame.Framework/Windows8/XamlGame.cs
+++ b/MonoGame.Framework/Windows8/XamlGame.cs
@@ -64,5 +64,12 @@ namespace MonoGame.Framework
 
             return Create(args.Arguments, window, swapPanel);
         }
+
+        static public T Create(ProtocolActivatedEventArgs args, CoreWindow window, SwapChainBackgroundPanel swapPanel)
+        {
+            MetroGamePlatform.PreviousExecutionState = args.PreviousExecutionState;
+
+            return Create(args.Uri.AbsoluteUri, window, swapPanel);
+        }
     }
 }


### PR DESCRIPTION
...ationView class, but that's an old class, which the most recent template doesn't use anymore (https://github.com/mono/MonoGame/wiki/Windows-8-Project-Types). The reason that this event is important is to enable game custom protocol activation.
