### PR TITLE
Cache whether or not a VBO is bound when using GL

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -138,6 +138,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private bool _pixelShaderDirty;
 
 #if OPENGL
+        private bool _vertexBufferBound;
         static List<Action> disposeActions = new List<Action>();
         static object disposeActionsLock = new object();
 #endif
@@ -535,6 +536,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _vertexBufferDirty = true;
             _vertexShaderDirty = true;
             _pixelShaderDirty = true;
+            _vertexBufferBound = false;
 
             // Set the default scissor rect.
             _scissorRectangleDirty = true;
@@ -2075,6 +2077,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                     GL.BindBuffer(BufferTarget.ElementArrayBuffer, _indexBuffer.ibo);
                     GraphicsExtensions.CheckGLError();
+                    _vertexBufferBound = true;
 #endif
                 }
                 _indexBufferDirty = false;
@@ -2092,6 +2095,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 {
                     GL.BindBuffer(BufferTarget.ArrayBuffer, _vertexBuffer.vbo);
                     GraphicsExtensions.CheckGLError();
+                    _vertexBufferBound = true;
                 }
 #endif
             }
@@ -2317,11 +2321,15 @@ namespace Microsoft.Xna.Framework.Graphics
             ApplyState(true);
 
             // Unbind current VBOs.
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
-            GraphicsExtensions.CheckGLError();
-            GL.BindBuffer(BufferTarget.ElementArrayBuffer, 0);
-            GraphicsExtensions.CheckGLError();
-            _vertexBufferDirty = _indexBufferDirty = true;
+            if (_vertexBufferBound)
+            {
+            	GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
+            	GraphicsExtensions.CheckGLError();
+            	GL.BindBuffer(BufferTarget.ElementArrayBuffer, 0);
+            	GraphicsExtensions.CheckGLError();
+            	_vertexBufferDirty = _indexBufferDirty = true;
+             	_vertexBufferBound = false;
+            }
 
             // Pin the buffers.
             var vbHandle = GCHandle.Alloc(vertexData, GCHandleType.Pinned);
@@ -2402,11 +2410,15 @@ namespace Microsoft.Xna.Framework.Graphics
             ApplyState(true);
 
             // Unbind current VBOs.
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
-            GraphicsExtensions.CheckGLError();
-            GL.BindBuffer(BufferTarget.ElementArrayBuffer, 0);
-            GraphicsExtensions.CheckGLError();
-            _vertexBufferDirty = _indexBufferDirty = true;
+            if (_vertexBufferBound)
+            {
+            	GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
+            	GraphicsExtensions.CheckGLError();
+            	GL.BindBuffer(BufferTarget.ElementArrayBuffer, 0);
+            	GraphicsExtensions.CheckGLError();
+            	_vertexBufferDirty = _indexBufferDirty = true;
+            	_vertexBufferBound = false;
+            }
 
             // Pin the buffers.
             var vbHandle = GCHandle.Alloc(vertexData, GCHandleType.Pinned);
@@ -2462,11 +2474,15 @@ namespace Microsoft.Xna.Framework.Graphics
             ApplyState(true);
 
             // Unbind current VBOs.
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
-            GraphicsExtensions.CheckGLError();
-            GL.BindBuffer(BufferTarget.ElementArrayBuffer, 0);
-            GraphicsExtensions.CheckGLError();
-            _vertexBufferDirty = _indexBufferDirty = true;
+            if (_vertexBufferBound)
+            {
+            	GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
+            	GraphicsExtensions.CheckGLError();
+            	GL.BindBuffer(BufferTarget.ElementArrayBuffer, 0);
+            	GraphicsExtensions.CheckGLError();
+            	_vertexBufferDirty = _indexBufferDirty = true;
+            	_vertexBufferBound = false;
+            }
 
             // Pin the buffers.
             var vbHandle = GCHandle.Alloc(vertexData, GCHandleType.Pinned);


### PR DESCRIPTION
Reduces number of redundant glBindBuffer() calls when using DrawUser*Primitives several times in a row.

Basically, at the moment, every DrawUser_Primatives call (with the GL backend) starts by calling glBindBuffer() a couple of times to bind the null buffer as both a vertex and element (index) buffer. This patch basically caches whether or not the last draw operation was from a User pointer, and so the glBindBuffer calls only happen on the first DrawUser_Primatives call after a non-user-pointer call.

The actual performance improvement here is pretty small, but it sure makes digging through traces in apitrace more pleasent.

NB: It would be possible to cache whether or not vertex and index buffers are bound separately, but I doubt it's worth it.

— David
