### PR TITLE
Change clear colour for Intel performance.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -125,9 +125,13 @@ namespace Microsoft.Xna.Framework.Graphics
 
         // On Intel Integrated graphics, there is a fast hw unit for doing
         // clears to colors where all components are either 0 or 255.
-        // Despite XNA4 using CornflowerBlue here, we use black to avoid
+        // Despite XNA4 using Purple here, we use black (in Release) to avoid
         // performance warnings on Intel/Mesa
+#if DEBUG
+        private static readonly Color DiscardColor = new Color(68, 34, 136, 255);
+#else
         private static readonly Color DiscardColor = new Color(0, 0, 0, 255);
+#endif
 
         /// <summary>
         /// The active vertex shader.


### PR DESCRIPTION
_THIS BREAKS XNA COMPATIBILITY!_

Modern (Sandybridge +) Intel Integrated Graphics chipsets have a fast clear/blit unit ('blorp') which, at least under Mesa, can only do fast color clears if all of the channels are being cleared to either full (1.0 or 255) or empty (0). The default XNA discard colour, CornflowerBlue, does not have this property. This patch changes the discard colour to black (0,0,0,255) as this is the colour likely to be best supported by hardware.

This patch gets rid of a per-clear performance warning on Intel Ivybride/Mesa 10.0 git using ARB_debug_output.

I perfectly understand if you guys don't want to break the spec, but I thought I'd put this out there anyway.
