### PR TITLE
Added new Kindle devices for inverted orientation

### DIFF
--- a/MonoGame.Framework/Android/AndroidCompatibility.cs
+++ b/MonoGame.Framework/Android/AndroidCompatibility.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Xna.Framework
     public static class AndroidCompatibility
     {
 		/// <summary>
-		/// Becaue the Kindle Fire devices default orientation is fliped by 180 degrees from all the other android devices
+		/// Because the Kindle Fire devices default orientation is fliped by 180 degrees from all the other android devices
 		/// on the market we need to do some special processing to make sure that LandscapeLeft is the correct way round.
 		/// This list contains all the Build.Model strings of the effected devices, it should be added to if and when
-		/// more devices exxhibit the same issues
+		/// more devices exhibit the same issues.
 		/// </summary>
-		private static readonly string[] Kindles = new[] { "KFTT", "KFJWI", "KFJWA" };
+        private static readonly string[] Kindles = new[] { "KFTT", "KFJWI", "KFJWA", "KFSOWI", "KFTHWA", "KFTHWI", "KFAPWA", "KFAPWI" };
 
         public enum ESVersions
         {


### PR DESCRIPTION
Amazon released new Kindle devices that cause MonoGame games to run upside down.

To give some background on the issue, all kindles since the Kindle Fire HD report their landscape right and landscape left orientations opposite of standard Android devices. Info on this [here](https://forums.developer.amazon.com/forums/message.jspa?messageID=1606). I can't find the original docs by Amazon, but they recommended checking `Android.OS.Build.Model` and inverting your game...

Dean Ellis originally put in this fix based on some changes we used in Draw a Stickman: EPIC.

This is the updated list we are using now in [Battlepillars for Amazon](http://www.amazon.com/Hitcents-Battlepillars/dp/B00GGNF6Y0/ref=sr_1_1?s=mobile-apps&ie=UTF8&qid=1384193019&sr=1-1&keywords=battlepillars). Our app was just approved through their testing process:

`RESULTS: YOUR APP CLEARED TESTING FOR ALL TARGETED DEVICES
Non-Amazon Android (Samsung - 4.2.X )   PASS
Fire HDX 7 WAN (3rd Gen)    PASS    
Kindle Fire HD 7 (3rd Gen)  PASS    
Fire HD 8.9 WAN (2nd Gen)   PASS    
Fire HDX 7 WiFi (3rd Gen)   PASS    
Fire HD 8.9 Wifi (2nd Gen)  PASS    
Fire HDX 8.9 WAN (3rd Gen)  PASS    
Fire HDX 8.9 WiFi (3rd Gen) PASS    
Kindle Fire (1st Gen)   PASS    
Kindle Fire (2nd Gen)   PASS    
Kindle Fire HD 7 (2nd Gen)  PASS`
