### PR TITLE
Replaced touch mechanizm for Windows Phone.

### DIFF
--- a/MonoGame.Framework/WindowsPhone/XamlGame.cs
+++ b/MonoGame.Framework/WindowsPhone/XamlGame.cs
@@ -74,7 +74,8 @@ namespace MonoGame.Framework.WindowsPhone
                             break;
                     }
 
-                    var pos = new Vector2((float)touchPoint.Position.X, (float)touchPoint.Position.Y);
+                    var dipFactor = DisplayProperties.LogicalDpi / 96.0f;
+                    var pos = new Vector2((float)touchPoint.Position.X, (float)touchPoint.Position.Y) * dipFactor;
                     
                     // Compute touch id other than MouseTouchId. 
                     // (Id from FrameReported always starts from 0 for first finger.)


### PR DESCRIPTION
Replaced **Windows.Phone.Input.Interop** manipulation mechanism to **Touch.Frame reported**, due to loosing PointerReleased events and leaving ghost touches in TouchPanel. Issue #2140.
