### PR TITLE
Fix for frame buffer exception on exit (at least with OS X). Should be a...

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -412,6 +412,7 @@ namespace Microsoft.Xna.Framework
         public void Exit()
         {
             Platform.Exit();
+			_suppressDraw = true;
         }
 
         public void ResetElapsedTime()


### PR DESCRIPTION
Fix for Crash after Exit() on Mac OS X. Affects all platforms, but should be a low-risk change.

Issue: https://github.com/mono/MonoGame/issues/2155
