### PR TITLE
Fix vertical font padding in SharpFontImporter

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/Font/SharpFontImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Font/SharpFontImporter.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 			{
 				XOffset = -padWidth,
 				XAdvance = face.Glyph.Metrics.HorizontalAdvance >> 6,
-				YOffset = -padHeight,
+                YOffset = -(face.Glyph.Metrics.HorizontalBearingY >> 6),
 				CharacterWidths = abc
 			};
 		}

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 					if (!output.CharacterMap.Contains(glyph.Character))
 						output.CharacterMap.Add(glyph.Character);
 					output.Glyphs.Add(new Rectangle(glyph.Subrect.X, glyph.Subrect.Y, glyph.Subrect.Width, glyph.Subrect.Height));
-					output.Cropping.Add(new Rectangle(0,0,glyph.Subrect.Width, glyph.Subrect.Height));
+                    output.Cropping.Add(new Rectangle(0, (int)(glyph.YOffset + glyphs.Select(x => x.YOffset).Max()), glyph.Subrect.Width, glyph.Subrect.Height));
 					ABCFloat abc = glyph.CharacterWidths;
 					output.Kerning.Add(new Vector3(abc.A, abc.B, abc.C));
 				}


### PR DESCRIPTION
This fixes the vertical font padding in the SharpFontImporter.  Currently fonts imported in the MonoGame content pipeline look like this when rendered:

![fontbroken](https://f.cloud.github.com/assets/2063515/1771050/e1b8c088-67a7-11e3-8560-0538db765e65.PNG)

This change ensures that fonts are rendered correctly; after this change it looks like this:

![fontfixed](https://f.cloud.github.com/assets/2063515/1771052/f2a0a122-67a7-11e3-8804-b18731086f5c.PNG)
