### PR TITLE
Fixes an error on the iOS Keyboard

### DIFF
--- a/MonoGame.Framework/iOS/GamerServices/KeyboardInputViewController.cs
+++ b/MonoGame.Framework/iOS/GamerServices/KeyboardInputViewController.cs
@@ -133,8 +133,9 @@ namespace Microsoft.Xna.Framework {
 			if (InterfaceOrientation == UIInterfaceOrientation.LandscapeLeft ||
 			    InterfaceOrientation == UIInterfaceOrientation.LandscapeRight)
             {
-                keyboardSize.Width = Math.Max(keyboardSize.Height, keyboardSize.Width);
-                keyboardSize.Height = Math.Min(keyboardSize.Height, keyboardSize.Width);
+                var tmpkeyboardSize = keyboardSize;
+                keyboardSize.Width = Math.Max(tmpkeyboardSize.Height, tmpkeyboardSize.Width);
+                keyboardSize.Height = Math.Min(tmpkeyboardSize.Height, tmpkeyboardSize.Width);
 			}
 
 			var view = (KeyboardInputView)View;


### PR DESCRIPTION
This error happens when the orientation is on landscape. The
uitextfield just goes off screen and you can’t see what you type.
It happens to be just a wrong logic inside KeyboardInputViewController.
