### PR TITLE
Use IWindowInfo.Handle to retrieve window handle

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -351,11 +351,7 @@ namespace Microsoft.Xna.Framework
             windowState = window.WindowState;            
 
 #if WINDOWS
-            {
-                var windowInfoType = window.WindowInfo.GetType();
-                var propertyInfo = windowInfoType.GetProperty("WindowHandle");
-                _windowHandle = (IntPtr)propertyInfo.GetValue(window.WindowInfo, null);
-            }
+            _windowHandle = window.WindowInfo.Handle;
 #endif
             // Provide the graphics context for background loading
             Threading.BackgroundContext = new GraphicsContext(GraphicsMode.Default, window.WindowInfo);


### PR DESCRIPTION
(PR re-issued after rebase fail at https://github.com/mono/MonoGame/pull/2166)

OpenTK 1.1 offers a public GameWindow.WindowInfo.Handle property. This patch removes reflection from the startup path in favor of accessing the Handle property directly.

This patch depends on https://github.com/kungfubanana/MonoGame-Dependencies/pull/43
