### PR TITLE
[ContentReaders] Allocate just the right amount of memory for Lists

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Xna.Framework.Content
             int count = input.ReadInt32();
             Dictionary<TKey, TValue> dictionary = existingInstance;
             if (dictionary == null)
-                dictionary = new Dictionary<TKey, TValue>();
+                dictionary = new Dictionary<TKey, TValue>(count);
             else
                 dictionary.Clear();
 

--- a/MonoGame.Framework/Content/ContentReaders/ListReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ListReader.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Xna.Framework.Content
         {
             int count = input.ReadInt32();
             List<T> list = existingInstance;
-            if (list == null) list = new List<T>();
+            if (list == null) list = new List<T>(count);
             for (int i = 0; i < count; i++)
             {
                 // list.Add(input.ReadObject<T>(elementReader));

--- a/MonoGame.Framework/Content/ContentReaders/ModelReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ModelReader.cs
@@ -87,11 +87,11 @@ namespace Microsoft.Xna.Framework.Content
 		
 		protected internal override Model Read(ContentReader reader, Model existingInstance)
 		{
-			List<ModelBone> bones = new List<ModelBone>();
-
             // Read the bone names and transforms.
             uint boneCount = reader.ReadUInt32();
             //Debug.WriteLine("Bone count: {0}", boneCount);
+
+            List<ModelBone> bones = new List<ModelBone>((int)boneCount);
 
             for (uint i = 0; i < boneCount; i++)
             {
@@ -156,7 +156,7 @@ namespace Microsoft.Xna.Framework.Content
                 int partCount = reader.ReadInt32();
                 //Debug.WriteLine("Mesh part count: {0}", partCount);
 
-                List<ModelMeshPart> parts = new List<ModelMeshPart>();
+                List<ModelMeshPart> parts = new List<ModelMeshPart>(partCount);
 
                 for (uint j = 0; j < partCount; j++)
                 {


### PR DESCRIPTION
Allocate the exact amount of memory for list.
This makes the content loaders more memory efficient and also improves
performance by eliminating the need to perform resizing operations in
the case of big arrays (ex. models with skinnning data).
