### PR TITLE
NuGet update release for 7th January

### DIFF
--- a/MonoGame.NuGetPackager/Package.Binaries.nuspec
+++ b/MonoGame.NuGetPackager/Package.Binaries.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
     <metadata>
         <id>MonoGame.Binaries</id>
-        <version>3.1.2-alpha</version>
+        <version>3.1.3-alpha</version>
         <title>MonoGame.Binaries</title>
         <authors>Simon-Darkside</authors>
         <owners>MonoGameTeam</owners>
@@ -13,7 +13,7 @@
         <description>MonoGame is an open source implementation of the Microsoft XNA 4.x Framework.
       The goal is to make it easy for XNA developers to create cross-platform games with extremely high code reuse. We currently support iOS, Android, Windows (both OpenGL and DirectX), Mac OS X, Linux, Windows 8 Store, Windows Phone 8, PlayStation Mobile, and the OUYA console.</description>
         <summary>MonoGame is an open source cross platform implementation of Microsoft's XNA 4.x Framework</summary>
-        <releaseNotes>Updated dev release - 10 December 2013</releaseNotes>
+        <releaseNotes>Updated dev release - 07 January 2014 - inc Windows GL build fix</releaseNotes>
         <copyright>Copyright  2013</copyright>
         <language>en-US</language>
     </metadata>

--- a/MonoGame.NuGetPackager/Package.ContentProcesors.nuspec
+++ b/MonoGame.NuGetPackager/Package.ContentProcesors.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
     <metadata>
         <id>MonoGame.ContentProcessors</id>
-        <version>3.1.2-alpha</version>
+        <version>3.1.3-alpha</version>
         <title>MonoGame.ContentProcessors</title>
         <authors>Simon-Darkside</authors>
         <owners>MonoGameTeam</owners>
@@ -14,7 +14,7 @@
 		MonoGame is an open source implementation of the Microsoft XNA 4.x Framework.
       The goal is to make it easy for XNA developers to create cross-platform games with extremely high code reuse. We currently support iOS, Android, Windows (both OpenGL and DirectX), Mac OS X, Linux, Windows 8 Store, Windows Phone 8, PlayStation Mobile, and the OUYA console.</description>
         <summary>MonoGame is an open source cross platform implementation of Microsoft's XNA 4.x Framework</summary>
-        <releaseNotes>Updated dev release - 10 December 2013</releaseNotes>
+        <releaseNotes>Updated dev release - 07 January 2014</releaseNotes>
         <copyright>Copyright  2013</copyright>
         <language>en-US</language>
         <references>

--- a/MonoGame.NuGetPackager/Package.nuspec
+++ b/MonoGame.NuGetPackager/Package.nuspec
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
     <metadata>
         <id>MonoGame</id>
-        <version>3.1.2-alpha</version>
+        <version>3.1.3-alpha</version>
         <title>MonoGame</title>
         <authors>Simon-Darkside</authors>
         <owners>MonoGameTeam</owners>
@@ -13,55 +13,16 @@
         <description>MonoGame is an open source implementation of the Microsoft XNA 4.x Framework.
       The goal is to make it easy for XNA developers to create cross-platform games with extremely high code reuse. We currently support iOS, Android, Windows (both OpenGL and DirectX), Mac OS X, Linux, Windows 8 Store, Windows Phone 8, PlayStation Mobile, and the OUYA console.</description>
         <summary>MonoGame is an open source cross platform implementation of Microsoft's XNA 4.x Framework</summary>
-        <releaseNotes>Updated dev release - 10 December 2013</releaseNotes>
+        <releaseNotes>Updated dev release - 07 January 2014 - inc Windows GL build fix
+
+Removed binaries from this package and added dependency to the separate binaries NuGet package</releaseNotes>
         <copyright>Copyright  2013</copyright>
         <language>en-US</language>
+        <dependencies>
+            <dependency id="MonoGame.Binaries" version="3.1.3-alpha" />
+        </dependencies>
     </metadata>
     <files>
-        <file src="bin\Release\build\net40\Lidgren.Network.dll" target="build\net40\Lidgren.Network.dll" />
-        <file src="..\MonoGame.Framework\Bin\WindowsGL\Release\MonoGame.Framework.dll" target="build\net40\MonoGame.Framework.dll" />
-        <file src="build\net40\MonoGame.targets" target="build\net40\MonoGame.targets" />
-        <file src="bin\Release\build\net40\OpenTK.dll" target="build\net40\OpenTK.dll" />
-        <file src="bin\Release\build\net40\Tao.Sdl.dll" target="build\net40\Tao.Sdl.dll" />
-        <file src="..\MonoGame.Framework\Bin\Windows8\Release\MonoGame.Framework.dll" target="build\netcore\MonoGame.Framework.dll" />
-        <file src="..\MonoGame.Framework\Bin\Windows8\Release\MonoGame.Framework.pri" target="build\netcore\MonoGame.Framework.pri" />
-        <file src="build\netcore\MonoGame.targets" target="build\netcore\MonoGame.targets" />
-        <file src="bin\Release\build\netcore\SharpDX.Direct2D1.dll" target="build\netcore\SharpDX.Direct2D1.dll" />
-        <file src="bin\Release\build\netcore\SharpDX.Direct3D11.dll" target="build\netcore\SharpDX.Direct3D11.dll" />
-        <file src="bin\Release\build\netcore\SharpDX.dll" target="build\netcore\SharpDX.dll" />
-        <file src="bin\Release\build\netcore\SharpDX.DXGI.dll" target="build\netcore\SharpDX.DXGI.dll" />
-        <file src="bin\Release\build\netcore\SharpDX.MediaFoundation.dll" target="build\netcore\SharpDX.MediaFoundation.dll" />
-        <file src="bin\Release\build\netcore\SharpDX.XAudio2.dll" target="build\netcore\SharpDX.XAudio2.dll" />
-        <file src="bin\Release\build\netcore\SharpDX.XInput.dll" target="build\netcore\SharpDX.XInput.dll" />
-        <file src="..\MonoGame.Framework\Bin\WindowsPhone\ARM\Release\MonoGame.Framework.dll" target="build\wp8\ARM\MonoGame.Framework.dll" />
-        <file src="..\MonoGame.Framework\Bin\WindowsPhone\ARM\Release\MonoGame.Framework.pdb" target="build\wp8\ARM\MonoGame.Framework.pdb" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.Direct3D11.dll" target="build\wp8\ARM\SharpDX.Direct3D11.dll" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.Direct3D11.xml" target="build\wp8\ARM\SharpDX.Direct3D11.xml" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.dll" target="build\wp8\ARM\SharpDX.dll" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.DXGI.dll" target="build\wp8\ARM\SharpDX.DXGI.dll" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.DXGI.xml" target="build\wp8\ARM\SharpDX.DXGI.xml" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.MediaFoundation.dll" target="build\wp8\ARM\SharpDX.MediaFoundation.dll" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.MediaFoundation.xml" target="build\wp8\ARM\SharpDX.MediaFoundation.xml" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.WP8.dll" target="build\wp8\ARM\SharpDX.WP8.dll" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.WP8.winmd" target="build\wp8\ARM\SharpDX.WP8.winmd" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.XAudio2.dll" target="build\wp8\ARM\SharpDX.XAudio2.dll" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.XAudio2.xml" target="build\wp8\ARM\SharpDX.XAudio2.xml" />
-        <file src="bin\Release\build\wp8\ARM\SharpDX.xml" target="build\wp8\ARM\SharpDX.xml" />
-        <file src="..\MonoGame.Framework\Bin\WindowsPhone\x86\Release\MonoGame.Framework.dll" target="build\wp8\x86\MonoGame.Framework.dll" />
-        <file src="..\MonoGame.Framework\Bin\WindowsPhone\x86\Release\MonoGame.Framework.pdb" target="build\wp8\x86\MonoGame.Framework.pdb" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.Direct3D11.dll" target="build\wp8\x86\SharpDX.Direct3D11.dll" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.Direct3D11.xml" target="build\wp8\x86\SharpDX.Direct3D11.xml" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.dll" target="build\wp8\x86\SharpDX.dll" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.DXGI.dll" target="build\wp8\x86\SharpDX.DXGI.dll" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.DXGI.xml" target="build\wp8\x86\SharpDX.DXGI.xml" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.MediaFoundation.dll" target="build\wp8\x86\SharpDX.MediaFoundation.dll" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.MediaFoundation.xml" target="build\wp8\x86\SharpDX.MediaFoundation.xml" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.WP8.dll" target="build\wp8\x86\SharpDX.WP8.dll" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.WP8.winmd" target="build\wp8\x86\SharpDX.WP8.winmd" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.XAudio2.dll" target="build\wp8\x86\SharpDX.XAudio2.dll" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.XAudio2.xml" target="build\wp8\x86\SharpDX.XAudio2.xml" />
-        <file src="bin\Release\build\wp8\x86\SharpDX.xml" target="build\wp8\x86\SharpDX.xml" />
-        <file src="build\wp8\MonoGame.targets" target="build\wp8\MonoGame.targets" />
         <file src="content\net40\Game1.cs.pp" target="content\net40\Game1.cs.pp" />
         <file src="content\net40\Program.cs.pp" target="content\net40\Program.cs.pp" />
         <file src="bin\Release\content\net40\SDL.dll" target="content\net40\SDL.dll" />


### PR DESCRIPTION
- No Code changes
- Main NuGet package now depends on binaries release rather than duplicating references (will make it easier for projects using the full proj to just update binaries)
- Windows GL build now no longer crashes with Sharp DX errors
