### PR TITLE
 Implemented "Garbage-Free" GraphicsDevice.GetRenderTargets

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1870,6 +1870,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void GetRenderTargets(RenderTargetBinding[] outTargets)
         {
+            Debug.Assert(outTargets.Length == _currentRenderTargetCount, "Invalid outTargets array length!");
             Array.Copy(_currentRenderTargetBindings, outTargets, _currentRenderTargetCount);
         }
 


### PR DESCRIPTION
Implemented property in GraphicsDevice to get the current Render Count
and overloaded GetRenderTargets to copy to an array you provide instead
of generating a new one (therefore, creating garbage).  Only problem is
that it is the user's responsibility to make sure the array they create
can fit the render contents or an exception will be thrown.
