### PR TITLE
WP back button cancel fix

### DIFF
--- a/MonoGame.Framework/WindowsPhone/GamePad.cs
+++ b/MonoGame.Framework/WindowsPhone/GamePad.cs
@@ -8,8 +8,11 @@ namespace Microsoft.Xna.Framework.Input
 
         internal static void GamePageWP8_BackKeyPress(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            back = true;
-            e.Cancel = true;
+            if (!e.Cancel)
+            {
+                back = true;
+                e.Cancel = true;
+            }
         }
 
         public static Microsoft.Xna.Framework.Input.GamePadCapabilities GetCapabilities(PlayerIndex playerIndex)


### PR DESCRIPTION
A quick fix to only fire back button events on Windows Phone if they weren't handled/fired yet. Useful if you want to use some silverlight UI elements to replace the standard Guide keyboard and message boxes for example.
