### PR TITLE
DisplayMode.AspectRatio fix

### DIFF
--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Xna.Framework.Graphics
         #region Properties
         
         public float AspectRatio {
-            get { return width / height; }
+            get { return (float)width / (float)height; }
         }
 
         public SurfaceFormat Format {


### PR DESCRIPTION
DisplayMode.AspectRatio was always returning 1.0f because width and height are int, and weren't being cast to float for the division.
