### PR TITLE
Include OpenTK.dll.config as copy-on-build for Linux

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.Linux.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Linux.csproj
@@ -429,6 +429,10 @@
       <Link>Tao.Sdl.dll.config</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\ThirdParty\Libs\OpenTK.dll.config">
+      <Link>OpenTK.dll.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Linux\Graphics\" />


### PR DESCRIPTION
For some reason, the OpenTK.dll.config file is not specified as part of the MonoGame Linux project.  When this file is not copied to the output directory, it can not load OpenAL correctly.
