### PR TITLE
Fixed DrawingSurfaceBackgroundGrid in Game.xaml

### DIFF
--- a/MonoGame.Framework/WindowsPhone/XamlGame.cs
+++ b/MonoGame.Framework/WindowsPhone/XamlGame.cs
@@ -117,6 +117,8 @@ namespace MonoGame.Framework.WindowsPhone
                     mediaElement = (MediaElement)child;
                 else if (drawingSurface == null && child is DrawingSurface)
                     drawingSurface = (DrawingSurface)child;
+                else if (drawingSurface == null && child is DrawingSurfaceBackgroundGrid)
+                    drawingSurface = (DrawingSurfaceBackgroundGrid)child;
             }
 
             if (!(drawingSurface is DrawingSurfaceBackgroundGrid) && !(drawingSurface is DrawingSurface))


### PR DESCRIPTION
credit to nZeus/MonoGame, fixes issue with functions not being called in WP8 builds.
