### PR TITLE
Resolves issue with content loading in develop

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -305,15 +305,17 @@ namespace Microsoft.Xna.Framework.Content
 				//MonoGame try to load as a non-content file
 
                 assetName = TitleContainer.GetFilename(Path.Combine(RootDirectory, assetName));
-
+                
                 assetName = Normalize<T>(assetName);
 	
 				if (string.IsNullOrEmpty(assetName))
 				{
 					throw new ContentLoadException("Could not load " + originalAssetName + " asset as a non-content file!", ex);
 				}
+                // Make sure we take into account the Location when we load the content
+                var absolutePath = Path.Combine(TitleContainer.Location, assetName);
 
-                result = ReadRawAsset<T>(assetName, originalAssetName);
+                result = ReadRawAsset<T>(absolutePath, originalAssetName);
 
                 // Because Raw Assets skip the ContentReader step, they need to have their
                 // disopsables recorded here. Doing it outside of this catch will 

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -128,7 +128,10 @@ namespace Microsoft.Xna.Framework.Content
             if (MetroHelper.AppDataFileExists(fileName))
                 return fileName;
 #else
-            if (File.Exists(fileName))
+            
+            // If we are checking for file location, We need to take the real location into account.
+            var absolutePath = Path.Combine(TitleContainer.Location, fileName);            
+            if (File.Exists(absolutePath))
 				return fileName;
 #endif
 			


### PR DESCRIPTION
Makes loading of content behave the same across all platforms. 
As long as content is placed in 'Content' folder then default paths for resources loading 
seems to work in all environments. 
