### PR TITLE
Fixed Intermediate Output Paths

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -23,6 +23,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Android\Debug\</OutputPath>
+    <IntermediateOutputPath>obj\Android\Debug\</IntermediateOutputPath>
     <DefineConstants>TRACE;DEBUG;ANDROID;GLES;GLSL;OPENGL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -34,6 +35,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>True</Optimize>
     <OutputPath>bin\Android\Release\</OutputPath>
+    <IntermediateOutputPath>obj\Android\Release\</IntermediateOutputPath>
     <DefineConstants>TRACE;ANDROID;GLES;OPENGL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/MonoGame.Framework/MonoGame.Framework.Linux.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Linux.csproj
@@ -15,6 +15,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Linux\Debug</OutputPath>
+    <IntermediateOutputPath>obj\Linux\Debug</IntermediateOutputPath>
     <DefineConstants>DEBUG;LINUX;OPENGL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,6 +27,7 @@
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Linux\Release</OutputPath>
+    <IntermediateOutputPath>obj\Linux\Release</IntermediateOutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>

--- a/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.MacOS.csproj
@@ -17,6 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\MacOS\Debug</OutputPath>
+    <IntermediateOutputPath>obj\MacOS\Debug</IntermediateOutputPath>
     <DefineConstants>DEBUG;MONOMAC;OPENGL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -32,6 +33,7 @@
     <DebugType>none</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\MacOS\Release</OutputPath>
+    <IntermediateOutputPath>obj\MacOS\Release</IntermediateOutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
@@ -47,6 +49,7 @@
     <DebugType>none</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\MacOS\Distribution</OutputPath>
+    <IntermediateOutputPath>obj\MacOS\Distribution</IntermediateOutputPath>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>MONOMAC;OPENGL</DefineConstants>

--- a/MonoGame.Framework/MonoGame.Framework.Ouya.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Ouya.csproj
@@ -25,6 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\OUYA\Debug\</OutputPath>
+    <IntermediateOutputPath>obj\OUYA\Debug\</IntermediateOutputPath>
     <DefineConstants>TRACE;DEBUG;ANDROID;GLES;GLSL;OPENGL;OUYA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -36,6 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>True</Optimize>
     <OutputPath>bin\OUYA\Release\</OutputPath>
+    <IntermediateOutputPath>obj\OUYA\Release\</IntermediateOutputPath>
     <DefineConstants>TRACE;ANDROID;GLES;OPENGL;OUYA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/MonoGame.Framework/MonoGame.Framework.PSMobile.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.PSMobile.csproj
@@ -16,6 +16,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\PSMobile\Debug</OutputPath>
+    <IntermediateOutputPath>obj\PSMobile\Debug</IntermediateOutputPath>
     <DefineConstants>DEBUG;PSM</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,6 +27,7 @@
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\PSMobile\Release</OutputPath>
+    <IntermediateOutputPath>obj\PSMobile\Release</IntermediateOutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/MonoGame.Framework/MonoGame.Framework.Windows.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows.csproj
@@ -22,6 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Windows\Debug\</OutputPath>
+    <IntermediateOutputPath>obj\Windows\Debug\</IntermediateOutputPath>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>true</DebugSymbols>
@@ -37,6 +38,7 @@
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Windows\Release\</OutputPath>
+    <IntermediateOutputPath>obj\Windows\Release\</IntermediateOutputPath>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RegisterForComInterop>False</RegisterForComInterop>

--- a/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Windows8.csproj
@@ -20,6 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Windows8\Debug\</OutputPath>
+    <IntermediateOutputPath>obj\Windows8\Debug\</IntermediateOutputPath>
     <DefineConstants>TRACE;NETFX_CORE;DEBUG;WINRT;WINDOWS_STOREAPP;DIRECTX;DIRECTX11_1;WINDOWS_MEDIA_ENGINE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -30,6 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Windows8\Release\</OutputPath>
+    <IntermediateOutputPath>obj\Windows8\Release\</IntermediateOutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINRT;WINDOWS_STOREAPP;DIRECTX;DIRECTX11_1;WINDOWS_MEDIA_ENGINE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsGL.csproj
@@ -22,6 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\WindowsGL\Debug\</OutputPath>
+    <IntermediateOutputPath>obj\WindowsGL\Debug\</IntermediateOutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -33,6 +34,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\WindowsGL\Release\</OutputPath>
+    <IntermediateOutputPath>obj\WindowsGL\Release\</IntermediateOutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DefineConstants>TRACE;WINDOWS;OPENGL</DefineConstants>
@@ -43,6 +45,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\WindowsGL\Debug</OutputPath>
+    <IntermediateOutputPath>obj\WindowsGL\Debug\</IntermediateOutputPath>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>true</DebugSymbols>
@@ -56,6 +59,7 @@
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\WindowsGL\Release</OutputPath>
+    <IntermediateOutputPath>obj\WindowsGL\Release</IntermediateOutputPath>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RegisterForComInterop>False</RegisterForComInterop>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsPhone.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsPhone.csproj
@@ -24,6 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\WindowsPhone\Debug</OutputPath>
+    <IntermediateOutputPath>obj\WindowsPhone\Debug</IntermediateOutputPath>
     <DefineConstants>TRACE;DEBUG;SILVERLIGHT;WINDOWS_PHONE;WINRT;DIRECTX</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
@@ -35,6 +36,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\WindowsPhone\Release</OutputPath>
+    <IntermediateOutputPath>obj\WindowsPhone\Release</IntermediateOutputPath>
     <DefineConstants>TRACE;SILVERLIGHT;WINDOWS_PHONE;WINRT;DIRECTX</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
@@ -47,6 +49,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\WindowsPhone\x86\Debug</OutputPath>
+    <IntermediateOutputPath>obj\WindowsPhone\x86\Debug</IntermediateOutputPath>
     <DefineConstants>TRACE;DEBUG;SILVERLIGHT;WINDOWS_PHONE;WINRT;DIRECTX</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
@@ -59,6 +62,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\WindowsPhone\x86\Release</OutputPath>
+    <IntermediateOutputPath>obj\WindowsPhone\x86\Release</IntermediateOutputPath>
     <DefineConstants>TRACE;SILVERLIGHT;WINDOWS_PHONE;WINRT;DIRECTX</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
@@ -71,6 +75,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\WindowsPhone\ARM\Debug</OutputPath>
+    <IntermediateOutputPath>obj\WindowsPhone\ARM\Debug</IntermediateOutputPath>
     <DefineConstants>TRACE;DEBUG;SILVERLIGHT;WINDOWS_PHONE;WINRT;DIRECTX</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
@@ -82,6 +87,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\WindowsPhone\ARM\Release</OutputPath>
+    <IntermediateOutputPath>obj\WindowsPhone\ARM\Release</IntermediateOutputPath>
     <DefineConstants>TRACE;SILVERLIGHT;WINDOWS_PHONE;WINRT;DIRECTX</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -20,6 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <IntermediateOutputPath>obj\iPhoneSimulator\Debug</IntermediateOutputPath>
     <DefineConstants>DEBUG;IOS;GLES;OPENGL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -37,6 +38,7 @@
     <DebugType>none</DebugType>
     <Optimize>True</Optimize>
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <IntermediateOutputPath>obj\iPhoneSimulator\Release</IntermediateOutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -48,6 +50,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\Debug</OutputPath>
+    <IntermediateOutputPath>obj\iPhone\Debug</IntermediateOutputPath>
     <DefineConstants>DEBUG;IOS;GLES;OPENGL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -60,6 +63,7 @@
     <DebugType>none</DebugType>
     <Optimize>True</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
+    <IntermediateOutputPath>obj\iPhone\Release</IntermediateOutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>


### PR DESCRIPTION
This adds the `<IntermediateOutputPath>` property to each project configuration so that intermediate files are completely separate for each configuration and platform.

I suspect this is what is causing https://github.com/mono/MonoGame/issues/2227.
