### PR TITLE
[WP8] Calling SoundEffectInstance.Stop(true) unstable state.

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -296,26 +296,7 @@ namespace Microsoft.Xna.Framework.Audio
 		
 		public void Stop()
         {
-#if DIRECTX
-            if (_voice != null)
-            {
-                _voice.Stop(0);
-                _voice.FlushSourceBuffers();
-            }
-
-		    _paused = false;
-#else
-            if ( _sound != null )
-			{
-#if ANDROID
-				_sound.Stop(_streamId);
-				_streamId = -1;
-#else
-                _sound.Stop();
-#endif
-                soundState = SoundState.Stopped;
-			}
-#endif
+            Stop(true);
         }
 
         public void Stop(bool immediate)
@@ -323,8 +304,13 @@ namespace Microsoft.Xna.Framework.Audio
 #if DIRECTX            
             if (_voice != null)
             {   
-                _voice.Stop(immediate ? 0 : (int)PlayFlags.Tails);
-                if (immediate) _voice.FlushSourceBuffers();
+                if (immediate)
+                {
+                    _voice.Stop(0);
+                    _voice.FlushSourceBuffers();
+                }
+                else 
+                    _voice.Stop((int)PlayFlags.Tails);
             }
 
             _paused = false;


### PR DESCRIPTION
By calling SoundEffectInstance.Stop(true), any subsequent calls to
SoundEffectInstance.Play(...) have no effect.

By calling Calling SoundEffectInstance.Stop(true) the object gets into
an unstable state.

The buffer is not cleared, which causes the .State to always return
.Playing , which in turn causes .Play() to always return early without
starting the _voice.

The behavior of .Stop(true) should be similar to .Stop().
