### PR TITLE
Fixes bug where the WindowsPhone template will not work in Visual Studio 2013

### DIFF
--- a/ProjectTemplates/VisualStudio2012/WindowsPhone/__Game.vstemplate
+++ b/ProjectTemplates/VisualStudio2012/WindowsPhone/__Game.vstemplate
@@ -42,7 +42,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Microsoft.VisualStudio.SmartDevice.ProjectSystem.Base, Version=11.0.0.0, Culture=Neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <Assembly>Microsoft.VisualStudio.SmartDevice.ProjectSystem.Base</Assembly>
     <FullClassName>Microsoft.VisualStudio.SmartDevice.ProjectSystem.Wizards.ProjectTemplateWizard</FullClassName>
   </WizardExtension>
 </VSTemplate>


### PR DESCRIPTION
This change in the __Game.vstemplate will make it so that visual studio 2013 will look for any Microsoft.VisualStudio.SmartDevice.ProjectSystem.Base assembly reference.

Currently I am not able to test this behaviour on Visual Studio 2012.

An alternative would be to create a separate template for Visual Studio 2013.
