### PR TITLE
[WP8] Fix missing deactivated event when closing the game

### DIFF
--- a/MonoGame.Framework/WindowsPhone/WPGamePlatform.cs
+++ b/MonoGame.Framework/WindowsPhone/WPGamePlatform.cs
@@ -165,6 +165,10 @@ namespace MonoGame.Framework.WindowsPhone
         
         public override void Exit()
         {
+            // Closing event is not fired when termiate is called. We need to deactivate the game manually.
+            if (Game.Instance != null)
+                this.IsActive = false;
+
             System.Windows.Application.Current.Terminate();
         }
 


### PR DESCRIPTION
Up until now the Deactivated event was not fired on Windows Phone 8 when the game is closed using Game.Exit() (e.g. back button was pressed). This PR fixes this issue.

http://msdn.microsoft.com/en-us/library/windowsphone/develop/system.windows.application.terminate%28v=vs.105%29.aspx

> The Terminate method does not raise any application lifecycle events. Before you call this method, you must save the state of the app.
