### PR TITLE
Fix for wrong auto rotation on iOS

### DIFF
--- a/MonoGame.Framework/iOS/OrientationConverter.cs
+++ b/MonoGame.Framework/iOS/OrientationConverter.cs
@@ -113,9 +113,11 @@ namespace Microsoft.Xna.Framework
                 case((DisplayOrientation)0):
                 case((DisplayOrientation)3):
                     return UIInterfaceOrientationMask.Landscape;
-                case((DisplayOrientation)1):
-                    return UIInterfaceOrientationMask.LandscapeLeft;
+                // NOTE: in XNA, Orientation Left is a 90 degree rotation counterclockwise, while on iOS
+		// it is a 90 degree rotation CLOCKWISE. They are BACKWARDS! 
                 case((DisplayOrientation)2):
+                    return UIInterfaceOrientationMask.LandscapeLeft;
+                case((DisplayOrientation)1):
                     return UIInterfaceOrientationMask.LandscapeRight;
                 case((DisplayOrientation)4):
                     return UIInterfaceOrientationMask.Portrait;


### PR DESCRIPTION
iOS has inverted LanscapeLeft and LandscapeRight orientation compared to XNA.
While other methods take that in account, it was missing in ToUIInterfaceOrientationMask, which was a potential source of unwanted auto rotation (overriding SupportedOrientations) and crashes if the rotation resulted in unsupported Info.plist orientations.

See codeplex discussion for details: https://monogame.codeplex.com/discussions/535677
