### PR TITLE
Now State returns the proper state from the Source on OpenAL (Desktop)

### DIFF
--- a/MonoGame.Framework/Desktop/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Desktop/Audio/SoundEffectInstance.cs
@@ -431,6 +431,24 @@ namespace Microsoft.Xna.Framework.Audio
         /// </summary>
 		public SoundState State {
 			get {
+                if(hasSourceId)
+                {
+                    var state = AL.GetSourceState(sourceId);
+                    switch (state)
+                    {
+                        case ALSourceState.Initial:
+                            return SoundState.Stopped;
+                        case ALSourceState.Paused:
+                            return SoundState.Paused;
+                        case ALSourceState.Playing:
+                            return SoundState.Playing;
+                        case ALSourceState.Stopped:
+                            return SoundState.Stopped;
+                        default:
+                            return SoundState.Stopped;
+                    }
+                }
+                else
 				return soundState;
 			}
 		}


### PR DESCRIPTION
Otherwise we will never find out when a sound stopped playing. This fix might apply on iOS/Android platforms too, but I cannot test this at the moment.
