### PR TITLE
Bugfix in Texture2D.getData: Copy rectangle data

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -708,6 +708,7 @@ namespace Microsoft.Xna.Framework.Graphics
 							w++;
 						}
 						z++;
+						w = 0;
 					}
 				} else {
 					GL.GetTexImage(TextureTarget.Texture2D, level, this.glFormat, this.glType, data);


### PR DESCRIPTION
Could lead to an array access out of boundaries and it was simply wrong.
Just adding a w = 0;
