### PR TITLE
Fixed measure string to return correct width if spacing is used

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     hasCurrentGlyph = true;                        
                 }
 
-                var proposedWidth = offset.X + currentGlyph.WidthIncludingBearings;
+                var proposedWidth = offset.X + currentGlyph.WidthIncludingBearings + Spacing;
                 if (proposedWidth > width)
                     width = proposedWidth;
 


### PR DESCRIPTION
MeasureString did not return the correct width because it was calculating width like this (S denotes spacing, C denoes character):
S C S C
XNA calculates spacing like this:
S C S C S

This is a comparison of XNA's and MonoGame's behaviour when text boxes are aligned to the right.
![comparison](https://f.cloud.github.com/assets/431167/2381020/da4fe5dc-a8b7-11e3-8e62-213b5b72dadf.png)

With this fix the images line up perfectly.
