### PR TITLE
Added additional iOS application events to Game class

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -143,6 +143,12 @@ namespace Microsoft.Xna.Framework
             Platform.Deactivated += OnDeactivated;
             _services.AddService(typeof(GamePlatform), Platform);
 
+#if IOS
+            Platform.EnterBackground += OnEnterBackground;
+            Platform.EnterForeground += OnEnterForeground;
+            Platform.MemoryWarningReceived += OnMemoryWarningReceived;
+#endif
+
 #if WINDOWS_STOREAPP
             Platform.ViewStateChanged += Platform_ApplicationViewChanged;
 #endif
@@ -224,6 +230,13 @@ namespace Microsoft.Xna.Framework
                         Platform.Activated -= OnActivated;
                         Platform.Deactivated -= OnDeactivated;
                         _services.RemoveService(typeof(GamePlatform));
+
+#if IOS
+                        Platform.EnterBackground -= OnEnterBackground;
+                        Platform.EnterForeground -= OnEnterForeground;
+                        Platform.MemoryWarningReceived -= OnMemoryWarningReceived;
+#endif
+
 #if WINDOWS_STOREAPP
                         Platform.ViewStateChanged -= Platform_ApplicationViewChanged;
 #endif
@@ -395,6 +408,12 @@ namespace Microsoft.Xna.Framework
         public event EventHandler<EventArgs> Deactivated;
         public event EventHandler<EventArgs> Disposed;
         public event EventHandler<EventArgs> Exiting;
+
+#if IOS
+        public event EventHandler<EventArgs> EnterBackground;
+        public event EventHandler<EventArgs> EnterForeground;
+        public event EventHandler<EventArgs> MemoryWarningReceived;
+#endif
 
 #if WINDOWS_STOREAPP
         [CLSCompliant(false)]
@@ -651,6 +670,26 @@ namespace Microsoft.Xna.Framework
 			AssertNotDisposed();
 			Raise(Deactivated, args);
 		}
+
+#if IOS
+		protected virtual void OnEnterBackground(object sender, EventArgs args)
+		{
+			AssertNotDisposed();
+			Raise(EnterBackground, args);
+		}
+
+		protected virtual void OnEnterForeground(object sender, EventArgs args)
+		{
+			AssertNotDisposed();
+			Raise(EnterForeground, args);
+		}
+
+		protected virtual void OnMemoryWarningReceived(object sender, EventArgs args)
+		{
+			AssertNotDisposed();
+			Raise(MemoryWarningReceived, args);
+		}
+#endif
 
         #endregion Protected Methods
 

--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -167,6 +167,23 @@ namespace Microsoft.Xna.Framework
             }
         }
 
+#if IOS
+		protected void OnEnterBackground()
+		{
+			Raise(EnterBackground, EventArgs.Empty);
+		}
+
+		protected void OnEnterForeground()
+		{
+			Raise(EnterForeground, EventArgs.Empty);
+		}
+
+		protected void OnMemoryWarningReceived()
+		{
+			Raise(MemoryWarningReceived, EventArgs.Empty);
+		}
+#endif
+
 #if WINDOWS_STOREAPP
         private ApplicationViewState _viewState;
         public ApplicationViewState ViewState
@@ -247,6 +264,12 @@ namespace Microsoft.Xna.Framework
         public event EventHandler<EventArgs> AsyncRunLoopEnded;
         public event EventHandler<EventArgs> Activated;
         public event EventHandler<EventArgs> Deactivated;
+
+#if IOS
+		public event EventHandler<EventArgs> EnterBackground;
+		public event EventHandler<EventArgs> EnterForeground;
+		public event EventHandler<EventArgs> MemoryWarningReceived;
+#endif
 
 #if WINDOWS_STOREAPP
         public event EventHandler<ViewStateChangedEventArgs> ViewStateChanged;

--- a/MonoGame.Framework/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/iOS/iOSGamePlatform.cs
@@ -292,12 +292,16 @@ namespace Microsoft.Xna.Framework
 
         private void Application_WillEnterForeground(NSNotification notification)
         {
-			// Already handled in Application_DidBecomeActive. See below for IsActive state change.	
+			OnEnterForeground();
+
+			// IsActive state change already handled in Application_WillResignActive. See below.
         }
 
         private void Application_DidEnterBackground(NSNotification notification)
         {
-			// Already handled in Application_WillResignActive. See below for IsActive state change.
+			OnEnterBackground();
+
+			// IsActive state change already handled in Application_WillResignActive. See below.
         }
 
         private void Application_DidBecomeActive(NSNotification notification)
@@ -322,6 +326,8 @@ namespace Microsoft.Xna.Framework
 
         private void Application_DidReceiveMemoryWarning(NSNotification notification)
         {
+            OnMemoryWarningReceived();
+
             // FIXME: Possibly add some more sophisticated behavior here.  It's
             //        also possible that this is not iOSGamePlatform's job.
             GC.Collect();


### PR DESCRIPTION
## Overview

MonoGame already gives us access to these iOS app lifecycle events (through Game.Activated and Game.Deactivated):
- `applicationDidBecomeActive`
- `applicationWillResignActive`

But although MonoGame has callbacks for these additional iOS application events under the hood, there was previously no way to access them through the Game class:
- `applicationDidEnterBackground`
- `applicationWillEnterForeground`
- `applicationDidReceiveMemoryWarning`

This commit adds `EnterBackground`, `EnterForeground`, and `MemoryWarningReceived` events to the MonoGame Game class (conditionally compiled for IOS only).

I personally think it's good to be able to respond to these other events from XNA game code. For me, simply responding to Activated and Deactivated isn't ideal; my game saves constantly and aggressively, but I only occasionally want to upload my save data to the cloud (using iCloud on iOS). For me, applicationDidEnterBackground is the perfect time to do this, because it signals that the user is potentially quitting the game for a while (vs. simply deactivating the game, which might only last a second or two).
## Concerns

First of all, this is my first ever GitHub fork and commit, so I apologize if I screw this up. I hope I'm doing this right :)

Secondly, I noticed that some of the other custom Game event declarations use a `[CLSCompliant(false)]` attribute, for example:

``` C#
#if WINDOWS_STOREAPP
    [CLSCompliant(false)]
    public event EventHandler<ViewStateChangedEventArgs> ApplicationViewChanged;
#endif

#if WINRT
    [CLSCompliant(false)]
    public ApplicationExecutionState PreviousExecutionState { get; internal set; }
#endif
```

I'm not sure exactly what that attribute means. Should the event declarations I added for EnterBackground, EnterForeground, and MemoryWarningReceived also be decorated with the same attribute?
