### PR TITLE
Color improvements

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -27,6 +27,7 @@ SOFTWARE.
 
 using System;
 using System.Runtime.Serialization;
+using System.Text;
 
 namespace Microsoft.Xna.Framework
 {


### PR DESCRIPTION
Ok, I rethink about MonoGame and its compatibility with XNA. Now I wisely prefer extensions over core changes. 

This commit unblock existing private constructor - Color(uint packedValue). For what ? If you want write extensions for Color, on low level, in your own lib, you must write something like this -

 Color c = new Color();
            c.PackedValue = 0xFFFFFFFF;
            return c;

This is inelegant and has lower performance than this

 return new Color(0xFFFFFFFF);

Primary rule for initial XNA microsoft developers was simplify - and this simplificy cuts a lot of performance.

Also, this commit - refresh comments and code in github layout to more better view and fixing ToString - now it works like in XNA.
