### PR TITLE
Move non-portable thread check guards to specific platforms that use it.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -474,6 +474,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void PlatformApplyState(bool applyShaders)
         {
+            Threading.EnsureUIThread();
+
             if ( _scissorRectangleDirty )
 	        {
                 var scissorRect = _scissorRectangle;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.PSM.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.PSM.cs
@@ -93,6 +93,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void PlatformApplyState(bool applyShaders)
         {
+            // TODO: This was on both the OpenGL and PSM path previously - is it necessary?
+            Threading.EnsureUIThread();
+
             if ( _scissorRectangleDirty )
 	            _scissorRectangleDirty = false;
 

--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -104,10 +104,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void SetTextures(GraphicsDevice device)
         {
-#if !DIRECTX
-            Threading.EnsureUIThread();
-#endif
-
             // Skip out if nothing has changed.
             if (_dirty == 0)
                 return;


### PR DESCRIPTION
There was some code to ensure graphics code was only executing on the main thread on Android from commit 203a315. WinRT didn't support the threading check, so it had to be #ifdef'd out. It was done with a !WINRT or !DIRECTX check, though, causing platforms without the method to fail to compile. Since only OpenGL and PSM actually use it, I've moved the code to those specific areas and left them out of the main file.

I traced the calls back and see that TextureCollection.SetTextures is only ever called by PlatformApplyState, which seems like the logical place to move such a check.

Also, it may in fact be OpenGL-only, if any PSM devs are watching could they comment?
