### PR TITLE
Add support for loading indexed image files into a texture through Texture2D.FromStream

### DIFF
--- a/MonoGame.Framework/Graphics/ImageEx.cs
+++ b/MonoGame.Framework/Graphics/ImageEx.cs
@@ -18,16 +18,38 @@ namespace System.Drawing
 #if WINRT
 
 #else
-        internal static void RGBToBGR(this Image bmp)
+        internal static Image RGBToBGR(this Image bmp)
         {
-            System.Drawing.Imaging.ImageAttributes ia = new System.Drawing.Imaging.ImageAttributes();
-            System.Drawing.Imaging.ColorMatrix cm = new System.Drawing.Imaging.ColorMatrix(rgbtobgr);
-
-            ia.SetColorMatrix(cm);
-            using (System.Drawing.Graphics g = System.Drawing.Graphics.FromImage(bmp))
+            Image newBmp;
+            if ((bmp.PixelFormat & Imaging.PixelFormat.Indexed) != 0)
             {
-                g.DrawImage(bmp, new System.Drawing.Rectangle(0, 0, bmp.Width, bmp.Height), 0, 0, bmp.Width, bmp.Height, System.Drawing.GraphicsUnit.Pixel, ia);
+                newBmp = new Bitmap(bmp.Width, bmp.Height, Imaging.PixelFormat.Format32bppArgb);
             }
+            else
+            {
+                newBmp = bmp;
+            }
+        
+            try
+            {
+                System.Drawing.Imaging.ImageAttributes ia = new System.Drawing.Imaging.ImageAttributes();
+                System.Drawing.Imaging.ColorMatrix cm = new System.Drawing.Imaging.ColorMatrix(rgbtobgr);
+
+                ia.SetColorMatrix(cm);
+                using (System.Drawing.Graphics g = System.Drawing.Graphics.FromImage(newBmp))
+                {
+                    g.DrawImage(bmp, new System.Drawing.Rectangle(0, 0, bmp.Width, bmp.Height), 0, 0, bmp.Width, bmp.Height, System.Drawing.GraphicsUnit.Pixel, ia);
+                }
+            }
+            finally
+            {
+                if (newBmp != bmp)
+                {
+                    bmp.Dispose();
+                }
+            }
+            
+            return newBmp;
         }
 #endif
 

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -187,10 +187,11 @@ namespace Microsoft.Xna.Framework.Graphics
             return toReturn;
 #endif
 #if WINDOWS
-            using (Bitmap image = (Bitmap)Bitmap.FromStream(stream))
+            Bitmap image = (Bitmap)Bitmap.FromStream(stream);
+            try
             {
                 // Fix up the Image to match the expected format
-                image.RGBToBGR();
+                image = (Bitmap)image.RGBToBGR();
 
                 var data = new byte[image.Width * image.Height * 4];
 
@@ -206,6 +207,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 texture.SetData(data);
 
                 return texture;
+            }
+            finally
+            {
+                image.Dispose();
             }
 #endif
         }

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -485,10 +485,11 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 #endif
 #if WINDOWS || LINUX
-            using (Bitmap image = (Bitmap)Bitmap.FromStream(stream))
+            Bitmap image = (Bitmap)Bitmap.FromStream(stream);
+            try
             {
                 // Fix up the Image to match the expected format
-                image.RGBToBGR();
+                image = (Bitmap)image.RGBToBGR();
 
                 var data = new byte[image.Width * image.Height * 4];
 
@@ -504,6 +505,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 texture.SetData(data);
 
                 return texture;
+            }
+            finally
+            {
+                image.Dispose();
             }
 #endif
         }


### PR DESCRIPTION
This resolves mono/MonoGame#806 and can be useful if loading images from external sources for use as textures, so I think it could be worth incorporating into MonoGame proper. This should retain the same behaviour as before for non-indexed images. It isn't quite as pretty as the old code, though, because indexed images aren't processed in place.
