### PR TITLE
Set line height when processing sprite fonts.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 
 				// Adjust line and character spacing.
 				lineSpacing += input.Spacing;
+				output.VerticalLineSpacing = (int)lineSpacing;
 
 				foreach (Glyph glyph in glyphs)
 				{


### PR DESCRIPTION
This fixes an issue where the SpriteFont processor calculates but doesn't set the line height.
