### PR TITLE
Fix bug where GraphicsDevice.Clear() always cleared stencil and depth buffers.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -721,23 +721,20 @@ namespace Microsoft.Xna.Framework.Graphics
 		
 #endif // WINDOWS
 
-        public void PlatformClear(Color color)
-        {
-            var options = ClearOptions.Target;
-
-            if (_currentDepthStencilView != null)
-            {
-                options |= ClearOptions.DepthBuffer;
-
-                if (_currentDepthStencilView.Description.Format == SharpDX.DXGI.Format.D24_UNorm_S8_UInt)
-                    options |= ClearOptions.Stencil;
-            }
-            
-            PlatformClear(options, color.ToVector4(), _viewport.MaxDepth, 0);
-        }
-
         public void PlatformClear(ClearOptions options, Vector4 color, float depth, int stencil)
         {
+            // Clear options for depth/stencil buffer if not attached.
+            if (_currentDepthStencilView != null)
+            {
+                if (_currentDepthStencilView.Description.Format != SharpDX.DXGI.Format.D24_UNorm_S8_UInt)
+                    options &= ~ClearOptions.Stencil;
+            }
+            else
+            {
+                options &= ~ClearOptions.DepthBuffer;
+                options &= ~ClearOptions.Stencil;
+            }
+
             lock (_d3dContext)
             {
                 // Clear the diffuse render buffer.
@@ -757,7 +754,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 if ((options & ClearOptions.Stencil) == ClearOptions.Stencil)
                     flags |= SharpDX.Direct3D11.DepthStencilClearFlags.Stencil;
 
-                if (flags != 0 && _currentDepthStencilView != null)
+                if (flags != 0)
                     _d3dContext.ClearDepthStencilView(_currentDepthStencilView, flags, depth, (byte)stencil);
             }
         }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -179,20 +179,12 @@ namespace Microsoft.Xna.Framework.Graphics
             _shaderProgram = -1;
         }
 
-        public void PlatformClear(Color color)
-        {
-            var options = ClearOptions.Target;
-
-            // TODO: We need to figure out how to detect if
-            // we have a depth stencil buffer or not!
-            options |= ClearOptions.DepthBuffer;
-            options |= ClearOptions.Stencil;
-
-            PlatformClear(options, color.ToVector4(), _viewport.MaxDepth, 0);
-        }
-
         public void PlatformClear(ClearOptions options, Vector4 color, float depth, int stencil)
         {
+            // TODO: We need to figure out how to detect if we have a
+            // depth stencil buffer or not, and clear options relating
+            // to them if not attached.
+
             // Unlike with XNA and DirectX...  GL.Clear() obeys several
             // different render states:
             //

--- a/MonoGame.Framework/Graphics/GraphicsDevice.PSM.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.PSM.cs
@@ -44,10 +44,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void PlatformClear(ClearOptions options, Vector4 color, float depth, int stencil)
         {
-            // TODO: We need to figure out how to detect if
-            // we have a depth stencil buffer or not!
-            options |= ClearOptions.DepthBuffer;
-            options |= ClearOptions.Stencil;
+            // TODO: We need to figure out how to detect if we have a
+            // depth stencil buffer or not, and clear options relating
+            // to them if not attached.
 
             _graphics.SetClearColor(color.ToPssVector4());
             _graphics.Clear();

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -265,7 +265,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void Clear(Color color)
         {
-            PlatformClear(color);
+            var options = ClearOptions.Target;
+            options |= ClearOptions.DepthBuffer;
+            options |= ClearOptions.Stencil;
+            PlatformClear(options, color.ToVector4(), _viewport.MaxDepth, 0);
         }
 
         public void Clear(ClearOptions options, Color color, float depth, int stencil)


### PR DESCRIPTION
This was a consequence of moving platform-specific code that prior to @eeafc23378861d1401ebdba417431b4e850e8abf only ran for the single-parameter form of Clear() into a PlatformClear() method used by all forms of Clear().

This change splits it out again.
