### PR TITLE
Fixed a MediaPlayer.Play() bug on windows

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -91,10 +91,11 @@ namespace Microsoft.Xna.Framework.Media
             // Cleanup the last song first.
             if (State != MediaState.Stopped)
             {
-                _session.Stop();
+				_session.Stop();
+				_session.Close();
                 _volumeController.Dispose();
                 _clock.Dispose();
-            }
+			}
 
             // Set the new song.
             _session.SetTopology(0, song.Topology);
@@ -138,9 +139,10 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         private static void PlatformStop()
-        {
-            _session.ClearTopologies();
-            _session.Stop();
+		{
+			_session.ClearTopologies();
+			_session.Stop();
+			_session.Close();
             _volumeController.Dispose();
             _volumeController = null;
             _clock.Dispose();


### PR DESCRIPTION
re: this issue: https://github.com/mono/MonoGame/issues/2330
where only the first call to MediaPlayer.Play() takes effect, and subsequent calls will simply re-play the first song.

I've found that if a session is closed after being stopped, before the next song's topology is loaded, the correct song will be loaded and played, and the SharpDX exception is no longer thrown.
I have tested locally (windows 7) and it appears to work.
