### PR TITLE
Added support for bypassing the content pipeline in MGCB

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PathHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PathHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.Xna.Framework.Content.Pipeline;
 
 namespace MonoGame.Framework.Content.Pipeline.Builder
 {
-    static class PathHelper
+    public static class PathHelper
     {
         /// <summary>
         /// The/universal/standard/directory/seperator.

--- a/Tools/MGCB/BuildContent.cs
+++ b/Tools/MGCB/BuildContent.cs
@@ -118,7 +118,7 @@ namespace MGCB
             if (!Path.IsPathRooted(sourceFile))
                 sourceFile = Path.Combine(Directory.GetCurrentDirectory(), sourceFile);
 
-            sourceFile = NormalizePath(sourceFile);
+            sourceFile = PathHelper.Normalize(sourceFile);
 
             // Remove duplicates... keep this new one.
             var previous = _content.FindIndex(e => string.Equals(e.SourceFile, sourceFile, StringComparison.InvariantCultureIgnoreCase));
@@ -151,7 +151,7 @@ namespace MGCB
             if (!Path.IsPathRooted(sourceFile))
                 sourceFile = Path.Combine(Directory.GetCurrentDirectory(), sourceFile);
 
-            sourceFile = NormalizePath(sourceFile);
+            sourceFile = PathHelper.Normalize(sourceFile);
 
             // Remove duplicates... keep this new one.
             var previous = _copyItems.FindIndex(e => string.Equals(e, sourceFile, StringComparison.InvariantCultureIgnoreCase));
@@ -182,9 +182,9 @@ namespace MGCB
 
         public void Build(out int successCount, out int errorCount)
         {
-            var projectDirectory = NormalizePath(Directory.GetCurrentDirectory());
-            var outputPath = NormalizePath(Path.GetFullPath(Path.Combine(projectDirectory, OutputDir)));
-            var intermediatePath = NormalizePath(Path.GetFullPath(Path.Combine(projectDirectory, IntermediateDir)));
+            var projectDirectory = PathHelper.Normalize(Directory.GetCurrentDirectory());
+            var outputPath = PathHelper.Normalize(Path.GetFullPath(Path.Combine(projectDirectory, OutputDir)));
+            var intermediatePath = PathHelper.Normalize(Path.GetFullPath(Path.Combine(projectDirectory, IntermediateDir)));
             _manager = new PipelineManager(projectDirectory, outputPath, intermediatePath);
             _manager.Logger = new ConsoleLogger();
 
@@ -307,15 +307,6 @@ namespace MGCB
                     ++errorCount;
                 }
             }
-        }
-
-        /// <summary>
-        /// Returns a path with a standardized (forward slash) directory separator char.
-        /// </summary>
-        private string NormalizePath(string path)
-        {
-            return path.Replace(Path.DirectorySeparatorChar, '/')
-                       .Replace(Path.DirectorySeparatorChar, '/');
         }
     }
 }


### PR DESCRIPTION
At first glance this PR sounds nonsensical--why would anyone want to bypass content building in a content builder? In short, because we're basically emulating the functionality of the Visual Studio-powered content pipeline, where a common pattern is to just copy an asset to the target directory.

With Visual Studio, you'd include the file in your content project and set the Build Action to either None or Content. In this case you'd add a command to the MGCB response file:

```
/copy:myAssetDir/myAssetFile.raw
```

The file will be copied to a mirrored directory structure in the output directory.
