### PR TITLE
Correct handling of WeakReference so they are correctly removed from the list

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsResource.cs
+++ b/MonoGame.Framework/Graphics/GraphicsResource.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Xna.Framework.Graphics
         // disposed yet.
         GraphicsDevice graphicsDevice;
 
-        private readonly WeakReference _selfReference;
+        private WeakReference _selfReference;
 
         internal GraphicsResource()
         {
@@ -157,6 +157,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     resources.Remove(_selfReference);
                 }
 
+                _selfReference = null;
                 graphicsDevice = null;
                 disposed = true;
             }


### PR DESCRIPTION
Fixes #1991

Here is a test case for the different alternative ways of implementing this:
https://gist.github.com/danzel/6c3c72108d00cb3d2bbd

Only by doing it this way does the WeakReference actually get removed from the list.

I did minor whitespace cleanup on the dispose related lines, so please view on:
https://github.com/danzel/MonoGame/commit/5395e77d82f98a481b5c8f3181b308d5e22a47f3?w=1
