### PR TITLE
Add GraphicsDevice.GetBackBufferData and implementations for GL/DirectX

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1197,6 +1197,11 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        private void PlatformGetBackBufferData<T>(T[] data) where T : struct
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Sends queued-up commands in the command buffer to the graphics processing unit (GPU).
         /// </summary>

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1199,7 +1199,38 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGetBackBufferData<T>(T[] data) where T : struct
         {
-            throw new NotImplementedException();
+            var dataBytes = data as byte[];
+
+            if (dataBytes == null)
+                throw new Exception("GetBackBufferData only supports byte[]");
+
+            lock (_d3dContext)
+            {
+                //You can't Map the BackBuffer surface, so we copy to another texture
+                using (var dxgiBackBuffer = _swapChain.GetBackBuffer<Surface>(0))
+                using (var backBufferTexture = dxgiBackBuffer.QueryInterface<SharpDX.Direct3D11.Texture2D>())
+                {
+                    var desc = backBufferTexture.Description;
+                    desc.BindFlags = SharpDX.Direct3D11.BindFlags.None;
+                    desc.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.Read;
+                    desc.Usage = SharpDX.Direct3D11.ResourceUsage.Staging;
+
+                    using (var texture = new SharpDX.Direct3D11.Texture2D(_d3dDevice, desc))
+                    {
+                        _d3dContext.CopyResource(backBufferTexture, texture);
+
+                        DataStream dataStream;
+                        var dataBox = _d3dContext.MapSubresource(texture, 0, 0, SharpDX.Direct3D11.MapMode.Read, SharpDX.Direct3D11.MapFlags.None, out dataStream);
+
+                        //Copy each line one at a time as there may be overhang from Pitch
+                        for (var y = 0; y < _viewport.Height; y++)
+                        {
+                            dataStream.Seek(y * dataBox.RowPitch, System.IO.SeekOrigin.Begin);
+                            dataStream.Read(dataBytes, y * _viewport.Width * 4, _viewport.Width * 4);
+                        }
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1206,14 +1206,20 @@ namespace Microsoft.Xna.Framework.Graphics
 
             lock (_d3dContext)
             {
+#if WINDOWS_PHONE
+                using (var backBufferTexture = new SharpDX.Direct3D11.Texture2D(_renderTargetView.Resource.NativePointer))
+#endif
+#if WINDOWS || WINDOWS_STOREAPP
                 //You can't Map the BackBuffer surface, so we copy to another texture
                 using (var dxgiBackBuffer = _swapChain.GetBackBuffer<Surface>(0))
                 using (var backBufferTexture = dxgiBackBuffer.QueryInterface<SharpDX.Direct3D11.Texture2D>())
+#endif
                 {
                     var desc = backBufferTexture.Description;
                     desc.BindFlags = SharpDX.Direct3D11.BindFlags.None;
                     desc.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.Read;
                     desc.Usage = SharpDX.Direct3D11.ResourceUsage.Staging;
+                    desc.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
 
                     using (var texture = new SharpDX.Direct3D11.Texture2D(_d3dDevice, desc))
                     {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -681,28 +681,25 @@ namespace Microsoft.Xna.Framework.Graphics
             //TODO: We could probably support other types
 
             var dataBytes = data as byte[];
-            if (dataBytes != null) //typeof(T) == typeof(byte)
-            {
-                Debug.Assert(data.Length == (_viewport.Width * _viewport.Height * 4));
-                GL.ReadPixels(0, 0, _viewport.Width, _viewport.Height, PixelFormat.Rgba, PixelType.UnsignedByte, data);
 
-                //In GL this is upside down (top row is the bottom row), so loop through fixing it up
-                var rowSize = _viewport.Width * 4;
-                var row = new byte[rowSize];
-                for (var y = 0; y < _viewport.Height / 2; y++)
-                {
-                    //Copy the top row out
-                    Array.Copy(dataBytes, y * rowSize, row, 0, rowSize);
-                    //Copy the bottom row over the top row
-                    Array.Copy(dataBytes, (_viewport.Height - y - 1) * rowSize, dataBytes, y * rowSize, rowSize);
-                    //Copy the backup over the bottom row
-                    Array.Copy(row, 0, dataBytes, (_viewport.Height - y - 1) * rowSize, rowSize);
-                }
-            }
-            else
+            if (dataBytes == null)
+                throw new Exception("GetBackBufferData only supports byte[]");
+
+            Debug.Assert(data.Length == (_viewport.Width * _viewport.Height * 4));
+            GL.ReadPixels(0, 0, _viewport.Width, _viewport.Height, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+
+            //In GL this is upside down (top row is the bottom row), so loop through fixing it up
+            var rowSize = _viewport.Width * 4;
+            var row = new byte[rowSize];
+            for (var y = 0; y < _viewport.Height / 2; y++)
             {
-                throw new NotImplementedException("We only know how to GetBackBufferData for byte[], not for " + typeof(T));
+                //Copy the top row out
+                Array.Copy(dataBytes, y * rowSize, row, 0, rowSize);
+                //Copy the bottom row over the top row
+                Array.Copy(dataBytes, (_viewport.Height - y - 1) * rowSize, dataBytes, y * rowSize, rowSize);
+                //Copy the backup over the bottom row
+                Array.Copy(row, 0, dataBytes, (_viewport.Height - y - 1) * rowSize, rowSize);
             }
-        }
+    }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -32,6 +32,8 @@ using FramebufferTarget = OpenTK.Graphics.ES20.All;
 using FramebufferAttachment = OpenTK.Graphics.ES20.All;
 using RenderbufferTarget = OpenTK.Graphics.ES20.All;
 using RenderbufferStorage = OpenTK.Graphics.ES20.All;
+using PixelType = OpenTK.Graphics.ES20.All;
+using PixelFormat = OpenTK.Graphics.ES20.All;
 #endif
 
 
@@ -686,7 +688,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new Exception("GetBackBufferData only supports byte[]");
 
             Debug.Assert(data.Length == (_viewport.Width * _viewport.Height * 4));
-            GL.ReadPixels(0, 0, _viewport.Width, _viewport.Height, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+            GL.ReadPixels(0, 0, _viewport.Width, _viewport.Height, PixelFormat.Rgba, PixelType.UnsignedByte, dataBytes);
 
             //In GL this is upside down (top row is the bottom row), so loop through fixing it up
             var rowSize = _viewport.Width * 4;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -680,7 +680,13 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGetBackBufferData<T>(T[] data) where T : struct
         {
+#if MONOMAC
+            var tByteSize = Marshal.SizeOf(typeof(T));
+#endif
+#if !MONOMAC
             var tByteSize = OpenTK.BlittableValueType.StrideOf(data);
+#endif
+
             Debug.Assert((data.Length * tByteSize) >= (_viewport.Width * _viewport.Height * 4));
 
             GL.ReadPixels(0, 0, _viewport.Width, _viewport.Height, PixelFormat.Rgba, PixelType.UnsignedByte, data);

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -680,28 +680,23 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGetBackBufferData<T>(T[] data) where T : struct
         {
-            //TODO: We could probably support other types
+            var tByteSize = OpenTK.BlittableValueType.StrideOf(data);
+            Debug.Assert((data.Length * tByteSize) >= (_viewport.Width * _viewport.Height * 4));
 
-            var dataBytes = data as byte[];
-
-            if (dataBytes == null)
-                throw new Exception("GetBackBufferData only supports byte[]");
-
-            Debug.Assert(data.Length == (_viewport.Width * _viewport.Height * 4));
-            GL.ReadPixels(0, 0, _viewport.Width, _viewport.Height, PixelFormat.Rgba, PixelType.UnsignedByte, dataBytes);
+            GL.ReadPixels(0, 0, _viewport.Width, _viewport.Height, PixelFormat.Rgba, PixelType.UnsignedByte, data);
 
             //In GL this is upside down (top row is the bottom row), so loop through fixing it up
-            var rowSize = _viewport.Width * 4;
-            var row = new byte[rowSize];
+            var rowSize = _viewport.Width * 4 / tByteSize;
+            var row = new T[rowSize];
             for (var y = 0; y < _viewport.Height / 2; y++)
             {
                 //Copy the top row out
-                Array.Copy(dataBytes, y * rowSize, row, 0, rowSize);
+                Array.Copy(data, y * rowSize, row, 0, rowSize);
                 //Copy the bottom row over the top row
-                Array.Copy(dataBytes, (_viewport.Height - y - 1) * rowSize, dataBytes, y * rowSize, rowSize);
+                Array.Copy(data, (_viewport.Height - y - 1) * rowSize, data, y * rowSize, rowSize);
                 //Copy the backup over the bottom row
-                Array.Copy(row, 0, dataBytes, (_viewport.Height - y - 1) * rowSize, rowSize);
+                Array.Copy(row, 0, data, (_viewport.Height - y - 1) * rowSize, rowSize);
             }
-    }
+        }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.PSM.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.PSM.cs
@@ -158,6 +158,11 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new NotImplementedException("Not implemented");
         }
 
+        private void PlatformGetBackBufferData<T>(T[] data) where T : struct
+        {
+            throw new NotImplementedException();
+        }
+
         internal PssVertexBuffer GetVertexBuffer(VertexFormat[] vertexFormat, int requiredVertexLength, int requiredIndexLength)
         {
             int bestMatchIndex = -1;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
@@ -84,6 +84,11 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new NotImplementedException();
         }
 
+        private void PlatformGetBackBufferData<T>(T[] data) where T : struct
+        {
+            throw new NotImplementedException();
+        }
+
         private static GraphicsProfile PlatformGetHighestSupportedGraphicsProfile(GraphicsDevice graphicsDevice)
         {
             return GraphicsProfile.HiDef;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -670,6 +670,11 @@ namespace Microsoft.Xna.Framework.Graphics
             PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
         }
 
+        public void GetBackBufferData<T>(T[] data) where T : struct
+        {
+            PlatformGetBackBufferData(data);
+        }
+
         private static int GetElementCountArray(PrimitiveType primitiveType, int primitiveCount)
         {
             //TODO: Overview the calculation

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -670,6 +670,11 @@ namespace Microsoft.Xna.Framework.Graphics
             PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
         }
 
+        /// <summary>
+        /// Gets the Pixel data of what is currently drawn on screen.
+        /// On OpenGL this is in BGRA format. On DirectX it is RGBA format.
+        /// </summary>
+        /// <typeparam name="T">A byte[] of size (ViewPort.Width * ViewPort.Height * 4)</typeparam>
         public void GetBackBufferData<T>(T[] data) where T : struct
         {
             PlatformGetBackBufferData(data);

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -672,7 +672,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         /// <summary>
         /// Gets the Pixel data of what is currently drawn on screen.
-        /// On OpenGL this is in BGRA format. On DirectX it is RGBA format.
+        /// On XNA/OpenGL this is in BGRA format. On DirectX/iOS/Android it is RGBA format.
         /// </summary>
         /// <typeparam name="T">A byte[] of size (ViewPort.Width * ViewPort.Height * 4)</typeparam>
         public void GetBackBufferData<T>(T[] data) where T : struct


### PR DESCRIPTION
This allows taking screenshots of your running game!

At the moment the implementation only supports byte[] data and returns the data as RGBA/BGRA 32bit, it could be extended to support more formats.
The format of the pixels differs by platform. XNA and WindowsGL return it in BGRA, WindowsDX, iOS, Android returns it in RGBA.

It should be possible to get WindowsDX to return data in the same format, but this was my first time doing DirectX programming :) (Doing a cpu side swap just so user code can undo it seems wrong)
Android and iOS image code handles RGBA data, so they aren't really an issue.

Only the simplest version of this function is implemented, there are two others which have not been included:
http://msdn.microsoft.com/en-us/library/microsoft.xna.framework.graphics.graphicsdevice.getbackbufferdata.aspx

Tested on iOS, Android, Windows(GL/DX).

I have an example for WindowsDX, WindowsGL, iOS and Android using this here:
https://github.com/danzel/WrapTest/blob/master/WrapTest/WrapTest/Game1.cs#L199-L250
It might be nice to have this example code somewhere, any suggestions?

Fixes #1885