### PR TITLE
Fix crash in DisposeAll

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsResource.cs
+++ b/MonoGame.Framework/Graphics/GraphicsResource.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             lock (resourcesLock)
             {
-                foreach (var resource in resources)
+                foreach (var resource in resources.ToArray())
                 {
                     var target = resource.Target;
                     if (target != null)


### PR DESCRIPTION
We need to copy this list as disposing items in it causes it to be modified.

This was technically broken before, but disposing resources wouldn't make them get removed from the list. It does now, so this is broken!

Refs #2375
