### PR TITLE
Remove unused code from Texture2D.DirectX and do a minor tidy up

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -5,13 +5,6 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using Microsoft.Xna.Framework.Content;
-using System.Diagnostics;
-using System.Drawing;
-
-#if WINDOWS
-using System.Drawing.Imaging;
-#endif
 
 #if WINRT
 #if WINDOWS_PHONE
@@ -20,10 +13,9 @@ using System.Windows;
 using System.Windows.Media.Imaging;
 #else
 using Windows.Graphics.Imaging;
-using Windows.UI.Xaml.Media.Imaging;
-#endif
 using Windows.Storage.Streams;
 using System.Threading.Tasks;
+#endif
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics


### PR DESCRIPTION
Fixes #2306

Removed the MONOMAC regions.
Removed the extra way to load in PlatformFromStream.
Did a minor tidy up on CreateTex2DFromBitmap / LoadBitmap (including whitespace).
Tidy up usings.

View without whitespace changes:
https://github.com/danzel/MonoGame/commit/fc379d30edd72b274c31dcf7c29a64553f4dd560?w=1
