### PR TITLE
Clamp MediaPlayer volume to [0, 1] range

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -110,14 +110,14 @@ namespace Microsoft.Xna.Framework.Media
         public static float Volume
         {
             get { return _volume; }
-			set 
-			{       
-				_volume = value;
+            set
+            {
+                _volume = MathHelper.Clamp(value, 0, 1);
 
                 PlatformSetVolume();
-			}
+            }
         }
-		
+
 		#endregion
 		
         public static void Pause()


### PR DESCRIPTION
Fixes #2362

Verified XNA behaves the same way with:

``` c#
var volBefore = MediaPlayer.Volume;
MediaPlayer.Volume = 2;
var volAfter = MediaPlayer.Volume;
MediaPlayer.Volume = float.NegativeInfinity;
var volAfter2 = MediaPlayer.Volume;
```

Without whitespace:
https://github.com/danzel/MonoGame/commit/edccac94988b64d3c12ec6409d925c8e31022541?w=1
