### PR TITLE
Fix WM_QUIT drain in TestGameBase

### DIFF
--- a/Test/Framework/TestGameBase.cs
+++ b/Test/Framework/TestGameBase.cs
@@ -310,7 +310,7 @@ namespace MonoGame.Tests {
 
 			do {
 				int result = GetMessage (out msg, IntPtr.Zero, 0, 0);
-				if (result == -1)
+				if (result == -1 || result == 0)
 					return;
 			} while (msg.msg != WM_QUIT);
 		}


### PR DESCRIPTION
According to MSDN, WM_QUIT causes GetMessage to return 0. Checking for
this fixes a hang issue when running the tests for the Windows build of MonoGame on
Windows 8.1.
