### PR TITLE
Disable the web platform from being generated by default

### DIFF
--- a/Build/Module.xml
+++ b/Build/Module.xml
@@ -4,8 +4,8 @@
   <ModuleAssemblies />
   <DefaultAction>Generate</DefaultAction>
   <SupportedPlatforms>Android,Linux,Ouya,PSMobile,Windows8,Windows,WindowsGL,WindowsPhone,iOS,MacOS,Web</SupportedPlatforms>
-  <DefaultWindowsPlatforms>Android,Linux,Ouya,PSMobile,Windows8,Windows,WindowsGL,WindowsPhone,iOS,Web</DefaultWindowsPlatforms>
-  <DefaultMacOSPlatforms>MacOS,iOS,WindowsGL,Android,Web</DefaultMacOSPlatforms>
-  <DefaultLinuxPlatforms>Linux,WindowsGL,Web</DefaultLinuxPlatforms>
+  <DefaultWindowsPlatforms>Android,Linux,Ouya,PSMobile,Windows8,Windows,WindowsGL,WindowsPhone,iOS</DefaultWindowsPlatforms>
+  <DefaultMacOSPlatforms>MacOS,iOS,WindowsGL,Android</DefaultMacOSPlatforms>
+  <DefaultLinuxPlatforms>Linux,WindowsGL</DefaultLinuxPlatforms>
   <DisableSynchronisation>true</DisableSynchronisation>
 </ModuleInfo>


### PR DESCRIPTION
This "fixes" #2390 by preventing it from being generated by default.  The web platform is probably something that people will want to opt-in to anyway, so we don't necessarily want to add it back as a default again (especially since the Web platform triggers downloading and building JSIL).
