### PR TITLE
Remove new VectorX usage in static (out VectorX) methods

### DIFF
--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -122,9 +122,8 @@ namespace Microsoft.Xna.Framework
 
         public static void Barycentric(ref Vector2 value1, ref Vector2 value2, ref Vector2 value3, float amount1, float amount2, out Vector2 result)
         {
-            result = new Vector2(
-                MathHelper.Barycentric(value1.X, value2.X, value3.X, amount1, amount2),
-                MathHelper.Barycentric(value1.Y, value2.Y, value3.Y, amount1, amount2));
+            result.X = MathHelper.Barycentric(value1.X, value2.X, value3.X, amount1, amount2);
+            result.Y = MathHelper.Barycentric(value1.Y, value2.Y, value3.Y, amount1, amount2);
         }
 
         public static Vector2 CatmullRom(Vector2 value1, Vector2 value2, Vector2 value3, Vector2 value4, float amount)
@@ -136,9 +135,8 @@ namespace Microsoft.Xna.Framework
 
         public static void CatmullRom(ref Vector2 value1, ref Vector2 value2, ref Vector2 value3, ref Vector2 value4, float amount, out Vector2 result)
         {
-            result = new Vector2(
-                MathHelper.CatmullRom(value1.X, value2.X, value3.X, value4.X, amount),
-                MathHelper.CatmullRom(value1.Y, value2.Y, value3.Y, value4.Y, amount));
+            result.X = MathHelper.CatmullRom(value1.X, value2.X, value3.X, value4.X, amount);
+            result.Y = MathHelper.CatmullRom(value1.Y, value2.Y, value3.Y, value4.Y, amount);
         }
 
         public static Vector2 Clamp(Vector2 value1, Vector2 min, Vector2 max)
@@ -150,9 +148,8 @@ namespace Microsoft.Xna.Framework
 
         public static void Clamp(ref Vector2 value1, ref Vector2 min, ref Vector2 max, out Vector2 result)
         {
-            result = new Vector2(
-                MathHelper.Clamp(value1.X, min.X, max.X),
-                MathHelper.Clamp(value1.Y, min.Y, max.Y));
+            result.X = MathHelper.Clamp(value1.X, min.X, max.X);
+            result.Y = MathHelper.Clamp(value1.Y, min.Y, max.Y);
         }
 
         public static float Distance(Vector2 value1, Vector2 value2)
@@ -285,9 +282,8 @@ namespace Microsoft.Xna.Framework
 
         public static void Lerp(ref Vector2 value1, ref Vector2 value2, float amount, out Vector2 result)
         {
-            result = new Vector2(
-                MathHelper.Lerp(value1.X, value2.X, amount),
-                MathHelper.Lerp(value1.Y, value2.Y, amount));
+            result.X = MathHelper.Lerp(value1.X, value2.X, amount);
+            result.Y = MathHelper.Lerp(value1.Y, value2.Y, amount);
         }
 
         public static Vector2 Max(Vector2 value1, Vector2 value2)
@@ -384,9 +380,8 @@ namespace Microsoft.Xna.Framework
 
         public static void SmoothStep(ref Vector2 value1, ref Vector2 value2, float amount, out Vector2 result)
         {
-            result = new Vector2(
-                MathHelper.SmoothStep(value1.X, value2.X, amount),
-                MathHelper.SmoothStep(value1.Y, value2.Y, amount));
+            result.X = MathHelper.SmoothStep(value1.X, value2.X, amount);
+            result.Y = MathHelper.SmoothStep(value1.Y, value2.Y, amount);
         }
 
         public static Vector2 Subtract(Vector2 value1, Vector2 value2)
@@ -410,8 +405,10 @@ namespace Microsoft.Xna.Framework
 
         public static void Transform(ref Vector2 position, ref Matrix matrix, out Vector2 result)
         {
-            result = new Vector2((position.X * matrix.M11) + (position.Y * matrix.M21) + matrix.M41,
-                                 (position.X * matrix.M12) + (position.Y * matrix.M22) + matrix.M42);
+            var x = (position.X * matrix.M11) + (position.Y * matrix.M21) + matrix.M41;
+            var y = (position.X * matrix.M12) + (position.Y * matrix.M22) + matrix.M42;
+            result.X = x;
+            result.Y = y;
         }
 
         public static Vector2 Transform(Vector2 position, Quaternion quat)
@@ -427,7 +424,8 @@ namespace Microsoft.Xna.Framework
             Quaternion.Multiply(ref quat, ref v, out t);
             Quaternion.Multiply(ref t, ref i, out v);
 
-            result = new Vector2(v.X, v.Y);
+            result.X = v.X;
+            result.Y = v.Y;
         }
 		
 		public static void Transform (
@@ -464,8 +462,10 @@ namespace Microsoft.Xna.Framework
 
         public static void TransformNormal(ref Vector2 normal, ref Matrix matrix, out Vector2 result)
         {
-            result = new Vector2((normal.X * matrix.M11) + (normal.Y * matrix.M21),
-                                 (normal.X * matrix.M12) + (normal.Y * matrix.M22));
+            var x = (normal.X * matrix.M11) + (normal.Y * matrix.M21);
+            var y = (normal.X * matrix.M12) + (normal.Y * matrix.M22);
+            result.X = x;
+            result.Y = y;
         }
 
         public override string ToString()

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -183,10 +183,9 @@ namespace Microsoft.Xna.Framework
 
         public static void Barycentric(ref Vector3 value1, ref Vector3 value2, ref Vector3 value3, float amount1, float amount2, out Vector3 result)
         {
-            result = new Vector3(
-                MathHelper.Barycentric(value1.X, value2.X, value3.X, amount1, amount2),
-                MathHelper.Barycentric(value1.Y, value2.Y, value3.Y, amount1, amount2),
-                MathHelper.Barycentric(value1.Z, value2.Z, value3.Z, amount1, amount2));
+            result.X = MathHelper.Barycentric(value1.X, value2.X, value3.X, amount1, amount2);
+            result.Y = MathHelper.Barycentric(value1.Y, value2.Y, value3.Y, amount1, amount2);
+            result.Z = MathHelper.Barycentric(value1.Z, value2.Z, value3.Z, amount1, amount2);
         }
 
         public static Vector3 CatmullRom(Vector3 value1, Vector3 value2, Vector3 value3, Vector3 value4, float amount)
@@ -199,10 +198,9 @@ namespace Microsoft.Xna.Framework
 
         public static void CatmullRom(ref Vector3 value1, ref Vector3 value2, ref Vector3 value3, ref Vector3 value4, float amount, out Vector3 result)
         {
-            result = new Vector3(
-                MathHelper.CatmullRom(value1.X, value2.X, value3.X, value4.X, amount),
-                MathHelper.CatmullRom(value1.Y, value2.Y, value3.Y, value4.Y, amount),
-                MathHelper.CatmullRom(value1.Z, value2.Z, value3.Z, value4.Z, amount));
+            result.X = MathHelper.CatmullRom(value1.X, value2.X, value3.X, value4.X, amount);
+            result.Y = MathHelper.CatmullRom(value1.Y, value2.Y, value3.Y, value4.Y, amount);
+            result.Z = MathHelper.CatmullRom(value1.Z, value2.Z, value3.Z, value4.Z, amount);
         }
 
         public static Vector3 Clamp(Vector3 value1, Vector3 min, Vector3 max)
@@ -215,10 +213,9 @@ namespace Microsoft.Xna.Framework
 
         public static void Clamp(ref Vector3 value1, ref Vector3 min, ref Vector3 max, out Vector3 result)
         {
-            result = new Vector3(
-                MathHelper.Clamp(value1.X, min.X, max.X),
-                MathHelper.Clamp(value1.Y, min.Y, max.Y),
-                MathHelper.Clamp(value1.Z, min.Z, max.Z));
+            result.X = MathHelper.Clamp(value1.X, min.X, max.X);
+            result.Y = MathHelper.Clamp(value1.Y, min.Y, max.Y);
+            result.Z = MathHelper.Clamp(value1.Z, min.Z, max.Z);
         }
 
         public static Vector3 Cross(Vector3 vector1, Vector3 vector2)
@@ -229,9 +226,12 @@ namespace Microsoft.Xna.Framework
 
         public static void Cross(ref Vector3 vector1, ref Vector3 vector2, out Vector3 result)
         {
-            result = new Vector3(vector1.Y * vector2.Z - vector2.Y * vector1.Z,
-                                 -(vector1.X * vector2.Z - vector2.X * vector1.Z),
-                                 vector1.X * vector2.Y - vector2.X * vector1.Y);
+            var x = vector1.Y * vector2.Z - vector2.Y * vector1.Z;
+            var y = -(vector1.X * vector2.Z - vector2.X * vector1.Z);
+            var z = vector1.X * vector2.Y - vector2.X * vector1.Y;
+            result.X = x;
+            result.Y = y;
+            result.Z = z;
         }
 
         public static float Distance(Vector3 vector1, Vector3 vector2)
@@ -364,12 +364,11 @@ namespace Microsoft.Xna.Framework
 
         public static void Lerp(ref Vector3 value1, ref Vector3 value2, float amount, out Vector3 result)
         {
-            result = new Vector3(
-                MathHelper.Lerp(value1.X, value2.X, amount),
-                MathHelper.Lerp(value1.Y, value2.Y, amount),
-                MathHelper.Lerp(value1.Z, value2.Z, amount));
+            result.X = MathHelper.Lerp(value1.X, value2.X, amount);
+            result.Y = MathHelper.Lerp(value1.Y, value2.Y, amount);
+            result.Z = MathHelper.Lerp(value1.Z, value2.Z, amount);
         }
-                
+
         public static Vector3 Max(Vector3 value1, Vector3 value2)
         {
             return new Vector3(
@@ -380,10 +379,9 @@ namespace Microsoft.Xna.Framework
 
         public static void Max(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
         {
-            result = new Vector3(
-                MathHelper.Max(value1.X, value2.X),
-                MathHelper.Max(value1.Y, value2.Y),
-                MathHelper.Max(value1.Z, value2.Z));
+            result.X = MathHelper.Max(value1.X, value2.X);
+            result.Y = MathHelper.Max(value1.Y, value2.Y);
+            result.Z = MathHelper.Max(value1.Z, value2.Z);
         }
 
         public static Vector3 Min(Vector3 value1, Vector3 value2)
@@ -396,10 +394,9 @@ namespace Microsoft.Xna.Framework
 
         public static void Min(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
         {
-            result = new Vector3(
-                MathHelper.Min(value1.X, value2.X),
-                MathHelper.Min(value1.Y, value2.Y),
-                MathHelper.Min(value1.Z, value2.Z));
+            result.X = MathHelper.Min(value1.X, value2.X);
+            result.Y = MathHelper.Min(value1.Y, value2.Y);
+            result.Z = MathHelper.Min(value1.Z, value2.Z);
         }
 
         public static Vector3 Multiply(Vector3 value1, Vector3 value2)
@@ -440,7 +437,9 @@ namespace Microsoft.Xna.Framework
 
         public static void Negate(ref Vector3 value, out Vector3 result)
         {
-            result = new Vector3(-value.X, -value.Y, -value.Z);
+            result.X = -value.X;
+            result.Y = -value.Y;
+            result.Z = -value.Z;
         }
 
         public void Normalize()
@@ -464,35 +463,34 @@ namespace Microsoft.Xna.Framework
             result.Z = value.Z * factor;
         }
 
-	public static Vector3 Reflect(Vector3 vector, Vector3 normal)
-	{
-		// I is the original array
-		// N is the normal of the incident plane
-		// R = I - (2 * N * ( DotProduct[ I,N] ))
-		Vector3 reflectedVector;
-		// inline the dotProduct here instead of calling method
-		float dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
-		reflectedVector.X = vector.X - (2.0f * normal.X) * dotProduct;
-		reflectedVector.Y = vector.Y - (2.0f * normal.Y) * dotProduct;
-		reflectedVector.Z = vector.Z - (2.0f * normal.Z) * dotProduct;
+        public static Vector3 Reflect(Vector3 vector, Vector3 normal)
+        {
+            // I is the original array
+            // N is the normal of the incident plane
+            // R = I - (2 * N * ( DotProduct[ I,N] ))
+            Vector3 reflectedVector;
+            // inline the dotProduct here instead of calling method
+            float dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
+            reflectedVector.X = vector.X - (2.0f * normal.X) * dotProduct;
+            reflectedVector.Y = vector.Y - (2.0f * normal.Y) * dotProduct;
+            reflectedVector.Z = vector.Z - (2.0f * normal.Z) * dotProduct;
 
-		return reflectedVector;
-	}
+            return reflectedVector;
+        }
 
-	public static void Reflect(ref Vector3 vector, ref Vector3 normal, out Vector3 result)
-	{
-		// I is the original array
-		// N is the normal of the incident plane
-		// R = I - (2 * N * ( DotProduct[ I,N] ))
+        public static void Reflect(ref Vector3 vector, ref Vector3 normal, out Vector3 result)
+        {
+            // I is the original array
+            // N is the normal of the incident plane
+            // R = I - (2 * N * ( DotProduct[ I,N] ))
 
-		// inline the dotProduct here instead of calling method
-		float dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
-		result.X = vector.X - (2.0f * normal.X) * dotProduct;
-		result.Y = vector.Y - (2.0f * normal.Y) * dotProduct;
-		result.Z = vector.Z - (2.0f * normal.Z) * dotProduct;
+            // inline the dotProduct here instead of calling method
+            float dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
+            result.X = vector.X - (2.0f * normal.X) * dotProduct;
+            result.Y = vector.Y - (2.0f * normal.Y) * dotProduct;
+            result.Z = vector.Z - (2.0f * normal.Z) * dotProduct;
+        }
 
-	}
-		
         public static Vector3 SmoothStep(Vector3 value1, Vector3 value2, float amount)
         {
             return new Vector3(
@@ -503,10 +501,9 @@ namespace Microsoft.Xna.Framework
 
         public static void SmoothStep(ref Vector3 value1, ref Vector3 value2, float amount, out Vector3 result)
         {
-            result = new Vector3(
-                MathHelper.SmoothStep(value1.X, value2.X, amount),
-                MathHelper.SmoothStep(value1.Y, value2.Y, amount),
-                MathHelper.SmoothStep(value1.Z, value2.Z, amount));
+            result.X = MathHelper.SmoothStep(value1.X, value2.X, amount);
+            result.Y = MathHelper.SmoothStep(value1.Y, value2.Y, amount);
+            result.Z = MathHelper.SmoothStep(value1.Z, value2.Z, amount);
         }
 
         public static Vector3 Subtract(Vector3 value1, Vector3 value2)
@@ -545,9 +542,12 @@ namespace Microsoft.Xna.Framework
 
         public static void Transform(ref Vector3 position, ref Matrix matrix, out Vector3 result)
         {
-            result = new Vector3((position.X * matrix.M11) + (position.Y * matrix.M21) + (position.Z * matrix.M31) + matrix.M41,
-                                 (position.X * matrix.M12) + (position.Y * matrix.M22) + (position.Z * matrix.M32) + matrix.M42,
-                                 (position.X * matrix.M13) + (position.Y * matrix.M23) + (position.Z * matrix.M33) + matrix.M43);
+            var x = (position.X * matrix.M11) + (position.Y * matrix.M21) + (position.Z * matrix.M31) + matrix.M41;
+            var y = (position.X * matrix.M12) + (position.Y * matrix.M22) + (position.Z * matrix.M32) + matrix.M42;
+            var z = (position.X * matrix.M13) + (position.Y * matrix.M23) + (position.Z * matrix.M33) + matrix.M43;
+            result.X = x;
+            result.Y = y;
+            result.Z = z;
         }
 
         public static void Transform(Vector3[] sourceArray, ref Matrix matrix, Vector3[] destinationArray)
@@ -708,9 +708,12 @@ namespace Microsoft.Xna.Framework
 
         public static void TransformNormal(ref Vector3 normal, ref Matrix matrix, out Vector3 result)
         {
-            result = new Vector3((normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31),
-                                 (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32),
-                                 (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33));
+            var x = (normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31);
+            var y = (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32);
+            var z = (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33);
+            result.X = x;
+            result.Y = y;
+            result.Z = z;
         }
 
         #endregion Public methods

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -140,19 +140,19 @@ namespace Microsoft.Xna.Framework
 
         public static Vector4 Add(Vector4 value1, Vector4 value2)
         {
-            value1.W += value2.W;
             value1.X += value2.X;
             value1.Y += value2.Y;
             value1.Z += value2.Z;
+            value1.W += value2.W;
             return value1;
         }
 
         public static void Add(ref Vector4 value1, ref Vector4 value2, out Vector4 result)
         {
-            result.W = value1.W + value2.W;
             result.X = value1.X + value2.X;
             result.Y = value1.Y + value2.Y;
             result.Z = value1.Z + value2.Z;
+            result.W = value1.W + value2.W;
         }
 
         public static Vector4 Barycentric(Vector4 value1, Vector4 value2, Vector4 value3, float amount1, float amount2)
@@ -175,17 +175,14 @@ namespace Microsoft.Xna.Framework
         public static void Barycentric(ref Vector4 value1, ref Vector4 value2, ref Vector4 value3, float amount1, float amount2, out Vector4 result)
         {
 #if(USE_FARSEER)
-            result = new Vector4(
-                SilverSpriteMathHelper.Barycentric(value1.X, value2.X, value3.X, amount1, amount2),
-                SilverSpriteMathHelper.Barycentric(value1.Y, value2.Y, value3.Y, amount1, amount2),
-                SilverSpriteMathHelper.Barycentric(value1.Z, value2.Z, value3.Z, amount1, amount2),
-                SilverSpriteMathHelper.Barycentric(value1.W, value2.W, value3.W, amount1, amount2));
+            result.X = SilverSpriteMathHelper.Barycentric(value1.X, value2.X, value3.X, amount1, amount2);
+            result.Y = SilverSpriteMathHelper.Barycentric(value1.Y, value2.Y, value3.Y, amount1, amount2);
+            result.Z = SilverSpriteMathHelper.Barycentric(value1.Z, value2.Z, value3.Z, amount1, amount2);            result.W = SilverSpriteMathHelper.Barycentric(value1.W, value2.W, value3.W, amount1, amount2);
 #else
-            result = new Vector4(
-                MathHelper.Barycentric(value1.X, value2.X, value3.X, amount1, amount2),
-                MathHelper.Barycentric(value1.Y, value2.Y, value3.Y, amount1, amount2),
-                MathHelper.Barycentric(value1.Z, value2.Z, value3.Z, amount1, amount2),
-                MathHelper.Barycentric(value1.W, value2.W, value3.W, amount1, amount2));
+            result.X = MathHelper.Barycentric(value1.X, value2.X, value3.X, amount1, amount2);
+            result.Y = MathHelper.Barycentric(value1.Y, value2.Y, value3.Y, amount1, amount2);
+            result.Z = MathHelper.Barycentric(value1.Z, value2.Z, value3.Z, amount1, amount2);
+            result.W = MathHelper.Barycentric(value1.W, value2.W, value3.W, amount1, amount2);
 #endif
         }
 
@@ -209,17 +206,15 @@ namespace Microsoft.Xna.Framework
         public static void CatmullRom(ref Vector4 value1, ref Vector4 value2, ref Vector4 value3, ref Vector4 value4, float amount, out Vector4 result)
         {
 #if(USE_FARSEER)
-            result = new Vector4(
-                SilverSpriteMathHelper.CatmullRom(value1.X, value2.X, value3.X, value4.X, amount),
-                SilverSpriteMathHelper.CatmullRom(value1.Y, value2.Y, value3.Y, value4.Y, amount),
-                SilverSpriteMathHelper.CatmullRom(value1.Z, value2.Z, value3.Z, value4.Z, amount),
-                SilverSpriteMathHelper.CatmullRom(value1.W, value2.W, value3.W, value4.W, amount));
+            result.X = SilverSpriteMathHelper.CatmullRom(value1.X, value2.X, value3.X, value4.X, amount);
+            result.Y = SilverSpriteMathHelper.CatmullRom(value1.Y, value2.Y, value3.Y, value4.Y, amount);
+            result.Z = SilverSpriteMathHelper.CatmullRom(value1.Z, value2.Z, value3.Z, value4.Z, amount);
+            result.W = SilverSpriteMathHelper.CatmullRom(value1.W, value2.W, value3.W, value4.W, amount);
 #else
-            result = new Vector4(
-                MathHelper.CatmullRom(value1.X, value2.X, value3.X, value4.X, amount),
-                MathHelper.CatmullRom(value1.Y, value2.Y, value3.Y, value4.Y, amount),
-                MathHelper.CatmullRom(value1.Z, value2.Z, value3.Z, value4.Z, amount),
-                MathHelper.CatmullRom(value1.W, value2.W, value3.W, value4.W, amount));
+            result.X = MathHelper.CatmullRom(value1.X, value2.X, value3.X, value4.X, amount);
+            result.Y = MathHelper.CatmullRom(value1.Y, value2.Y, value3.Y, value4.Y, amount);
+            result.Z = MathHelper.CatmullRom(value1.Z, value2.Z, value3.Z, value4.Z, amount);
+            result.W = MathHelper.CatmullRom(value1.W, value2.W, value3.W, value4.W, amount);
 #endif
         }
 
@@ -234,11 +229,10 @@ namespace Microsoft.Xna.Framework
 
         public static void Clamp(ref Vector4 value1, ref Vector4 min, ref Vector4 max, out Vector4 result)
         {
-            result = new Vector4(
-                MathHelper.Clamp(value1.X, min.X, max.X),
-                MathHelper.Clamp(value1.Y, min.Y, max.Y),
-                MathHelper.Clamp(value1.Z, min.Z, max.Z),
-                MathHelper.Clamp(value1.W, min.W, max.W));
+            result.X = MathHelper.Clamp(value1.X, min.X, max.X);
+            result.Y = MathHelper.Clamp(value1.Y, min.Y, max.Y);
+            result.Z = MathHelper.Clamp(value1.Z, min.Z, max.Z);
+            result.W = MathHelper.Clamp(value1.W, min.W, max.W);
         }
 
         public static float Distance(Vector4 value1, Vector4 value2)
@@ -377,11 +371,10 @@ namespace Microsoft.Xna.Framework
 
         public static void Lerp(ref Vector4 value1, ref Vector4 value2, float amount, out Vector4 result)
         {
-            result = new Vector4(
-                MathHelper.Lerp(value1.X, value2.X, amount),
-                MathHelper.Lerp(value1.Y, value2.Y, amount),
-                MathHelper.Lerp(value1.Z, value2.Z, amount),
-                MathHelper.Lerp(value1.W, value2.W, amount));
+            result.X = MathHelper.Lerp(value1.X, value2.X, amount);
+            result.Y = MathHelper.Lerp(value1.Y, value2.Y, amount);
+            result.Z = MathHelper.Lerp(value1.Z, value2.Z, amount);
+            result.W = MathHelper.Lerp(value1.W, value2.W, amount);
         }
 
         public static Vector4 Max(Vector4 value1, Vector4 value2)
@@ -395,11 +388,10 @@ namespace Microsoft.Xna.Framework
 
         public static void Max(ref Vector4 value1, ref Vector4 value2, out Vector4 result)
         {
-            result = new Vector4(
-               MathHelper.Max(value1.X, value2.X),
-               MathHelper.Max(value1.Y, value2.Y),
-               MathHelper.Max(value1.Z, value2.Z),
-               MathHelper.Max(value1.W, value2.W));
+            result.X = MathHelper.Max(value1.X, value2.X);
+            result.Y = MathHelper.Max(value1.Y, value2.Y);
+            result.Z = MathHelper.Max(value1.Z, value2.Z);
+            result.W = MathHelper.Max(value1.W, value2.W);
         }
 
         public static Vector4 Min(Vector4 value1, Vector4 value2)
@@ -413,11 +405,10 @@ namespace Microsoft.Xna.Framework
 
         public static void Min(ref Vector4 value1, ref Vector4 value2, out Vector4 result)
         {
-            result = new Vector4(
-               MathHelper.Min(value1.X, value2.X),
-               MathHelper.Min(value1.Y, value2.Y),
-               MathHelper.Min(value1.Z, value2.Z),
-               MathHelper.Min(value1.W, value2.W));
+            result.X = MathHelper.Min(value1.X, value2.X);
+            result.Y = MathHelper.Min(value1.Y, value2.Y);
+            result.Z = MathHelper.Min(value1.Z, value2.Z);
+            result.W = MathHelper.Min(value1.W, value2.W);
         }
 
         public static Vector4 Multiply(Vector4 value1, Vector4 value2)
@@ -462,7 +453,10 @@ namespace Microsoft.Xna.Framework
 
         public static void Negate(ref Vector4 value, out Vector4 result)
         {
-            result = new Vector4(-value.X, -value.Y, -value.Z,-value.W);
+            result.X = -value.X;
+            result.Y = -value.Y;
+            result.Z = -value.Z;
+            result.W = -value.W;
         }
 
         public void Normalize()
@@ -508,17 +502,15 @@ namespace Microsoft.Xna.Framework
         public static void SmoothStep(ref Vector4 value1, ref Vector4 value2, float amount, out Vector4 result)
         {
 #if(USE_FARSEER)
-            result = new Vector4(
-                SilverSpriteMathHelper.SmoothStep(value1.X, value2.X, amount),
-                SilverSpriteMathHelper.SmoothStep(value1.Y, value2.Y, amount),
-                SilverSpriteMathHelper.SmoothStep(value1.Z, value2.Z, amount),
-                SilverSpriteMathHelper.SmoothStep(value1.W, value2.W, amount));
+            result.X = SilverSpriteMathHelper.SmoothStep(value1.X, value2.X, amount);
+            result.Y = SilverSpriteMathHelper.SmoothStep(value1.Y, value2.Y, amount);
+            result.Z = SilverSpriteMathHelper.SmoothStep(value1.Z, value2.Z, amount);
+            result.W = SilverSpriteMathHelper.SmoothStep(value1.W, value2.W, amount);
 #else
-            result = new Vector4(
-                MathHelper.SmoothStep(value1.X, value2.X, amount),
-                MathHelper.SmoothStep(value1.Y, value2.Y, amount),
-                MathHelper.SmoothStep(value1.Z, value2.Z, amount),
-                MathHelper.SmoothStep(value1.W, value2.W, amount));
+            result.X = MathHelper.SmoothStep(value1.X, value2.X, amount);
+            result.Y = MathHelper.SmoothStep(value1.Y, value2.Y, amount);
+            result.Z = MathHelper.SmoothStep(value1.Z, value2.Z, amount);
+            result.W = MathHelper.SmoothStep(value1.W, value2.W, amount);
 #endif
         }
 
@@ -561,26 +553,30 @@ namespace Microsoft.Xna.Framework
 
         public static void Transform(ref Vector2 position, ref Matrix matrix, out Vector4 result)
         {
-            result = new Vector4((position.X * matrix.M11) + (position.Y * matrix.M21) + matrix.M41,
-                                 (position.X * matrix.M12) + (position.Y * matrix.M22) + matrix.M42,
-                                 (position.X * matrix.M13) + (position.Y * matrix.M23) + matrix.M43,
-                                 (position.X * matrix.M14) + (position.Y * matrix.M24) + matrix.M44);
+            result.X = (position.X * matrix.M11) + (position.Y * matrix.M21) + matrix.M41;
+            result.Y = (position.X * matrix.M12) + (position.Y * matrix.M22) + matrix.M42;
+            result.Z = (position.X * matrix.M13) + (position.Y * matrix.M23) + matrix.M43;
+            result.W = (position.X * matrix.M14) + (position.Y * matrix.M24) + matrix.M44;
         }
 
         public static void Transform(ref Vector3 position, ref Matrix matrix, out Vector4 result)
         {
-            result = new Vector4((position.X * matrix.M11) + (position.Y * matrix.M21) + (position.Z * matrix.M31) + matrix.M41,
-                                 (position.X * matrix.M12) + (position.Y * matrix.M22) + (position.Z * matrix.M32) + matrix.M42,
-                                 (position.X * matrix.M13) + (position.Y * matrix.M23) + (position.Z * matrix.M33) + matrix.M43,
-                                 (position.X * matrix.M14) + (position.Y * matrix.M24) + (position.Z * matrix.M34) + matrix.M44);
+            result.X = (position.X * matrix.M11) + (position.Y * matrix.M21) + (position.Z * matrix.M31) + matrix.M41;
+            result.Y = (position.X * matrix.M12) + (position.Y * matrix.M22) + (position.Z * matrix.M32) + matrix.M42;
+            result.Z = (position.X * matrix.M13) + (position.Y * matrix.M23) + (position.Z * matrix.M33) + matrix.M43;
+            result.W = (position.X * matrix.M14) + (position.Y * matrix.M24) + (position.Z * matrix.M34) + matrix.M44;
         }
 
         public static void Transform(ref Vector4 vector, ref Matrix matrix, out Vector4 result)
         {
-            result = new Vector4((vector.X * matrix.M11) + (vector.Y * matrix.M21) + (vector.Z * matrix.M31) + (vector.W * matrix.M41),
-                                 (vector.X * matrix.M12) + (vector.Y * matrix.M22) + (vector.Z * matrix.M32) + (vector.W * matrix.M42),
-                                 (vector.X * matrix.M13) + (vector.Y * matrix.M23) + (vector.Z * matrix.M33) + (vector.W * matrix.M43),
-                                 (vector.X * matrix.M14) + (vector.Y * matrix.M24) + (vector.Z * matrix.M34) + (vector.W * matrix.M44));
+            var x = (vector.X * matrix.M11) + (vector.Y * matrix.M21) + (vector.Z * matrix.M31) + (vector.W * matrix.M41);
+            var y = (vector.X * matrix.M12) + (vector.Y * matrix.M22) + (vector.Z * matrix.M32) + (vector.W * matrix.M42);
+            var z = (vector.X * matrix.M13) + (vector.Y * matrix.M23) + (vector.Z * matrix.M33) + (vector.W * matrix.M43);
+            var w = (vector.X * matrix.M14) + (vector.Y * matrix.M24) + (vector.Z * matrix.M34) + (vector.W * matrix.M44);
+            result.X = x;
+            result.Y = y;
+            result.Z = z;
+            result.W = w;
         }
 
         public override string ToString()


### PR DESCRIPTION
Change all VectorX static methods with `out VectorX` parameters to directly assign the fields rather than constructing new VectorXs.

`Vector3.Reflect` had the wrong spacing, fixed.
`Vector4` must have had wrong line endings, sorry.

Whitespace free diff (needed for `Vector4`)
https://github.com/danzel/MonoGame/commit/36b4c5edaf4417f80ac57270f0a7ba7e3fcfefc6?w=1

When doing this I had to be careful not to always just assign to the output object. In cases where we use one of the values to calculate another (use X to calculate Y), we must not change X until all of the calculations are done as the objects may be referencing the same object.

A good example of this is `Vector2.Transform`:
https://github.com/danzel/MonoGame/commit/36b4c5edaf4417f80ac57270f0a7ba7e3fcfefc6?w=1#diff-98c66ffb85bd2f51034c56bffda1119fL411
position and result could reference the same object, so we cannot assign result.X immediately or it would change the calculation of Y.
This is not normally necessary and leads to extra code, as such is only done when required.

Fixes #1611
