### PR TITLE
Don't grab a copy of the render targets array just to check length. 

### DIFF
--- a/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Xna.Framework.Graphics
         internal void PlatformApplyState(GraphicsDevice device)
         {
             // When rendering offscreen the faces change order.
-            var offscreen = device.GetRenderTargets().Length > 0;
+            var offscreen = device.IsRenderTargetBound;
 
             if (CullMode == CullMode.None)
             {


### PR DESCRIPTION
Issue was pointed out by @EugenyN in #2360
