### PR TITLE
Followup To #2104

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Pipeline.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Pipeline.targets
@@ -41,7 +41,7 @@
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">obj\$(Platform)\$(Configuration)</IntermediateOutputPath>
     
     <ContentResponseFile>$(IntermediateOutputPath)\mgcontent.txt</ContentResponseFile>	
-    <MonoGameContentBuilderExe>$(MSBuildExtensionsPath)\MonoGame\v3.0\MGCB.exe</MonoGameContentBuilderExe>
+    <MonoGameContentBuilderExe>$(MSBuildProgramFiles32)\MonoGame\v3.0\MGCB.exe</MonoGameContentBuilderExe>
     <MonoGamePlatform Condition="'$(MonoGamePlatform)' == ''">Windows</MonoGamePlatform>
 
     <AssemblySearchPaths>

--- a/ProjectTemplates/VisualStudio2010/Content/Builder/Builder.csproj
+++ b/ProjectTemplates/VisualStudio2010/Content/Builder/Builder.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-  <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.ContentPipeline.targets" />
+  <Import Project="$(MSBuildProgramFiles32)\MonoGame\v3.0\MonoGame.ContentPipeline.targets" />
   <PropertyGroup>
     <ProjectGuid>$guid1$</ProjectGuid>
     <ProjectTypeGuids>{6D335F3A-9D43-41b4-9D22-F6F17C4BE596};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/ProjectTemplates/VisualStudio2010/Content/Content/Content.contentproj
+++ b/ProjectTemplates/VisualStudio2010/Content/Content/Content.contentproj
@@ -44,7 +44,7 @@
     <Reference Include="Microsoft.Xna.Framework.Content.Pipeline.AudioImporters" />
     <Reference Include="Microsoft.Xna.Framework.Content.Pipeline.VideoImporters" />
     <Reference Include="MonoGameContentProcessors">
-      <HintPath>$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGameContentProcessors.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\MonoGame\v3.0\MonoGameContentProcessors.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixed the remaining uses of `$(MSBuildExtensionsPath)` as explained in #2104.
