### PR TITLE
Fix SoundEffectInstance Properties

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal bool _IsPooled = true;
 
-        private float _pan = 0.0f;
-        private float _volume = 1.0f;
-        private float _pitch = 0.0f;
+        private float _pan;
+        private float _volume;
+        private float _pitch;
 
         public bool IsLooped
         { 
@@ -36,6 +36,7 @@ namespace Microsoft.Xna.Framework.Audio
                     throw new ArgumentOutOfRangeException();
 
                 PlatformSetPan(value);
+                _pan = value;
             }
         }
 
@@ -48,6 +49,7 @@ namespace Microsoft.Xna.Framework.Audio
                     throw new ArgumentOutOfRangeException();
 
                 PlatformSetPitch(value);
+                _pitch = value;
             }
         }
 
@@ -60,6 +62,7 @@ namespace Microsoft.Xna.Framework.Audio
                     throw new ArgumentOutOfRangeException();
 
                 PlatformSetVolume(value);
+                _volume = value;
             }
         }
 
@@ -67,12 +70,18 @@ namespace Microsoft.Xna.Framework.Audio
 
         public bool IsDisposed { get { return isDisposed; } }
 
-        internal SoundEffectInstance(){}
+        internal SoundEffectInstance()
+        {
+            _pan = 0.0f;
+            _volume = 1.0f;
+            _pitch = 0.0f;            
+        }
         
         /// <summary>
         /// Creates a standalone SoundEffectInstance from given wavedata.
         /// </summary>
         internal SoundEffectInstance(byte[] buffer, int sampleRate, int channels)
+            : base()
         {
             PlatformInitialize(buffer, sampleRate, channels);
         }


### PR DESCRIPTION
The volume, pitch, and pan were not being set consistently across all platforms.  This ensures the set/get always works correctly regardless of what the platform implementations do.  Based on #2408.
