### PR TITLE
AllowAltF4 - bug fix

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameForm.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameForm.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Xna.Framework.Windows
 
                     var wParam = m.WParam.ToInt32();
 
-                    if (!AllowAltF4 && wParam == 0xF060 && m.LParam.ToInt32() == 0)
+                    if (!AllowAltF4 && wParam == 0xF060 && m.LParam.ToInt32() == 0 && Focused)
                     {
                         m.Result = IntPtr.Zero;
                         return;

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -282,9 +282,9 @@ namespace MonoGame.Framework
                     break;
             }
 
-            if (args.State == SharpDX.RawInput.KeyState.KeyDown && !KeyState.Contains(xnaKey))
+            if ((args.State == SharpDX.RawInput.KeyState.KeyDown || args.State == SharpDX.RawInput.KeyState.SystemKeyDown) && !KeyState.Contains(xnaKey))
                 KeyState.Add(xnaKey);
-            else if (args.State == SharpDX.RawInput.KeyState.KeyUp)
+            else if (args.State == SharpDX.RawInput.KeyState.KeyUp || args.State == SharpDX.RawInput.KeyState.SystemKeyUp)
                 KeyState.Remove(xnaKey);
         }
 


### PR DESCRIPTION
AllowAltF4 seems not worked completely correctly on WindowsDX platform - this would fix it and will equate its behaviour to WindowsGL version. Also this request added possibility to use Alt(ex -keyboardState.IsKeyDown(Keys.LeftAlt)) on WindowsDX.
