### PR TITLE
Always use the native platform for OpenTK

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -102,6 +102,8 @@ namespace Microsoft.Xna.Framework
 		public OpenTKGamePlatform(Game game)
             : base(game)
         {
+            OpenTK.Toolkit.Init(new OpenTK.ToolkitOptions { Backend = OpenTK.PlatformBackend.PreferNative });
+
             _view = new OpenTKGameWindow();
             _view.Game = game;
             this.Window = _view;


### PR DESCRIPTION
This fixes #2416 by preventing SDL2 from being used in OpenTK.
