### PR TITLE
Made TextureCube.SetData take a generic type.

### DIFF
--- a/MonoGame.Framework/Graphics/TextureCube.DirectX.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.DirectX.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new NotImplementedException();
         }
 
-        private void PlatformSetData(CubeMapFace face, int level, IntPtr dataPtr, int xOffset, int yOffset, int width, int height)
+        private void PlatformSetData<T>(CubeMapFace face, int level, IntPtr dataPtr, int xOffset, int yOffset, int width, int height)
         {
                 var box = new DataBox(dataPtr, GetPitch(width), 0);
 

--- a/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
         }
 
-        private void PlatformSetData(CubeMapFace face, int level, IntPtr dataPtr, int xOffset, int yOffset, int width, int height)
+        private void PlatformSetData<T>(CubeMapFace face, int level, IntPtr dataPtr, int xOffset, int yOffset, int width, int height)
         {
             Threading.BlockOnUIThread(() =>
             {

--- a/MonoGame.Framework/Graphics/TextureCube.PSM.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.PSM.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new NotImplementedException();
         }
 
-        private void PlatformSetData(CubeMapFace face, int level, IntPtr dataPtr, int xOffset, int yOffset, int width, int height)
+        private void PlatformSetData<T>(CubeMapFace face, int level, IntPtr dataPtr, int xOffset, int yOffset, int width, int height)
         {
             throw new NotImplementedException();
         }

--- a/MonoGame.Framework/Graphics/TextureCube.Web.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.Web.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new NotImplementedException();
         }
 
-        private void PlatformSetData(CubeMapFace face, int level, IntPtr dataPtr, int xOffset, int yOffset, int width, int height)
+        private void PlatformSetData<T>(CubeMapFace face, int level, IntPtr dataPtr, int xOffset, int yOffset, int width, int height)
         {
             throw new NotImplementedException();
         }

--- a/MonoGame.Framework/Graphics/TextureCube.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
                     }
                 }
-                PlatformSetData(face, level, dataPtr, xOffset, yOffset, width, height);
+                PlatformSetData<T>(face, level, dataPtr, xOffset, yOffset, width, height);
             }
             finally
             {


### PR DESCRIPTION
Similar to the earlier change to Texture3D, I need the type to calculate some offsets in the platform method. We have some ideas to make everything cleaner, but this is a decent minimal change for now.
