### PR TITLE
Copy OpenTK.dll.config on build

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -54,8 +54,12 @@
       <Link>Tao.Sdl.dll.config</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\ThirdParty\Dependencies\OpenTK.dll.config">
+      <Platforms>Linux,MacOS</Platforms>
+      <Link>OpenTK.dll.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
 
-    
     <!-- Microsoft.Xna.Framework -->
     <Compile Include="BoundingBox.cs" />
     <Compile Include="BoundingFrustum.cs" />


### PR DESCRIPTION
Currently MonoGame doesn't copy OpenTK.dll.config, which prevented @thefiddler's changes from actually taking effect.
