### PR TITLE
Process hold gestures even if no gesture events are occurring.

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchPanelState.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanelState.cs
@@ -347,6 +347,11 @@ namespace Microsoft.Xna.Framework.Input.Touch
                     UpdateGestures(stateChanged);
                 }
 
+                // We must run this even if _gestureEvents is empty,
+                // as some gestures occur as a result of the passage of time,
+                // even without new gesture events.
+                UpdateGestures(false);
+
                 return GestureList.Count > 0;
             }
         }


### PR DESCRIPTION
This PR fixes a problem wherein hold gestures are not recognised promptly, or sometimes at all.

Currently, new gestures are only checked for when _gestureEvents is non-empty. However, Android at least does not add to _gestureEvents while a touch location stays still, and it seems plausible that other platforms behave similarly.

This causes a hold gesture to not be recognised unless and until the user moves the touch location (at least slightly) at some point after the appropriate time has passed. If the hold is released without moving, the hold gesture is not processed at all. As a result, the hold gesture is unreliable unless the user deliberately waits, then performs a small motion to trigger it.

This commit causes gestures to be processed unconditionally of whether any new gesture events were received, allowing the hold gesture to be recognised and processed properly after the passage of the appropriate amount of time.
