### PR TITLE
MediaPlayer.IsRepeating fix

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -89,13 +89,14 @@ namespace Microsoft.Xna.Framework.Media
             if (State != MediaState.Stopped)
             {
 				_session.Stop();
-				_session.Close();
+                _session.ClearTopologies();
+                _session.Close();
                 _volumeController.Dispose();
                 _clock.Dispose();
 			}
 
             // Set the new song.
-            _session.SetTopology(0, song.Topology);
+            _session.SetTopology(SessionSetTopologyFlags.Immediate, song.Topology);
 
             // Get the volume interface.
             IntPtr volumeObj;

--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -215,6 +215,17 @@ namespace Microsoft.Xna.Framework.Media
 		
 		private static void NextSong(int direction)
 		{
+            if (IsRepeating && _queue.ActiveSongIndex >= _queue.Count - 1)
+            {
+                _queue.ActiveSongIndex = 0;
+                
+                // Setting direction to 0 will force the first song
+                // in the queue to be played.
+                // if we're on "shuffle", then it'll pick a random one
+                // anyway, regardless of the "direction".
+                direction = 0;
+            }
+
 			var nextSong = _queue.GetNextSong(direction, IsShuffled);
 
             if (nextSong == null)


### PR DESCRIPTION
Fixes multi-song playback for Windows platforms, and repeating a queue of songs for all other platforms.
