### PR TITLE
Change TitleContainer to be explicitly initialized when Game is constructed

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -123,6 +123,9 @@ namespace Microsoft.Xna.Framework
         public Game()
         {
             _instance = this;
+
+            TitleContainer.Initialize();
+
             LaunchParameters = new LaunchParameters();
             _services = new GameServiceContainer();
             _components = new GameComponentCollection();

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Xna.Framework
 {
     public static class TitleContainer
     {
-        static TitleContainer() 
+        internal static void Initialize() 
         {
 #if WINDOWS || LINUX
             Location = AppDomain.CurrentDomain.BaseDirectory;


### PR DESCRIPTION
To ensure retina is tested (on iOS) from a UI thread.

Fixes #1596
