### PR TITLE
Resolve PSSTexture not disposing (Issue #2122)

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #if DIRECTX
             "Microsoft.Xna.Framework.Graphics.Effect.Resources.SpriteEffect.dx11.mgfxo"
 #elif PSM
-            "MonoGame.Framework.PSMobile.PSSuite.Graphics.Resources.SpriteEffect.cgx" //FIXME: This shader is totally incomplete
+            "Microsoft.Xna.Framework.PSSuite.Graphics.Resources.SpriteEffect.cgx" //FIXME: This shader is totally incomplete
 #else
             "Microsoft.Xna.Framework.Graphics.Effect.Resources.SpriteEffect.ogl.mgfxo"
 #endif

--- a/MonoGame.Framework/Graphics/Texture2D.PSM.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.PSM.cs
@@ -156,6 +156,17 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformReload(Stream textureStream)
         {
         }
+		
+		
+		protected override void Dispose(bool disposing)
+        {
+		    if (disposing)
+		    {
+			    if (_texture2D != null)
+			        _texture2D.Dispose();
+		    }
+            base.Dispose(disposing);
+        }
 	}
 }
 


### PR DESCRIPTION
Properly dispose of PSM's _texture2D Fixes #2122
Correct issue where PSM SpriteEffect.cgx was named incorrectly
