### PR TITLE
Ensure foreground context is current on the main thread

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -184,7 +184,9 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 Threading.BackgroundContext = new GraphicsContext(mode, wnd, major, minor, flags);
                 Threading.WindowInfo = wnd;
+                Threading.BackgroundContext.MakeCurrent(null);
             }
+            Context.MakeCurrent(wnd);
 #endif
 
             MaxTextureSlots = 16;


### PR DESCRIPTION
Background must be non-current, otherwise it will raise error 170 (resource is in use) on the next MakeCurrent() call.

Fixes issue #2474
