### PR TITLE
Make disabling SynchronizeWithVerticalRetrace work on WindowsGL

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -89,23 +89,6 @@ namespace Microsoft.Xna.Framework
         private bool isCurrentlyFullScreen = false;
         private Toolkit toolkit;
         
-        public override bool VSyncEnabled
-        {
-            get
-            {
-                var context = GraphicsContext.CurrentContext;
-                return context != null && context.SwapInterval != 0;
-            }
-            set
-            {
-                var context = GraphicsContext.CurrentContext;
-                if (context != null)
-                {
-                    context.SwapInterval = value ? 1 : 0;
-                }
-            }
-        }
-        
 		public OpenTKGamePlatform(Game game)
             : base(game)
         {

--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -218,17 +218,7 @@ namespace Microsoft.Xna.Framework
             }
         }
 #endif
-  
-        public virtual bool VSyncEnabled
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-            set {
-            }
-        }
-        
+
         #endregion
 
         #region Events

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -279,9 +279,15 @@ namespace Microsoft.Xna.Framework
 
 #elif WINDOWS || LINUX
             ((OpenTKGamePlatform)_game.Platform).ResetWindowBounds();
-            _graphicsDevice.Context.SwapInterval =
-                _graphicsDevice.PresentationParameters.PresentationInterval.GetSwapInterval();
-            _game.Platform.VSyncEnabled = _synchronizedWithVerticalRetrace;
+
+            //Set the swap interval based on if vsync is desired or not.
+            //See GetSwapInterval for more details
+            int swapInterval;
+            if (_synchronizedWithVerticalRetrace)
+                swapInterval = _graphicsDevice.PresentationParameters.PresentationInterval.GetSwapInterval();
+            else
+                swapInterval = 0;
+            _graphicsDevice.Context.SwapInterval = swapInterval;
 #elif MONOMAC
             _graphicsDevice.PresentationParameters.IsFullScreen = _wantFullScreen;
 


### PR DESCRIPTION
So you can disable VSync and get lots of screen tearing if that is your thing.
This is now implemented properly like it is on other platforms.

I have a little test project for this here:
https://github.com/danzel/WrapTest/compare/disable-vsync
You can move `graphics.SynchronizeWithVerticalRetrace` around and check the behaviour.

This is how it works in XNA (And MonoGameDX), but worked differently in WindowsGL:

Set it in Game constructor - Setting is applied. (Didn't work in GL)
Set in Initialize (No ApplyChanges) - Nothing happens (This would previously set it in GL)
Set in Initialize and ApplyChanges - Setting is applied

Fixes #1862
