### PR TITLE
Fix stencil clear

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Xna.Framework.Graphics
             // DepthStencilState.Default has the Stencil Test disabled; 
             // make sure stencil test is enabled before we clear since
             // some drivers won't clear with stencil test disabled
-            DepthStencilState = this.clearDepthStencilState
+            DepthStencilState = this.clearDepthStencilState;
 		    BlendState = BlendState.Opaque;
             PlatformApplyState(false);
 


### PR DESCRIPTION
Some drivers (especially on Android) will obey the stencil test when clearing the stencil buffer (the specs says it shouldn't). This workaround ensure that the stencil buffer will properly be cleared.
