### PR TITLE
Ensure a playing song is stopped when switching songs.

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -215,6 +215,8 @@ namespace Microsoft.Xna.Framework.Media
 		
 		private static void NextSong(int direction)
 		{
+            Stop();
+
             if (IsRepeating && _queue.ActiveSongIndex >= _queue.Count - 1)
             {
                 _queue.ActiveSongIndex = 0;
@@ -228,9 +230,7 @@ namespace Microsoft.Xna.Framework.Media
 
 			var nextSong = _queue.GetNextSong(direction, IsShuffled);
 
-            if (nextSong == null)
-                Stop();
-            else
+            if (nextSong != null)
                 PlaySong(nextSong);
 
             if (ActiveSongChanged != null)


### PR DESCRIPTION
With multiple songs queued up in MediaPlayer and using the MediaPlayer.Default implementation, my existing Song wasn't being told to stop playing before the next one could start, resulting in a resource conflict or overlapping songs. It looks like in many cases the underlying platforms are enforcing a one-song-at-a-time setup. For those who don't, this should prevent conflicts.

@RayBatts Does this look sane?
