### PR TITLE
Fix ConsiderUsingStaticTypeRule rule for Hash

### DIFF
--- a/MonoGame.Framework/Utilities/Hash.cs
+++ b/MonoGame.Framework/Utilities/Hash.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace MonoGame.Utilities
 {
-    internal class Hash
+    internal static class Hash
     {
         // Modified FNV Hash in C#
         // http://stackoverflow.com/a/468084


### PR DESCRIPTION
This makes the Hash class a static class, fixing a Gendarme static analysis rule:

http://www.flibitijibibo.com/fna/gendarme_nonet.html#ConsiderUsingStaticTypeRule
https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Design.ConsiderUsingStaticTypeRule%282.10%29

This change should have no functional difference.
