### PR TITLE
Expose SpriteFont Texture and Glyph.

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -117,6 +117,22 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
+        /// <summary>
+        /// Gets the texture that this SpriteFont draws from.
+        /// </summary>
+        /// <remarks>Can be used to implement custom rendering of a SpriteFont</remarks>
+        public Texture2D Texture { get { return _texture; } }
+
+        /// <summary>
+        /// Returns a copy of the dictionary containing the glyphs in this SpriteFont.
+        /// </summary>
+        /// <returns>A new Dictionary containing all of the glyphs inthis SpriteFont</returns>
+        /// <remarks>Can be used to calculate character bounds when implementing custom SpriteFont rendering.</remarks>
+        public Dictionary<char, Glyph> GetGlyphs()
+        {
+            return new Dictionary<char, Glyph>(_glyphs);
+        }
+
 		private ReadOnlyCollection<char> _characters;
 
 		/// <summary>
@@ -401,14 +417,39 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
-		struct Glyph 
+        /// <summary>
+        /// Struct that defines the spacing, Kerning, and bounds of a character.
+        /// </summary>
+        /// <remarks>Provides the data necessary to implement custom SpriteFont rendering.</remarks>
+		public struct Glyph 
         {
+            /// <summary>
+            /// The char associated with this glyph.
+            /// </summary>
 			public char Character;
+            /// <summary>
+            /// Rectangle in the font texture where this letter exists.
+            /// </summary>
 			public Rectangle BoundsInTexture;
+            /// <summary>
+            /// Cropping applied to the BoundsInTexture to calculate the bounds of the actual character.
+            /// </summary>
 			public Rectangle Cropping;
+            /// <summary>
+            /// The amount of space between the left side ofthe character and its first pixel in the X dimention.
+            /// </summary>
             public float LeftSideBearing;
+            /// <summary>
+            /// The amount of space between the right side of the character and its last pixel in the X dimention.
+            /// </summary>
             public float RightSideBearing;
+            /// <summary>
+            /// Width of the character before kerning is applied. 
+            /// </summary>
             public float Width;
+            /// <summary>
+            /// Width of the character before kerning is applied. 
+            /// </summary>
             public float WidthIncludingBearings;
 
 			public static readonly Glyph Empty = new Glyph();


### PR DESCRIPTION
Made Glyph into a public class as well as added accessors  for SpriteFont.Texture and SpriteFont.Glyphs.

This allows for users to implement custom rendering of SpriteFonts, should they wish.

No functional changes.
