### PR TITLE
Fix support for ETC1 compressed textures

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -660,6 +660,10 @@ namespace Microsoft.Xna.Framework.Graphics
                     
 
 #if IOS || ANDROID
+            case SurfaceFormat.RgbEtc1:
+                glInternalFormat = (PixelInternalFormat)0x8D64; // GL_ETC1_RGB8_OES
+                glFormat = (PixelFormat)All.CompressedTextureFormats;
+                break;
 			case SurfaceFormat.RgbPvrtc2Bpp:
 				glInternalFormat = PixelInternalFormat.CompressedRgbPvrtc2Bppv1Img;
 				glFormat = (PixelFormat)All.CompressedTextureFormats;


### PR DESCRIPTION
Added missing case for ETC1 format in GraphicsExtensions.GetGLFormat
