### PR TITLE
Hook up Javascript implementations to JSAPI class

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1327,6 +1327,17 @@
     <Compile Include="Web\WebGameWindow.cs">
       <Platforms>Web</Platforms>
     </Compile>
+    <Compile Include="Libraries\JSAPI.cs">
+      <Platforms>Web</Platforms>
+    </Compile>
+    <Content Include="Libraries\MonoGame.Web.js">
+      <Platforms>Web</Platforms>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="MonoGame.Framework.manifest.js">
+      <Platforms>Web</Platforms>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
 	
     <!-- OpenGL Stock Effects -->
     <EmbeddedResource Include="Graphics\Effect\Resources\AlphaTestEffect.ogl.mgfxo">

--- a/MonoGame.Framework/Libraries/JSAPI.cs
+++ b/MonoGame.Framework/Libraries/JSAPI.cs
@@ -1,0 +1,13 @@
+﻿namespace MonoGame.Web
+{
+    using JSIL.Meta;
+
+    [JSStubOnly]
+    public class JSAPI
+    {
+        public string Test()
+        {
+            return null;
+        }
+    }
+}

--- a/MonoGame.Framework/Libraries/MonoGame.Web.js
+++ b/MonoGame.Framework/Libraries/MonoGame.Web.js
@@ -1,0 +1,25 @@
+﻿"use strict";
+
+if (typeof (JSIL) === "undefined")
+    throw new Error("JSIL.Core required");
+
+var $jsilmg = JSIL.DeclareAssembly("MonoGame.Web");
+
+var $sdlasms = new JSIL.AssemblyCollection({
+    2: "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+    4: "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+});
+
+JSIL.DeclareNamespace("MonoGame");
+JSIL.DeclareNamespace("MonoGame.Web");
+
+JSIL.ImplementExternals("MonoGame.Web.JSAPI", function ($interfaceBuilder) {
+    var $ = $interfaceBuilder;
+
+    $.Method({ Static: false, Public: true, Virtual: true }, "Test",
+      new JSIL.MethodSignature($.String, [], []),
+      function Test() {
+          return "hello";
+      }
+    );
+});

--- a/MonoGame.Framework/MonoGame.Framework.manifest.js
+++ b/MonoGame.Framework/MonoGame.Framework.manifest.js
@@ -1,0 +1,2 @@
+﻿// Ensure JSIL loads the MonoGame.Web library.
+contentManifest["JSIL"].push(["Library", "MonoGame.Web.js"]);


### PR DESCRIPTION
To enable this to work, developers need to modify the default index.htm generated by Protobuild to have:

```
    manifests: [
      "MonoGame.Framework",
      "JSILPort.exe"
    ],
```

This will cause the appropriate MonoGame libraries to load.

If you build a web project referencing MonoGame and you do:

```
public static class Program
{
    public static void Main(string[] args)
    {
        var api = new JSAPI();
        Console.WriteLine(api.Test());
    }
}
```

The web page will output "hello" as declared in the Javascript file (even though the C# implementation returns null).
