### PR TITLE
BitmapContent.Copy, PixelBitmapContent.CopyTo

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/BitmapContent.cs
@@ -80,7 +80,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 throw new ArgumentNullException("sourceBitmap");
             if (destinationBitmap == null)
                 throw new ArgumentNullException("destinationBitmap");
-            Copy(sourceBitmap, new Rectangle(0, 0, sourceBitmap.Width, sourceBitmap.Height), destinationBitmap, new Rectangle(0, 0, destinationBitmap.Width, destinationBitmap.Height));
+
+            var sourceRegion = new Rectangle(0, 0, sourceBitmap.Width, sourceBitmap.Height);
+            var destinationRegion = new Rectangle(0, 0, destinationBitmap.Width, destinationBitmap.Height);
+
+            Copy(sourceBitmap, sourceRegion, destinationBitmap, destinationRegion);
         }
 
         /// <summary>
@@ -94,6 +98,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         public static void Copy(BitmapContent sourceBitmap, Rectangle sourceRegion, BitmapContent destinationBitmap, Rectangle destinationRegion)
         {
             ValidateCopyArguments(sourceBitmap, sourceRegion, destinationBitmap, destinationRegion);
+
+            if (sourceBitmap.TryCopyTo(destinationBitmap, sourceRegion, destinationRegion) ||
+                destinationBitmap.TryCopyFrom(sourceBitmap, sourceRegion, destinationRegion))
+                return;
+
             throw new NotImplementedException();
         }
 
@@ -115,8 +124,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         /// <returns>Description of the bitmap.</returns>
         public override string ToString()
         {
-            // See what Microsoft's implementation returns
-            throw new NotImplementedException();
+            return string.Format("{0}, {1}x{2}", GetType().Name, Width, Height);
         }
 
         /// <summary>

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -6,6 +6,7 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
+using Microsoft.Xna.Framework.Graphics;
 using Nvidia.TextureTools;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
@@ -155,10 +156,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         /// <summary>
         /// Compresses TextureContent in a format appropriate to the platform
         /// </summary>
-        public static void CompressTexture(TextureContent content, ContentProcessorContext context, bool generateMipmaps, bool premultipliedAlpha)
+        public static void CompressTexture(GraphicsProfile profile, TextureContent content, ContentProcessorContext context, bool generateMipmaps, bool premultipliedAlpha)
         {
             // TODO: At the moment, only DXT compression from windows machine is supported
-            // Add more here as they become available.
+            //       Add more here as they become available.
             switch (context.TargetPlatform)
             {
                 case TargetPlatform.Windows:
@@ -172,7 +173,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 case TargetPlatform.NativeClient:
                 case TargetPlatform.Xbox360:
 					context.Logger.LogMessage("Using DXT Compression");
-				    CompressDxt(content, generateMipmaps);
+				    CompressDxt(profile, content, generateMipmaps);
 				    break;
                 case TargetPlatform.iOS:
 					context.Logger.LogMessage("Using PVRTC Compression");
@@ -250,12 +251,15 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             }
         }
 
-        private static void CompressDxt(TextureContent content, bool generateMipmaps)
+        private static void CompressDxt(GraphicsProfile profile, TextureContent content, bool generateMipmaps)
         {
             var texData = content.Faces[0][0];
 
-            if (!IsPowerOfTwo(texData.Width) || !IsPowerOfTwo(texData.Height))
-                throw new PipelineException("DXT Compressed textures width and height must be powers of two.");
+            if (profile == GraphicsProfile.Reach)
+            {
+                if (!IsPowerOfTwo(texData.Width) || !IsPowerOfTwo(texData.Height))
+                    throw new PipelineException("DXT Compressed textures width and height must be powers of two in GraphicsProfile.Reach.");                
+            }
 
             var _dxtCompressor = new Compressor();
             var inputOptions = new InputOptions();

--- a/MonoGame.Framework.Content.Pipeline/Graphics/PixelBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PixelBitmapContent.cs
@@ -104,19 +104,39 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             }
         }
 
-        protected override bool TryCopyFrom(BitmapContent sourceBitmap, Rectangle sourceRegion, Rectangle destRegion)
+        protected override bool TryCopyFrom(BitmapContent srcBitmap, Rectangle srcRect, Rectangle dstRect)
         {
-            throw new NotImplementedException();
+            return false;
         }
 
-        protected override bool TryCopyTo(BitmapContent destBitmap, Rectangle sourceRegion, Rectangle destRegion)
+        protected override bool TryCopyTo(BitmapContent dstBitmap, Rectangle srcRect, Rectangle dstRect)
         {
-            throw new NotImplementedException();
-        }
+            SurfaceFormat format;
+            if (!dstBitmap.TryGetFormat(out format) || format != _format)
+                return false;
 
-        public override string ToString()
-        {
-            return base.ToString();
+            var dst = dstBitmap as PixelBitmapContent<T>;
+            for (var i = 0; i < dstRect.Height; i++)
+            {
+                var dy = dstRect.Y + i;
+                for (var j = 0; j < dstRect.Width; j++)
+                {
+                    var dx = dstRect.X + j;
+
+                    var uv = new Vector2()
+                    {
+                        X = j / (float)dstRect.Width,
+                        Y = i / (float)dstRect.Height,
+                    };
+
+                    var sx = MathHelper.Clamp((int)Math.Round(uv.X * srcRect.Width) + srcRect.X, 0, Width - 1);
+                    var sy = MathHelper.Clamp((int)Math.Round(uv.Y * srcRect.Height) + srcRect.Y, 0, Height - 1);
+                    var pixel = GetPixel(sx, sy);
+                    dst.SetPixel(dx, dy, pixel);
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 				bitmapContent.SetPixelData(outputBitmap.GetData());
 				output.Texture.Faces.Add(new MipmapChain(bitmapContent));
 
-            	GraphicsUtil.CompressTexture(output.Texture, context, false, false);
+                GraphicsUtil.CompressTexture(context.TargetProfile, output.Texture, context, false, false);
 			}
 			catch(Exception ex) {
 				context.Logger.LogImportantMessage("{0}", ex.ToString());

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontTextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontTextureProcessor.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 			bitmapContent.SetPixelData (outputBitmap.GetData ());
 			output.Texture.Faces.Add (new MipmapChain (bitmapContent));
 
-			GraphicsUtil.CompressTexture (output.Texture, context, false, false);
+            GraphicsUtil.CompressTexture(context.TargetProfile, output.Texture, context, false, false);
 
 			return output;
 		}

--- a/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
@@ -72,7 +72,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             }
 
             // Set the first layer
-            input.Faces[0][0].SetPixelData(input._bitmap.GetData());
+            // JCF: This should be already set...
+            //input.Faces[0][0].SetPixelData(input._bitmap.GetData());
 
             if (TextureFormat == TextureProcessorOutputFormat.NoChange)
                 return input;
@@ -80,7 +81,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 			{
 			    if (TextureFormat == TextureProcessorOutputFormat.DxtCompressed || 
                     TextureFormat == TextureProcessorOutputFormat.Compressed )
-                	GraphicsUtil.CompressTexture(input, context, GenerateMipmaps, PremultiplyAlpha);
+                	GraphicsUtil.CompressTexture(context.TargetProfile, input, context, GenerateMipmaps, PremultiplyAlpha);
 			}
 			catch(EntryPointNotFoundException ex) {
 				context.Logger.LogImportantMessage ("Could not find the entry point to compress the texture", ex.ToString());


### PR DESCRIPTION
Implemented several of the previously missing methods for converting between bitmap types.
Fixed other small issues which were causing incompatibility with my own processor (for sprite sheets).
