### PR TITLE
TouchPanelCapabilities (IsConnected, MaximumTouchCount) for all platforms

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -55,8 +55,6 @@ namespace Microsoft.Xna.Framework.Input.Touch
 	{
         private TouchLocation[] _collection;
 
-        private bool _isConnected;
-
         private static readonly TouchLocation[] emptyCollection = new TouchLocation[0];
 
 		#region Properties
@@ -64,18 +62,16 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <summary>
         /// States if a touch screen is available.
         /// </summary>
-		public bool IsConnected { get { return _isConnected; } }
+        public bool IsConnected { get { return TouchPanel.GetCapabilities().IsConnected; } }
 
 		#endregion
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TouchCollection"/> with a pre-determined set of touch locations.
         /// </summary>
-        /// <param name="isConnected">True if the TouchPanel is connected</param>
         /// <param name="touches">Array of <see cref="TouchLocation"/> items to initialize with.</param>
-        public TouchCollection(bool isConnected, TouchLocation[] touches)
+        public TouchCollection(TouchLocation[] touches)
         {
-            _isConnected = isConnected;
             _collection = touches;
         }
 

--- a/MonoGame.Framework/Input/Touch/TouchPanelState.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanelState.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
             while (Refresh(consumeState, _touchState, _touchEvents))
                 consumeState = false;
 
-            return new TouchCollection(Capabilities.IsConnected, _touchState.ToArray());
+            return new TouchCollection(_touchState.ToArray());
         }
 
         internal void AddEvent(int id, TouchLocationState state, Vector2 position)


### PR DESCRIPTION
I've implemented figuring out the TouchPanelCapabilities for each platform.
At the moment they are all #if'd in to the file, happy to tidy this up if you can suggest how :)

TouchCollection.IsConnected is also correctly implemented now, it is set based on the capabilities, rather than always saying true.

Fixes #2531
Fixes #2532
Improves Mono-Game/MonoGame.Samples#15
