### PR TITLE
Fixed SpriteFont DrawInto bug

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
                     //  so that text does not hang off the left side of its rectangle.
                     if (firstGlyphOfLine) {
-                        offset.X = Math.Max(offset.X, 0);
+                        offset.X = Math.Max(currentGlyph.LeftSideBearing, 0);
                         firstGlyphOfLine = false;
                     } else {
                         offset.X += currentGlyph.LeftSideBearing;


### PR DESCRIPTION
This fixes a `SpriteFont.DrawInto` bug related to `firstGlyphOfLine`. In an attempt to make sure lines don't start with negative bearing, the initial `offset.X` was incorrectly always set to 0 (`offset.X==0` for firstGlyphOfLine), which is not in sync with XNA behavior. It's true that the _minimum_ initial offset should be 0, but it's not true that the _maximum_ initial offset should be 0. If the first glyph of a line starts with positive LeftSideBearing, then that should be added to the start of the line.

Pretty much any monospaced bitmap/pixel font provides a good test case, e.g., [Namco's Classic Arcade Font](https://www.google.com/search?q=namco+classic+arcade+font&tbm=isch). Notice how the shorter "T" character in "THE" is incorrectly flush with the left side of the line in the [top half of this image](http://i.imgur.com/Ilp3lrC.png) (pre-bug fix) causing the letters to fall out of alignment later on in the line, but the "T" characters are correctly offset by their left side bearing in the bottom half (post-bug fix) which keeps everything in alignment (and in sync with XNA behavior).
