### PR TITLE
gave default variant to session start to prevent invalid pointer error.

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -133,7 +133,8 @@ namespace Microsoft.Xna.Framework.Media
 
         private static void PlatformResume()
         {
-            _session.Start(null, null);
+            var varStart = new Variant();
+            _session.Start(null, varStart);
         }
 
         private static void PlatformStop()


### PR DESCRIPTION
fixes a issue with resuming media using sharpdx documented int issue #2330

Pausing and resuming a song raise a SharpDX exception:
"HRESULT: [0x80004003], Module: [General], ApiCode: [E_POINTER/Invalid pointer], Message: Invalid pointer"
at SharpDX.Result.CheckError()
at SharpDX.MediaFoundation.MediaSession.Start(Nullable guidTimeFormatRef, Nullable varStartPositionRef)
at Microsoft.Xna.Framework.Media.MediaPlayer.Resume()

found that setting the default variant for session start negated the invalid pointer issue.
