### PR TITLE
Fixed editing Output/IntermediateDir in textbox

### DIFF
--- a/Tools/Pipeline/Common/Util.cs
+++ b/Tools/Pipeline/Common/Util.cs
@@ -1,24 +1,35 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MonoGame.Tools.Pipeline.Common
 {
     internal static class Util
     {
+        /// <summary>        
+        /// Returns the path 'filspec' made relative path 'folder'.
+        /// 
+        /// If 'folder' is not an absolute path, throws ArgumentException.
+        /// If 'filespec' is not an absolute path, returns 'filespec' unmodified.
+        /// </summary>
         public static string GetRelativePath(string filespec, string folder)
         {
+            if (!Path.IsPathRooted(filespec))
+                return filespec;
+
+            if (!Path.IsPathRooted(folder))
+                throw new ArgumentException("Must be an absolute path.", "folder");
+
             var pathUri = new Uri(filespec);
 
-            // Folders must end in a slash
-            if (!folder.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            if (folder[folder.Length-1] != Path.DirectorySeparatorChar)
                 folder += Path.DirectorySeparatorChar;
 
             var folderUri = new Uri(folder);
-            return Uri.UnescapeDataString(folderUri.MakeRelativeUri(pathUri).ToString().Replace('/', Path.DirectorySeparatorChar));
+            var result = folderUri.MakeRelativeUri(pathUri).ToString();
+            result = result.Replace('/', Path.DirectorySeparatorChar);
+            result = Uri.UnescapeDataString(result);
+
+            return result;
         }
     }
 }

--- a/Tools/Pipeline/Windows/PipelineProjectProxy.cs
+++ b/Tools/Pipeline/Windows/PipelineProjectProxy.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing.Design;
+using System.IO;
 using FolderSelect;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Graphics;
@@ -12,6 +13,9 @@ using MonoGame.Tools.Pipeline.Common;
 
 namespace MonoGame.Tools.Pipeline
 {
+    /// <summary>
+    /// Wraps a PipelineProject object, defining its appearance within the windows specific IView (MainView).
+    /// </summary>
     internal class PipelineProjectProxy : IProjectItem
     {
         private readonly PipelineProject _project;
@@ -37,7 +41,7 @@ namespace MonoGame.Tools.Pipeline
         {
             get { return _project.IntermediateDir; }
             set
-            {
+            {       
                 _project.IntermediateDir = Util.GetRelativePath(value, _project.Location);
             }
         }


### PR DESCRIPTION
Assigning a path which is already relative to the project no longer causes an exception (was trying and failing to make a URI from an un-rooted path).
