### PR TITLE
Fixed Pipeline Output

### DIFF
--- a/Tools/MGCB/Program.cs
+++ b/Tools/MGCB/Program.cs
@@ -13,6 +13,10 @@ namespace MGCB
     {
         static int Main(string[] args)
         {
+            // We force all stderr to redirect to stdout
+            // to avoid any out of order console output.
+            Console.SetError(Console.Out);
+
             var content = new BuildContent();
 
             // Parse the command line.

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -269,17 +269,14 @@ namespace MonoGame.Tools.Pipeline
             _buildProcess.StartInfo.CreateNoWindow = true;
             _buildProcess.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
             _buildProcess.StartInfo.UseShellExecute = false;
-            _buildProcess.StartInfo.RedirectStandardError = true;
             _buildProcess.StartInfo.RedirectStandardOutput = true;
             _buildProcess.OutputDataReceived += (sender, args) => _view.OutputAppend(args.Data);
-            _buildProcess.ErrorDataReceived += (sender, args) => _view.OutputAppend(args.Data);
 
             //string stdError = null;
             try
             {
                 _buildProcess.Start();
                 _buildProcess.BeginOutputReadLine();
-                _buildProcess.BeginErrorReadLine();
                 _buildProcess.WaitForExit();
             }
             catch (Exception ex)


### PR DESCRIPTION
Forced MGCB to only use stdout fixing the out of order messages in the Pipeline GUI tool output window.
