### PR TITLE
Change TitleContainer Init back to a static constructor

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -124,8 +124,6 @@ namespace Microsoft.Xna.Framework
         {
             _instance = this;
 
-            TitleContainer.Initialize();
-
             LaunchParameters = new LaunchParameters();
             _services = new GameServiceContainer();
             _components = new GameComponentCollection();

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Xna.Framework
 {
     public static class TitleContainer
     {
-        internal static void Initialize() 
+        static TitleContainer() 
         {
 #if WINDOWS || LINUX
             Location = AppDomain.CurrentDomain.BaseDirectory;

--- a/MonoGame.Framework/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/iOS/iOSGamePlatform.cs
@@ -99,7 +99,10 @@ namespace Microsoft.Xna.Framework
 			
 			// Setup our OpenALSoundController to handle our SoundBuffer pools
 			soundControllerInstance = OpenALSoundController.GetInstance;
-			
+
+            //Run the static constructor of TitleContainer to ensure it happens on the main thread
+            System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(TitleContainer).TypeHandle);
+
             Directory.SetCurrentDirectory(NSBundle.MainBundle.ResourcePath);
 
             _applicationObservers = new List<NSObject>();


### PR DESCRIPTION
We have Have iOS explicitly run the TitleContainer static constructor to ensure it happens on the main thread.

I found out about this method from here:
http://stackoverflow.com/a/4652926
And tested it working on iOS.

Fixes #2549

I have an alternate way of achieving this without using the crazy method, I think I prefer this one though.
