### PR TITLE
Change TitleContainer Init back to a static constructor (Other version)

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -124,8 +124,6 @@ namespace Microsoft.Xna.Framework
         {
             _instance = this;
 
-            TitleContainer.Initialize();
-
             LaunchParameters = new LaunchParameters();
             _services = new GameServiceContainer();
             _components = new GameComponentCollection();

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Xna.Framework
 {
     public static class TitleContainer
     {
-        internal static void Initialize() 
+        static TitleContainer() 
         {
 #if WINDOWS || LINUX
             Location = AppDomain.CurrentDomain.BaseDirectory;

--- a/MonoGame.Framework/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/iOS/iOSGamePlatform.cs
@@ -99,8 +99,9 @@ namespace Microsoft.Xna.Framework
 			
 			// Setup our OpenALSoundController to handle our SoundBuffer pools
 			soundControllerInstance = OpenALSoundController.GetInstance;
-			
-            Directory.SetCurrentDirectory(NSBundle.MainBundle.ResourcePath);
+
+            //This also runs the TitleContainer static constructor, ensuring it is done on the main thread
+            Directory.SetCurrentDirectory(TitleContainer.Location);
 
             _applicationObservers = new List<NSObject>();
 


### PR DESCRIPTION
Have iOS access TitleContainer.Location so the static constructor is called instead of having an explicit function call.

Fixes #2549

This is an alternate implementation to #2557
