### PR TITLE
Make use of FileHelpers.NormalizeFilePathSeparators

### DIFF
--- a/MonoGame.Framework/Audio/SoundBank.cs
+++ b/MonoGame.Framework/Audio/SoundBank.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Audio
 {
@@ -25,15 +26,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// <param name="fileName">Path to a .xsb SoundBank file.</param>
         public SoundBank(AudioEngine audioEngine, string fileName)
         {
-#if WINRT
-            const char notSeparator = '/';
-            const char separator = '\\';
-#else
-            const char notSeparator = '\\';
-            var separator = Path.DirectorySeparatorChar;
-#endif
-            // Check for windows-style directory separator character
-            filename = fileName.Replace(notSeparator, separator);
+            filename = FileHelpers.NormalizeFilePathSeparators(fileName);
 			audioengine = audioEngine;
 		}
 		

--- a/MonoGame.Framework/Audio/WaveBank.cs
+++ b/MonoGame.Framework/Audio/WaveBank.cs
@@ -29,6 +29,7 @@ using System;
 using System.IO;
 
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Audio
 {
@@ -105,15 +106,7 @@ namespace Microsoft.Xna.Framework.Audio
 
             int wavebank_offset = 0;
 
-#if WINRT
-			const char notSeparator = '/';
-			const char separator = '\\';
-#else
-            const char notSeparator = '\\';
-            var separator = Path.DirectorySeparatorChar;
-#endif
-			// Check for windows-style directory separator character
-			nonStreamingWaveBankFilename = nonStreamingWaveBankFilename.Replace(notSeparator, separator);
+            nonStreamingWaveBankFilename = FileHelpers.NormalizeFilePathSeparators(nonStreamingWaveBankFilename);
 
 #if !ANDROID
             BinaryReader reader = new BinaryReader(TitleContainer.OpenStream(nonStreamingWaveBankFilename));

--- a/MonoGame.Framework/Content/ContentReader.cs
+++ b/MonoGame.Framework/Content/ContentReader.cs
@@ -148,17 +148,10 @@ namespace Microsoft.Xna.Framework.Content
 
             if (!String.IsNullOrEmpty(externalReference))
             {
-#if WINRT
-                const char notSeparator = '/';
-                const char separator = '\\';
-#else
-                const char notSeparator = '\\';
-                var separator = Path.DirectorySeparatorChar;
-#endif
-                externalReference = externalReference.Replace(notSeparator, separator);
+                externalReference = FileHelpers.NormalizeFilePathSeparators(externalReference);
 
                 // Get a uri for the asset path using the file:// schema and no host
-                var src = new Uri("file:///" + assetName.Replace(notSeparator, separator));
+                var src = new Uri("file:///" + FileHelpers.NormalizeFilePathSeparators(assetName));
 
                 // Add the relative path to the external reference
                 var dst = new Uri(src, externalReference);

--- a/MonoGame.Framework/Content/ContentReaders/SongReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SongReader.cs
@@ -43,6 +43,7 @@ using System;
 using System.IO;
 
 using Microsoft.Xna.Framework.Media;
+using Microsoft.Xna.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
@@ -65,17 +66,10 @@ namespace Microsoft.Xna.Framework.Content
 			
 			if (!String.IsNullOrEmpty(path))
 			{
-#if WINRT
-				const char notSeparator = '/';
-				const char separator = '\\';
-#else
-				const char notSeparator = '\\';
-				var separator = Path.DirectorySeparatorChar;
-#endif
-				path = path.Replace(notSeparator, separator);
+                path = FileHelpers.NormalizeFilePathSeparators(path);
 				
 				// Get a uri for the asset path using the file:// schema and no host
-				var src = new Uri("file:///" + input.AssetName.Replace(notSeparator, separator));
+                var src = new Uri("file:///" + FileHelpers.NormalizeFilePathSeparators(input.AssetName));
 				
 				// Add the relative path to the external reference
 				var dst = new Uri(src, path);

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -41,7 +41,6 @@
 using System;
 using System.IO;
 using System.Text;
-
 #if WINRT
 using System.Threading.Tasks;
 #elif IOS
@@ -52,6 +51,7 @@ using MonoMac.Foundation;
 #elif PSM
 using Sce.PlayStation.Core;
 #endif
+using Microsoft.Xna.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework
 {
@@ -148,15 +148,7 @@ namespace Microsoft.Xna.Framework
         // this same logic is duplicated all over the code base.
         internal static string GetFilename(string name)
         {
-#if WINRT
-            const char notSeparator = '/';
-            const char separator = '\\';
-#else
-            const char notSeparator = '\\';
-            var separator = Path.DirectorySeparatorChar;
-#endif
-
-            return new Uri("file:///" + name).LocalPath.Substring(1).Replace(notSeparator, separator);
+            return FileHelpers.NormalizeFilePathSeparators(new Uri("file:///" + name).LocalPath.Substring(1));
         }
     }
 }

--- a/MonoGame.Framework/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework/Utilities/FileHelpers.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Xna.Framework.Utilities
 
 		#region public properties
 		
-		#if WINRT
+#if WINRT
 		public static char notSeparator = '/';
 		public static char separator = '\\';
 #else
@@ -206,14 +206,9 @@ namespace Microsoft.Xna.Framework.Utilities
 		}
 
 		// Renamed from - public static string GetFilename(string name)
-		public static string NormalizeFilePathSeperators(string name)
+		public static string NormalizeFilePathSeparators(string name)
 		{
-#if WINRT
-			name = name.Replace('/', '\\');
-#else
-			name = name.Replace('\\', Path.DirectorySeparatorChar);
-#endif
-			return name;
+            return name.Replace(notSeparator, separator);
 		}
 
 


### PR DESCRIPTION
First part of the FileHelpers things for #2555

This is an easy one that makes a nice cleanup, so submitting it by itself.

The remaining FileHelpers are mostly just used by StorageDevice, so maybe we leave them for now as #2389 is going to tackle them.
If you do plan on using the code in there, `DirectoryGetFiles` and `DirectoryGetDirectories` both ignore the given path on WINDOWS_STOREAPP.
It looks like this bug was copy/pasted out of StorageDevice.
(I'll send a PR to fix them when I get a chance.)
