### PR TITLE
Fixed broken SoundEffectInstance.IsLooped on Android.

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -320,25 +320,15 @@ namespace Microsoft.Xna.Framework.Audio
 #endif
 
 #if ANDROID
-			if (sourceId != 0 && _looped != value)
-				_looped = value;
+            if (sourceId != 0)
+                s_soundPool.SetLoop(sourceId, value ? -1 : 0);
+            _looped = value;
 #endif
         }
 
         private bool PlatformGetIsLooped()
         {
-#if OPENAL
-            
             return _looped;
-#endif
-
-#if ANDROID
-
-			if (sourceId != 0)
-				return _looped;
-            
-            return false;
-#endif
         }
 
         private void PlatformSetPan(float value)


### PR DESCRIPTION
```
SoundEffectInstance sei = se.CreateInstance();
sei.IsLooped = true;
sei.Play();
```

Sound does not loop on Android. This PR fixes it.
