### PR TITLE
VertexDeclaration.FromType() fix 

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			if (vertexType == null)
 				throw new ArgumentNullException("vertexType", "Cannot be null");
 
-            if (ReflectionHelpers.IsValueType(vertexType))
+            if (!ReflectionHelpers.IsValueType(vertexType))
             {
 				throw new ArgumentException("vertexType", "Must be value type");
 			}


### PR DESCRIPTION
VertexDeclaration.FromType()  must throw exception when vertexType is
NOT a ValueType.
#2571
