### PR TITLE
Android: SoundEffectInstance.Volume , .Pan and .Pitch.

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -185,7 +185,6 @@ namespace Microsoft.Xna.Framework.Audio
 
 #if ANDROID
             inst._soundId = _soundID;
-            inst._sampleRate = Rate;
 #endif
         }
 

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -40,8 +40,6 @@ namespace Microsoft.Xna.Framework.Audio
 
 		internal int _soundId = -1;
 
-		internal float _sampleRate;
-
 #endif
 
         #region Initialization
@@ -118,11 +116,32 @@ namespace Microsoft.Xna.Framework.Audio
             hasSourceId = true;
         }
 
+#endif // WINDOWS || LINUX || MONOMAC || IOS
+
+#if ANDROID
+
         /// <summary>
-        /// Converts the XNA [-1,1] pitch range to OpenAL (-1,+INF].
+        /// Converts the XNA volume [0, 1] and pan [-1, 1] to Android SoundPool left and right volume [0, 1].
+        /// <param name="xnaVolume">The volume of the sound in the Microsoft XNA range.</param>
+        /// <param name="xnaPan">The pan of the sound in the Microsoft XNA range.</param>
+        /// <param name="leftVolume">Android SoundPool left volume.</param>
+        /// <param name="rightVolume">Android SoundPool right volume.</param>
+        /// </summary>
+        private static void XnaVolumeAndPanToAndroidVolume(float xnaVolume, float xnaPan, out float leftVolume, out float rightVolume)
+        {
+            float panRatio = (xnaPan + 1.0f) / 2.0f;
+            float volumeTotal = SoundEffect.MasterVolume * xnaVolume;
+            leftVolume = volumeTotal * (1.0f - panRatio);
+            rightVolume = volumeTotal * panRatio;
+        }
+
+#endif // ANDROID
+
+        /// <summary>
+        /// Converts the XNA [-1, 1] pitch range to OpenAL pitch (0, INF) or Android SoundPool playback rate [0.5, 2].
         /// <param name="xnaPitch">The pitch of the sound in the Microsoft XNA range.</param>
         /// </summary>
-        private float XnaPitchToAlPitch(float xnaPitch)
+        private static float XnaPitchToAlPitch(float xnaPitch)
         {
             /*XNA sets pitch bounds to [-1.0f, 1.0f], each end being one octave.
             •OpenAL's AL_PITCH boundaries are (0.0f, INF). *
@@ -139,8 +158,6 @@ namespace Microsoft.Xna.Framework.Audio
 
             return (float)Math.Pow(2, xnaPitch);
         }
-
-#endif // WINDOWS || LINUX || MONOMAC || IOS
 
         #endregion // Initialization
 
@@ -240,15 +257,12 @@ namespace Microsoft.Xna.Framework.Audio
 					sourceId = 0;
 				}
 
-				float panRatio = (_pan + 1.0f) / 2.0f;
-				float volumeTotal = SoundEffect.MasterVolume * _volume;
-				float volumeLeft = volumeTotal * (1.0f - panRatio);
-				float volumeRight = volumeTotal * panRatio;
+                float volumeLeft, volumeRight;
+                XnaVolumeAndPanToAndroidVolume(_volume, _pan, out volumeLeft, out volumeRight);
 
-				float rate = (float)Math.Pow(2, _sampleRate);
-				rate = Math.Max(Math.Min(rate, 2.0f), 0.5f);
+                float playbackRate = XnaPitchToAlPitch(_pitch);
 
-				sourceId = s_soundPool.Play(_soundId, volumeLeft, volumeRight, 1, _looped ? -1 : 0, _sampleRate);
+                sourceId = s_soundPool.Play(_soundId, volumeLeft, volumeRight, 1, _looped ? -1 : 0, playbackRate);
 			}
 #endif
             soundState = SoundState.Playing;
@@ -335,41 +349,32 @@ namespace Microsoft.Xna.Framework.Audio
         {
 
 #if OPENAL
-
-            _pan = value;
-			if (!hasSourceId)
-				return;
-            
-            AL.Source(sourceId, ALSource3f.Position, _pan, 0.0f, 0.1f);
-
+            if (hasSourceId)
+                AL.Source(sourceId, ALSource3f.Position, value, 0.0f, 0.1f);
             return;
-
 #endif
-            
-#if ANDROID
 
-			if (sourceId != 0 && _pan != value)
-				_pan = value;
+#if ANDROID
+            if (sourceId != 0)
+            {
+                float leftVolume, rightVolume;
+                XnaVolumeAndPanToAndroidVolume(_volume, value, out leftVolume, out rightVolume);
+                s_soundPool.SetVolume(sourceId, leftVolume, rightVolume);
+            }
 #endif
         }
 
         private void PlatformSetPitch(float value)
         {
 #if OPENAL
-            _pitch = value;
-
-			if (hasSourceId)
-				AL.Source (sourceId, ALSourcef.Pitch, XnaPitchToAlPitch(_pitch));
-
+            if (hasSourceId)
+                AL.Source (sourceId, ALSourcef.Pitch, XnaPitchToAlPitch(value));
             return;
 #endif
 
 #if ANDROID
-
-            // TODO: This doesn't look right...
-
-			if (sourceId != 0 && _sampleRate != value)
-				_sampleRate = value;
+            if (sourceId != 0)
+                s_soundPool.SetRate(sourceId, XnaPitchToAlPitch(value));
 #endif
         }
 
@@ -420,19 +425,19 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformSetVolume(float value)
         {
-
 #if OPENAL
-
-            _volume = value;
-			if (hasSourceId)
-				AL.Source (sourceId, ALSourcef.Gain, _volume * SoundEffect.MasterVolume);
-
+            if (hasSourceId)
+                AL.Source(sourceId, ALSourcef.Gain, value * SoundEffect.MasterVolume);
             return;
 #endif
 
 #if ANDROID
-			if (sourceId != 0 && _volume != value)
-				_volume = value;
+            if (sourceId != 0)
+            {
+                float leftVolume, rightVolume;
+                XnaVolumeAndPanToAndroidVolume(value, _pan, out leftVolume, out rightVolume);
+                s_soundPool.SetVolume(sourceId, leftVolume, rightVolume);
+            }
 #endif
         }
 

--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Xna.Framework.Audio
                 if (value < -1.0f || value > 1.0f)
                     throw new ArgumentOutOfRangeException();
 
-                PlatformSetPan(value);
                 _pan = value;
+                PlatformSetPan(value);
             }
         }
 
@@ -53,8 +53,8 @@ namespace Microsoft.Xna.Framework.Audio
                 if (value < -1.0f || value > 1.0f)
                     throw new ArgumentOutOfRangeException();
 
-                PlatformSetPitch(value);
                 _pitch = value;
+                PlatformSetPitch(value);
             }
         }
 
@@ -71,8 +71,8 @@ namespace Microsoft.Xna.Framework.Audio
                 if (value < 0.0f || value > 1.0f)
                     throw new ArgumentOutOfRangeException();
 
-                PlatformSetVolume(value);
                 _volume = value;
+                PlatformSetVolume(value);
             }
         }
 


### PR DESCRIPTION
Android: `SoundEffectInstance.Volume` , `.Pan` and `.Pitch` now work before and after `SoundEffectInstance.Play()`.
