### PR TITLE
Page URLs for Documentation

### DIFF
--- a/Documentation/Styles/MonoGame/html/Page.cshtml
+++ b/Documentation/Styles/MonoGame/html/Page.cshtml
@@ -14,7 +14,7 @@
     <head>
     @Helpers.PageHead.Dump(title)
     </head>
-	<body onload="window.top.resizeDocs();window.top.scrollTo(0,0);window.top.document.title='@title | MonoGame'">
+	<body onload="onPageLoad('@title | MonoGame', '@Model.Topic.PageId');">
     @Helpers.PageBody.Dump(bodyTemplateName)
 
     <br />

--- a/Documentation/Styles/MonoGame/html/PageBody.cshtml
+++ b/Documentation/Styles/MonoGame/html/PageBody.cshtml
@@ -1,0 +1,23 @@
+﻿@*
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+*@
+@model SharpDoc.TemplateContext
+@using SharpDoc.Model
+@helper Dump(string bodyTemplateName)
+{
+    <script type="text/javascript" language="javascript">
+            if(window == window.top)
+                location.href = "/documentation/?page=@Model.Topic.PageId";
+            document.addEvent('domready', function () {
+                InstallCodeTabs();
+            });
+    </script>
+    <div class="sharpdoc">
+        <div class="content">
+            @Include(bodyTemplateName)
+        </div>
+    </div>
+}
+

--- a/Documentation/Styles/MonoGame/js/sharpdoc.js
+++ b/Documentation/Styles/MonoGame/js/sharpdoc.js
@@ -44,7 +44,7 @@ function autoResize(id) {
 }
 
 function loadContent(rootTopic, extension) {
-    var data = window.location.search;
+    var data = window.top.location.search;
     var url = rootTopic + extension;
     var topicToHighlight = rootTopic;
 
@@ -61,6 +61,15 @@ function loadContent(rootTopic, extension) {
     
     $("mainFrame").setAttribute("src", url);
     hightLightTopic(topicToHighlight);
+}
+
+function onPageLoad(pageTitle, pageId) 
+{
+	var topWindow = window.top;
+	topWindow.resizeDocs();
+	topWindow.scrollTo(0,0);
+	topWindow.document.title = pageTitle;
+	topWindow.history.replaceState(null, pageTitle, '?page=' + pageId);
 }
 
 /*


### PR DESCRIPTION
This PR adds support for page specific URLs to the documentation style.  For example:

  http://www.monogame.net/documentation/?page=N_Microsoft_Xna_Framework
  http://www.monogame.net/documentation/?page=M_Microsoft_Xna_Framework_BoundingBox_Equals
  http://www.monogame.net/documentation/?page=T_Microsoft_Xna_Framework_Color
  http://www.monogame.net/documentation/?page=api
  http://www.monogame.net/documentation/?page=2mgfx_md

This could still be better if we tried to reduce the URL size as some of them can get crazy:

  http://www.monogame.net/documentation/?page=M_Microsoft_Xna_Framework_Content_Pipeline_Serialization_Compiler_ContentCompiler_Compile

... not sure yet what to do about that.

I could also maybe move to support "url mod rewrite" so we could have this:

  http://www.monogame.net/documentation/T_Microsoft_Xna_Framework_Color/

... but it doesn't seem worth it to me.
