### PR TITLE
Fix burst of Game.Update calls at the start of the game

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -421,6 +421,7 @@ namespace Microsoft.Xna.Framework
             }
 
             BeginRun();
+            _gameTimer = Stopwatch.StartNew();
             switch (runBehavior)
             {
             case GameRunBehavior.Asynchronous:
@@ -440,7 +441,7 @@ namespace Microsoft.Xna.Framework
 
         private TimeSpan _accumulatedElapsedTime;
         private readonly GameTime _gameTime = new GameTime();
-        private Stopwatch _gameTimer = Stopwatch.StartNew();
+        private Stopwatch _gameTimer;
         private long _previousTicks = 0;
 
         public void Tick()


### PR DESCRIPTION
Found while investigating #2595
Test project: https://github.com/danzel/DrawTextTest/tree/isrunningslowlytest

We start the Game._gameTimer Stopwatch when the Game class is constructed. This is before we have done any of the system initialisation, which can take a while.
As such, the first time we get in to Tick, we think the game has already been running for quite a while and we need to do lots of Update calls to catch up (usually _maxElapsedTime  worth).

Instead now we only start the StopWatch when we are about to start the Update/Draw loop.

With the above test project on XNA start up looks like (see out.txt):

```
Update 0 False, 
Update 1 False, 
Draw 0 False, 
Update 2 False, 
Update 3 False, 
Draw 1 False, 
Update 4 False, 
Draw 2 False, 
Update 5 False, 
(And so on, Update Draw...)
```

But in Monogame it looked like:

```
Update 0 True, 
Update 1 True, 
Update 2 True, 
Update 3 True, 
Update 4 True, 
Update 5 True, 
Update 6 True, 
Update 7 True, 
Update 8 True, 
Update 9 True, 
Update 10 True, 
Update 11 True, 
Update 12 True, 
Update 13 True, 
Update 14 True, 
Draw 0 True, 
Update 15 True, 
Update 16 True, 
Update 17 True, 
Draw 1 True, 
Update 18 False, 
Draw 2 False, 
Update 19 False, 
Draw 3 False, 
(And so on)
```

Now the start of monogame looks like:

```
Update 0 False, 
Draw 0 False, 
Update 1 False, 
Update 2 False, 
Draw 1 False, 
Update 3 False, 
Draw 2 False, 
Update 4 False, 
Draw 3 False, 
(silky smooth!)
```
