### PR TITLE
Fixed Game.Exit() crash on WinGL and Linux platforms.

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -216,6 +216,13 @@ namespace Microsoft.Xna.Framework
             OnClientSizeChanged();
         }
 
+        internal void ProcessEvents()
+        {
+            Window.ProcessEvents();
+            UpdateWindowState();
+            HandleInput();
+        }
+
         private void UpdateWindowState()
         {
             // we should wait until window's not fullscreen to resize
@@ -347,21 +354,6 @@ namespace Microsoft.Xna.Framework
         protected override void SetTitle(string title)
         {
             window.Title = title;            
-        }
-
-        internal void Run()
-        {
-            while (window.Exists)
-            {
-                window.ProcessEvents();
-                UpdateWindowState();
-
-                if (Game != null)
-                {
-                    HandleInput();
-                    Game.Tick();
-                }
-            }
         }
 
         internal void ToggleFullScreen()


### PR DESCRIPTION
We must not call Game.Tick() after Game.Exit().
Fixes issue #2605.
