### PR TITLE
Get android working again

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -413,7 +413,11 @@ namespace Microsoft.Xna.Framework
         {
             AssertNotDisposed();
             if (!Platform.BeforeRun())
+            {
+                BeginRun();
+                _gameTimer = Stopwatch.StartNew();
                 return;
+            }
 
             if (!_initialized) {
                 DoInitialize ();


### PR DESCRIPTION
Get platforms that return false in BeforeRun working again (Just Android)

I broke this before, the Stopwatch would never be created.

refs #2615
