### PR TITLE
Fixed texture memory leak when reloading textures after app resume on Android

### DIFF
--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGraphicsDeviceResetting()
         {
-            glTexture = -1;
+            DeleteGLTexture();
             glLastSamplerState = null;
         }
 
@@ -31,17 +31,25 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (!IsDisposed)
             {
-                GraphicsDevice.AddDisposeAction(() =>
-                {
-                    GL.DeleteTextures(1, ref glTexture);
-                    GraphicsExtensions.CheckGLError();
-                    glTexture = -1;
-                });
-
+                DeleteGLTexture();
                 glLastSamplerState = null;
             }
 
             base.Dispose(disposing);
+        }
+
+        private void DeleteGLTexture()
+        {
+            if (glTexture > 0)
+            {
+                int texture = glTexture;
+                GraphicsDevice.AddDisposeAction(() =>
+                {
+                    GL.DeleteTextures(1, ref texture);
+                    GraphicsExtensions.CheckGLError();
+                });
+            }
+            glTexture = -1;
         }
     }
 }


### PR DESCRIPTION
If I suspend and resume my app 4 times, then Android OS kills it for using too much memory.
To fix the leak I call `GL.DeleteTextures(1, ref glTexture)` inside `Texture.PlatformGraphicsDeviceResetting()`.
