### PR TITLE
Make content extensions public again

### DIFF
--- a/MonoGame.Framework/Content/ContentExtensions.cs
+++ b/MonoGame.Framework/Content/ContentExtensions.cs
@@ -8,7 +8,7 @@ using System.Reflection.Emit;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    internal static class ContentExtensions
+    public static class ContentExtensions
     {
         public static ConstructorInfo GetDefaultConstructor(this Type type)
         {


### PR DESCRIPTION
Make content extensions public again as it has very useful reflection methods. We use them in our other projects.

@tomspilman turned this into internal around a month ago in this commit https://github.com/mono/MonoGame/commit/562ff8d654c903bf97f64962b954b4b8fad91ec7, but while the others are MonoGame specific, these are very general reflection methods, unrelated to MonoGame.
