### PR TITLE
MouseState.Button out of date

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -200,6 +200,11 @@ namespace MonoGame.Framework
 
         private void OnActivated(object sender, EventArgs eventArgs)
         {
+            var buttons = Control.MouseButtons;
+            var position = Control.MousePosition;
+            _mouseDownButtonsState = buttons;
+            OnMouseState(null, new MouseEventArgs(buttons, 0, position.X, position.Y, 0));
+
             _platform.IsActive = true;
         }
 


### PR DESCRIPTION
MonoGame stops processing mouse events when the game is not active, leading to the mouse buttons being 'out of date' when the game window becomes active again. 

Fix is to reset to current actual state on window activate.
