### PR TITLE
Add support for SamplerState.MaxMipLevel (WindowsGL and iOS)

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -120,6 +120,8 @@ namespace Microsoft.Xna.Framework.Graphics
         internal static int MaxTextureAnisotropy { get; private set; }
 #endif
 
+        internal static bool SupportsTextureMaxLevel { get; private set; }
+
         internal static void Initialize(GraphicsDevice device)
         {
 			SupportsNonPowerOfTwo = GetNonPowerOfTwo(device);
@@ -129,11 +131,13 @@ namespace Microsoft.Xna.Framework.Graphics
 			SupportsDepth24 = device._extensions.Contains("GL_OES_depth24");
 			SupportsPackedDepthStencil = device._extensions.Contains("GL_OES_packed_depth_stencil");
 			SupportsDepthNonLinear = device._extensions.Contains("GL_NV_depth_nonlinear");
+            SupportsTextureMaxLevel = device._extensions.Contains("GL_APPLE_texture_max_level");
 #else
-			SupportsTextureFilterAnisotropic = true;
+            SupportsTextureFilterAnisotropic = true;
 			SupportsDepth24 = true;
 			SupportsPackedDepthStencil = true;
 			SupportsDepthNonLinear = false;
+            SupportsTextureMaxLevel = true;
 #endif
 
             // Texture compression

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -23,8 +23,10 @@ namespace Microsoft.Xna.Framework.Graphics
         private static float MaxTextureMaxAnisotropy = GraphicsCapabilities.MaxTextureAnisotropy;
 #if GLES
         private const TextureParameterName TextureParameterNameTextureMaxAnisotropy = (TextureParameterName)All.TextureMaxAnisotropyExt;
+        private const TextureParameterName TextureParameterNameTextureMaxLevel = (TextureParameterName)0x813D;
 #else
         private const TextureParameterName TextureParameterNameTextureMaxAnisotropy = (TextureParameterName)ExtTextureFilterAnisotropic.TextureMaxAnisotropyExt;
+        private const TextureParameterName TextureParameterNameTextureMaxLevel = TextureParameterName.TextureMaxLevel;
 #endif
 
     internal void Activate(TextureTarget target, bool useMipmaps = false)
@@ -144,6 +146,17 @@ namespace Microsoft.Xna.Framework.Graphics
             GL.TexParameter(target, TextureParameterName.TextureLodBias, MipMapLevelOfDetailBias);
             GraphicsExtensions.CheckGLError();
 #endif
+            if (GraphicsCapabilities.SupportsTextureMaxLevel)
+            {
+                if (this.MaxMipLevel > 0)
+                {
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterNameTextureMaxLevel, this.MaxMipLevel);
+                }
+                else
+                {
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterNameTextureMaxLevel, 1000);
+                }
+            }
         }
 
     private int GetWrapMode(TextureAddressMode textureAddressMode)


### PR DESCRIPTION
SamplerState.MaxMipLevel allows to limit the maximum mipmap (the smallest one) used when mipmap filtering is enabled.
This adds support for it on WindowsGL (native support) and iOS (i am not sure there are any equivalent extension from other vendors).

This has been tested in production for a while in our branch; i am slowly bringing back all the changes we made since our last fork.
