### PR TITLE
Divided accelerometer values on Android by gravity to match XNA and iOS.

### DIFF
--- a/MonoGame.Framework/Android/Devices/Sensors/Accelerometer.cs
+++ b/MonoGame.Framework/Android/Devices/Sensors/Accelerometer.cs
@@ -177,7 +177,8 @@ namespace Microsoft.Devices.Sensors
                             accelerometer.IsDataValid = (values != null && values.Count == 3);
                             if (accelerometer.IsDataValid)
                             {
-                                reading.Acceleration = new Vector3(values[0], values[1], values[2]);
+                                const float gravity = Android.Hardware.SensorManager.GravityEarth;
+                                reading.Acceleration = new Vector3(values[0], values[1], values[2]) / gravity;
                                 reading.Timestamp = DateTime.Now;
                             }
                             accelerometer.CurrentValue = reading;


### PR DESCRIPTION
XNA and iOS report accelerometer values in gravitational units, default value is (0; 1; 0).
Android reports values in SI units (m/s^2), default value is (0; 9.81; 0).
This PR makes [Android](http://developer.android.com/reference/android/hardware/SensorEvent.html#values) accelerometer values match [XNA](http://msdn.microsoft.com/en-us/library/windowsphone/develop/microsoft.devices.sensors.accelerometerreadingeventargs.aspx) and [iOS](https://developer.apple.com/library/ios/documentation/coremotion/reference/CMAccelerometerData_Class/Reference/Reference.html#//apple_ref/doc/c_ref/CMAcceleration).
Android apps that were using old values will be broken.
