### PR TITLE
Fixed iOS NumericOverFlow Exceptions 

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -324,7 +324,10 @@ namespace Microsoft.Xna.Framework
         {
             get
             {
-                return (byte)((this._packedValue & 0x00ff0000) >> 16);
+                unchecked
+                {
+                    return (byte) (this._packedValue >> 16);
+                }
             }
             set
             {
@@ -340,7 +343,10 @@ namespace Microsoft.Xna.Framework
         {
             get
             {
-                return (byte)((this._packedValue & 0x0000ff00) >> 8);
+                unchecked
+                {
+                    return (byte)(this._packedValue >> 8);
+                }
             }
             set
             {
@@ -356,7 +362,10 @@ namespace Microsoft.Xna.Framework
         {
             get
             {
-                return (byte)(this._packedValue & 0x000000ff);
+                unchecked
+                {
+                    return (byte) this._packedValue;
+                }
             }
             set
             {
@@ -372,7 +381,10 @@ namespace Microsoft.Xna.Framework
         {
             get
             {
-                return (byte)((this._packedValue & 0xff000000) >> 24);
+                unchecked
+                {
+                    return (byte)(this._packedValue >> 24);
+                }
             }
             set
             {

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
@@ -31,7 +31,10 @@ namespace Microsoft.Xna.Framework.Graphics
             var data = new byte[_parameters.Length];
             for (var i = 0; i < _parameters.Length; i++)
             {
-                data[i] = (byte)MathHelper.Clamp(_parameters[i] | _offsets[i], byte.MinValue, byte.MaxValue);
+                unchecked
+                {
+                    data[i] = (byte)(_parameters[i] | _offsets[i]);
+                }
             }
 
             HashKey = MonoGame.Utilities.Hash.ComputeHash(data);


### PR DESCRIPTION
for Color components and Constantbuffer PlatformInitialize

I have been getting numericoverflow exceptions in iOS after updating to Xamarin.iOS 3.0.54.0 in Visual Studio with latest version of Xcode, VS2013 update 2. 

This is a simple bit mask/shift fix to ensure that the values are never larger than Byte which solves the issue. There may be other places that require this but I have only found these so far.
