### PR TITLE
Fix for #2460. Windows Phone 8 compilation on VS2013.2.

### DIFF
--- a/MonoGame.Framework/Graphics/PresentationParameters.cs
+++ b/MonoGame.Framework/Graphics/PresentationParameters.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Xna.Framework.Graphics
             depthStencilFormat = DepthFormat.None;
             multiSampleCount = 0;
             PresentationInterval = PresentInterval.Default;
-            DisplayOrientation = DisplayOrientation.Default;
+            DisplayOrientation = Microsoft.Xna.Framework.DisplayOrientation.Default;
         }
 
         public PresentationParameters Clone()


### PR DESCRIPTION
You just can't compile WP8 version when using VS2013.2. https://connect.microsoft.com/VisualStudio/feedback/details/865927/compiling-monogame-for-windowsphone-fails . A simple full name reference fixes the problem. This is a temporary fix, but with no down side. This probably won't break any other version.
