### PR TITLE
Fixed bug in detection of "natural" orientation of Android device.

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameActivity.cs
+++ b/MonoGame.Framework/Android/AndroidGameActivity.cs
@@ -1,17 +1,8 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 using Android.App;
 using Android.Content;
-using Android.Hardware;
 using Android.OS;
-using Android.Runtime;
 using Android.Views;
-using Android.Widget;
-
-using Microsoft.Xna.Framework.Input.Touch;
 
 namespace Microsoft.Xna.Framework
 {
@@ -21,6 +12,7 @@ namespace Microsoft.Xna.Framework
         internal Game Game { private get; set; }
 
         private ScreenReceiver screenReceiver;
+        private OrientationListener _orientationListener;
 
         public bool AutoPauseAndResumeMediaPlayer = true;
 
@@ -43,6 +35,8 @@ namespace Microsoft.Xna.Framework
 		    screenReceiver = new ScreenReceiver();
 		    RegisterReceiver(screenReceiver, filter);
 
+            _orientationListener = new OrientationListener(this);
+
             RequestWindowFeature(WindowFeatures.NoTitle);
 
 			Game.Activity = this;
@@ -62,6 +56,8 @@ namespace Microsoft.Xna.Framework
             if (Paused != null)
                 Paused(this, EventArgs.Empty);
 
+            if (_orientationListener.CanDetectOrientation())
+                _orientationListener.Disable();
         }
 
         public static event EventHandler Resumed;
@@ -78,12 +74,15 @@ namespace Microsoft.Xna.Framework
                     return;
                 ((GraphicsDeviceManager)deviceManager).ForceSetFullScreen();
                 ((AndroidGameWindow)Game.Window).GameView.RequestFocus();
+                if (_orientationListener.CanDetectOrientation())
+                    _orientationListener.Enable();
             }
         }
 
 		protected override void OnDestroy ()
 		{
             UnregisterReceiver(screenReceiver);
+            _orientationListener = null;
             if (Game != null)
                 Game.Dispose();
             Game = null;

--- a/MonoGame.Framework/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Android/AndroidGameWindow.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Xna.Framework
         internal IResumeManager Resumer;
 
         private readonly Game _game;
-        private readonly OrientationListener _orientationListener;
         private Rectangle _clientBounds;
         private DisplayOrientation _supportedOrientations = DisplayOrientation.Default;
         private DisplayOrientation _currentOrientation;
@@ -38,7 +37,6 @@ namespace Microsoft.Xna.Framework
         public AndroidGameWindow(AndroidGameActivity activity, Game game)
         {
             _game = game;
-            _orientationListener = new OrientationListener(Game.Activity, this);
             Initialize(activity);
 
             game.Services.AddService(typeof(View), GameView);
@@ -47,9 +45,6 @@ namespace Microsoft.Xna.Framework
         private void Initialize(Context context)
         {
             _clientBounds = new Rectangle(0, 0, context.Resources.DisplayMetrics.WidthPixels, context.Resources.DisplayMetrics.HeightPixels);
-
-            if (_orientationListener.CanDetectOrientation())
-                _orientationListener.Enable();
 
             GameView = new MonoGameAndroidGameView(context, this, _game);
             GameView.RenderFrame += OnRenderFrame;


### PR DESCRIPTION
My setup: landscape game running on a 480*854 device having portrait "natural" orientation.
Device is lying on a flat surface, I launch the game. `OrientationListener.GetDeviceDefaultOrientation()` is called from `Activity.OnCreate()`, it returns `Landscape` "natural" orientation, which is wrong.
I grab device in my hand and rotate it. The screen flips when phone orientation is portrait or reverse portrait.

This pull request contains fixes:
- Value of "natural" orientation is computed on first `OnOrientationChanged()` call (not in ctor, because it may return invalid value if called too early).
- Orientation listener is active between `Activity.OnResume()`/`OnPause()` calls.
- Orientation value of `OrientationUnknown` (-1) is ignored.
