### PR TITLE
Fixed shifted drawing on KitKat after app resume.

### DIFF
--- a/MonoGame.Framework/Android/ScreenReciever.cs
+++ b/MonoGame.Framework/Android/ScreenReciever.cs
@@ -14,8 +14,7 @@ namespace Microsoft.Xna.Framework
 			Android.Util.Log.Info("MonoGame", intent.Action.ToString());
 			if(intent.Action == Intent.ActionScreenOff)
 			{
-				ScreenReceiver.ScreenLocked = true;
-				MediaPlayer.IsMuted = true;
+                OnLocked();
 			}
 			else if(intent.Action == Intent.ActionScreenOn)
 			{
@@ -26,18 +25,27 @@ namespace Microsoft.Xna.Framework
                 // http://stackoverflow.com/questions/4260794/how-to-tell-if-device-is-sleeping
                 KeyguardManager keyguard = (KeyguardManager)context.GetSystemService(Context.KeyguardService);
                 if (!keyguard.InKeyguardRestrictedInputMode())
-                {
-                    ScreenReceiver.ScreenLocked = false;
-                    MediaPlayer.IsMuted = false;
-                }
+                    OnUnlocked();
 			}
 			else if(intent.Action == Intent.ActionUserPresent)
 			{
                 // This intent is broadcast when the user unlocks the phone
-				ScreenReceiver.ScreenLocked = false;
-				MediaPlayer.IsMuted = false;
-			}
+                OnUnlocked();
+            }
 		}
-	}
+
+        private void OnLocked()
+        {
+            ScreenReceiver.ScreenLocked = true;
+            MediaPlayer.IsMuted = true;
+        }
+
+        private void OnUnlocked()
+        {
+            ScreenReceiver.ScreenLocked = false;
+            MediaPlayer.IsMuted = false;
+            ((AndroidGameWindow)Game.Instance.Window).GameView.Resume();
+        }
+    }
 }
 

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -70,12 +70,6 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             _screen = screen;
         }
-#elif ANDROID
-        private View _view;
-        internal GraphicsAdapter(View screen)
-        {
-            _view = screen;
-        }
 #else
         internal GraphicsAdapter()
         {
@@ -105,7 +99,8 @@ namespace Microsoft.Xna.Framework.Graphics
                        60,
                        SurfaceFormat.Color);
 #elif ANDROID
-                return new DisplayMode(_view.Width, _view.Height, 60, SurfaceFormat.Color);
+                View view = ((AndroidGameWindow)Game.Instance.Window).GameView;
+                return new DisplayMode(view.Width, view.Height, 60, SurfaceFormat.Color);
 #elif (WINDOWS && OPENGL) || LINUX
 
                 return new DisplayMode(OpenTK.DisplayDevice.Default.Width, OpenTK.DisplayDevice.Default.Height, (int)OpenTK.DisplayDevice.Default.RefreshRate, SurfaceFormat.Color);
@@ -134,7 +129,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					adapters = new ReadOnlyCollection<GraphicsAdapter>(
 						new GraphicsAdapter[] {new GraphicsAdapter(UIScreen.MainScreen)});
 #elif ANDROID
-                    adapters = new ReadOnlyCollection<GraphicsAdapter>(new GraphicsAdapter[] { new GraphicsAdapter(((AndroidGameWindow)Game.Instance.Window).GameView) });
+                    adapters = new ReadOnlyCollection<GraphicsAdapter>(new GraphicsAdapter[] { new GraphicsAdapter() });
 #else
                     adapters = new ReadOnlyCollection<GraphicsAdapter>(
 						new GraphicsAdapter[] {new GraphicsAdapter()});


### PR DESCRIPTION
Fixed issues:
https://github.com/mono/MonoGame/issues/2492
http://community.monogame.net/t/bug-after-samsung-update-detecting-viewport-height-as-width/593
Reproduced and tested on Android emulator.
