### PR TITLE
No garbage generation in SensorBase.

### DIFF
--- a/MonoGame.Framework/Microsoft/Devices/Sensors/SensorBase.cs
+++ b/MonoGame.Framework/Microsoft/Devices/Sensors/SensorBase.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Devices.Sensors
         bool disposed;
 		private TimeSpan timeBetweenUpdates;
 	    private TSensorReading currentValue;
+        private SensorReadingEventArgs<TSensorReading> eventArgs = new SensorReadingEventArgs<TSensorReading>(default(TSensorReading));
 
 		public TSensorReading CurrentValue 
         {
@@ -23,8 +24,11 @@ namespace Microsoft.Devices.Sensors
 		    protected set
 		    {
 		        currentValue = value;
-		        if (this.CurrentValueChanged != null)
-		            this.CurrentValueChanged(this, new SensorReadingEventArgs<TSensorReading>(currentValue));
+                if (this.CurrentValueChanged != null)
+                {
+                    eventArgs.SensorReading = value;
+                    this.CurrentValueChanged(this, eventArgs);
+                }
 		    }
 		}
 		public bool IsDataValid { get; protected set; }


### PR DESCRIPTION
For each accelerometer event new `SensorReadingEventArgs` object was created.
