### PR TITLE
Non-static GraphicsCapabilities [2]

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Xna.Framework.Content
 
             // If the system does not fully support Power of Two textures,
             // skip any mip maps supplied with any non PoT textures.
-			if (levelCount > 1 && !GraphicsCapabilities.SupportsNonPowerOfTwo &&
+            if (levelCount > 1 && !reader.GraphicsDevice.GraphicsCapabilities.SupportsNonPowerOfTwo &&
                 (!MathHelper.IsPowerOfTwo(width) || !MathHelper.IsPowerOfTwo(height)))
             {
                 levelCountOutput = 1;
@@ -113,12 +113,12 @@ namespace Microsoft.Xna.Framework.Content
 #else
 				case SurfaceFormat.Dxt1:
                 case SurfaceFormat.Dxt1a:
-                    if (!GraphicsCapabilities.SupportsDxt1)
+                    if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsDxt1)
                         convertedFormat = SurfaceFormat.Color;
                     break;
 				case SurfaceFormat.Dxt3:
 				case SurfaceFormat.Dxt5:
-                    if (!GraphicsCapabilities.SupportsS3tc)
+                    if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
 					    convertedFormat = SurfaceFormat.Color;
 					break;
 #endif
@@ -150,15 +150,15 @@ namespace Microsoft.Xna.Framework.Content
 #if !IOS
 					case SurfaceFormat.Dxt1:
                     case SurfaceFormat.Dxt1a:
-                        if (!GraphicsCapabilities.SupportsDxt1)
+                        if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsDxt1)
 						    levelData = DxtUtil.DecompressDxt1(levelData, levelWidth, levelHeight);
 						break;
 					case SurfaceFormat.Dxt3:
-                        if (!GraphicsCapabilities.SupportsS3tc)
+                        if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
 						    levelData = DxtUtil.DecompressDxt3(levelData, levelWidth, levelHeight);
 						break;
 					case SurfaceFormat.Dxt5:
-                        if (!GraphicsCapabilities.SupportsS3tc)
+                        if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
     						levelData = DxtUtil.DecompressDxt5(levelData, levelWidth, levelHeight);
 						break;
 #endif

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -1,42 +1,6 @@
-#region License
-/*
-Microsoft Public License (Ms-PL)
-MonoGame - Copyright © 2009 The MonoGame Team
-
-All rights reserved.
-
-This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-accept the license, do not use the software.
-
-1. Definitions
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-U.S. copyright law.
-
-A "contribution" is the original software, or any additions or changes to the software.
-A "contributor" is any person that distributes its contribution under this license.
-"Licensed patents" are a contributor's patent claims that read directly on its contribution.
-
-2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-
-3. Conditions and Limitations
-(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-your patent license from such contributor to the software ends automatically.
-(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-notices that are present in the software.
-(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-code form, you may only do so under a license that complies with this license.
-(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-purpose and non-infringement.
-*/
-#endregion License
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 using System;
 using System.Collections.Generic;
@@ -57,72 +21,77 @@ namespace Microsoft.Xna.Framework.Graphics
     /// current graphics device. A very useful thread for investigating GL extenion names
     /// http://stackoverflow.com/questions/3881197/opengl-es-2-0-extensions-on-android-devices
     /// </summary>
-    internal static class GraphicsCapabilities
+    internal class GraphicsCapabilities
     {
+        public GraphicsCapabilities(GraphicsDevice graphicsDevice)
+        {
+            Initialize(graphicsDevice);
+        }
         /// <summary>
         /// Whether the device fully supports non power-of-two textures, including
         /// mip maps and wrap modes other than CLAMP_TO_EDGE
         /// </summary>
-        internal static bool SupportsNonPowerOfTwo { get; private set; }
+        internal bool SupportsNonPowerOfTwo { get; private set; }
 
         /// <summary>
         /// Whether the device supports anisotropic texture filtering
         /// </summary>
-		internal static bool SupportsTextureFilterAnisotropic { get; private set; }
+		internal bool SupportsTextureFilterAnisotropic { get; private set; }
 
-		internal static bool SupportsDepth24 { get; private set; }
+		internal bool SupportsDepth24 { get; private set; }
 
-		internal static bool SupportsPackedDepthStencil { get; private set; }
+		internal bool SupportsPackedDepthStencil { get; private set; }
 
-		internal static bool SupportsDepthNonLinear { get; private set; }
+		internal bool SupportsDepthNonLinear { get; private set; }
 
         /// <summary>
         /// Gets the support for DXT1
         /// </summary>
-        internal static bool SupportsDxt1 { get; private set; }
+        internal bool SupportsDxt1 { get; private set; }
 
         /// <summary>
         /// Gets the support for S3TC (DXT1, DXT3, DXT5)
         /// </summary>
-        internal static bool SupportsS3tc { get; private set; }
+        internal bool SupportsS3tc { get; private set; }
 
         /// <summary>
         /// Gets the support for PVRTC
         /// </summary>
-        internal static bool SupportsPvrtc { get; private set; }
+        internal bool SupportsPvrtc { get; private set; }
 
         /// <summary>
         /// Gets the support for ETC1
         /// </summary>
-        internal static bool SupportsEtc1 { get; private set; }
+        internal bool SupportsEtc1 { get; private set; }
 
         /// <summary>
         /// Gets the support for ATITC
         /// </summary>
-        internal static bool SupportsAtitc { get; private set; }
+        internal bool SupportsAtitc { get; private set; }
 
 #if OPENGL
         /// <summary>
         /// True, if GL_ARB_framebuffer_object is supported; false otherwise.
         /// </summary>
-        internal static bool SupportsFramebufferObjectARB { get; private set; }
+        internal bool SupportsFramebufferObjectARB { get; private set; }
 
         /// <summary>
         /// True, if GL_EXT_framebuffer_object is supported; false otherwise.
         /// </summary>
-        internal static bool SupportsFramebufferObjectEXT { get; private set; }
+        internal bool SupportsFramebufferObjectEXT { get; private set; }
 
         /// <summary>
         /// Gets the max texture anisotropy. This value typically lies
         /// between 0 and 16, where 0 means anisotropic filtering is not
         /// supported.
         /// </summary>
-        internal static int MaxTextureAnisotropy { get; private set; }
+        internal int MaxTextureAnisotropy { get; private set; }
 #endif
 
-        internal static bool SupportsTextureMaxLevel { get; private set; }
+        internal bool SupportsTextureMaxLevel { get; private set; }
 
-        internal static void Initialize(GraphicsDevice device)
+
+        internal void Initialize(GraphicsDevice device)
         {
 			SupportsNonPowerOfTwo = GetNonPowerOfTwo(device);
 
@@ -183,7 +152,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
         }
 
-        static bool GetNonPowerOfTwo(GraphicsDevice device)
+        bool GetNonPowerOfTwo(GraphicsDevice device)
         {
 #if OPENGL
 #if GLES

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Xna.Framework.Graphics
         private readonly RenderTargetBinding[] _currentRenderTargetBindings = new RenderTargetBinding[4];
         private int _currentRenderTargetCount;
 
+        internal GraphicsCapabilities GraphicsCapabilities { get; private set; }
+
         public TextureCollection Textures { get; private set; }
 
         public SamplerStateCollection SamplerStates { get; private set; }
@@ -127,6 +129,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentNullException("presentationParameters");
             PresentationParameters = gdi.PresentationParameters;
             SetupGL();
+            GraphicsCapabilities = new GraphicsCapabilities(this);
             GraphicsProfile = gdi.GraphicsProfile;
             Initialize();
         }
@@ -136,6 +139,7 @@ namespace Microsoft.Xna.Framework.Graphics
             PresentationParameters = new PresentationParameters();
             PresentationParameters.DepthStencilFormat = DepthFormat.Depth24;
             SetupGL();
+            GraphicsCapabilities = new GraphicsCapabilities(this);
             Initialize();
         }
 
@@ -155,6 +159,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentNullException("presentationParameters");
             PresentationParameters = presentationParameters;
             SetupGL();
+            GraphicsCapabilities = new GraphicsCapabilities(this);
             GraphicsProfile = graphicsProfile;
             Initialize();
         }
@@ -180,8 +185,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void Initialize()
         {
-            GraphicsCapabilities.Initialize(this);
-
             PlatformInitialize();
 
             // Force set the default render states.
@@ -393,10 +396,13 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             internal set
             {
-                //check Profile
+                //Check if Profile is supported.
+                //Note: A better aproach would be to recreate the Device with
+                //      the appropriate feature level each time Profile is changed.
                 if(value > GraphicsDevice.GetHighestSupportedGraphicsProfile(this))
                     throw new System.NotSupportedException(String.Format("Could not find a graphics device that supports the {0} profile", value.ToString()));
                 _graphicsProfile = value;
+                GraphicsCapabilities.Initialize(this);
             }
         }
 

--- a/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
@@ -50,14 +50,14 @@ namespace Microsoft.Xna.Framework.Graphics
 				break;
 #if GLES
 				case DepthFormat.Depth24: 
-					glDepthFormat = GraphicsCapabilities.SupportsDepth24 ? GLDepthComponent24 : GraphicsCapabilities.SupportsDepthNonLinear ? GLDepthComponent16NonLinear : GLDepthComponent16; 
+					glDepthFormat = graphicsDevice.GraphicsCapabilities.SupportsDepth24 ? GLDepthComponent24 : GraphicsCapabilities.SupportsDepthNonLinear ? GLDepthComponent16NonLinear : GLDepthComponent16; 
 				break;
 				case DepthFormat.Depth24Stencil8:
-					glDepthFormat = GraphicsCapabilities.SupportsDepth24 ? GLDepthComponent24 : GraphicsCapabilities.SupportsDepthNonLinear ? GLDepthComponent16NonLinear : GLDepthComponent16;
+					glDepthFormat = graphicsDevice.GraphicsCapabilities.SupportsDepth24 ? GLDepthComponent24 : GraphicsCapabilities.SupportsDepthNonLinear ? GLDepthComponent16NonLinear : GLDepthComponent16;
 					glStencilFormat = GLStencilIndex8; 
 				break;
 #else
-				case DepthFormat.Depth24: 
+                case DepthFormat.Depth24: 
 				  	glDepthFormat = GLDepthComponent24;
 				break;
 				case DepthFormat.Depth24Stencil8:
@@ -74,7 +74,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			if (preferredDepthFormat == DepthFormat.Depth24Stencil8)
 			{
-				if (GraphicsCapabilities.SupportsPackedDepthStencil)
+                if (graphicsDevice.GraphicsCapabilities.SupportsPackedDepthStencil)
 				{
 					this.glStencilBuffer = this.glDepthBuffer;
 					GraphicsDevice.Renderbuffer.Bind(GLRenderbuffer, this.glDepthBuffer);

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Xna.Framework.Graphics
 {
   public partial class SamplerState
   {
-        private static float MaxTextureMaxAnisotropy = GraphicsCapabilities.MaxTextureAnisotropy;
 #if GLES
         private const TextureParameterName TextureParameterNameTextureMaxAnisotropy = (TextureParameterName)All.TextureMaxAnisotropyExt;
         private const TextureParameterName TextureParameterNameTextureMaxLevel = (TextureParameterName)0x813D;
@@ -34,7 +33,7 @@ namespace Microsoft.Xna.Framework.Graphics
             switch (Filter)
       {
       case TextureFilter.Point:
-				if (GraphicsCapabilities.SupportsTextureFilterAnisotropic)
+				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
                     GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
@@ -45,7 +44,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
         break;
       case TextureFilter.Linear:
-				if (GraphicsCapabilities.SupportsTextureFilterAnisotropic)
+				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
                     GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
@@ -56,9 +55,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
         break;
       case TextureFilter.Anisotropic:
-				if (GraphicsCapabilities.SupportsTextureFilterAnisotropic)
+				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, MathHelper.Clamp(this.MaxAnisotropy, 1.0f, SamplerState.MaxTextureMaxAnisotropy));
+                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, MathHelper.Clamp(this.MaxAnisotropy, 1.0f, GraphicsDevice.GraphicsCapabilities.MaxTextureAnisotropy));
                     GraphicsExtensions.CheckGLError();
                 }
         GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.LinearMipmapLinear : TextureMinFilter.Linear));
@@ -67,7 +66,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
         break;
       case TextureFilter.PointMipLinear:
-				if (GraphicsCapabilities.SupportsTextureFilterAnisotropic)
+				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
                     GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
@@ -78,7 +77,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
         break;
             case TextureFilter.LinearMipPoint:
-				if (GraphicsCapabilities.SupportsTextureFilterAnisotropic)
+				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
                     GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
@@ -89,7 +88,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
                 break;
             case TextureFilter.MinLinearMagPointMipLinear:
-				if (GraphicsCapabilities.SupportsTextureFilterAnisotropic)
+				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
                     GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
@@ -100,7 +99,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
                 break;
             case TextureFilter.MinLinearMagPointMipPoint:
-				if (GraphicsCapabilities.SupportsTextureFilterAnisotropic)
+				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
                     GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
@@ -111,7 +110,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
                 break;
             case TextureFilter.MinPointMagLinearMipLinear:
-				if (GraphicsCapabilities.SupportsTextureFilterAnisotropic)
+				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
                     GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
@@ -122,7 +121,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
                 break;
             case TextureFilter.MinPointMagLinearMipPoint:
-				if (GraphicsCapabilities.SupportsTextureFilterAnisotropic)
+				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
                     GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
@@ -146,7 +145,7 @@ namespace Microsoft.Xna.Framework.Graphics
             GL.TexParameter(target, TextureParameterName.TextureLodBias, MipMapLevelOfDetailBias);
             GraphicsExtensions.CheckGLError();
 #endif
-            if (GraphicsCapabilities.SupportsTextureMaxLevel)
+            if (GraphicsDevice.GraphicsCapabilities.SupportsTextureMaxLevel)
             {
                 if (this.MaxMipLevel > 0)
                 {


### PR DESCRIPTION
Every GraphicsDevice now have it's own GraphicsCapabilities because an application (tools/viewer/editors/etc)might have more that one Device, possibly with different GraphicsProfile/FeatureLevel.

We need to check for capabilities only before performing actions on a devices, so a GraphicsDevice instance -and its GraphicsCapabilities- will always be accessible when needed. So, I don't see change cause any real issues in the future.

I have only tested this under WP8/Win8 in a real production project.
