### PR TITLE
PipelineTool output window line-wrapping.

### DIFF
--- a/Tools/Pipeline/Windows/MainView.Designer.cs
+++ b/Tools/Pipeline/Windows/MainView.Designer.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Windows.Forms;
+
 namespace MonoGame.Tools.Pipeline
 {
     partial class MainView
@@ -41,7 +43,7 @@ namespace MonoGame.Tools.Pipeline
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainView));
             this._treeView = new MonoGame.Tools.Pipeline.MultiSelectTreeview();
             this._propertyGrid = new System.Windows.Forms.PropertyGrid();
-            this._outputWindow = new System.Windows.Forms.TextBox();
+            this._outputWindow = new System.Windows.Forms.RichTextBox();
             this._mainMenu = new System.Windows.Forms.MenuStrip();
             this._fileMenu = new System.Windows.Forms.ToolStripMenuItem();
             this._newProjectMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -75,11 +77,11 @@ namespace MonoGame.Tools.Pipeline
             this._treeNewItemMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._treeAddItemMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._treeDeleteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+            this._treeOpenFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this._treeOpenFileLocationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this._treeRebuildMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-            this._treeOpenFileLocationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this._treeOpenFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             _toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             _toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             _toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
@@ -173,13 +175,13 @@ namespace MonoGame.Tools.Pipeline
             this._outputWindow.Dock = System.Windows.Forms.DockStyle.Fill;
             this._outputWindow.HideSelection = false;
             this._outputWindow.Location = new System.Drawing.Point(0, 0);
-            this._outputWindow.Multiline = true;
             this._outputWindow.Name = "_outputWindow";
             this._outputWindow.ReadOnly = true;
-            this._outputWindow.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+            this._outputWindow.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
             this._outputWindow.Size = new System.Drawing.Size(531, 537);
             this._outputWindow.TabIndex = 0;
-            this._outputWindow.WordWrap = false;
+            this._outputWindow.TabStop = false;
+            this._outputWindow.Text = "";
             // 
             // _mainMenu
             // 
@@ -212,18 +214,18 @@ namespace MonoGame.Tools.Pipeline
             this._fileMenu.Size = new System.Drawing.Size(37, 20);
             this._fileMenu.Text = "&File";
             // 
-            // _newMenuItem
+            // _newProjectMenuItem
             // 
-            this._newProjectMenuItem.Name = "_newMenuItem";
+            this._newProjectMenuItem.Name = "_newProjectMenuItem";
             this._newProjectMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.N)));
             this._newProjectMenuItem.Size = new System.Drawing.Size(182, 22);
             this._newProjectMenuItem.Text = "New...";
             this._newProjectMenuItem.Click += new System.EventHandler(this.OnNewProjectClick);
             // 
-            // _openMenuItem
+            // _openProjectMenuItem
             // 
-            this._openProjectMenuItem.Name = "_openMenuItem";
+            this._openProjectMenuItem.Name = "_openProjectMenuItem";
             this._openProjectMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
             this._openProjectMenuItem.Size = new System.Drawing.Size(182, 22);
             this._openProjectMenuItem.Text = "Open...";
@@ -241,9 +243,9 @@ namespace MonoGame.Tools.Pipeline
             this.toolStripSeparator3.Name = "toolStripSeparator3";
             this.toolStripSeparator3.Size = new System.Drawing.Size(179, 6);
             // 
-            // _importMenuItem
+            // _importProjectMenuItem
             // 
-            this._importProjectMenuItem.Name = "_importMenuItem";
+            this._importProjectMenuItem.Name = "_importProjectMenuItem";
             this._importProjectMenuItem.Size = new System.Drawing.Size(182, 22);
             this._importProjectMenuItem.Text = "Import...";
             this._importProjectMenuItem.Click += new System.EventHandler(this.OnImportProjectClick);
@@ -436,7 +438,7 @@ namespace MonoGame.Tools.Pipeline
             this.toolStripSeparator4,
             this._treeRebuildMenuItem});
             this._treeContextMenu.Name = "itemContextMenu";
-            this._treeContextMenu.Size = new System.Drawing.Size(174, 170);
+            this._treeContextMenu.Size = new System.Drawing.Size(174, 148);
             this._treeContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.MainMenuMenuActivate);
             // 
             // _treeNewItemMenuItem
@@ -461,6 +463,25 @@ namespace MonoGame.Tools.Pipeline
             this._treeDeleteMenuItem.Text = "&Delete";
             this._treeDeleteMenuItem.Click += new System.EventHandler(this.OnDeleteItemClick);
             // 
+            // toolStripSeparator6
+            // 
+            this.toolStripSeparator6.Name = "toolStripSeparator6";
+            this.toolStripSeparator6.Size = new System.Drawing.Size(170, 6);
+            // 
+            // _treeOpenFileMenuItem
+            // 
+            this._treeOpenFileMenuItem.Name = "_treeOpenFileMenuItem";
+            this._treeOpenFileMenuItem.Size = new System.Drawing.Size(173, 22);
+            this._treeOpenFileMenuItem.Text = "Open File";
+            this._treeOpenFileMenuItem.Click += new System.EventHandler(this.ContextMenu_OpenFile_Click);
+            // 
+            // _treeOpenFileLocationMenuItem
+            // 
+            this._treeOpenFileLocationMenuItem.Name = "_treeOpenFileLocationMenuItem";
+            this._treeOpenFileLocationMenuItem.Size = new System.Drawing.Size(173, 22);
+            this._treeOpenFileLocationMenuItem.Text = "Open File Location";
+            this._treeOpenFileLocationMenuItem.Click += new System.EventHandler(this.ContextMenu_OpenFileLocation_Click);
+            // 
             // toolStripSeparator4
             // 
             this.toolStripSeparator4.Name = "toolStripSeparator4";
@@ -472,25 +493,6 @@ namespace MonoGame.Tools.Pipeline
             this._treeRebuildMenuItem.Size = new System.Drawing.Size(173, 22);
             this._treeRebuildMenuItem.Text = "Rebuild";
             this._treeRebuildMenuItem.Click += new System.EventHandler(this.RebuildItemsMenuItemClick);
-            // 
-            // toolStripSeparator6
-            // 
-            this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(170, 6);
-            // 
-            // _treeOpenFileLocationMenuItem
-            // 
-            this._treeOpenFileLocationMenuItem.Name = "_treeOpenFileLocationMenuItem";
-            this._treeOpenFileLocationMenuItem.Size = new System.Drawing.Size(173, 22);
-            this._treeOpenFileLocationMenuItem.Text = "Open File Location";
-            this._treeOpenFileLocationMenuItem.Click += new System.EventHandler(this.ContextMenu_OpenFileLocation_Click);
-            // 
-            // _treeOpenFileMenuItem
-            // 
-            this._treeOpenFileMenuItem.Name = "_treeOpenFileMenuItem";
-            this._treeOpenFileMenuItem.Size = new System.Drawing.Size(173, 22);
-            this._treeOpenFileMenuItem.Text = "Open File";
-            this._treeOpenFileMenuItem.Click += new System.EventHandler(this.ContextMenu_OpenFile_Click);
             // 
             // MainView
             // 
@@ -506,13 +508,13 @@ namespace MonoGame.Tools.Pipeline
             this.Text = "MonoGame Pipeline";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainView_FormClosing);
             this.Load += new System.EventHandler(this.MainView_Load);
+            this.Shown += new System.EventHandler(this.MainView_Shown);
             _splitTreeProps.Panel1.ResumeLayout(false);
             _splitTreeProps.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(_splitTreeProps)).EndInit();
             _splitTreeProps.ResumeLayout(false);
             _splitEditorOutput.Panel1.ResumeLayout(false);
             _splitEditorOutput.Panel2.ResumeLayout(false);
-            _splitEditorOutput.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(_splitEditorOutput)).EndInit();
             _splitEditorOutput.ResumeLayout(false);
             this._mainMenu.ResumeLayout(false);
@@ -541,7 +543,7 @@ namespace MonoGame.Tools.Pipeline
         private System.Windows.Forms.ToolStripMenuItem _viewHelpMenuItem;
         private System.Windows.Forms.ToolStripMenuItem _aboutMenuItem;
         private System.Windows.Forms.ToolStripMenuItem _saveAsMenuItem;
-        private System.Windows.Forms.TextBox _outputWindow;
+        private System.Windows.Forms.RichTextBox _outputWindow;
         private System.Windows.Forms.ToolStripMenuItem _closeMenuItem;
         private System.Windows.Forms.ToolStripMenuItem _importProjectMenuItem;
         private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;

--- a/Tools/Pipeline/Windows/MainView.cs
+++ b/Tools/Pipeline/Windows/MainView.cs
@@ -8,10 +8,11 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace MonoGame.Tools.Pipeline
-{
+{    
     partial class MainView : Form, IView, IProjectObserver
     {
         // The project which will be opened as soon as a controller is attached.
@@ -46,6 +47,8 @@ namespace MonoGame.Tools.Pipeline
                 if (_outputWindow.Font.Name == faces[f])
                     break;               
             }
+
+            _outputWindow.SelectionHangingIndent = TextRenderer.MeasureText(" ", _outputWindow.Font).Width;            
 
             _treeIcons = new ImageList();
             _treeIcons.Images.Add(Image.FromStream(System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream(@"MonoGame.Tools.Pipeline.Icons.blueprint.png")));
@@ -685,6 +688,33 @@ namespace MonoGame.Tools.Pipeline
                 Process.Start("explorer.exe", "/select, " + filePath);
 
             }
+        }
+
+        // http://stackoverflow.com/a/3955553/168235
+        #region Custom Word-Wrapping (Output Window)
+        
+        const uint EM_SETWORDBREAKPROC = 0x00D0;
+
+        [DllImport("user32.dll")]
+        extern static IntPtr SendMessage(IntPtr hwnd, uint message, IntPtr wParam, IntPtr lParam);
+
+        delegate int EditWordBreakProc(IntPtr text, int pos_in_text, int bCharSet, int action);
+
+        event EditWordBreakProc WordWrapCallbackEvent;
+        
+        private int WordWrapCallback(IntPtr text, int pos_in_text, int bCharSet, int action)
+        {
+            return 0;
+        }
+        #endregion
+
+        private void MainView_Shown(object sender, EventArgs e)
+        {
+            WordWrapCallbackEvent = new EditWordBreakProc(WordWrapCallback);
+
+            IntPtr ptr_func = Marshal.GetFunctionPointerForDelegate(WordWrapCallbackEvent);
+
+            SendMessage(_outputWindow.Handle, EM_SETWORDBREAKPROC, IntPtr.Zero, ptr_func);
         }
     }
 }


### PR DESCRIPTION
Disabled horizontal scroll bars.
Added a small hanging indent value.
Overriding default word-wrap so that it wraps individual characters instead of words (try with this off and you'll see why I'm doing it).
