### PR TITLE
PipelineTool PropertyGrid Usability

### DIFF
--- a/Tools/Pipeline/Common/PipelineController.IncludeAction.cs
+++ b/Tools/Pipeline/Common/PipelineController.IncludeAction.cs
@@ -41,7 +41,7 @@ namespace MonoGame.Tools.Pipeline
                     _files[i] = item.OriginalPath;
 
                     _con._view.AddTreeItem(item);                    
-                    _con.Selection.Add(item, _con);                    
+                    _con.Selection.Add(_con, item);                    
                 }
 
                 _con._view.EndTreeUpdate();
@@ -60,7 +60,7 @@ namespace MonoGame.Tools.Pipeline
                         if (item.OriginalPath == f)
                         {
                             _con._project.ContentItems.Remove(item);
-                            _con.Selection.Remove(item, _con);
+                            _con.Selection.Remove(_con, item);
                             break;
                         }
                     }

--- a/Tools/Pipeline/Common/PipelineController.NewAction.cs
+++ b/Tools/Pipeline/Common/PipelineController.NewAction.cs
@@ -53,7 +53,7 @@ namespace MonoGame.Tools.Pipeline
                     item.ResolveTypes();
 
                     _con._view.AddTreeItem(item);
-                    _con.Selection.Add(item, _con);
+                    _con.Selection.Add(_con, item);
                 }
 
                 _con._view.EndTreeUpdate();
@@ -85,7 +85,7 @@ namespace MonoGame.Tools.Pipeline
                     {
                         _con._project.ContentItems.Remove(item);
                         _con._view.RemoveTreeItem(item);
-                        _con.Selection.Remove(item, _con);
+                        _con.Selection.Remove(_con, item);
                     }
                 }
                     

--- a/Tools/Pipeline/Common/Selection.cs
+++ b/Tools/Pipeline/Common/Selection.cs
@@ -1,15 +1,21 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace MonoGame.Tools.Pipeline
 {
-    internal delegate void SelectionModified(Selection selection, object source);
+    internal struct SelectionModifiedArgs
+    {
+        public IEnumerable<IProjectItem> PreviousItems;
+    }
+
+    internal delegate void SelectionModified(object sender, Selection selection, SelectionModifiedArgs args);    
 
     internal class Selection : IEnumerable<IProjectItem>
     {
         private readonly List<IProjectItem> _list;
 
-        public event SelectionModified Modified;
+        public event SelectionModified Modified;        
 
         public int Count
         {
@@ -21,25 +27,94 @@ namespace MonoGame.Tools.Pipeline
             _list = new List<IProjectItem>();
         }
         
-        public void Add(IProjectItem item, object source)
+        public void Add(object sender, IProjectItem item)
         {
+            var args = new SelectionModifiedArgs()
+                {
+                    PreviousItems = new List<IProjectItem>(_list),
+                };
+            
             _list.Add(item);
+
             if (Modified != null)
-                Modified(this, source);
+                Modified(sender, this, args);
         }
 
-        public void Remove(IProjectItem item, object source)
+        public void Remove(object sender, IProjectItem item)
         {
+            var args = new SelectionModifiedArgs()
+            {
+                PreviousItems = new List<IProjectItem>(_list),
+            };
+
             _list.Remove(item);
+
             if (Modified != null)
-                Modified(this, source);
+                Modified(sender, this, args);
         }
 
-        public void Clear(object source)
+        public void Clear(object sender)
         {
+            var args = new SelectionModifiedArgs()
+            {
+                PreviousItems = new List<IProjectItem>(_list),
+            };
+
             _list.Clear();
+
             if (Modified != null)
-                Modified(this, source);
+                Modified(sender, this, args);
+        }
+
+        public bool Equals(IEnumerable<IProjectItem> other)
+        {
+            foreach (var i in other)
+            {
+                var found = false;
+                foreach (var j in _list)
+                {
+                    if (j.OriginalPath.Equals(i.OriginalPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                    return false;                
+            }
+
+            foreach (var i in _list)
+            {
+                var found = false;
+                foreach (var j in other)
+                {
+                    if (j.OriginalPath.Equals(i.OriginalPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                    return false;
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return (_list != null ? _list.GetHashCode() : 0);
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as IEnumerable<IProjectItem>;
+            if (other == null)
+                return false;
+
+            return Equals(other);
         }
 
         public IEnumerator<IProjectItem> GetEnumerator()

--- a/Tools/Pipeline/Pipeline.csproj
+++ b/Tools/Pipeline/Pipeline.csproj
@@ -35,6 +35,12 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AdamsLair.WinForms">
+      <HintPath>packages\AdamsLair.WinForms.1.0.0.1\lib\net40-Client\AdamsLair.WinForms.dll</HintPath>
+    </Reference>
+    <Reference Include="PopupControl">
+      <HintPath>packages\AdamsLair.WinForms.PopupControl.1.0.0.0\lib\net40\PopupControl.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />
@@ -73,6 +79,7 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Windows\FolderEditing.cs" />
+    <Compile Include="Windows\PropertyGridExtensions.cs" />
     <Compile Include="Windows\UpdateAction.cs" />
     <Compile Include="Windows\MainView.cs">
       <SubType>Form</SubType>
@@ -113,6 +120,7 @@
     <EmbeddedResource Include="Windows\NewContentDialog.resx">
       <DependentUpon>NewContentDialog.cs</DependentUpon>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/Tools/Pipeline/Pipeline.csproj
+++ b/Tools/Pipeline/Pipeline.csproj
@@ -35,12 +35,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AdamsLair.WinForms">
-      <HintPath>packages\AdamsLair.WinForms.1.0.0.1\lib\net40-Client\AdamsLair.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="PopupControl">
-      <HintPath>packages\AdamsLair.WinForms.PopupControl.1.0.0.0\lib\net40\PopupControl.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />
@@ -120,7 +114,6 @@
     <EmbeddedResource Include="Windows\NewContentDialog.resx">
       <DependentUpon>NewContentDialog.cs</DependentUpon>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/Tools/Pipeline/Windows/PropertyGridExtensions.cs
+++ b/Tools/Pipeline/Windows/PropertyGridExtensions.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace MonoGame.Tools.Pipeline
+{
+    public static class PropertyGridExtensions
+    {
+        public static IEnumerable<GridItem> EnumerateGroups(this PropertyGrid propertyGrid)
+        {
+            if (propertyGrid.SelectedGridItem == null)
+                yield break;
+
+            foreach (var i in propertyGrid.EnumerateItems())
+            {
+                if (i.Expandable)
+                {
+                    yield return i;
+                }
+            }
+        }
+
+        public static IEnumerable<GridItem> EnumerateItems(this PropertyGrid propertyGrid)
+        {
+            if (propertyGrid.SelectedGridItem == null)
+                yield break;
+
+            var root = propertyGrid.SelectedGridItem;
+            while (root.Parent != null)
+                root = root.Parent;
+
+            yield return root;
+
+            foreach (var i in root.EnumerateItems())
+            {
+                yield return i;
+            }            
+        }
+
+        public static GridItem GetGroup(this PropertyGrid propertyGrid, string label)
+        {
+            if (propertyGrid.SelectedGridItem == null)
+                return null;
+
+            foreach (var i in propertyGrid.EnumerateItems())
+            {
+                if (i.Expandable && i.Label == label)
+                {
+                    return i;
+                }
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<GridItem> EnumerateItems(this GridItem item)
+        {
+            foreach (GridItem i in item.GridItems)
+            {
+                yield return i;
+
+                foreach (var j in i.EnumerateItems())
+                {
+                    yield return j;
+                }
+            }
+        }        
+    }
+}


### PR DESCRIPTION
ContentItem.Processor property is expanded by default in the property grid.

When PropertyGrid updates in response to a selection change:
- selected property / griditem is synchronized
- expanded griditems are synchronized

Selection.Modified signature changed.
