### PR TITLE
Implement video passthrough in content pipeline

### DIFF
--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -151,6 +151,7 @@
     <Compile Include="Processors\TextureProcessorOutputFormat.cs" />
     <Compile Include="Processors\VertexBufferContent.cs" />
     <Compile Include="Processors\VertexDeclarationContent.cs" />
+    <Compile Include="Processors\VideoProcessor.cs" />
 
     <!-- TwoMGFX-->
     <Compile Include="..\Tools\2MGFX\CommandLineParser.cs">	
@@ -325,6 +326,7 @@
     <Compile Include="Serialization\Compiler\Vector4Writer.cs" />
     <Compile Include="Serialization\Compiler\VertexBufferWriter.cs" />
     <Compile Include="Serialization\Compiler\VertexDeclarationWriter.cs" />
+    <Compile Include="Serialization\Compiler\VideoWriter.cs" />
 
 
     <!-- Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate -->
@@ -356,6 +358,7 @@
     <Compile Include="ExternalTool.cs" />
     <Compile Include="FbxImporter.cs" />
     <Compile Include="FontDescriptionImporter.cs" />
+    <Compile Include="H264Importer.cs" />
     <Compile Include="IContentImporter.cs" />
     <Compile Include="IContentProcessor.cs" />
     <Compile Include="InvalidContentException.cs" />

--- a/MonoGame.Framework.Content.Pipeline/H264Importer.cs
+++ b/MonoGame.Framework.Content.Pipeline/H264Importer.cs
@@ -1,0 +1,20 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Content.Pipeline
+{
+    [ContentImporter(".mp4", DisplayName = "H.264 Video - MonoGame", DefaultProcessor = "VideoProcessor")]
+    public class H264Importer : ContentImporter<VideoContent>
+    {
+        public H264Importer()
+        {
+        }
+
+        public override VideoContent Import(string filename, ContentImporterContext context)
+        {
+            var content = new VideoContent(filename);
+            return content;
+        }
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Processors/VideoProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/VideoProcessor.cs
@@ -1,0 +1,32 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using MonoGame.Framework.Content.Pipeline.Builder;
+using System.IO;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
+{
+    [ContentProcessor(DisplayName = "Video - MonoGame")]
+    public class VideoProcessor : ContentProcessor<VideoContent, VideoContent>
+    {
+        public override VideoContent Process(VideoContent input, ContentProcessorContext context)
+        {
+            var relative = Path.GetDirectoryName(PathHelper.GetRelativePath(context.OutputDirectory, context.OutputFilename));
+            var relVideoPath = PathHelper.Normalize(Path.Combine(relative, Path.GetFileName(input.Filename)));
+            var absVideoPath = PathHelper.Normalize(Path.Combine(context.OutputDirectory, relVideoPath));
+
+            // Make sure the output folder for the video exists.
+            Directory.CreateDirectory(Path.GetDirectoryName(absVideoPath));
+
+            // Copy the already encoded video file over
+            File.Copy(input.Filename, absVideoPath, true);
+            context.AddOutputFile(absVideoPath);
+
+            // Fixup relative path
+            input.Filename = PathHelper.GetRelativePath(context.OutputFilename, absVideoPath);
+
+            return input;
+        }
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/VideoWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/VideoWriter.cs
@@ -1,0 +1,20 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
+{
+    [ContentTypeWriter]
+    class VideoWriter : BuiltInContentWriter<VideoContent>
+    {
+        protected internal override void Write(ContentWriter output, VideoContent value)
+        {
+            output.Write(value.Filename);
+            output.Write((int)value.Duration.TotalMilliseconds);
+            output.Write(value.Width);
+            output.Write(value.Height);
+            output.Write(value.FramesPerSecond);
+            output.Write((int)value.VideoSoundtrackType);
+        }
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/WmvImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/WmvImporter.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// <returns>Resulting game asset.</returns>
         public override VideoContent Import(string filename, ContentImporterContext context)
         {
-            throw new NotImplementedException();
+            var content = new VideoContent(filename);
+            return content;
         }
     }
 }

--- a/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using Microsoft.Xna.Framework.Media;
+using Microsoft.Xna.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
@@ -27,16 +28,19 @@ namespace Microsoft.Xna.Framework.Content
 
         protected internal override Video Read(ContentReader input, Video existingInstance)
         {
-            string path = input.ReadObject<string>();
+            string path = input.ReadString();
 
-            path = Path.Combine(input.ContentManager.RootDirectory, path);
-            path = TitleContainer.GetFilename(path);
+            if (!string.IsNullOrEmpty(path))
+            {
+                path = FileHelpers.ResolveRelativePath(input.AssetName, path);
+                path = Path.Combine(input.ContentManager.RootDirectoryFullPath, path);
+            }
 
-            var durationMS = input.ReadObject<int>();
-            var width = input.ReadObject<int>();
-            var height = input.ReadObject<int>();
-            var framesPerSecond = input.ReadObject<Single>();
-            var soundTrackType = input.ReadObject<int>();   // 0 = Music, 1 = Dialog, 2 = Music and dialog
+            var durationMS = input.ReadInt32();
+            var width = input.ReadInt32();
+            var height = input.ReadInt32();
+            var framesPerSecond = input.ReadSingle();
+            var soundTrackType = input.ReadInt32();   // 0 = Music, 1 = Dialog, 2 = Music and dialog
             return new Video(path, durationMS)
             {
                 Width = width,

--- a/MonoGame.Framework/Media/VideoSoundtrackType.cs
+++ b/MonoGame.Framework/Media/VideoSoundtrackType.cs
@@ -10,13 +10,15 @@ namespace Microsoft.Xna.Framework.Media
     public enum VideoSoundtrackType
     {
         /// <summary>
-        /// This video contains only dialog.
-        /// </summary>
-        Dialog,
-        /// <summary>
         /// This video contains only music.
         /// </summary>
         Music,
+
+        /// <summary>
+        /// This video contains only dialog.
+        /// </summary>
+        Dialog,
+
         /// <summary>
         /// This video contains music and dialog.
         /// </summary>


### PR DESCRIPTION
This adds support for video passthrough in the content pipeline. The VideoContent object acquires metadata  for the VideoContent object by parsing output from ffprobe (part of FFMPEG).

For the processor phase, no transcoding is performed. It could be done with FFMPEG, but video authoring is such a specialized process, I imagine most authors will want to use their own tools for it.
