### PR TITLE
Add Obscured/Unobscured listeners 

### DIFF
--- a/MonoGame.Framework/WindowsPhone/WPGameWindow.cs
+++ b/MonoGame.Framework/WindowsPhone/WPGameWindow.cs
@@ -105,6 +105,14 @@ namespace MonoGame.Framework.WindowsPhone
             _orientation = ToOrientation(Page.Orientation);
             Page.OrientationChanged += Page_OrientationChanged;
 
+            Page.Loaded += delegate
+            {
+                var frame = (PhoneApplicationFrame)Application.Current.RootVisual;
+
+                frame.Obscured += delegate { if (Game.Instance != null) Platform.IsActive = false; };
+                frame.Unobscured += delegate { if (Game.Instance != null) Platform.IsActive = true; };
+            };
+
             PhoneApplicationService.Current.Activated += (sender, e) => { if (Game.Instance != null) Platform.IsActive = true; };
             PhoneApplicationService.Current.Launching += (sender, e) => { if (Game.Instance != null) Platform.IsActive = true; };
             PhoneApplicationService.Current.Deactivated += (sender, e) => { if (Game.Instance != null) Platform.IsActive = false; };


### PR DESCRIPTION
So we know when popups are in front of us.
We set IsActive=false while a popup is obscuring us, as per WP7 behavior:
http://msdn.microsoft.com/en-us/library/microsoft.xna.framework.game.isactive.aspx

Fixes #2709
