### PR TITLE
Fixed "Loading Content Twice" bug.

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -218,10 +218,17 @@ namespace Microsoft.Xna.Framework.Content
             }
 
             T result = default(T);
+            
+            // On some platforms, name and slash direction matter.
+            // We store the asset by a lowercase, /-seperating key rather than how the
+            // path to the file was passed to us to avoid
+            // loading "content/asset1.xnb" and "content\\ASSET1.xnb" as if they were two 
+            // different files. This matches stock XNA behavior.
+            var key = assetName.Replace('\\', '/').ToLower();
 
             // Check for a previously loaded asset first
             object asset = null;
-            if (loadedAssets.TryGetValue(assetName, out asset))
+            if (loadedAssets.TryGetValue(key, out asset))
             {
                 if (asset is T)
                 {
@@ -232,7 +239,7 @@ namespace Microsoft.Xna.Framework.Content
             // Load the asset.
             result = ReadAsset<T>(assetName, null);
 
-            loadedAssets[assetName] = result;
+            loadedAssets[key] = result;
             return result;
 		}
 		


### PR DESCRIPTION
ContentManager used to store its loaded assets by the path passed into Load<T>(). Because of this, something like "Content\Texture.xnb" and "content/Texture.XNB" would be loaded twice since it would fail the string comparison in the dictionary lookup.

Now we store content by a separate key, which is created by forcing the assetName/path to use all forward slashes and lowercase. This modified key isn't used anywhere else other than looking up already loaded assets, so it shouldn't break behavior anywhere else.

Note that this PR emulates the behavior of stock XNA, since path separators and casing don't matter on Windows.
