### PR TITLE
Fixed logic error when copying a file to its output folder

### DIFF
--- a/Tools/Pipeline/Common/PipelineProjectParser.cs
+++ b/Tools/Pipeline/Common/PipelineProjectParser.cs
@@ -358,7 +358,7 @@ namespace MonoGame.Tools.Pipeline
                             string include, copyToOutputDirectory;
                             ReadIncludeContent(io, out include, out copyToOutputDirectory);
 
-                            if (string.IsNullOrEmpty(copyToOutputDirectory) || !copyToOutputDirectory.Equals("Never"))
+                            if (!string.IsNullOrEmpty(copyToOutputDirectory) && !copyToOutputDirectory.Equals("Never"))
                             {
                                 var sourceFilePath = Path.GetDirectoryName(projectFilePath);
                                 sourceFilePath += "\\" + include;


### PR DESCRIPTION
Found a logic error here. If the copyToOutputDirectory string was null, the next check would throw an exception since it tries to call Equals() on it.
