### PR TITLE
Fixed possible ArgumentNullException in ContentTypeReaderManager.

### DIFF
--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -190,7 +190,9 @@ namespace Microsoft.Xna.Framework.Content
                                     originalReaderTypeString + " (" + readerTypeString + ")");
                     }
 
-                    _contentReaders.Add(contentReaders[i].TargetType, contentReaders[i]);
+                    var targetType = contentReaders[i].TargetType;
+                    if (targetType != null)
+                      _contentReaders.Add(targetType, contentReaders[i]);
 
                     // I think the next 4 bytes refer to the "Version" of the type reader,
                     // although it always seems to be zero


### PR DESCRIPTION
ContentTypeReader.TargetType can be null, e.g. for ExternalReferenceReader.
