### PR TITLE
Time improvements

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -449,6 +449,15 @@ namespace Microsoft.Xna.Framework
         private Stopwatch _gameTimer;
         private long _previousTicks = 0;
         private int _updateFrameLag;
+        private int _FPS = 0;
+        private int _FPSCounter = 0;
+        private TimeSpan _FPSDelta = TimeSpan.Zero;
+        private static TimeSpan _oneSecond = TimeSpan.FromSeconds(1.0);
+
+        /// <summary>
+        /// Gets frames per second value of the current <see cref="Game"/> loop.
+        /// </summary>
+        public int FPS { get { return _FPS; } private set { _FPS = value; } }   
 
         public void Tick()
         {
@@ -541,6 +550,21 @@ namespace Microsoft.Xna.Framework
             {
                 DoDraw(_gameTime);
             }
+
+            // Update FPS
+
+            _FPSDelta += _gameTime.ElapsedGameTime;
+
+            if (_FPSDelta >= _oneSecond)
+            {
+                _FPSDelta = TimeSpan.Zero;
+                _FPS = _FPSCounter;
+                _FPSCounter = 0;
+            }
+            else
+            {
+                _FPSCounter++;
+            }   
         }
 
         #endregion

--- a/MonoGame.Framework/GameTime.cs
+++ b/MonoGame.Framework/GameTime.cs
@@ -50,6 +50,11 @@ namespace Microsoft.Xna.Framework
 
         public bool IsRunningSlowly { get; set; }
 
+        /// <summary>
+        /// Gets amount of time between game moments which is usable for update objects movement.
+        /// </summary>
+        public float DeltaTime { get { return (float) ElapsedGameTime.TotalSeconds; } }
+
         public GameTime()
         {
             TotalGameTime = TimeSpan.Zero;


### PR DESCRIPTION
I think this commit is reasonable addition and can decrease amount of time developers spends on write own implementation or copy/paste process. Ironically, this time spends on time. Why not added DeltaTime property for easy and understandable way of applying delta time ? And why not FPS when every single game uses it ?
