### PR TITLE
Changed iOS Twitter API to use UIImage

### DIFF
--- a/MonoGame.Framework/iOS/GamerServices/Guide.cs
+++ b/MonoGame.Framework/iOS/GamerServices/Guide.cs
@@ -166,6 +166,11 @@ namespace Microsoft.Xna.Framework.GamerServices
         [CLSCompliant(false)]
         public static GKMatch Match { get; private set; }
 
+        static Guide()
+        {
+            Initialise(Game.Instance);
+        }
+
         internal static void Initialise(Game game)
         {
             var osVersionString = UIDevice.CurrentDevice.SystemVersion;


### PR DESCRIPTION
Changed iOS Twitter API to use `UIImage` instead of `string`, as requested here:
https://github.com/mono/MonoGame/pull/2718

Bonus warning fix: Corrected the XML comment documentation for `ShowMatchMaker` so that it no longer generates an invalid XML warning.
