### PR TITLE
Fixed music volume on WP8

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.WP.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WP.cs
@@ -190,7 +190,11 @@ namespace Microsoft.Xna.Framework.Media
             {
                 Deployment.Current.Dispatcher.BeginInvoke(() =>
                 {
-                    _mediaElement.Volume = _volume;
+                    // Unlike other implementations, MediaElement uses a linear scale for volume
+                    // On WP8 a volume of 0.85 seems to refer to 50% volume according to MSDN
+                    // http://msdn.microsoft.com/EN-US/library/windowsphone/develop/system.windows.controls.mediaelement.volume%28v=vs.105%29.aspx
+                    // Therefore a good approximation could be to use the 4th root of volume
+                    _mediaElement.Volume = Math.Pow(_volume, 1/4d);
                 });
             }
         }


### PR DESCRIPTION
Unlike other volume implementations, MediaElement uses a linear scale. This means that if you set the volume to 50%, it will not be half as loud, but it will be almost totally silent instead. The approximation of using the 4th root seems to work well.

See discussion for further details:
http://community.monogame.net/t/wp8-music-volume/178
