### PR TITLE
Handle touches going off our UIElement in Win8

### DIFF
--- a/MonoGame.Framework/Windows8/InputEvents.cs
+++ b/MonoGame.Framework/Windows8/InputEvents.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Xna.Framework
                 // to it else we'll get events for overlapping XAML controls.
                 inputElement.PointerPressed += UIElement_PointerPressed;
                 inputElement.PointerReleased += UIElement_PointerReleased;
+                inputElement.PointerCanceled += UIElement_PointerReleased;
                 inputElement.PointerMoved += UIElement_PointerMoved;
                 inputElement.PointerWheelChanged += UIElement_PointerWheelChanged;
             }


### PR DESCRIPTION
See #1198 for the bug details.

There are 2 possible ways to fix this:
- Listen to PointerExited events and count these as a PointerRelease.
- 'Capture' the pointer when it is pressed, this means that we get the events for it even if it is dragged off our element. I chose this fix.

I also added listening to the PointerCanceled event as we don't get PointerReleased events in certain other situations

Docs:
http://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.uielement.capturepointer
http://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.uielement.pointercanceled
