### PR TITLE
Fixes bug where the WindowsStore / WindowsStoreXaml template will not work in Visual Studio 2013.

### DIFF
--- a/ProjectTemplates/VisualStudio2012/WindowsStore/__Game.vstemplate
+++ b/ProjectTemplates/VisualStudio2012/WindowsStore/__Game.vstemplate
@@ -33,7 +33,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards</Assembly>
     <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.CreateProjectCertificate.Wizard</FullClassName>
   </WizardExtension>
 </VSTemplate>

--- a/ProjectTemplates/VisualStudio2012/WindowsStoreXaml/__XamlGame.vstemplate
+++ b/ProjectTemplates/VisualStudio2012/WindowsStoreXaml/__XamlGame.vstemplate
@@ -39,7 +39,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <Assembly>Microsoft.VisualStudio.WinRT.TemplateWizards</Assembly>
     <FullClassName>Microsoft.VisualStudio.WinRT.TemplateWizards.CreateProjectCertificate.Wizard</FullClassName>
   </WizardExtension>
 </VSTemplate>


### PR DESCRIPTION
Possible fix for #2228.

This fix removes the version bit of the offending assembly for both the WindowsStore and WindowsStoreXaml project templates for Visual Studio 2013.

To test the fix, either update the WindowsStore.zip and WindowsStoreXaml.zip on your local install with the files below or download https://github.com/Jark/sharing/raw/master/WindowsStore.zip and https://github.com/Jark/sharing/raw/master/WindowsStoreXaml.zip and overwrite the existing templates (after a backup of course) in `%USERPROFILE%\Documents\Visual Studio 2013\Templates\ProjectTemplates\Visual C#\MonoGame`

I have not verified this on my local machine yet, so unless we get verification this should not be merged in yet.
