### PR TITLE
Fixed VideoWriter/Reader

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/VideoWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/VideoWriter.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
     {
         protected internal override void Write(ContentWriter output, VideoContent value)
         {
-            output.Write(value.Filename);
-            output.Write((int)value.Duration.TotalMilliseconds);
-            output.Write(value.Width);
-            output.Write(value.Height);
-            output.Write(value.FramesPerSecond);
-            output.Write((int)value.VideoSoundtrackType);
+            output.WriteObject<string>(value.Filename);
+            output.WriteObject<int>((int)value.Duration.TotalMilliseconds);
+            output.WriteObject<int>(value.Width);
+            output.WriteObject<int>(value.Height);
+            output.WriteObject<float>(value.FramesPerSecond);
+            output.WriteObject<int>((int)value.VideoSoundtrackType);
         }
     }
 }

--- a/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Xna.Framework.Content
 
         protected internal override Video Read(ContentReader input, Video existingInstance)
         {
-            string path = input.ReadString();
+            string path = input.ReadObject<string>();
 
             if (!string.IsNullOrEmpty(path))
             {
@@ -36,11 +36,12 @@ namespace Microsoft.Xna.Framework.Content
                 path = Path.Combine(input.ContentManager.RootDirectoryFullPath, path);
             }
 
-            var durationMS = input.ReadInt32();
-            var width = input.ReadInt32();
-            var height = input.ReadInt32();
-            var framesPerSecond = input.ReadSingle();
-            var soundTrackType = input.ReadInt32();   // 0 = Music, 1 = Dialog, 2 = Music and dialog
+            var durationMS = input.ReadObject<int>();
+            var width = input.ReadObject<int>();
+            var height = input.ReadObject<int>();
+            var framesPerSecond = input.ReadObject<float>();
+            var soundTrackType = input.ReadObject<int>();  // 0 = Music, 1 = Dialog, 2 = Music and dialog
+
             return new Video(path, durationMS)
             {
                 Width = width,


### PR DESCRIPTION
Fixed format of VideoWriter/Reader to match XNA.

This was broken in https://github.com/mono/MonoGame/pull/2703 when the format was incorrectly interpreted as raw values instead of "object" types.
