### PR TITLE
Fixed Texture2D.GetData on Windows Phone

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         for (var row = 0; row < rows; row++)
                         {
                             int i;
-                            for (i = row * rowSize; i < elementCount; i++)
+                            for (i = row * rowSize; i < (row + 1) * rowSize; i++)
                                 data[i] = stream.Read<T>();
 
                             if (i >= elementCount)


### PR DESCRIPTION
I made a mistake in my last commit with this one. It is now fixed. Tested on Lumia 930 which uses row pitching.
