### PR TITLE
Fixed AndroidRuntimeException: requestFeature() must be called before adding content

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameActivity.cs
+++ b/MonoGame.Framework/Android/AndroidGameActivity.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Xna.Framework
 		/// </param>
 		protected override void OnCreate (Bundle savedInstanceState)
 		{
-			base.OnCreate (savedInstanceState);
+            RequestWindowFeature(WindowFeatures.NoTitle);
+            base.OnCreate(savedInstanceState);
 
 			IntentFilter filter = new IntentFilter();
 		    filter.AddAction(Intent.ActionScreenOff);
@@ -36,8 +37,6 @@ namespace Microsoft.Xna.Framework
 		    RegisterReceiver(screenReceiver, filter);
 
             _orientationListener = new OrientationListener(this);
-
-            RequestWindowFeature(WindowFeatures.NoTitle);
 
 			Game.Activity = this;
 		}


### PR DESCRIPTION
This exception is raised when Android system recreates activity that uses Fragments.
To fix this, I moved `RequestWindowFeature(WindowFeatures.NoTitle)` before `base.OnCreate (savedInstanceState)`.
http://stackoverflow.com/questions/16939814/android-util-androidruntimeexception-requestfeature-must-be-called-before-add
https://github.com/JakeWharton/ActionBarSherlock/issues/310

> UNHANDLED EXCEPTION: Android.Util.AndroidRuntimeException: Exception of type 'Android.Util.AndroidRuntimeException' was thrown.
> at Android.Runtime.JNIEnv.CallBooleanMethod (intptr,intptr,Android.Runtime.JValue[]) <0x00104>
> at Android.App.Activity.RequestWindowFeature (Android.Views.WindowFeatures) <0x000eb>
> at Microsoft.Xna.Framework.AndroidGameActivity.OnCreate (Android.OS.Bundle) <0x0010b>
> at ParkingManiaAndroid.MainActivity.OnCreate (Android.OS.Bundle) <0x000c7>
> at Android.App.Activity.n_OnCreate_Landroid_os_Bundle_ (intptr,intptr,intptr) <0x0005b>
> at (wrapper dynamic-method) object.7042bef8-f299-40b4-99cf-a71abe9ffb25 (intptr,intptr,intptr) <0x00043>
>  --- End of managed exception stack trace ---
> android.util.AndroidRuntimeException: requestFeature() must be called before adding content
> at com.android.internal.policy.impl.PhoneWindow.requestFeature(PhoneWindow.java:301)
> at android.app.Activity.requestWindowFeature(Activity.java:3305)
> at parkingmaniaandroid.MainActivity.n_onCreate(Native Method)
> at parkingmaniaandroid.MainActivity.onCreate(MainActivity.java:38)
> at android.app.Activity.performCreate(Activity.java:5165)
> at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1103)
> at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2419)
> at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2520)
> at android.app.ActivityThread.access$600(ActivityThread.java:162)
> at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1366)
> at android.os.Handler.dispatchMessage(Handler.java:99)
> at android.os.Looper.loop(Looper.java:158)
> at android.app.ActivityThread.main(ActivityThread.java:5751)
> at java.lang.reflect.Method.invokeNative(Native Method)
> at java.lang.reflect.Method.invoke(Method.java:511)
> at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1083)
> at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:850)
> at dalvik.system.NativeStart.main(Native Method)
