### PR TITLE
Fixed volume up/down buttons being handled twice on Android.

### DIFF
--- a/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
@@ -264,14 +264,16 @@ namespace Microsoft.Xna.Framework
 
             if (keyCode == Keycode.VolumeUp)
             {
-                AudioManager audioManager = (AudioManager)Game.Activity.GetSystemService(Context.AudioService);
+                AudioManager audioManager = (AudioManager)Context.GetSystemService(Context.AudioService);
                 audioManager.AdjustStreamVolume(Stream.Music, Adjust.Raise, VolumeNotificationFlags.ShowUi);
+                return true;
             }
 
             if (keyCode == Keycode.VolumeDown)
             {
-                AudioManager audioManager = (AudioManager)Game.Activity.GetSystemService(Context.AudioService);
+                AudioManager audioManager = (AudioManager)Context.GetSystemService(Context.AudioService);
                 audioManager.AdjustStreamVolume(Stream.Music, Adjust.Lower, VolumeNotificationFlags.ShowUi);
+                return true;
             }
 
             return base.OnKeyDown(keyCode, e);


### PR DESCRIPTION
Volume up/down buttons were changing volume by 2 steps instead of 1 step.
Bug caused by https://github.com/mono/MonoGame/pull/2789.
