### PR TITLE
Error Cleanup In IntermediateReader.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/EnumSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/EnumSerializer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
             }
             catch (Exception ex)
             {
-                throw new InvalidContentException(string.Format("Invalid enum value `{0}` for type `{1}`", str, TargetType.Name), ex);
+                throw input.NewInvalidContentException(ex, "Invalid enum value '{0}' for type '{1}'", str, TargetType.Name);
             }
         }
 

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateSerializer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
         {
             var serializer = new IntermediateSerializer();
             var reader = new IntermediateReader(serializer, input, referenceRelocationPath);
-            T asset;
+            var asset = default(T);
 
             try
             {
@@ -88,7 +88,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
             }
             catch (XmlException xmlException)
             {
-                throw new InvalidContentException("An error occured parsing Xml.", xmlException);
+                throw reader.NewInvalidContentException(xmlException, "An error occured parsing.");
             }
 
             return asset;


### PR DESCRIPTION
Some cleanup in how `IntermediateReader` throws `InvalidContentException`s.
