### PR TITLE
Fixed ResizeToPowerOfTwo

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
@@ -62,7 +62,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             if (ResizeToPowerOfTwo)
             {
                 if (!GraphicsUtil.IsPowerOfTwo(bmp.Width) || !GraphicsUtil.IsPowerOfTwo(bmp.Height))
+                {
                     input.Resize(GraphicsUtil.GetNextPowerOfTwo(bmp.Width), GraphicsUtil.GetNextPowerOfTwo(bmp.Height));
+                    bmp = input.Faces[0][0];
+                }
             }
 
             if (PremultiplyAlpha)


### PR DESCRIPTION
This fixes the ResizeToPowerOfTwo feature of TextureProcessor which was previously not working at all.
