### PR TITLE
Reverted PR #2660 as it caused issue #2812

### DIFF
--- a/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
@@ -60,36 +60,8 @@ namespace Microsoft.Xna.Framework
         //AndroidGameView also implements ISurfaceHolderCallback and has these methods.
         //That is why these get called even though we never register as a SurfaceHolderCallback
 
-        private bool _isSurfaceChanged = false;
-        private int _prevSurfaceWidth = 0;
-        private int _prevSurfaceHeight = 0;
-
         void ISurfaceHolderCallback.SurfaceChanged(ISurfaceHolder holder, Android.Graphics.Format format, int width, int height)
         {
-            if ((int)Android.OS.Build.VERSION.SdkInt >= 19)
-            {
-                if (!_isSurfaceChanged)
-                {
-                    _isSurfaceChanged = true;
-                    _prevSurfaceWidth = width;
-                    _prevSurfaceHeight = height;
-                }
-                else
-                {
-                    // Forcing reinitialization of the view if SurfaceChanged() is called more than once to fix shifted drawing on KitKat.
-                    // See https://github.com/mono/MonoGame/issues/2492.
-                    if (!ScreenReceiver.ScreenLocked && Game.Instance.Platform.IsActive &&
-                        (_prevSurfaceWidth != width || _prevSurfaceHeight != height))
-                    {
-                        _prevSurfaceWidth = width;
-                        _prevSurfaceHeight = height;
-
-                        base.SurfaceDestroyed(holder);
-                        base.SurfaceCreated(holder);
-                    }
-                }
-            }
-
             SurfaceChanged(holder, format, width, height);
             Android.Util.Log.Debug("MonoGame", "MonoGameAndroidGameView.SurfaceChanged: format = " + format + ", width = " + width + ", height = " + height);
 
@@ -107,7 +79,6 @@ namespace Microsoft.Xna.Framework
         {
             SurfaceCreated(holder);
             Android.Util.Log.Debug("MonoGame", "MonoGameAndroidGameView.SurfaceCreated: surfaceFrame = " + holder.SurfaceFrame.ToString());
-            _isSurfaceChanged = false;
         }
 
         #endregion


### PR DESCRIPTION
Reverted PR https://github.com/mono/MonoGame/pull/2660 (Fixed shifted drawing on KitKat after app resume) to fix https://github.com/mono/MonoGame/issues/2812 (Android 4.4 KitKat Home/Back Button Black Screen).
Some other solution needs to be found to fix shifted drawing on KitKat after app resume.
