### PR TITLE
Fixed issue #2492 (Drawing shifted up and off screen in KitKat)

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameActivity.cs
+++ b/MonoGame.Framework/Android/AndroidGameActivity.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Xna.Framework
 
 		public override void OnConfigurationChanged (Android.Content.Res.Configuration newConfig)
 		{
-			// we need to refresh the viewport here.
 			base.OnConfigurationChanged (newConfig);
 		}
 

--- a/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
@@ -61,36 +61,8 @@ namespace Microsoft.Xna.Framework
         //AndroidGameView also implements ISurfaceHolderCallback and has these methods.
         //That is why these get called even though we never register as a SurfaceHolderCallback
 
-        private bool _isSurfaceChanged = false;
-        private int _prevSurfaceWidth = 0;
-        private int _prevSurfaceHeight = 0;
-
         void ISurfaceHolderCallback.SurfaceChanged(ISurfaceHolder holder, Android.Graphics.Format format, int width, int height)
         {
-            if ((int)Android.OS.Build.VERSION.SdkInt >= 19)
-            {
-                if (!_isSurfaceChanged)
-                {
-                    _isSurfaceChanged = true;
-                    _prevSurfaceWidth = width;
-                    _prevSurfaceHeight = height;
-                }
-                else
-                {
-                    // Forcing reinitialization of the view if SurfaceChanged() is called more than once to fix shifted drawing on KitKat.
-                    // See https://github.com/mono/MonoGame/issues/2492.
-                    if (!ScreenReceiver.ScreenLocked && Game.Instance.Platform.IsActive &&
-                        (_prevSurfaceWidth != width || _prevSurfaceHeight != height))
-                    {
-                        _prevSurfaceWidth = width;
-                        _prevSurfaceHeight = height;
-
-                        base.SurfaceDestroyed(holder);
-                        base.SurfaceCreated(holder);
-                    }
-                }
-            }
-
             SurfaceChanged(holder, format, width, height);
             Android.Util.Log.Debug("MonoGame", "MonoGameAndroidGameView.SurfaceChanged: format = " + format + ", width = " + width + ", height = " + height);
 
@@ -108,7 +80,6 @@ namespace Microsoft.Xna.Framework
         {
             SurfaceCreated(holder);
             Android.Util.Log.Debug("MonoGame", "MonoGameAndroidGameView.SurfaceCreated: surfaceFrame = " + holder.SurfaceFrame.ToString());
-            _isSurfaceChanged = false;
         }
 
         #endregion

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -566,6 +566,8 @@ namespace Microsoft.Xna.Framework
         internal void ResetClientBounds()
         {
 #if ANDROID
+            ((AndroidGameWindow)_game.Window).GameView.MakeCurrent();
+
             float preferredAspectRatio = (float)PreferredBackBufferWidth /
                                          (float)PreferredBackBufferHeight;
             float displayAspectRatio = (float)GraphicsDevice.DisplayMode.Width / 


### PR DESCRIPTION
This is a second attempt to fix issue #2492.
This requires having ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize
