### PR TITLE
Removed unused using's from some templates

### DIFF
--- a/ProjectTemplates/VisualStudio2010/Linux/Game1.cs
+++ b/ProjectTemplates/VisualStudio2010/Linux/Game1.cs
@@ -1,13 +1,6 @@
-﻿#region Using Statements
-using System;
-using System.Collections.Generic;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Content;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using Microsoft.Xna.Framework.Storage;
-using Microsoft.Xna.Framework.GamerServices;
-#endregion
 
 namespace $safeprojectname$
 {

--- a/ProjectTemplates/VisualStudio2010/Windows/Game1.cs
+++ b/ProjectTemplates/VisualStudio2010/Windows/Game1.cs
@@ -1,13 +1,6 @@
-﻿#region Using Statements
-using System;
-using System.Collections.Generic;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Content;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using Microsoft.Xna.Framework.Storage;
-using Microsoft.Xna.Framework.GamerServices;
-#endregion
 
 namespace $safeprojectname$
 {

--- a/ProjectTemplates/VisualStudio2010/WindowsGL/Game1.cs
+++ b/ProjectTemplates/VisualStudio2010/WindowsGL/Game1.cs
@@ -1,13 +1,6 @@
-﻿#region Using Statements
-using System;
-using System.Collections.Generic;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Content;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using Microsoft.Xna.Framework.Storage;
-using Microsoft.Xna.Framework.GamerServices;
-#endregion
 
 namespace $safeprojectname$
 {


### PR DESCRIPTION
Microsoft.Xna.Framework.GamerServices is invalid and cause error and other using's is not used at beginning(in templates for OYUA or Win8 they arent exist already).
