### PR TITLE
Renamed default project names from GameName to Game

### DIFF
--- a/ProjectTemplates/VisualStudio2010/Android/MonoGameAndroid.vstemplate
+++ b/ProjectTemplates/VisualStudio2010/Android/MonoGameAndroid.vstemplate
@@ -7,7 +7,7 @@
     </ProjectSubType>
     <SortOrder>1000</SortOrder>
     <CreateNewFolder>true</CreateNewFolder>
-    <DefaultName>GameName</DefaultName>
+    <DefaultName>Game</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <LocationField>Enabled</LocationField>
     <EnableLocationBrowseButton>true</EnableLocationBrowseButton>

--- a/ProjectTemplates/VisualStudio2010/Content/MonoGameContent.vstemplate
+++ b/ProjectTemplates/VisualStudio2010/Content/MonoGameContent.vstemplate
@@ -5,7 +5,7 @@
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1000</SortOrder>
     <CreateNewFolder>true</CreateNewFolder>
-    <DefaultName>GameName</DefaultName>
+    <DefaultName>Game</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <LocationField>Enabled</LocationField>
     <EnableLocationBrowseButton>true</EnableLocationBrowseButton>

--- a/ProjectTemplates/VisualStudio2010/Linux/MyTemplate.vstemplate
+++ b/ProjectTemplates/VisualStudio2010/Linux/MyTemplate.vstemplate
@@ -8,7 +8,7 @@
     </ProjectSubType>
     <SortOrder>1000</SortOrder>
     <CreateNewFolder>true</CreateNewFolder>
-    <DefaultName>GameName</DefaultName>
+    <DefaultName>Game</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <LocationField>Enabled</LocationField>
     <EnableLocationBrowseButton>true</EnableLocationBrowseButton>

--- a/ProjectTemplates/VisualStudio2010/OUYA/MonoGameOUYA.vstemplate
+++ b/ProjectTemplates/VisualStudio2010/OUYA/MonoGameOUYA.vstemplate
@@ -7,7 +7,7 @@
     </ProjectSubType>
     <SortOrder>1000</SortOrder>
     <CreateNewFolder>true</CreateNewFolder>
-    <DefaultName>GameName</DefaultName>
+    <DefaultName>Game</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <LocationField>Enabled</LocationField>
     <EnableLocationBrowseButton>true</EnableLocationBrowseButton>

--- a/ProjectTemplates/VisualStudio2010/Windows/MyTemplate.vstemplate
+++ b/ProjectTemplates/VisualStudio2010/Windows/MyTemplate.vstemplate
@@ -8,7 +8,7 @@
     </ProjectSubType>
     <SortOrder>1000</SortOrder>
     <CreateNewFolder>true</CreateNewFolder>
-    <DefaultName>GameName</DefaultName>
+    <DefaultName>Game</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <LocationField>Enabled</LocationField>
     <EnableLocationBrowseButton>true</EnableLocationBrowseButton>

--- a/ProjectTemplates/VisualStudio2010/WindowsGL/MyTemplate.vstemplate
+++ b/ProjectTemplates/VisualStudio2010/WindowsGL/MyTemplate.vstemplate
@@ -8,7 +8,7 @@
     </ProjectSubType>
     <SortOrder>1000</SortOrder>
     <CreateNewFolder>true</CreateNewFolder>
-    <DefaultName>GameName</DefaultName>
+    <DefaultName>Game</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <LocationField>Enabled</LocationField>
     <EnableLocationBrowseButton>true</EnableLocationBrowseButton>

--- a/ProjectTemplates/VisualStudio2012/WindowsPhone/__Game.vstemplate
+++ b/ProjectTemplates/VisualStudio2012/WindowsPhone/__Game.vstemplate
@@ -10,7 +10,7 @@
     <ProjectType>CSharp</ProjectType>
     <SortOrder>40</SortOrder>
     <CreateNewFolder>true</CreateNewFolder>
-    <DefaultName>GameName</DefaultName>
+    <DefaultName>Game</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <LocationField>Enabled</LocationField>
     <EnableLocationBrowseButton>true</EnableLocationBrowseButton>

--- a/ProjectTemplates/VisualStudio2012/WindowsStore/__Game.vstemplate
+++ b/ProjectTemplates/VisualStudio2012/WindowsStore/__Game.vstemplate
@@ -10,7 +10,7 @@
     <ProjectType>CSharp</ProjectType>
     <SortOrder>40</SortOrder>
     <CreateNewFolder>true</CreateNewFolder>
-    <DefaultName>GameName</DefaultName>
+    <DefaultName>Game</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <LocationField>Enabled</LocationField>
     <EnableLocationBrowseButton>true</EnableLocationBrowseButton>

--- a/ProjectTemplates/VisualStudio2012/WindowsStoreXaml/__XamlGame.vstemplate
+++ b/ProjectTemplates/VisualStudio2012/WindowsStoreXaml/__XamlGame.vstemplate
@@ -10,7 +10,7 @@
     <ProjectType>CSharp</ProjectType>
     <SortOrder>40</SortOrder>
     <CreateNewFolder>true</CreateNewFolder>
-    <DefaultName>GameName</DefaultName>
+    <DefaultName>Game</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <LocationField>Enabled</LocationField>
     <EnableLocationBrowseButton>true</EnableLocationBrowseButton>


### PR DESCRIPTION
In XNA default project name is Game(1,2,3...). In MonoGame its GameName. If developer creates many projects for test, he/she may not have time for proper name and GameName is ugly and not pleasant, compared to original. 
