### PR TITLE
[WP8] Optimize .XAP size

### DIFF
--- a/ProjectTemplates/VisualStudio2012/WindowsPhone/Application.csproj
+++ b/ProjectTemplates/VisualStudio2012/WindowsPhone/Application.csproj
@@ -45,15 +45,7 @@
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>           
-    <AllowedReferenceRelatedFileExtensions>
-      <!-- Prevent default XML files copied to output in RELEASE. 
-           Only *.allowedextension files will be included, which doesn't exist in my case.
-       -->
-      .allowedextension
-    </AllowedReferenceRelatedFileExtensions>
-    <DocumentationFile>
-    </DocumentationFile>    
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|ARM' ">
     <DebugSymbols>true</DebugSymbols>
@@ -74,15 +66,7 @@
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>           
-    <AllowedReferenceRelatedFileExtensions>
-      <!-- Prevent default XML files copied to output in RELEASE. 
-           Only *.allowedextension files will be included, which doesn't exist in my case.
-       -->
-      .allowedextension
-    </AllowedReferenceRelatedFileExtensions>
-    <DocumentationFile>
-    </DocumentationFile>    
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="App.xaml.cs">
@@ -157,6 +141,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
+
+  <Target Name="AfterResolveReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(_ReferenceRelatedPaths)" Condition="'%(Extension)' == '.xml'" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="MonoGame_RemoveXnaAssemblies" AfterTargets="ImplicitlyExpandTargetFramework">
     <Message Text="MonoGame - Removing XNA Assembly references!" Importance="normal"/>


### PR DESCRIPTION
This prevent the .XML documentation files (MonoGame.Framework.xml,
SharpDX.xml, etc) to get copied into the .XAP file. Those are text files
and compress well in the xap but take significant space once the app is
deployed.
http://stackoverflow.com/questions/2011434/preventing-referenced-assembly-pdb-and-xml-files-copied-to-output

I created two projects, Game1 (old template) & Game2 (new template),
build with ARM/Release  and deploy to the phone.

In the /Bin directory:
Game1_Release_ARM.xap 1163 KB
Game2_Release_ARM.xap  572 KB

On the phone (Settings/Phone Storage/Apps)
Game1_Release_ARM.xap 14,15 MB
Game2_Release_ARM.xap  7,20 MB
