### PR TITLE
Boolean logic error

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -172,8 +172,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 var currentWidth = PresentationParameters.BackBufferWidth;
                 var currentHeight = PresentationParameters.BackBufferHeight;
 
-                if (_depthStencilView == null || (currentWidth != texture2D.Description.Width &&
-                    currentHeight != texture2D.Description.Height))
+                if (_depthStencilView == null || 
+                    currentWidth  != texture2D.Description.Width ||
+                    currentHeight != texture2D.Description.Height)
                 {
                     PresentationParameters.BackBufferWidth = texture2D.Description.Width;
                     PresentationParameters.BackBufferHeight = texture2D.Description.Height;


### PR DESCRIPTION
The statement here is wrong. If the backbuffer change from 480x800 to
480x480 (an awkward thing to do) the _depthStencilView will not get
updated.

More on this method on another issue.
