### PR TITLE
WinForm Easy Embed

### DIFF
--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -80,9 +80,9 @@ namespace Microsoft.Xna.Framework.Input
 
 #elif (WINDOWS && DIRECTX)
 
-        static System.Windows.Forms.Form Window;
+        static System.Windows.Forms.Control Window;
 
-        internal static void SetWindows(System.Windows.Forms.Form window)
+        internal static void SetWindows(System.Windows.Forms.Control window)
         {
             Window = window;
         }

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -117,7 +117,14 @@ namespace MonoGame.Framework
 
         public override void BeforeInitialize()
         {
-            _window.Initialize(Game.graphicsDeviceManager.PreferredBackBufferWidth, Game.graphicsDeviceManager.PreferredBackBufferHeight);
+            if (WindowsDeviceConfig.UseForm)
+            {
+                _window.Initialize(Game.graphicsDeviceManager.PreferredBackBufferWidth, Game.graphicsDeviceManager.PreferredBackBufferHeight);
+            }
+            else
+            {
+                _window.Initialize(WindowsDeviceConfig.ControlToUse.Width, WindowsDeviceConfig.ControlToUse.Height);
+            }
 
             base.BeforeInitialize();
 
@@ -169,17 +176,25 @@ namespace MonoGame.Framework
                 return;
             }
 
+            Form f = _window._form as Form;
+
             if (Game.graphicsDeviceManager.HardwareModeSwitch)
             {
                  Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
                  Game.GraphicsDevice.CreateSizeDependentResources(true);
                  Game.GraphicsDevice.ApplyRenderTargets(null);
-                _window._form.WindowState = FormWindowState.Maximized;
+                 if (f != null)
+                 {
+                     f.WindowState = FormWindowState.Maximized;
+                 }
             }
             else
             {
                 _window.IsBorderless = true;
-                _window._form.WindowState = FormWindowState.Maximized;
+                if (f != null)
+                {
+                    f.WindowState = FormWindowState.Maximized;
+                }
             }
 
             _alreadyInWindowedMode = false;
@@ -195,16 +210,25 @@ namespace MonoGame.Framework
                return;
             }
 
+            Form f = _window._form as Form;
+
             if (Game.graphicsDeviceManager.HardwareModeSwitch)
             {
-                _window._form.WindowState = FormWindowState.Normal;
+                if (f != null)
+                {
+                    f.WindowState = FormWindowState.Normal;
+                }
+            
                 Game.GraphicsDevice.PresentationParameters.IsFullScreen = false;
                 Game.GraphicsDevice.CreateSizeDependentResources(true);
                 Game.GraphicsDevice.ApplyRenderTargets(null);
             }
             else
             {
-                _window._form.WindowState = FormWindowState.Normal;
+                if (f != null)
+                {
+                    f.WindowState = FormWindowState.Normal;
+                }
                 _window.IsBorderless = false;
             }
             ResetWindowBounds();


### PR DESCRIPTION
Hey @tomspilman,

It feels like creating an embedded Game class in win forms is extremely difficult in MonoGame.  I've struggled with this for like 4 years now, and it seems that people on the web have hundreds of hacky work arounds to make this all work.

I was wondering if you would consider an addition like this which would greatly simplify making editors and other monogame embedded applications.  Given the small changes, it makes it possible for me to do use a Custom User Control and have Monogame render to that instead of to the hard coded WinFormsGameForm.  Controls will still work, mouse and everything.  Sample code below.

```
        private void Control_Load(object sender, EventArgs e)
        {
            if (this.DesignMode == false)
            {
                WindowsDeviceConfig.UseForm = false;
                WindowsDeviceConfig.ControlToUse = this;

                MyGame game = new MyGame();
                game.IsFixedTimeStep = false;

                Thread t = new Thread(new ThreadStart(() =>
                {
                    while (true)
                    {
                        this.Invoke(new MethodInvoker(() =>
                        {
                            game.RunOneFrame();
                        }));

                        Thread.Sleep(16);
                    }
                }));

                t.IsBackground = true;
                t.Name = "Monogame Thread";
                t.Start();                
            }
        }
```

Thoughts?
