### PR TITLE
OpenGL SamplerState had null GraphicsDevice

### DIFF
--- a/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     // GL.BindTexture(texture.glTarget, texture.glTexture);
                     // GraphicsExtensions.CheckGLError();
 
-                    sampler.Activate(texture.glTarget, texture.LevelCount > 1);
+                    sampler.Activate(device, texture.glTarget, texture.LevelCount > 1);
                     texture.glLastSamplerState = sampler;
                 }
             }

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics;
 
 #if MONOMAC
 using MonoMac.OpenGL;
@@ -29,8 +30,16 @@ namespace Microsoft.Xna.Framework.Graphics
         private const TextureParameterName TextureParameterNameTextureMaxLevel = TextureParameterName.TextureMaxLevel;
 #endif
 
-    internal void Activate(TextureTarget target, bool useMipmaps = false)
-    {
+        internal void Activate(GraphicsDevice device, TextureTarget target, bool useMipmaps = false)
+        {
+            if (GraphicsDevice == null)
+            {
+                // We're now bound to a device... no one should
+                // be changing the state of this object now!
+                GraphicsDevice = device;
+            }
+            Debug.Assert(GraphicsDevice == device, "The state was created for a different device!");
+
             switch (Filter)
       {
       case TextureFilter.Point:


### PR DESCRIPTION
The GraphicsDevice had never been set in the OpenGL version of SamplerState. This PR sets it and checks for the SamplerState being used on the same GraphicsDevice as it was first used, similar to the DirectX version.
