### PR TITLE
Implementing "Song.FromUri"

### DIFF
--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -69,6 +69,20 @@ namespace Microsoft.Xna.Framework.Media
 		{
 			get { return _name; }
 		}
+
+        public static Song FromUri(string name, Uri uri)
+        {
+            if (!uri.IsAbsoluteUri)
+            {
+                var song = new Song(uri.OriginalString);
+                song._name = name;
+                return song;
+            }
+            else
+            {
+                throw new NotImplementedException("Loading songs from an absolute path is not implemented");
+            }
+        }
 		
 		public void Dispose()
         {


### PR DESCRIPTION
As documented in: http://msdn.microsoft.com/en-us/library/microsoft.xna.framework.media.song.fromuri.aspx
This method is implemented so a project can load a song from disc using a relative uri. There are more use cases not implemented but this can serve as a start.
