### PR TITLE
Timer should only be initialized once when using RunOneFrame()

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -407,11 +407,11 @@ namespace Microsoft.Xna.Framework
 
             if (!_initialized) {
                 DoInitialize ();
+                _gameTimer = Stopwatch.StartNew();
                 _initialized = true;
             }
 
-            BeginRun();
-            _gameTimer = Stopwatch.StartNew();
+            BeginRun();            
 
             //Not quite right..
             Tick ();


### PR DESCRIPTION
As discussed in #2871, moves the initialization of the timer the one time initialize section.
