### PR TITLE
UseReferenceDevice Fix

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1236,7 +1236,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             GraphicsProfile graphicsProfile;
 
-            if (featureLevel >= FeatureLevel.Level_10_0)
+            if (featureLevel >= FeatureLevel.Level_10_0 || GraphicsAdapter.UseReferenceDevice)
                 graphicsProfile = GraphicsProfile.HiDef;
             else 
                 graphicsProfile = GraphicsProfile.Reach;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -399,8 +399,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 //Check if Profile is supported.
                 //TODO: [DirectX] Recreate the Device using the new 
                 //      feature level each time the Profile changes.
-                if(value > GraphicsDevice.GetHighestSupportedGraphicsProfile(this))
-                    throw new System.NotSupportedException(String.Format("Could not find a graphics device that supports the {0} profile", value.ToString()));
+                if(value > GetHighestSupportedGraphicsProfile(this))
+                    throw new NotSupportedException(String.Format("Could not find a graphics device that supports the {0} profile", value.ToString()));
                 _graphicsProfile = value;
                 GraphicsCapabilities.Initialize(this);
             }


### PR DESCRIPTION
This allows `GraphicsProfile.HiDef` when `GraphicsAdapter.UseReferenceDevice` is enabled.
