### PR TITLE
ScissorRectangleTest Fix

### DIFF
--- a/Test/Framework/Visual/ScissorRectangleTest.cs
+++ b/Test/Framework/Visual/ScissorRectangleTest.cs
@@ -42,6 +42,7 @@ namespace MonoGame.Tests.Visual
                 Game.GraphicsDevice.ScissorRectangle = new Rectangle(0, 0, 20, 20);
                 Game.GraphicsDevice.SetRenderTarget(_extraRenderTarget);
                 Game.GraphicsDevice.SetRenderTargets(renderTargets);
+                Game.GraphicsDevice.Clear(new Color(68, 34, 136, 255));
                 DrawTexture();
             };
 


### PR DESCRIPTION
Fixed one of the `ScissorRectangleTest` tests which was failing because we disabled the discarded render target clear in release builds.  By ensuring we always clear it makes the test consistent in debug and release without changing the goal of the test.
