### PR TITLE
Make AndroidGamePlatform.Exit() to finish current activity.

### DIFF
--- a/MonoGame.Framework/Android/AndroidGamePlatform.cs
+++ b/MonoGame.Framework/Android/AndroidGamePlatform.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Xna.Framework
 
         public override void Exit()
         {
-            Game.Activity.MoveTaskToBack(true);
+            Game.Activity.Finish();
         }
 
         public override void RunLoop()


### PR DESCRIPTION
This is default back key press behavior (http://developer.android.com/reference/android/app/Activity.html#onBackPressed%28%29). Previously activity was kept alive.
This PR partially reverts https://github.com/mono/MonoGame/pull/2813

My game has the exit yes/no dialog. When user confirms exit and relaunches the game, exit dialog is still visible.
