### PR TITLE
Fix for Guide.IsVisible for WP8

### DIFF
--- a/MonoGame.Framework/Windows/GamerServices/Guide.cs
+++ b/MonoGame.Framework/Windows/GamerServices/Guide.cs
@@ -445,7 +445,11 @@ namespace Microsoft.Xna.Framework.GamerServices
 		{ 
 			get
 			{
+#if WINDOWS_PHONE
+				return MsXna_Guide.IsVisible;
+#else
 				return isVisible;
+#endif
 			}
 			set
 			{


### PR DESCRIPTION
Guide.IsVisible returns a wrong value on windows phone.
