### PR TITLE
Changed MGEffectProcessor to build DirectX_11 if platform is Windows

### DIFF
--- a/MonoGame.ContentPipeline/ContentProcessors/Processors/MGEffectProcessor.cs
+++ b/MonoGame.ContentPipeline/ContentProcessors/Processors/MGEffectProcessor.cs
@@ -26,7 +26,7 @@ namespace MonoGameContentProcessors.Processors
 
             var options = new Options();
             options.SourceFile = input.Identity.SourceFilename;
-            options.Profile = platform == MonoGamePlatform.Windows8 ? ShaderProfile.DirectX_11 : ShaderProfile.OpenGL;
+            options.Profile = ( platform == MonoGamePlatform.Windows8 || platform == MonoGamePlatform.Windows ) ? ShaderProfile.DirectX_11 : ShaderProfile.OpenGL;
             options.Debug = DebugMode == EffectProcessorDebugMode.Debug;
             options.OutputFile = context.OutputFilename;
 


### PR DESCRIPTION
Currently, building using the monogame content pipeline produces OpenGL shaders when targeting Windows which fail at run time.  This fix changes the processor to build DX11 shader effects when targeting Windows.
