### PR TITLE
ProcessorParameters not using InvariantCulture

### DIFF
--- a/Tools/Pipeline/Common/ContentItem.cs
+++ b/Tools/Pipeline/Common/ContentItem.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System.ComponentModel;
+using System.Globalization;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors;
 
@@ -181,7 +182,7 @@ namespace MonoGame.Tools.Pipeline
                             // since we do not have a type converter for it.
                             if (converter.CanConvertFrom(srcType))
                             {
-                                var dst = converter.ConvertFrom(src);
+                                var dst = converter.ConvertFrom(null, CultureInfo.InvariantCulture, src);
                                 ProcessorParams[p.Name] = dst;
                             }
                         }


### PR DESCRIPTION
Importing the ProcessorParameters was the last place the InvariantCulture was not being used, resulting in errors if the user's local culture used a comma for a decimal separator.

Fixes #2923
