### PR TITLE
MonoGameAndroidGameView.OnKeyDown/OnKeyUp returns true only if the event was handled.

### DIFF
--- a/MonoGame.Framework/Android/Input/Keyboard.cs
+++ b/MonoGame.Framework/Android/Input/Keyboard.cs
@@ -52,34 +52,33 @@ namespace Microsoft.Xna.Framework.Input
 
         private static readonly IDictionary<Keycode, Keys> KeyMap = LoadKeyMap();
 
-        internal static void KeyDown(Keycode keyCode)
+        internal static bool KeyDown(Keycode keyCode)
         {
             Keys key;
             if (KeyMap.TryGetValue(keyCode, out key))
             {
                 if (!keys.Contains(key))
                     keys.Add(key);
+                return true;
             }
+            return false;
         }
 
-        internal static void KeyUp(Keycode keyCode)
+        internal static bool KeyUp(Keycode keyCode)
         {
             Keys key;
             if (KeyMap.TryGetValue(keyCode, out key))
             {
                 if (keys.Contains(key))
                     keys.Remove(key);
+                return true;
             }
+            return false;
         }
 
         private static IDictionary<Keycode, Keys> LoadKeyMap()
         {
-            // create a map for every Keycode and default it to none so that every possible key is mapped
-            var maps = Enum.GetValues(typeof (Keycode))
-                .Cast<Keycode>()
-                .ToDictionary(key => key, key => Keys.None);
-
-            // then update it with the actual mappings
+            IDictionary<Keycode, Keys> maps = new Dictionary<Keycode, Keys>();
             maps[Keycode.DpadLeft] = Keys.Left;
             maps[Keycode.DpadRight] = Keys.Right;
             maps[Keycode.DpadUp] = Keys.Up;
@@ -120,8 +119,7 @@ namespace Microsoft.Xna.Framework.Input
 			maps[Keycode.W] = Keys.W;
 			maps[Keycode.X] = Keys.X;
             maps[Keycode.Y] = Keys.Y;
-            maps[Keycode.C] = Keys.Z;
-			maps[Keycode.Back] = Keys.Escape;
+            maps[Keycode.Z] = Keys.Z;
             maps[Keycode.Back] = Keys.Back;
             maps[Keycode.Home] = Keys.Home;
             maps[Keycode.Enter] = Keys.Enter;

--- a/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
@@ -279,28 +279,33 @@ namespace Microsoft.Xna.Framework
                 return true;
 #endif
 
-            Keyboard.KeyDown(keyCode);
+            bool isHandled = Keyboard.KeyDown(keyCode);
             // we need to handle the Back key here because it doesnt work any other way
 #if !OUYA
             if (keyCode == Keycode.Back)
+            {
                 GamePad.Back = true;
+                isHandled = true;
+            }
 #endif
 
             if (keyCode == Keycode.VolumeUp)
             {
                 AudioManager audioManager = (AudioManager)Context.GetSystemService(Context.AudioService);
                 audioManager.AdjustStreamVolume(Stream.Music, Adjust.Raise, VolumeNotificationFlags.ShowUi);
-                return true;
+                isHandled = true;
             }
 
             if (keyCode == Keycode.VolumeDown)
             {
                 AudioManager audioManager = (AudioManager)Context.GetSystemService(Context.AudioService);
                 audioManager.AdjustStreamVolume(Stream.Music, Adjust.Lower, VolumeNotificationFlags.ShowUi);
-                return true;
+                isHandled = true;
             }
 
-            return true;
+            if (isHandled)
+                return true;
+            return base.OnKeyDown(keyCode, e);
         }
 
         public override bool OnKeyUp(Keycode keyCode, KeyEvent e)
@@ -309,8 +314,10 @@ namespace Microsoft.Xna.Framework
             if (GamePad.OnKeyUp(keyCode, e))
                 return true;
 #endif
-            Keyboard.KeyUp(keyCode);
-            return true;
+            bool isHandled = Keyboard.KeyUp(keyCode);
+            if (isHandled)
+                return true;
+            return base.OnKeyUp(keyCode, e);
         }
 
 #if OUYA


### PR DESCRIPTION
This allows to handle unhandled events in [Activity.OnKeyDown()](http://developer.android.com/reference/android/app/Activity.html#onKeyDown%28int,%20android.view.KeyEvent%29)/`OnKeyUp()`.
