### PR TITLE
'Debug Mode' Improvement

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -70,8 +70,16 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         /// </summary>
         public bool CompressContent { get; set; }
 
+        /// <summary>        
+        /// If true exceptions thrown from within an importer or processor are caught and then 
+        /// thrown from the context. Default value is true.
+        /// </summary>
+        public bool RethrowExceptions { get; set; }
+
         public PipelineManager(string projectDir, string outputDir, string intermediateDir)
         {
+            RethrowExceptions = true;
+
             Assemblies = new List<string>();
             Assemblies.Add(null);
             Logger = new PipelineBuildLogger();
@@ -500,18 +508,26 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
             // Try importing the content.
             object importedObject;
-            try
+            if (RethrowExceptions)
+            {
+                try
+                {
+                    var importContext = new PipelineImporterContext(this);
+                    importedObject = importer.Import(pipelineEvent.SourceFile, importContext);
+                }
+                catch (PipelineException)
+                {
+                    throw;
+                }
+                catch (Exception inner)
+                {
+                    throw new PipelineException(string.Format("Importer '{0}' had unexpected failure!", pipelineEvent.Importer), inner);
+                }
+            }
+            else
             {
                 var importContext = new PipelineImporterContext(this);
                 importedObject = importer.Import(pipelineEvent.SourceFile, importContext);
-            }
-            catch (PipelineException)
-            {
-                throw;
-            }
-            catch (Exception inner)
-            {
-                throw new PipelineException(string.Format("Importer '{0}' had unexpected failure!", pipelineEvent.Importer), inner);
             }
 
             // Make sure the input type is valid.
@@ -525,23 +541,32 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             }
 
             // Process the imported object.
+
             object processedObject;
-            try
+            if (RethrowExceptions)
+            {
+                try
+                {
+                    var processContext = new PipelineProcessorContext(this, pipelineEvent);
+                    processedObject = processor.Process(importedObject, processContext);
+                }
+                catch (PipelineException)
+                {
+                    throw;
+                }
+                catch (InvalidContentException)
+                {
+                    throw;
+                }
+                catch (Exception inner)
+                {
+                    throw new PipelineException(string.Format("Processor '{0}' had unexpected failure!", pipelineEvent.Processor), inner);
+                }
+            }
+            else
             {
                 var processContext = new PipelineProcessorContext(this, pipelineEvent);
                 processedObject = processor.Process(importedObject, processContext);
-            }
-            catch (PipelineException)
-            {
-                throw;
-            }
-            catch (InvalidContentException)
-            {
-                throw;
-            }
-            catch (Exception inner)
-            {
-                throw new PipelineException(string.Format("Processor '{0}' had unexpected failure!", pipelineEvent.Processor), inner);
             }
 
             return processedObject;

--- a/Tools/MGCB/BuildContent.cs
+++ b/Tools/MGCB/BuildContent.cs
@@ -221,6 +221,11 @@ namespace MGCB
             _manager.Logger = new ConsoleLogger();
             _manager.CompressContent = CompressContent;
 
+            // If the intent is to debug build, break at the original location
+            // of any exception, eg, within the actual importer/processor.
+            if (LaunchDebugger)
+                _manager.RethrowExceptions = false;
+
             // Feed all the assembly references to the pipeline manager
             // so it can resolve importers, processors, writers, and types.
             foreach (var r in References)


### PR DESCRIPTION
When MGCB is launched with the "LaunchDebugger" flag, exceptions thrown within the importer/processor will not be caught/re-thrown.

This means that the debugger you attach to mgcb with when prompted by a Pipeline Tool 'Debug Mode' build will properly break at the location of the actual error within the importer.import and processor.process call(s).
