### PR TITLE
Matching original xna behavior.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/Texture2DContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Texture2DContent.cs
@@ -9,10 +9,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
     public class Texture2DContent : TextureContent
     {
-        public MipmapChain Mipmaps { get; set; }
+        public MipmapChain Mipmaps
+        {
+            get { return Faces[0]; }
+            set { Faces[0] = value; }
+        }
 
-        public Texture2DContent() : 
-            base(new MipmapChainCollection())
+        public Texture2DContent() :
+            base(new MipmapChainCollection() { new MipmapChain() })
         {
 
         }

--- a/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 				systemBitmap = bitmap;
 			}
 
-            output.Faces.Add(new MipmapChain(systemBitmap.ToXnaBitmap()));
+            output.Faces[0][0] = systemBitmap.ToXnaBitmap();
             systemBitmap.Dispose();
 
             return output;


### PR DESCRIPTION
This fixes custom processors which were working with textures and assuming that:
1. Texture2DContent.Faces[0][0] would not generate a null reference for a newly allocated and uninitialized Texture2DContent.
2. texture2DContent.Mipmaps.Add(..) would not generate a null reference for a newly allocated and uninitialized Texture2DContent.
