### PR TITLE
Fixed GetData with row pitch when used with different element sizes

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -151,10 +151,11 @@ namespace Microsoft.Xna.Framework.Graphics
                         // We need to copy each row separatly and skip trailing zeros.
                         stream.Seek(startIndex, SeekOrigin.Begin);
 
+                        int elementSizeInByte = Marshal.SizeOf(typeof(T));
                         for (var row = 0; row < rows; row++)
                         {
                             int i;
-                            for (i = row * rowSize; i < (row + 1) * rowSize; i++)
+                            for (i = row * rowSize / elementSizeInByte; i < (row + 1) * rowSize / elementSizeInByte; i++)
                                 data[i] = stream.Read<T>();
 
                             if (i >= elementCount)


### PR DESCRIPTION
I originally fixed GetData to work with bytes, then @tomspilman changed it to work with Color, so now it's the time to make it work with different element sizes. I haven't tested it with extreme cases, like reading the 4 byte Color into a 3 byte struct.
