### PR TITLE
Not all desktops support anisotropic

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -95,14 +95,18 @@ namespace Microsoft.Xna.Framework.Graphics
         {
 			SupportsNonPowerOfTwo = GetNonPowerOfTwo(device);
 
+#if OPENGL
             SupportsTextureFilterAnisotropic = device._extensions.Contains("GL_EXT_texture_filter_anisotropic");
+#else
+            SupportsTextureFilterAnisotropic = true;
+#endif
 #if GLES
 			SupportsDepth24 = device._extensions.Contains("GL_OES_depth24");
 			SupportsPackedDepthStencil = device._extensions.Contains("GL_OES_packed_depth_stencil");
 			SupportsDepthNonLinear = device._extensions.Contains("GL_NV_depth_nonlinear");
             SupportsTextureMaxLevel = device._extensions.Contains("GL_APPLE_texture_max_level");
 #else
-			SupportsDepth24 = true;
+            SupportsDepth24 = true;
 			SupportsPackedDepthStencil = true;
 			SupportsDepthNonLinear = false;
             SupportsTextureMaxLevel = true;


### PR DESCRIPTION
Mesa3D does not support anisotropic filtering, so check for the extension before trying to use it.
