### PR TITLE
Implemented Cue.Apply3D()

### DIFF
--- a/MonoGame.Framework/Audio/Xact/ClipEvent.cs
+++ b/MonoGame.Framework/Audio/Xact/ClipEvent.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Xna.Framework.Audio
 
             _clip.Play();
         }
-	}
+
+        public abstract void Apply3D(AudioListener listener, AudioEmitter emitter);
+    }
 }
 

--- a/MonoGame.Framework/Audio/Xact/Cue.cs
+++ b/MonoGame.Framework/Audio/Xact/Cue.cs
@@ -196,8 +196,9 @@ namespace Microsoft.Xna.Framework.Audio
         /// </remarks>
 		public void Apply3D(AudioListener listener, AudioEmitter emitter) 
         {
-			
-		}
+            if (curSound != null)
+                curSound.Apply3D(listener, emitter);			
+        }
 
         internal void Update(float dt)
         {

--- a/MonoGame.Framework/Audio/Xact/PlayWaveEvent.cs
+++ b/MonoGame.Framework/Audio/Xact/PlayWaveEvent.cs
@@ -246,6 +246,12 @@ namespace Microsoft.Xna.Framework.Audio
 
             base.Update(dt);
         }
-	}
+
+        public override void Apply3D(AudioListener listener, AudioEmitter emitter)
+        {
+            if (_wav != null)
+                _wav.Apply3D(listener, emitter);
+        }
+    }
 }
 

--- a/MonoGame.Framework/Audio/Xact/XactClip.cs
+++ b/MonoGame.Framework/Audio/Xact/XactClip.cs
@@ -390,6 +390,12 @@ namespace Microsoft.Xna.Framework.Audio
 				return false; 
 			} 
 		}
-	}
+
+        public void Apply3D(AudioListener listener, AudioEmitter emitter)
+        {
+            foreach (var evt in _events)
+                evt.Apply3D(listener, emitter);
+        }
+    }
 }
 

--- a/MonoGame.Framework/Audio/Xact/XactSound.cs
+++ b/MonoGame.Framework/Audio/Xact/XactSound.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Xna.Framework.Audio
 {
@@ -304,7 +302,20 @@ namespace Microsoft.Xna.Framework.Audio
                 return _wave != null && _wave.State == SoundState.Paused;
 			}
 		}
-		
-	}
+
+        public void Apply3D(AudioListener listener, AudioEmitter emitter)
+        {
+            if (_complexSound)
+            {
+                foreach (var clip in _soundClips)
+                    clip.Apply3D(listener, emitter);
+            }
+            else
+            {
+                if (_wave != null)
+                    _wave.Apply3D(listener, emitter);
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
This PR implements the `Cue.Apply3D()` path in XAct.  This basically makes 3D audio work under XAct assuming `SoundEffectInstance.Apply3D()` is implemented on the target platform.
