### PR TITLE
Fixed stream disposing in Texture2D.Reload on WP8

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -395,6 +395,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 ConvertToABGR(bitmap.PixelHeight, bitmap.PixelWidth, bitmap.Pixels);
 
                 this.SetData<int>(bitmap.Pixels);
+
+                textureStream.Dispose();
             });
 #endif
         }


### PR DESCRIPTION
Reload is an async operation on WP8 (if it'd be a blocking one, we would end up with a deadlock due to the threading on the platform). The caller doesn't know when we finished working with the stream, therefore we need to dispose the texture stream inside MonoGame.
