### PR TITLE
Fixed MediaPlayer.ActiveSongChanged not called on play

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -116,13 +116,17 @@ namespace Microsoft.Xna.Framework.Media
 		/// Playback starts immediately at the beginning of the song.
 		/// </summary>
         public static void Play(Song song)
-        {                        
+        {
+            var previousSong = _queue.Count > 0 ? _queue[0] : null;
             _queue.Clear();
             _numSongsInQueuePlayed = 0;
             _queue.Add(song);
 			_queue.ActiveSongIndex = 0;
             
             PlaySong(song);
+
+            if (previousSong != song && ActiveSongChanged != null)
+                ActiveSongChanged.Invoke(null, EventArgs.Empty);
         }
 		
 		public static void Play(SongCollection collection, int index = 0)


### PR DESCRIPTION
It was called when moving to the next item of the Queue and when the song has finished playing, but wasn't called on Play.
