### PR TITLE
TouchPanelState.GetState() garbage

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -141,7 +141,8 @@ namespace Microsoft.Xna.Framework.Input.Touch
         {
             get
             {
-                if (index >= _count) throw new ArgumentOutOfRangeException("index");
+                if (index < 0 || index >= _count)
+                    throw new ArgumentOutOfRangeException("index");
 
                 switch (index)
                  { 

--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -13,13 +13,10 @@ namespace Microsoft.Xna.Framework.Input.Touch
     /// </summary>
     public struct TouchCollection : IList<TouchLocation>
 	{
+        private readonly int _count;
+        private readonly TouchLocation _value0, _value1, _value2, _value3;
         private readonly TouchLocation[] _collection;
-
-        private TouchLocation[] Collection
-        {
-            get { return _collection ?? EmptyLocationArray; }
-        }
-
+        
         #region Properties
 
         /// <summary>
@@ -41,7 +38,13 @@ namespace Microsoft.Xna.Framework.Input.Touch
             if (touches == null)
                 throw new ArgumentNullException("touches");
 
-            _collection = touches.ToArray();
+            _count = touches.Count;
+
+            _value0 = (_count > 0) ? touches[0] : TouchLocation.Invalid;
+            _value1 = (_count > 1) ? touches[1] : TouchLocation.Invalid;
+            _value2 = (_count > 2) ? touches[2] : TouchLocation.Invalid;
+            _value3 = (_count > 3) ? touches[3] : TouchLocation.Invalid;
+            _collection = (_count > 4) ? touches.ToArray() : null;
         }
         
         /// <summary>
@@ -52,17 +55,16 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <returns></returns>
         public bool FindById(int id, out TouchLocation touchLocation)
 		{
-            for (var i = 0; i < Collection.Length; i++)
+            for (var i = 0; i < Count; i++)
             {
-                var location = Collection[i];
-                if (location.Id == id)
+                if (this[i].Id == id)
                 {
-                    touchLocation = location;
+                    touchLocation = this[i];
                     return true;
                 }
             }
 
-            touchLocation = default(TouchLocation);
+            touchLocation = TouchLocation.Invalid;
             return false;
 		}
 
@@ -83,9 +85,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <returns></returns>
         public int IndexOf(TouchLocation item)
         {
-            for (var i = 0; i < Collection.Length; i++)
+            for (var i = 0; i < Count; i++)
             {
-                if (item == Collection[i])
+                if (item == this[i])
                     return i;
             }
 
@@ -120,12 +122,18 @@ namespace Microsoft.Xna.Framework.Input.Touch
         {
             get
             {
-                return Collection[index];
+                if (index >= _count) throw new ArgumentOutOfRangeException("index");
+
+                switch (index) 
+                 { 
+                     case 0: return _value0; 
+                     case 1: return _value1; 
+                     case 2: return _value2;
+                     case 3: return _value3;
+                     default: return _collection[index];
+                } 
             }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            set { throw new NotSupportedException(); }
         }
 
         /// <summary>
@@ -152,9 +160,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <returns>Returns true if queried item is found, false otherwise.</returns>
         public bool Contains(TouchLocation item)
         {
-            for (var i = 0; i < Collection.Length; i++)
+            for (var i = 0; i < Count; i++)
             {
-                if (item == Collection[i])
+                if (item == this[i])
                     return true;
             }
 
@@ -168,7 +176,10 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <param name="arrayIndex">The starting index of the copy operation.</param>
         public void CopyTo(TouchLocation[] array, int arrayIndex)
         {
-            Collection.CopyTo(array, arrayIndex);
+            for (var i = 0; i < Count; i++)
+            {
+                array[arrayIndex + i] = this[i];
+            }
         }
 
         /// <summary>
@@ -176,10 +187,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// </summary>
         public int Count
         {
-            get
-            {
-                return Collection.Length;
-            }
+            get { return _count; }
         }
 
         /// <summary>

--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -14,12 +14,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
     public struct TouchCollection : IList<TouchLocation>
 	{
         private readonly int _count;
-        private readonly TouchLocation _value00, _value01, _value02, _value03;
-        private readonly TouchLocation _value04, _value05, _value06, _value07;
-        private readonly TouchLocation _value08, _value09, _value10, _value11;
-        private readonly TouchLocation _value12, _value13, _value14, _value15;
-        private readonly TouchLocation _value16, _value17, _value18, _value19;
-        
+        private readonly TouchLocation _value0, _value1, _value2, _value3;
+        private readonly TouchLocation[] _collection;
+
         #region Properties
 
         /// <summary>
@@ -42,28 +39,19 @@ namespace Microsoft.Xna.Framework.Input.Touch
             if (touches == null)
                 throw new ArgumentNullException("touches");
 
-            _count = Math.Min(touches.Count, 20);
+            _count = touches.Count;
 
-            _value00 = (_count >  0) ? touches[ 0] : TouchLocation.Invalid;
-            _value01 = (_count >  1) ? touches[ 1] : TouchLocation.Invalid;
-            _value02 = (_count >  2) ? touches[ 2] : TouchLocation.Invalid;
-            _value03 = (_count >  3) ? touches[ 3] : TouchLocation.Invalid;
-            _value04 = (_count >  4) ? touches[ 4] : TouchLocation.Invalid;
-            _value05 = (_count >  5) ? touches[ 5] : TouchLocation.Invalid;
-            _value06 = (_count >  6) ? touches[ 6] : TouchLocation.Invalid;
-            _value07 = (_count >  7) ? touches[ 7] : TouchLocation.Invalid;
-            _value08 = (_count >  8) ? touches[ 8] : TouchLocation.Invalid;
-            _value09 = (_count >  9) ? touches[ 9] : TouchLocation.Invalid;
-            _value10 = (_count > 10) ? touches[10] : TouchLocation.Invalid;
-            _value11 = (_count > 11) ? touches[11] : TouchLocation.Invalid;
-            _value12 = (_count > 12) ? touches[12] : TouchLocation.Invalid;
-            _value13 = (_count > 13) ? touches[13] : TouchLocation.Invalid;
-            _value14 = (_count > 14) ? touches[14] : TouchLocation.Invalid;
-            _value15 = (_count > 15) ? touches[15] : TouchLocation.Invalid;
-            _value16 = (_count > 16) ? touches[16] : TouchLocation.Invalid;
-            _value17 = (_count > 17) ? touches[17] : TouchLocation.Invalid;
-            _value18 = (_count > 18) ? touches[18] : TouchLocation.Invalid;
-            _value19 = (_count > 19) ? touches[19] : TouchLocation.Invalid;
+            _value0 = (_count > 0) ? touches[0] : TouchLocation.Invalid;
+            _value1 = (_count > 1) ? touches[1] : TouchLocation.Invalid;
+            _value2 = (_count > 2) ? touches[2] : TouchLocation.Invalid;
+            _value3 = (_count > 3) ? touches[3] : TouchLocation.Invalid;
+            _collection = null;
+
+            if (_count > 4)
+            {
+                _collection = new TouchLocation[_count];
+                touches.CopyTo(_collection, 0);
+            }
         }
         
         /// <summary>
@@ -145,28 +133,12 @@ namespace Microsoft.Xna.Framework.Input.Touch
                     throw new ArgumentOutOfRangeException("index");
 
                 switch (index)
-                 { 
-                     case  0: return _value00;
-                     case  1: return _value01; 
-                     case  2: return _value02;
-                     case  3: return _value03;
-                     case  4: return _value04;
-                     case  5: return _value05;
-                     case  6: return _value06;
-                     case  7: return _value07;
-                     case  8: return _value08;
-                     case  9: return _value09;
-                     case 10: return _value10;
-                     case 11: return _value11;
-                     case 12: return _value12;
-                     case 13: return _value13;
-                     case 14: return _value14;
-                     case 15: return _value15;
-                     case 16: return _value16;
-                     case 17: return _value17;
-                     case 18: return _value18;
-                     case 19: return _value19;
-                     default: throw new Exception();
+                {
+                    case 0: return _value0;
+                    case 1: return _value1;
+                    case 2: return _value2;
+                    case 3: return _value3;
+                    default: return _collection[index];
                 } 
             }
             set { throw new NotSupportedException(); }

--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -14,8 +14,11 @@ namespace Microsoft.Xna.Framework.Input.Touch
     public struct TouchCollection : IList<TouchLocation>
 	{
         private readonly int _count;
-        private readonly TouchLocation _value0, _value1, _value2, _value3;
-        private readonly TouchLocation[] _collection;
+        private readonly TouchLocation _value00, _value01, _value02, _value03;
+        private readonly TouchLocation _value04, _value05, _value06, _value07;
+        private readonly TouchLocation _value08, _value09, _value10, _value11;
+        private readonly TouchLocation _value12, _value13, _value14, _value15;
+        private readonly TouchLocation _value16, _value17, _value18, _value19;
         
         #region Properties
 
@@ -30,18 +33,37 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// Initializes a new instance of the <see cref="TouchCollection"/> with a pre-determined set of touch locations.
         /// </summary>
         /// <param name="touches">Array of <see cref="TouchLocation"/> items to initialize with.</param>
-        public TouchCollection(List<TouchLocation> touches)
+        public TouchCollection(TouchLocation[] touches): this((IList<TouchLocation>)touches)
+        {
+        }
+        
+        internal TouchCollection(IList<TouchLocation> touches)
         {
             if (touches == null)
                 throw new ArgumentNullException("touches");
 
-            _count = touches.Count;
+            _count = Math.Min(touches.Count, 20);
 
-            _value0 = (_count > 0) ? touches[0] : TouchLocation.Invalid;
-            _value1 = (_count > 1) ? touches[1] : TouchLocation.Invalid;
-            _value2 = (_count > 2) ? touches[2] : TouchLocation.Invalid;
-            _value3 = (_count > 3) ? touches[3] : TouchLocation.Invalid;
-            _collection = (_count > 4) ? touches.ToArray() : null;
+            _value00 = (_count >  0) ? touches[ 0] : TouchLocation.Invalid;
+            _value01 = (_count >  1) ? touches[ 1] : TouchLocation.Invalid;
+            _value02 = (_count >  2) ? touches[ 2] : TouchLocation.Invalid;
+            _value03 = (_count >  3) ? touches[ 3] : TouchLocation.Invalid;
+            _value04 = (_count >  4) ? touches[ 4] : TouchLocation.Invalid;
+            _value05 = (_count >  5) ? touches[ 5] : TouchLocation.Invalid;
+            _value06 = (_count >  6) ? touches[ 6] : TouchLocation.Invalid;
+            _value07 = (_count >  7) ? touches[ 7] : TouchLocation.Invalid;
+            _value08 = (_count >  8) ? touches[ 8] : TouchLocation.Invalid;
+            _value09 = (_count >  9) ? touches[ 9] : TouchLocation.Invalid;
+            _value10 = (_count > 10) ? touches[10] : TouchLocation.Invalid;
+            _value11 = (_count > 11) ? touches[11] : TouchLocation.Invalid;
+            _value12 = (_count > 12) ? touches[12] : TouchLocation.Invalid;
+            _value13 = (_count > 13) ? touches[13] : TouchLocation.Invalid;
+            _value14 = (_count > 14) ? touches[14] : TouchLocation.Invalid;
+            _value15 = (_count > 15) ? touches[15] : TouchLocation.Invalid;
+            _value16 = (_count > 16) ? touches[16] : TouchLocation.Invalid;
+            _value17 = (_count > 17) ? touches[17] : TouchLocation.Invalid;
+            _value18 = (_count > 18) ? touches[18] : TouchLocation.Invalid;
+            _value19 = (_count > 19) ? touches[19] : TouchLocation.Invalid;
         }
         
         /// <summary>
@@ -121,13 +143,29 @@ namespace Microsoft.Xna.Framework.Input.Touch
             {
                 if (index >= _count) throw new ArgumentOutOfRangeException("index");
 
-                switch (index) 
+                switch (index)
                  { 
-                     case 0: return _value0; 
-                     case 1: return _value1; 
-                     case 2: return _value2;
-                     case 3: return _value3;
-                     default: return _collection[index];
+                     case  0: return _value00;
+                     case  1: return _value01; 
+                     case  2: return _value02;
+                     case  3: return _value03;
+                     case  4: return _value04;
+                     case  5: return _value05;
+                     case  6: return _value06;
+                     case  7: return _value07;
+                     case  8: return _value08;
+                     case  9: return _value09;
+                     case 10: return _value10;
+                     case 11: return _value11;
+                     case 12: return _value12;
+                     case 13: return _value13;
+                     case 14: return _value14;
+                     case 15: return _value15;
+                     case 16: return _value16;
+                     case 17: return _value17;
+                     case 18: return _value18;
+                     case 19: return _value19;
+                     default: throw new Exception();
                 } 
             }
             set { throw new NotSupportedException(); }

--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -24,9 +24,6 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// </summary>
         public bool IsConnected { get { return TouchPanel.GetCapabilities().IsConnected; } }
 
-        private static readonly TouchLocation[] EmptyLocationArray = new TouchLocation[0];
-        internal static readonly TouchCollection Empty = new TouchCollection(new List<TouchLocation>(0));
-        
 		#endregion
 
         /// <summary>

--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -28,22 +28,22 @@ namespace Microsoft.Xna.Framework.Input.Touch
         public bool IsConnected { get { return TouchPanel.GetCapabilities().IsConnected; } }
 
         private static readonly TouchLocation[] EmptyLocationArray = new TouchLocation[0];
-        internal static readonly TouchCollection Empty = new TouchCollection(EmptyLocationArray);
-
+        internal static readonly TouchCollection Empty = new TouchCollection(new List<TouchLocation>(0));
+        
 		#endregion
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TouchCollection"/> with a pre-determined set of touch locations.
         /// </summary>
         /// <param name="touches">Array of <see cref="TouchLocation"/> items to initialize with.</param>
-        public TouchCollection(TouchLocation[] touches)
+        public TouchCollection(List<TouchLocation> touches)
         {
             if (touches == null)
                 throw new ArgumentNullException("touches");
 
-            _collection = touches;
+            _collection = touches.ToArray();
         }
-
+        
         /// <summary>
         /// Returns <see cref="TouchLocation"/> specified by ID.
         /// </summary>

--- a/MonoGame.Framework/Input/Touch/TouchPanelState.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanelState.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
                 }
             }
 
-            var result = (_touchState.Count > 0) ? new TouchCollection(_touchState.ToArray()) : TouchCollection.Empty;
+            var result = (_touchState.Count > 0) ? new TouchCollection(_touchState) : TouchCollection.Empty;
             AgeTouches(_touchState);
             return result;
         }

--- a/MonoGame.Framework/Input/Touch/TouchPanelState.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanelState.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
                 }
             }
 
-            var result = (_touchState.Count > 0) ? new TouchCollection(_touchState) : TouchCollection.Empty;
+            var result = new TouchCollection(_touchState);
             AgeTouches(_touchState);
             return result;
         }


### PR DESCRIPTION
Implement TouchCollection as a fixed size array. 
https://github.com/mono/MonoGame/issues/2876

Garbage free for up to 4 TouchLocations. 
Otherwise the array is copied to TouchLocation[] _collection as before.
