### PR TITLE
Fix FBO leak

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -706,7 +706,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #if DEBUG
                 this.framebufferHelper.CheckFramebufferStatus();
 #endif
-                this.glFramebuffers.Add(_currentRenderTargetBindings, glFramebuffer);
+                this.glFramebuffers.Add((RenderTargetBinding[])_currentRenderTargetBindings.Clone(), glFramebuffer);
             }
             else
             {


### PR DESCRIPTION
The FBO cache (GraphicsDevice.glFramebuffers) wasn't initialized properly resulting in FBOs never being deleted. This is a serious issue if you are creating and deleting FBOs often during your game lifecycle.
