### PR TITLE
Fixes for Display Issues and Song Issues

### DIFF
--- a/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
@@ -58,7 +58,8 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 GraphicsDevice.AddDisposeAction(() =>
                 {
-                    this.GraphicsDevice.PlatformDeleteRenderTarget(this);
+                	if (this.GraphicsDevice != null)
+                    	this.GraphicsDevice.PlatformDeleteRenderTarget(this);
                 });
             }
 

--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -139,7 +139,8 @@ namespace Microsoft.Xna.Framework.Media
 
             // Get the volume interface.
             IntPtr volumeObj;
-
+            int trycount = 0;
+           	tryagain:
             
             try
             {
@@ -147,7 +148,12 @@ namespace Microsoft.Xna.Framework.Media
             }
             catch
             {
-                MediaFactory.GetService(_session, MRPolicyVolumeService, SimpleAudioVolumeGuid, out volumeObj);
+            	if (trycount >= 5)
+            		MediaFactory.GetService(_session,MRPolicyVolumeService,SimpleAudioVolumeGuid, out volumeObj);
+            	else {
+            		trycount++;
+            		goto tryagain;
+            	}
             }  
           
 


### PR DESCRIPTION
These two commits commit code that will help prevent some issues on Windows 7 and Ouya/Android devices.

Windows 7: The issue comes from attempting to get the Object Volume pointer, to handle control of the volume.  This is a Ugly hack, that originates from HardyCore77 on Codeplex Discussions (https://monogame.codeplex.com/discussions/453847).

Ouya/Android: I believe this error also occurs on Android, but I have only encountered it so far on Ouya.  When utilizing RenderTarget2D Class to create a Buffered Bitmap for drawing Sliced UI Elements, when going into the Game Play section, the system will at random execution times, stop running, while spaming the output on the console window, showing that Some object was not a Valid Reference.  I have traced it down to being the GraphicsDevice not being properly assigned when Dispose() is being called.  This simply runs a check to see if this.GraphicsDevice is valid, and not null, before attempting to execute the PlatformDeleteRenderTarget() method.
