### PR TITLE
Fixed SongReader and VideoReader not supporting parent directories

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/SongReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SongReader.cs
@@ -66,11 +66,11 @@ namespace Microsoft.Xna.Framework.Content
 			
 			if (!String.IsNullOrEmpty(path))
 			{
-                //resolve the relative path
-                path = FileHelpers.ResolveRelativePath(input.AssetName, path);
-
                 // Add the ContentManager's RootDirectory
-                path = Path.Combine(input.ContentManager.RootDirectoryFullPath, path);
+                var dirPath = Path.Combine(input.ContentManager.RootDirectoryFullPath, input.AssetName);
+
+                // Resolve the relative path
+                path = FileHelpers.ResolveRelativePath(dirPath, path);
 			}
 			
 			var durationMs = input.ReadObject<int>();

--- a/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
@@ -32,8 +32,11 @@ namespace Microsoft.Xna.Framework.Content
 
             if (!string.IsNullOrEmpty(path))
             {
-                path = FileHelpers.ResolveRelativePath(input.AssetName, path);
-                path = Path.Combine(input.ContentManager.RootDirectoryFullPath, path);
+                // Add the ContentManager's RootDirectory
+                var dirPath = Path.Combine(input.ContentManager.RootDirectoryFullPath, input.AssetName);
+
+                // Resolve the relative path
+                path = FileHelpers.ResolveRelativePath(dirPath, path);
             }
 
             var durationMS = input.ReadObject<int>();


### PR DESCRIPTION
Paths like `../Something` are supported in XNA and I added suppor for them in MonoGame in https://github.com/mono/MonoGame/pull/2261/files, however those changes were not propagated to `SongReader` and `VideoReader` yet.
