### PR TITLE
Allow loading of Android Bitmap into Texture2D using FromStream

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -464,7 +464,9 @@ namespace Microsoft.Xna.Framework.Graphics
         [CLSCompliant(false)]
         public static Texture2D FromStream(GraphicsDevice graphicsDevice, Bitmap bitmap)
         {
-            return PlatformFromStream(graphicsDevice, bitmap);
+            var texture = PlatformFromStream(graphicsDevice, bitmap);
+            bitmap.Recycle();
+            return texture;
         }
 #endif
 


### PR DESCRIPTION
The same way you can load CGImages on iOS and Mac, you can now load Android Bitmaps into textures.
