### PR TITLE
ImporterTypeDescription properly handles null TypeName values in Equals/GetHashCode.

### DIFF
--- a/Tools/Pipeline/Common/PipelineTypes.cs
+++ b/Tools/Pipeline/Common/PipelineTypes.cs
@@ -33,7 +33,7 @@ namespace MonoGame.Tools.Pipeline
 
         public override int GetHashCode()
         {
-            return TypeName.GetHashCode();
+            return TypeName == null ? 0 : TypeName.GetHashCode();
         }
 
         public override bool Equals(object obj)
@@ -41,8 +41,11 @@ namespace MonoGame.Tools.Pipeline
             var other = obj as ImporterTypeDescription;
             if (other == null)
                 return false;
+            
+            if (string.IsNullOrEmpty(other.TypeName) != string.IsNullOrEmpty(TypeName))
+                return false;
 
-            return this.TypeName.Equals(other.TypeName);
+            return TypeName.Equals(other.TypeName);
         }
     };
 


### PR DESCRIPTION
ImporterTypeDescription properly handles null TypeName values in Equals/GetHashCode.
