### PR TITLE
Exposing API for easily parsing the MGCB format

### DIFF
--- a/Tools/MGCB/CommandLineParser.cs
+++ b/Tools/MGCB/CommandLineParser.cs
@@ -89,7 +89,8 @@ namespace MGCB
 
         public readonly PreprocessorPropertyCollection _properties;
 
-        public event Action<string, object[]> OnError;
+        public delegate void ErrorCallback(string msg, object[] args);
+        public event ErrorCallback OnError;
 
         public MGBuildParser(object optionsObject)
         {

--- a/Tools/Pipeline/Common/ContentItem.cs
+++ b/Tools/Pipeline/Common/ContentItem.cs
@@ -9,15 +9,15 @@ using Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors;
 
 namespace MonoGame.Tools.Pipeline
 {
-    internal enum BuildAction
+    public enum BuildAction
     {
         Build,
         Copy,
     }
 
-    internal class ContentItem : IProjectItem
+    public class ContentItem : IProjectItem
     {
-        public IController Controller;
+        public IContentItemObserver Observer;
         
         public string ImporterName;
         public string ProcessorName;
@@ -70,8 +70,8 @@ namespace MonoGame.Tools.Pipeline
 
                 _buildAction = value;
 
-                if (Controller != null)
-                    Controller.OnItemModified(this);
+                if (Observer != null)
+                    Observer.OnItemModified(this);
             }
         }
 
@@ -97,8 +97,8 @@ namespace MonoGame.Tools.Pipeline
                     Processor = PipelineTypes.FindProcessor(_importer.DefaultProcessor, _importer);
                 }
 
-                if (Controller != null)
-                    Controller.OnItemModified(this);
+                if (Observer != null)
+                    Observer.OnItemModified(this);
             }
         }
 
@@ -125,8 +125,8 @@ namespace MonoGame.Tools.Pipeline
                     ProcessorParams.Add(p.Name, p.DefaultValue);
                 }
 
-                if (Controller != null)
-                    Controller.OnItemModified(this);
+                if (Observer != null)
+                    Observer.OnItemModified(this);
 
                 // Note:
                 // There is no need to validate that the new processor can accept input

--- a/Tools/Pipeline/Common/IController.cs
+++ b/Tools/Pipeline/Common/IController.cs
@@ -7,7 +7,12 @@ using System.Collections.Generic;
 
 namespace MonoGame.Tools.Pipeline
 {
-    interface IController
+    public interface IContentItemObserver
+    {
+        void OnItemModified(ContentItem item);
+    }
+
+    interface IController : IContentItemObserver
     {
         /// <summary>
         /// Types of content which can be created and added to a project. 
@@ -70,11 +75,6 @@ namespace MonoGame.Tools.Pipeline
         /// Notify controller that Project.References has been modified.
         /// </summary>
         void OnReferencesModified();
-
-        /// <summary>
-        /// Notify controller that a property of ContentItem has been modified.
-        /// </summary>        
-        void OnItemModified(ContentItem contentItem);
 
         void NewProject();
 

--- a/Tools/Pipeline/Common/PipelineController.ExcludeAction.cs
+++ b/Tools/Pipeline/Common/PipelineController.ExcludeAction.cs
@@ -58,7 +58,7 @@ namespace MonoGame.Tools.Pipeline
                 {
                     var item = new ContentItem()
                         {
-                            Controller = _con,
+                            Observer = _con,
                         };
                     obj.Apply(item);
                     item.ResolveTypes();

--- a/Tools/Pipeline/Common/PipelineController.IncludeAction.cs
+++ b/Tools/Pipeline/Common/PipelineController.IncludeAction.cs
@@ -34,8 +34,8 @@ namespace MonoGame.Tools.Pipeline
                     if (!parser.AddContent(f, true))
                         continue;
 
-                    var item = _con._project.ContentItems.Last();                    
-                    item.Controller = _con;
+                    var item = _con._project.ContentItems.Last();
+                    item.Observer = _con;
                     item.ResolveTypes();
 
                     _files[i] = item.OriginalPath;

--- a/Tools/Pipeline/Common/PipelineController.NewAction.cs
+++ b/Tools/Pipeline/Common/PipelineController.NewAction.cs
@@ -47,7 +47,7 @@ namespace MonoGame.Tools.Pipeline
                 if (parser.AddContent(fullpath, true))
                 {
                     var item = _con._project.ContentItems.Last();
-                    item.Controller = _con;
+                    item.Observer = _con;
                     item.ImporterName = _template.ImporterName;
                     item.ProcessorName = _template.ProcessorName;
                     item.ResolveTypes();

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using MGCB;
 
 namespace MonoGame.Tools.Pipeline
 {
@@ -71,7 +72,6 @@ namespace MonoGame.Tools.Pipeline
             _view = view;
             _view.Attach(this);
             _project = project;
-            _project.Controller = this;
             ProjectOpen = false;
 
             _templateItems = new List<ContentItemTemplate>();
@@ -210,8 +210,11 @@ namespace MonoGame.Tools.Pipeline
             {
                 _actionStack.Clear();
                 _project = new PipelineProject();
+                
                 var parser = new PipelineProjectParser(this, _project);
-                parser.OpenProject(projectFilePath);
+                var errorCallback = new MGBuildParser.ErrorCallback((msg, args) => View.OutputAppend(string.Format(Path.GetFileName(projectFilePath) + ": " + msg, args)));
+                parser.OpenProject(projectFilePath, errorCallback);
+
                 ResolveTypes();
 
                 ProjectOpen = true;
@@ -553,7 +556,7 @@ namespace MonoGame.Tools.Pipeline
             PipelineTypes.Load(_project);
             foreach (var i in _project.ContentItems)
             {
-                i.Controller = this;
+                i.Observer = this;
                 i.ResolveTypes();
                 _view.UpdateProperties(i);
             }

--- a/Tools/Pipeline/Common/PipelineProject.cs
+++ b/Tools/Pipeline/Common/PipelineProject.cs
@@ -11,10 +11,8 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Tools.Pipeline
 {
-    internal class PipelineProject : IProjectItem
+    public class PipelineProject : IProjectItem
     {        
-        public IController Controller;      
-  
         public string OriginalPath { get; set; }
 
         public List<ContentItem> ContentItems { get; private set; }                

--- a/Tools/Pipeline/Common/PipelineProjectParser.cs
+++ b/Tools/Pipeline/Common/PipelineProjectParser.cs
@@ -14,12 +14,12 @@ using PathHelper = MonoGame.Framework.Content.Pipeline.Builder.PathHelper;
 
 namespace MonoGame.Tools.Pipeline
 {
-    internal class PipelineProjectParser
+    public class PipelineProjectParser
     {
         #region Other Data
 
         private readonly PipelineProject _project;
-        private readonly IController _controller;
+        private readonly IContentItemObserver _observer;
         private readonly OpaqueDataDictionary _processorParams = new OpaqueDataDictionary();
         
         private string _processor;
@@ -156,7 +156,7 @@ namespace MonoGame.Tools.Pipeline
             // Create the item for processing later.
             var item = new ContentItem
             {
-                Controller = _controller,
+                Observer = _observer,
                 BuildAction = BuildAction.Build,
                 OriginalPath = sourceFile,
                 ImporterName = Importer,
@@ -207,13 +207,13 @@ namespace MonoGame.Tools.Pipeline
 
         #endregion
 
-        public PipelineProjectParser(IController controller, PipelineProject project)
+        public PipelineProjectParser(IContentItemObserver observer, PipelineProject project)
         {
-            _controller = controller;
+            _observer = observer;
             _project = project;
         }        
 
-        public void OpenProject(string projectFilePath)
+        public void OpenProject(string projectFilePath, MGBuildParser.ErrorCallback errorCallback)
         {
             _project.ContentItems.Clear();
 
@@ -222,7 +222,10 @@ namespace MonoGame.Tools.Pipeline
 
             var parser = new MGBuildParser(this);
             parser.Title = "Pipeline";
-            parser.OnError += (msg, args) => { _controller.View.OutputAppend(string.Format(Path.GetFileName(projectFilePath) + ": " + msg, args)); };
+
+            if (errorCallback != null)
+                parser.OnError += errorCallback;
+
             var commands = new string[]
                 {
                     string.Format("/@:{0}", projectFilePath),


### PR DESCRIPTION
The goal in this change is to allow other tools to understand the MGCB format by exposing PipelineProjectParser.
Most of the file changes below are removing unnecessary references to the IController type, which is something very specific to the PipelineTool, and cannot be made public.
Note that this PR does not in any way affect the behavior of the PipelineTool. All that happened was three classes went from internal to public.
