### PR TITLE
Implemented GraphicsDevice.Reset, Windows/DirectX only.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -318,12 +318,20 @@ namespace Microsoft.Xna.Framework.Graphics
             // Manually resetting the device is not currently supported.
             throw new NotImplementedException();
         }
+        */
 
+#if WINDOWS && DIRECTX
         public void Reset(PresentationParameters presentationParameters)
         {
-            throw new NotImplementedException();
-        }
+            PresentationParameters = presentationParameters;
 
+            // Update the back buffer.
+            CreateSizeDependentResources();
+            ApplyRenderTargets(null);        
+        }
+#endif
+
+        /*
         public void Reset(PresentationParameters presentationParameters, GraphicsAdapter graphicsAdapter)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Does the same thing as GraphicsDeviceManager.ApplyChanges within its Windows/DirectX block.
The common situation this is used is for a tool that needs to do xna rendering on a single control and doesn't even have a game/graphicsdevicemanager.
