### PR TITLE
Fix for RunOneFrame() mouse was not updating.

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -109,6 +109,12 @@ namespace MonoGame.Framework
             _window.MouseVisibleToggled();
         }
 
+        public override bool BeforeRun()
+        {
+            _window.UpdateWindows();
+            return base.BeforeRun();
+        }
+
         public override void BeforeInitialize()
         {
             _window.Initialize(Game.graphicsDeviceManager.PreferredBackBufferWidth, Game.graphicsDeviceManager.PreferredBackBufferHeight);

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -373,12 +373,16 @@ namespace MonoGame.Framework
             NativeMessage msg;
             while (!PeekMessage(out msg, IntPtr.Zero, 0, 0, 0))
             {
-                // Update the mouse state for each window.
-                foreach (var window in _allWindows)
-                    window.UpdateMouseState();
-
+                UpdateWindows();
                 Game.Tick();
             }
+        }
+
+        internal void UpdateWindows()
+        {
+            // Update the mouse state for each window.
+            foreach (var window in _allWindows)
+                window.UpdateMouseState();
         }
 
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
Since RunOneFrame doesn't use the RunLoop, it doesn't get registered in that case.  So I moved the registration to creation, and unregister on dispose.  
