### PR TITLE
Added support for executing MGFX under mono from the Pipeline tools

### DIFF
--- a/Tools/Pipeline/Common/IView.cs
+++ b/Tools/Pipeline/Common/IView.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace MonoGame.Tools.Pipeline
 {
@@ -50,5 +51,7 @@ namespace MonoGame.Tools.Pipeline
         bool ChooseContentFile(string initialDirectory, out List<string> files);        
         
         void OnTemplateDefined(ContentItemTemplate item);
+
+        Process CreateProcess(string exe, string commands);
     }
 }

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -370,7 +370,7 @@ namespace MonoGame.Tools.Pipeline
             {
                 var mgcbPath = Path.Combine(root, "MGCB.exe");
                 if (File.Exists(mgcbPath))
-                    return mgcbPath;
+                    return Path.GetFullPath(mgcbPath);
             }
 
             throw new FileNotFoundException("MGCB.exe is not in the search path!");
@@ -381,10 +381,8 @@ namespace MonoGame.Tools.Pipeline
             try
             {
                 // Prepare the process.
-                _buildProcess = new Process();
+                _buildProcess = _view.CreateProcess(FindMGCB(), commands);
                 _buildProcess.StartInfo.WorkingDirectory = Path.GetDirectoryName(_project.OriginalPath);
-                _buildProcess.StartInfo.FileName = FindMGCB();
-                _buildProcess.StartInfo.Arguments = commands;
                 _buildProcess.StartInfo.CreateNoWindow = true;
                 _buildProcess.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
                 _buildProcess.StartInfo.UseShellExecute = false;

--- a/Tools/Pipeline/Windows/MainView.cs
+++ b/Tools/Pipeline/Windows/MainView.cs
@@ -519,7 +519,15 @@ namespace MonoGame.Tools.Pipeline
         public void OutputClear()
         {
             _outputWindow.Clear();
-        }        
+        }
+
+        public Process CreateProcess(string exe, string commands)
+        {
+            var _buildProcess = new Process();
+            _buildProcess.StartInfo.FileName = exe;
+            _buildProcess.StartInfo.Arguments = commands;
+            return _buildProcess;
+        }
 
         private void ExitMenuItemClick(object sender, System.EventArgs e)
         {

--- a/Tools/Pipeline/Xwt/XwtView.cs
+++ b/Tools/Pipeline/Xwt/XwtView.cs
@@ -250,6 +250,22 @@ namespace MonoGame.Tools.Pipeline
         {
         }
 
+        public Process CreateProcess(string exe, string commands)
+        {
+            var _buildProcess = new Process();
+            if (Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX)
+            {
+                _buildProcess.StartInfo.FileName = exe;
+                _buildProcess.StartInfo.Arguments = commands;
+            }
+            else
+            {
+                _buildProcess.StartInfo.FileName = "mono";
+                _buildProcess.StartInfo.Arguments = string.Format("\"{0}\" {1}", exe, commands);
+            }
+            return _buildProcess;
+        }
+
 		#endregion
 
 


### PR DESCRIPTION
Because we need to run MGFX under mono on
Linux and MacOS we need to conditionally alter
the Process parameters. Rather than doing this
in the common code we call out to the IView
to have it create the Process Object for us.

Under Xwt we can run under either mono or
.net , but at least we keep the platform
specific code out of the Common code.
