### PR TITLE
Fix for obscure bug on WP8

### DIFF
--- a/MonoGame.Framework/WindowsPhone/WPGameWindow.cs
+++ b/MonoGame.Framework/WindowsPhone/WPGameWindow.cs
@@ -109,8 +109,13 @@ namespace MonoGame.Framework.WindowsPhone
             {
                 var frame = (PhoneApplicationFrame)Application.Current.RootVisual;
 
-                frame.Obscured += delegate { if (Game.Instance != null) Platform.IsActive = false; };
-                frame.Unobscured += delegate { if (Game.Instance != null) Platform.IsActive = true; };
+                frame.Obscured += (sender, e) => 
+                { 
+                    if (Game.Instance != null &&
+                        (!e.IsLocked || PhoneApplicationService.Current.ApplicationIdleDetectionMode != IdleDetectionMode.Enabled)) 
+                        Platform.IsActive = false;
+                };
+                frame.Unobscured += (sender, e) => { if (Game.Instance != null) Platform.IsActive = true; };
             };
 
             PhoneApplicationService.Current.Activated += (sender, e) => { if (Game.Instance != null) Platform.IsActive = true; };


### PR DESCRIPTION
There is a bug with the Obscure event.
The bug occurs sometimes when resume from the Lock screen and cause the
app to pause on a blank screen.
It never happens when the phone is attacked to the debugger so this
required some sort of on-screen logging to figure out.
(ver:8.10.14157.200, drv:3056.40000.1404.0003, Lumia Black) 

case #1
ApplicationIdleDetectionMode=Enabled (default)
App is suspended either by timeout or power button.

Obscured event triggered. IsLocked=true.
It's safe to ignore the Obscure event since the OS deactivates the app
anyway. IsActive is set to false by OnDeactivate.
When the user unlock the phone Unobscure event triggered but _SOMETIMES_
another Obscured event arrive after that, causing to app to remain in IsActive=false state.
That's why we need to ignore the event.

case #2
ApplicationIdleDetectionMode=Disabled
App is suspended either by timeout or power button.

Obscured event triggered. IsLocked=true.
We set IsActive=false on Obscure event as before.
When the user unlock the phone Unobscure event triggered and we set
IsActive=true.
Actually a second obscured event is triggered following by an
Unobscured, not an issue here.
In that mode the OS doesn't deactivate the app, allowing the app to run
under lock screen.
note: actually MonoGame doesn't allow run under lock screen
https://github.com/mono/MonoGame/pull/2084.

case #3
ApplicationIdleDetectionMode=Enabled|Disabled
App is suspended by a phone call.

Obscured event triggered. IsLocked=false.
We set IsActive=false on Obscure event as before.
When the action that obscured the app ends, an Unobscure event is
triggered and we set IsActive=true. No bug here.
That is similar to case #2, the OS doesn't deactivate the app.
