### PR TITLE
Pipeline: save processor parameters culture neutrally

### DIFF
--- a/Tools/Pipeline/Common/PipelineProjectParser.cs
+++ b/Tools/Pipeline/Common/PipelineProjectParser.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -336,7 +337,7 @@ namespace MonoGame.Tools.Pipeline
                                 if (value != null)
                                 {
                                     var converter = PipelineTypes.FindConverter(value.GetType());
-                                    var valueStr = converter.ConvertTo(value, typeof(string));
+                                    var valueStr = converter.ConvertTo(null, CultureInfo.InvariantCulture, value, typeof(string));
                                     line = string.Format(lineFormat, "processorParam", string.Format(processorParamFormat, j.Name, valueStr));
                                     io.WriteLine(line);
                                 }


### PR DESCRIPTION
This fixes #3022. Parameter conversion is now done with `CultureInfo.InvariantCulture` so the decimal separators etc. should be the same regardless of user culture. The `String.Format` calls in the same function _should_ work as they are, as they don't (currently) handle floating point numbers or dates.
