### PR TITLE
Fixed GameWindow Size Initialization 

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -417,6 +417,7 @@ namespace MonoGame.Framework
         {
             if (_form != null)
             {
+                _allWindows.Remove(this);
                 _form.Dispose();
                 _form = null;
             }


### PR DESCRIPTION
This fixes `GameWindow` size initialization under WindowsDX caused by https://github.com/mono/MonoGame/pull/2997.

I also added the fix from @thefiddler from https://github.com/mono/MonoGame/pull/3007.
