### PR TITLE
Fix GraphicsDevice.Present() not called on iOS

### DIFF
--- a/MonoGame.Framework/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/iOS/iOSGamePlatform.cs
@@ -225,7 +225,15 @@ namespace Microsoft.Xna.Framework
             Game.Tick ();
 
             if (!IsPlayingVideo)
+            {
+                if (Game.GraphicsDevice != null)
+                {
+                    // GraphicsDevice.Present() takes care of actually 
+                    // disposing resources disposed from a non-ui thread
+                    Game.GraphicsDevice.Present();
+                }
                 _viewController.View.Present ();
+            }
         }
 
         public override bool BeforeDraw(GameTime gameTime)


### PR DESCRIPTION
While investigating increased memory warnings on our iOS production build since integrating latest MonoGame stuff, we realized that GraphicsDevice.Present is not called on that platform. GraphicsDevice.Present takes care of disposing all graphics resources that where queued for disposal (if GraphicsResource.Dispose() is called from a non-ui thread) and not calling it can result in pretty significant memory leaks in certain scenarios.

This is the simplest fix we can do for now (Android already calls GraphicsDevice.Present in AndroidGamePlatform.Present) until the Present behavior is revamped.
