### PR TITLE
Fixed storage container creating existing directory

### DIFF
--- a/MonoGame.Framework/Storage/StorageContainer.cs
+++ b/MonoGame.Framework/Storage/StorageContainer.cs
@@ -136,10 +136,7 @@ namespace Microsoft.Xna.Framework.Storage
 				_storagePath = Path.Combine(_storagePath, "Player" + (int)playerIndex);
 
             // Create the "device" if need be
-            if (!Directory.Exists(_storagePath))
-            {
-                CreateDirectoryAbsolute(_storagePath);
-            }
+            CreateDirectoryAbsolute(_storagePath);
         }
 		
         /// <summary>
@@ -198,7 +195,10 @@ namespace Microsoft.Xna.Framework.Storage
             var task = folder.CreateFolderAsync(path, CreationCollisionOption.OpenIfExists);
             task.AsTask().Wait();
 #else
-            Directory.CreateDirectory(path);
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
 #endif
         }
 


### PR DESCRIPTION
Made the storage container code check if the directory exists before
creating a new one over the top.

The previous behaviour was causing a crash on software created using the
PSM build (and perhaps others) of MonoGame.

Refer to issue [**#3061**](https://github.com/mono/MonoGame/issues/3061) for more information.
