### PR TITLE
Fixed Song.PlayPosition on Android

### DIFF
--- a/MonoGame.Framework/Media/Song.Android.cs
+++ b/MonoGame.Framework/Media/Song.Android.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using Microsoft.Xna.Framework.Audio;
 
 namespace Microsoft.Xna.Framework.Media
 {
@@ -18,6 +17,7 @@ namespace Microsoft.Xna.Framework.Media
         private Genre genre;
         private string name;
         private TimeSpan duration;
+        private TimeSpan position;
         private Android.Net.Uri assetUri;
 
         static Song()
@@ -107,6 +107,7 @@ namespace Microsoft.Xna.Framework.Media
             _androidPlayer.Stop();
             _playingSong = null;
             _playCount = 0;
+            position = TimeSpan.Zero;
         }
 
         internal float Volume
@@ -126,10 +127,10 @@ namespace Microsoft.Xna.Framework.Media
         {
             get
             {
-                if (_playingSong == this)
-                    return TimeSpan.FromMilliseconds(_androidPlayer.CurrentPosition);
+                if (_playingSong == this && _androidPlayer.IsPlaying)
+                    position = TimeSpan.FromMilliseconds(_androidPlayer.CurrentPosition);
 
-                return TimeSpan.Zero;
+                return position;
             }
             set
             {


### PR DESCRIPTION
Fixed Song.PlayPosition that is invalid on Android after a Play-Pause cycle.
The fix was proposed by @dellis1972 here:
https://bugzilla.xamarin.com/show_bug.cgi?id=23171
