### PR TITLE
Fixed missing GetThumbnail and GetAlbumArt

### DIFF
--- a/MonoGame.Framework/Media/Album.cs
+++ b/MonoGame.Framework/Media/Album.cs
@@ -200,23 +200,8 @@ namespace Microsoft.Xna.Framework.Media
                 this.thumbnail.Dispose();
 #endif
         }
-
-#if WINDOWS_PHONE || WINDOWS_STOREAPP
-        /// <summary>
-        /// Returns the stream that contains the album art image data.
-        /// </summary>
-        public Stream GetAlbumArt()
-        {
-#if WINDOWS_PHONE
-            return this.album.GetAlbumArt();
-#elif WINDOWS_STOREAPP
-            if (this.HasArt)
-                return this.thumbnail.AsStream();
-            return null;
-#endif
-        }
-
-#elif IOS
+        
+#if IOS
         [CLSCompliant(false)]
         public UIImage GetAlbumArt()
         {
@@ -228,24 +213,25 @@ namespace Microsoft.Xna.Framework.Media
         {
             return MediaStore.Images.Media.GetBitmap(MediaLibrary.Context.ContentResolver, this.thumbnail);
         }
-#endif
-
-#if WINDOWS_PHONE || WINDOWS_STOREAPP
+#else
         /// <summary>
-        /// Returns the stream that contains the album thumbnail image data.
+        /// Returns the stream that contains the album art image data.
         /// </summary>
-        public Stream GetThumbnail()
+        public Stream GetAlbumArt()
         {
 #if WINDOWS_PHONE
-            return this.album.GetThumbnail();
+            return this.album.GetAlbumArt();
 #elif WINDOWS_STOREAPP
             if (this.HasArt)
                 return this.thumbnail.AsStream();
-
             return null;
+#else
+            throw new NotImplementedException();
 #endif
         }
-#elif IOS
+#endif
+
+#if IOS
         [CLSCompliant(false)]
         public UIImage GetThumbnail()
         {
@@ -259,6 +245,23 @@ namespace Microsoft.Xna.Framework.Media
             {
                 return Bitmap.CreateScaledBitmap(albumArt, 100, 100, false); // TODO: Check size
             }
+        }
+#else
+        /// <summary>
+        /// Returns the stream that contains the album thumbnail image data.
+        /// </summary>
+        public Stream GetThumbnail()
+        {
+#if WINDOWS_PHONE
+            return this.album.GetThumbnail();
+#elif WINDOWS_STOREAPP
+            if (this.HasArt)
+                return this.thumbnail.AsStream();
+
+            return null;
+#else
+            throw new NotImplementedException();
+#endif
         }
 #endif
 


### PR DESCRIPTION
Added missing Album.GetThumbnail and GetAlbumArt to platforms where it isn't implemented (throws NotImplementedException).

The diff is ugly because I had to shuffle some code:

``` C#
#if WINDOWS_PHONE || WINDOWS_STOREAPP
// Returns Stream (like XNA)
#elif IOS
// Returns UIImage
#elif ANDROID
// Returns Bitmap
#endif
```

to

``` C#
#if IOS
// Returns UIImage
#elif ANDROID
// Returns Bitmap
#else
// Returns Stream (like XNA)
#endif
```
