### PR TITLE
Fixes for the Content Pipeline targets

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Pipeline.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Pipeline.targets
@@ -40,7 +40,7 @@
     <OutputPath Condition="'$(OutputPath)' == ''">bin\$(Platform)\$(Configuration)</OutputPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">obj\$(Platform)\$(Configuration)</IntermediateOutputPath>
     
-    <ContentResponseFile>$(IntermediateOutputPath)\mgcontent.txt</ContentResponseFile>	
+    <ContentResponseFile>$(IntermediateOutputPath)\$(MSBuildProjectName).mgcontent.txt</ContentResponseFile>	
     <MonoGameContentBuilderExe>$(MSBuildProgramFiles32)\MonoGame\v3.0\MGCB.exe</MonoGameContentBuilderExe>
     <MonoGamePlatform Condition="'$(MonoGamePlatform)' == ''">Windows</MonoGamePlatform>
 


### PR DESCRIPTION
Two fixes for the targets file to build correctly using Visual Studio.
