### PR TITLE
Fix Visual Unit Test Shutdown

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -43,6 +43,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Windows.Forms;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
@@ -370,12 +371,15 @@ namespace MonoGame.Framework
             // typically will run all the tests on the same
             // process/thread.
 
-            NativeMessage msg;
-            while(PeekMessage(out msg, IntPtr.Zero, 0, 0, 1))
+            var msg = new NativeMessage();
+            do
             {
                 if (msg.msg == WM_QUIT)
-                  break;
-            }
+                    break;
+
+                Thread.Sleep(100);
+            } 
+            while (PeekMessage(out msg, IntPtr.Zero, 0, 0, 1));
         }
 
         private void OnIdle(object sender, EventArgs eventArgs)


### PR DESCRIPTION
This PR is an attempt to fix the false failed visual unit tests.

I suspect we're exiting quick enough that the WM_QUIT isn't in the message queue in time to consume it.  This introduces a tiny delay into shutdown in hopes we can more reliably process the WM_QUIT.
