### PR TITLE
Add a message explaining ProjectGuids to the definition files

### DIFF
--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Name="MonoGame.Framework.Content.Pipeline" Path="MonoGame.Framework.Content.Pipeline" Type="Library" Platforms="Linux,MacOS,Windows">
 
+  <!--
+    Using Protobuild in your own project?  ProjectGuids are only in use here
+    for backwards compatibility with existing users of MonoGame, and are not
+    required for new projects.
+
+    See https://github.com/hach-que/Protobuild/wiki/Project-GUIDs-in-Protobuild
+  -->
   <ProjectGuids>
 	<Platform Name="Linux">57696462-CE5E-4BC5-80AB-1B959E2420EA</Platform>
 	<Platform Name="MacOS">A6C47073-8FF9-4997-BA3A-BA257CC88CFE</Platform>

--- a/Build/Projects/MonoGame.Framework.Net.definition
+++ b/Build/Projects/MonoGame.Framework.Net.definition
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Name="MonoGame.Framework.Net" Path="MonoGame.Framework" Type="Library" Platforms="Android,iOS,Linux,MacOS,Ouya,PSMobile,Windows,Windows8,WindowsGL,WindowsPhone">
 
+  <!--
+    Using Protobuild in your own project?  ProjectGuids are only in use here
+    for backwards compatibility with existing users of MonoGame, and are not
+    required for new projects.
+
+    See https://github.com/hach-que/Protobuild/wiki/Project-GUIDs-in-Protobuild
+  -->
   <ProjectGuids>
 	<Platform Name="Android">713EE5CA-C850-42AD-AC67-B6546AC8BFFB</Platform>
 	<Platform Name="iOS">D4838656-8545-4DC5-8822-D4AD313E17AC</Platform>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Name="MonoGame.Framework" Path="MonoGame.Framework" Type="Library" Platforms="Android,Angle,iOS,Linux,MacOS,Ouya,PSMobile,Windows,Windows8,WindowsGL,WindowsPhone,WindowsPhone81,Web">
 
+  <!--
+    Using Protobuild in your own project?  ProjectGuids are only in use here
+    for backwards compatibility with existing users of MonoGame, and are not
+    required for new projects.
+
+    See https://github.com/hach-que/Protobuild/wiki/Project-GUIDs-in-Protobuild
+  -->
   <ProjectGuids>
   	<Platform Name="Android">BA9476CF-99BA-4D03-92F2-73D2C5E58883</Platform>
   	<Platform Name="Angle">ECF3C8B9-0AAC-4C32-B184-FAE88F6244B5</Platform>


### PR DESCRIPTION
This adds a message right about `<ProjectGuids>` in the MonoGame projects.  There was some user confusion that project GUIDs were required configuration for Protobuild projects (see https://github.com/hach-que/Protobuild/issues/66).  This led to duplicate project GUIDs, which meant that one or more projects didn't show up the solution (because we use duplicate project GUIDs to detect multiple references to the same third-party project).

To reduce confusion for anyone else using Protobuild in their own project, this adds a message explaining that they're not required and are only used for backwards compatibility with existing users of MonoGame.
