### PR TITLE
Fix autorotate behavior during launch on iOS

### DIFF
--- a/MonoGame.Framework/iOS/iOSGameViewController.cs
+++ b/MonoGame.Framework/iOS/iOSGameViewController.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Xna.Framework
 
         public override bool ShouldAutorotate()
         {
-            return _platform.Game.Initialized;
+            return true;
         }
         #endregion
 


### PR DESCRIPTION
This could cause orientation issues when launching on iOS. Strangely it was working fine on iOS 8 but caused issues on the upcoming iOS 8.1 (I suspect this might be the cause for some ppl having orientation issues, depending on what they do in their Game.Initialize)
