### PR TITLE
Remove GC.Collect() when receiving memory warnings

### DIFF
--- a/MonoGame.Framework/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/iOS/iOSGamePlatform.cs
@@ -334,7 +334,6 @@ namespace Microsoft.Xna.Framework
         {
             // FIXME: Possibly add some more sophisticated behavior here.  It's
             //        also possible that this is not iOSGamePlatform's job.
-            GC.Collect();
         }
 
         #endregion Notification Handling


### PR DESCRIPTION
As stated in the comment, this is not MonoGame's job. The app should be responsible of this and MonoGame should do its job without unexpected hiccups. The most MonoGame should do is to Log a warning (and do this for Android as well if applicable).
