### PR TITLE
Disable dithering on OpenGL(ES) platforms

### DIFF
--- a/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Xna.Framework.Graphics
             // When rendering offscreen the faces change order.
             var offscreen = device.IsRenderTargetBound;
 
+            // Turn off dithering to make sure data returned by Texture.GetData is accurate
+            GL.Disable(EnableCap.Dither);
+
             if (CullMode == CullMode.None)
             {
                 GL.Disable(EnableCap.CullFace);


### PR DESCRIPTION
With OpenGL/OpenGLES, dithering is enabled by default and it is up to the driver to decide when/how to apply dithering which can give unexpected results. For example, pixel data retrieved using `RenderTarget2D.GetData` can be slightly different than expected due to the nature of dithering.

This issue seem to mainly affect Mali T400 devices (most Galaxy S2, Galaxy Tab3, Galaxy Note).

Disabling dithering by default might result in more banding if the backbuffer/rendertaget is 16bit but at least it will be deterministic (performances might be better as well). AFAIK, XNA 4.0 doesn't expose a way to enable/disable dithering (DirectX 10 deprecated support for automatic dithering) so I am not sure if it was up to the Windows Phone device vendor to enable it or not.

We could disable dithering in the `GraphicsDevice` initialization to avoid redundant state changes but I added it to the RasterizerState to make sure it is disabled even if third party code re-enables it. The RasterizerState code do need some caching anyway, we should do this as a separate PR.
