### PR TITLE
[WP8] Do not reload .XNBs of types we don't need to reload

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -67,8 +67,8 @@ namespace Microsoft.Xna.Framework.Content
         private Dictionary<string, object> loadedAssets = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 		private List<IDisposable> disposableAssets = new List<IDisposable>();
         private bool disposed;
-		
-        private static HashSet<Type> reloadAssetExcludedTypes = new HashSet<Type>(new[] { 
+
+        protected static HashSet<Type> reloadAssetExcludedTypes = new HashSet<Type>(new[] { 
                 typeof(Microsoft.Xna.Framework.Audio.SoundEffect),
                 typeof(Microsoft.Xna.Framework.Media.Song),        
             });


### PR DESCRIPTION
Some types don't need to get reloaded, like for example SoundEffects. By
excluding those from ReloadAsset() we can speedup resuming.

Things to consider:
-SoundEffect is the only type I use in my active project that doesn't
contain GPU resources. Other types can be added to the list.
-Make the HashSet publicly accessible so users can add their own types.
-Instead of an Exclusion Set we can use an Inclusion Set  (Texture2D,
Texture3D, Cube, Model, etc)
