### PR TITLE
[WinStore] Add check at LoadFromStream method of Texture2D

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -188,6 +188,9 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
 #if !WINDOWS_PHONE
 
+            if (!stream.CanSeek)
+                throw new NotSupportedException("stream must support seek operations");
+
             // For reference this implementation was ultimately found through this post:
             // http://stackoverflow.com/questions/9602102/loading-textures-with-sharpdx-in-metro 
             Texture2D toReturn = null;


### PR DESCRIPTION
WIC does not support non-seekable streams.

For example when you load images from the web an exception is thrown by
DX but it's not very helpful to identify the problem.

http://sharpdx.org/forum/5-api-usage/379-sharpdx-wic-bitmapdecoder-class-not-working-with-outside-url
