### PR TITLE
Fixed null reference exception in Guide on Windows 8

### DIFF
--- a/MonoGame.Framework/Windows/GamerServices/Guide.cs
+++ b/MonoGame.Framework/Windows/GamerServices/Guide.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Xna.Framework.GamerServices
         static Guide()
         {
 #if WINDOWS_STOREAPP
-            _dispatcher = Windows.UI.Core.CoreWindow.GetForCurrentThread().Dispatcher;
+            _dispatcher = Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher;
 
 
             var licenseInformation = CurrentApp.LicenseInformation;


### PR DESCRIPTION
CoreWindow.GetForCurrentThread() is null when not called on the main thread, which results in a null reference exception when trying to get the dispatcher. Using `CoreApplication.MainView.CoreWindow.Dispatcher;` instead resolves this problem as it works when called from any thread.
