### PR TITLE
Fixed default values in FontTextureProcessor

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/FontTextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontTextureProcessor.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 
 		public FontTextureProcessor ()
 		{
+		    FirstCharacter = ' ';
+		    PremultiplyAlpha = true;
 		}
 
 		protected virtual char GetCharacterForIndex (int index)


### PR DESCRIPTION
While there is a DefaultValueAttribute for these, it is not actually set.
This was a problem for the import option in the pipeline tool. SpriteFonts have PremultiplyAlpha=true by default and it is not present in the XML. When it gets imported, PremultiplyAlpha gets set to the default value, which was incorrectly false. The generated mgcb files will have incorrect default values. In case of PremultiplyAlpha, it results in messed up textures.
