### PR TITLE
Cleaned up some more things in FontTextureProcessor

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/FontTextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontTextureProcessor.cs
@@ -100,11 +100,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             systemBitmap = GlyphPacker.ArrangeGlyphs(glyphs.ToArray(), compressed, compressed);
 			
 			foreach (Glyph glyph in glyphs) {
-                glyph.XAdvance += output.VerticalLineSpacing;
-				if (!output.CharacterMap.Contains (glyph.Character))
-					output.CharacterMap.Add (glyph.Character);
+				output.CharacterMap.Add (glyph.Character);
 				output.Glyphs.Add (new Rectangle (glyph.Subrect.X, glyph.Subrect.Y, glyph.Subrect.Width, glyph.Subrect.Height));
-                output.Cropping.Add(new Rectangle((int)glyph.XOffset, (int)glyph.YOffset, (int)glyph.XAdvance, output.VerticalLineSpacing));
+                output.Cropping.Add(new Rectangle((int)glyph.XOffset, (int)glyph.YOffset, glyph.Subrect.Width, glyph.Subrect.Height));
 				ABCFloat abc = glyph.CharacterWidths;
 				output.Kerning.Add (new Vector3 (abc.A, abc.B, abc.C));
 			}


### PR DESCRIPTION
Line spacing was incorrectly added to XAdvance (change didn't make any sense, value of XAdvance is not used anywhere).
Cropping rectangle width and height set to Subrect width and height, as XOffset and YOffset are essentially subrect X and Y:

In GlyphCropper:

``` C#
                glyph.Subrect.Y++;
                glyph.Subrect.Height--;

                glyph.YOffset++;
[...]
                glyph.Subrect.X++;
                glyph.Subrect.Width--;

                glyph.XOffset++;
```

Width of cropping rectangle is not used anywhere. Height of cropping rectangle is checked to see if its larger than the line spacing, but is never actually used.

In conclusion, this does not affect how the SpriteFont gets drawn on the screen.
