### PR TITLE
Fix RenderTarget disposing for OpenGL ports

### DIFF
--- a/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
@@ -58,8 +58,8 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 GraphicsDevice.AddDisposeAction(() =>
                 {
-					if (GraphicsDevice != null)
-						this.GraphicsDevice.PlatformDeleteRenderTarget(this);
+                    if (GraphicsDevice != null)
+                        this.GraphicsDevice.PlatformDeleteRenderTarget(this);
                 });
             }
 


### PR DESCRIPTION
This pull request adds a fix to prevent the application to crash when a renderTarget is disposed. In some cases the GraphicsDevice object is null when the callback of `AddDisposeAction` is called. This fix has been necessary for a one of my games using the WindowsGL port.
