### PR TITLE
Fixed possible exception in MediaLibrary on Windows 8

### DIFF
--- a/MonoGame.Framework/Media/MediaLibrary.WinRT.cs
+++ b/MonoGame.Framework/Media/MediaLibrary.WinRT.cs
@@ -18,13 +18,11 @@ namespace Microsoft.Xna.Framework.Media
         private static AlbumCollection albumCollection;
         private static SongCollection songCollection;
 
-        static MediaLibrary()
-        {
-            musicFolder = KnownFolders.MusicLibrary;
-        }
-
         private void PlatformLoad(Action<int> progressCallback)
         {
+            if (musicFolder == null)
+                musicFolder = KnownFolders.MusicLibrary;
+
             List<StorageFile> files = new List<StorageFile>();
             this.GetAllFiles(musicFolder, files);
 


### PR DESCRIPTION
Performing IO while calling MediaLibrary members causes the following exception:
![exception](https://cloud.githubusercontent.com/assets/431167/4892086/7e05b8ee-63ae-11e4-85f4-ec628157f5cd.png)

This can be fixed by only settings the music folder when it is needed in PlatformLoad.
