### PR TITLE
Added eight point BoundingSphereTest (Related to Issue #3030)

### DIFF
--- a/Test/Framework/Bounding.cs
+++ b/Test/Framework/Bounding.cs
@@ -26,6 +26,23 @@ namespace MonoGame.Tests.Framework
             var threePoint = BoundingSphere.CreateFromPoints(new[] { new Vector3(0, 0, 0), new Vector3(-1, 0, 0), new Vector3(1, 1, 1) });
             Assert.That(new BoundingSphere(new Vector3(0, 0.5f, 0.5f), 1.224745f), Is.EqualTo(threePoint).Using(BoundingSphereComparer.Epsilon));
 
+            var eightPointTestInput = new Vector3[]
+            {
+                new Vector3(54.58071f, 124.9063f, 56.0016f),
+                new Vector3(54.52138f, 124.9063f, 56.13985f),
+                new Vector3(54.52208f, 124.8235f, 56.14014f),
+                new Vector3(54.5814f, 124.8235f, 56.0019f),
+                new Vector3(1145.415f, 505.913f, -212.5173f),
+                new Vector3(611.4731f, 505.9535f, 1031.893f),
+                new Vector3(617.7462f, -239.7422f, 1034.584f),
+                new Vector3(1151.687f, -239.7035f, -209.8246f)
+            };
+            var eightPoint = BoundingSphere.CreateFromPoints(eightPointTestInput);
+            for (int i = 0; i < eightPointTestInput.Length; i++)
+            {
+                Assert.That(eightPoint.Contains(eightPointTestInput[i]) != ContainmentType.Disjoint);
+            }
+
             Assert.Throws<ArgumentException>(() => BoundingSphere.CreateFromPoints(new Vector3[] {}));
         }
 


### PR DESCRIPTION
Added eight point BoundingSphereTest that works with XNA test
environment but fails with monogame test environment

This changes is associated with issue #3030, "BoundingSphere.CreateFromPoints returns incorrect results"
