### PR TITLE
Correct links in project definitions for new Protobuild documentation

### DIFF
--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -6,7 +6,7 @@
     for backwards compatibility with existing users of MonoGame, and are not
     required for new projects.
 
-    See https://github.com/hach-que/Protobuild/wiki/Project-GUIDs-in-Protobuild
+    See https://protobuild.readthedocs.org/en/latest/faq.html#project-guids-faq
   -->
   <ProjectGuids>
 	<Platform Name="Linux">57696462-CE5E-4BC5-80AB-1B959E2420EA</Platform>

--- a/Build/Projects/MonoGame.Framework.Net.definition
+++ b/Build/Projects/MonoGame.Framework.Net.definition
@@ -6,7 +6,7 @@
     for backwards compatibility with existing users of MonoGame, and are not
     required for new projects.
 
-    See https://github.com/hach-que/Protobuild/wiki/Project-GUIDs-in-Protobuild
+    See https://protobuild.readthedocs.org/en/latest/faq.html#project-guids-faq
   -->
   <ProjectGuids>
 	<Platform Name="Android">713EE5CA-C850-42AD-AC67-B6546AC8BFFB</Platform>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -6,7 +6,7 @@
     for backwards compatibility with existing users of MonoGame, and are not
     required for new projects.
 
-    See https://github.com/hach-que/Protobuild/wiki/Project-GUIDs-in-Protobuild
+    See https://protobuild.readthedocs.org/en/latest/faq.html#project-guids-faq
   -->
   <ProjectGuids>
   	<Platform Name="Android">BA9476CF-99BA-4D03-92F2-73D2C5E58883</Platform>


### PR DESCRIPTION
Missed these links during the last PR.  This updates the project definitions so the FAQ on project GUIDs points to the right place.
