### PR TITLE
Ensure MonoGame builds successfully on Linux

### DIFF
--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -32,7 +32,7 @@
     <Compile Include="..\MGCB\CommandLineParser.cs">
       <Link>Common\CommandLineParser.cs</Link>
     </Compile>
-    <None Include="app.config" />
+    <None Include="App.config" />
 
     <Compile Include="Common\ActionStack.cs" />
     <Compile Include="Common\ContentFolder.cs" />


### PR DESCRIPTION
On Linux, MonoGame doesn't currently build successfully because the app.config file has different capitalization on disk than it does in the definition file.  

Without this change, you get:

```
/usr/lib/mono/4.5/Microsoft.Common.targets: error : Cannot copy /home/james/Projects/Redpoint/MonoGame/Tools/Pipeline/app.config to /home/james/Projects/Redpoint/MonoGame/Tools/Pipeline/bin/Linux/AnyCPU/Debug/Pipeline.exe.config, as the source file doesn't exist.
```

(because it's actually `App.config` on disk)
