### PR TITLE
Upgrade Android to OpenTK-1

### DIFF
--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -32,14 +32,14 @@
   <Platform Type="Android">
     <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
-    <Reference Include="OpenTK" />
+    <Reference Include="OpenTK-1.0" />
     <Reference Include="System.Core" />
   </Platform>
 
   <Platform Type="Ouya">
     <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
-    <Reference Include="OpenTK" />
+    <Reference Include="OpenTK-1.0" />
     <Reference Include="System.Core" />
     <Binary
       Name="Ouya.Console.Api"

--- a/MonoGame.Framework/Android/AndroidGameActivity.cs
+++ b/MonoGame.Framework/Android/AndroidGameActivity.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Xna.Framework
         private OrientationListener _orientationListener;
 
         public bool AutoPauseAndResumeMediaPlayer = true;
+        public bool RenderOnUIThread = true; 
 
 		/// <summary>
 		/// OnCreate called when the activity is launched from cold or after the app

--- a/MonoGame.Framework/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Android/AndroidGameWindow.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Xna.Framework
             _clientBounds = new Rectangle(0, 0, context.Resources.DisplayMetrics.WidthPixels, context.Resources.DisplayMetrics.HeightPixels);
 
             GameView = new MonoGameAndroidGameView(context, this, _game);
+            GameView.RenderOnUIThread = Game.Activity.RenderOnUIThread;
             GameView.RenderFrame += OnRenderFrame;
             GameView.UpdateFrame += OnUpdateFrame;
 

--- a/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Xna.Framework
             : base(context)
         {
             _gameWindow = androidGameWindow;
-            _game = game;
+			_game = game;
             _touchManager = new AndroidTouchEventManager(androidGameWindow);
         }
 
@@ -200,8 +200,8 @@ namespace Microsoft.Xna.Framework
         protected override void CreateFrameBuffer()
         {
             Android.Util.Log.Debug("MonoGame", "MonoGameAndroidGameView.CreateFrameBuffer");
-            GLContextVersion = GLContextVersion.Gles2_0;
 
+            ContextRenderingApi = GLVersion.ES2;
             int depth = 0;
             int stencil = 0;
             switch (_game.graphicsDeviceManager.PreferredDepthStencilFormat)

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Xna.Framework.Graphics
             int anisotropy = 0;
             if (SupportsTextureFilterAnisotropic)
             {
-#if GLES && !ANGLE
+#if GLES && !ANGLE && !ANDROID
                 GL.GetInteger(All.MaxTextureMaxAnisotropyExt, ref anisotropy);
 #else
                 GL.GetInteger((GetPName)All.MaxTextureMaxAnisotropyExt, out anisotropy);

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
@@ -183,7 +183,11 @@ namespace Microsoft.Xna.Framework.Graphics
             internal virtual void GenRenderbuffer(out int renderbuffer)
             {
                 renderbuffer = 0;
+#if !ANDROID
                 GL.GenRenderbuffers(1, ref renderbuffer);
+#else
+                GL.GenRenderbuffers(1, out renderbuffer);
+#endif
                 GraphicsExtensions.CheckGLError();
             }
 
@@ -211,7 +215,11 @@ namespace Microsoft.Xna.Framework.Graphics
             internal virtual void GenFramebuffer(out int framebuffer)
             {
                 framebuffer = 0;
+#if !ANDROID
                 GL.GenFramebuffers(1, ref framebuffer);
+#else
+                GL.GenFramebuffers(1, out framebuffer);
+#endif
                 GraphicsExtensions.CheckGLError();
             }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             MaxTextureSlots = 16;
 
-#if ANDROID || IOS
+#if  IOS
             GL.GetInteger(All.MaxTextureImageUnits, ref MaxTextureSlots);
             GraphicsExtensions.CheckGLError();
 
@@ -333,7 +333,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				bufferMask = bufferMask | ClearBufferMask.DepthBufferBit;
 			}
 
-#if GLES && !ANGLE
+#if GLES && !ANGLE && !ANDROID
 			GL.Clear((uint)bufferMask);
 #else
 			GL.Clear(bufferMask);

--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -796,7 +796,7 @@ namespace Microsoft.Xna.Framework.Graphics
         public static int GetBoundTexture2D()
         {
             var prevTexture = 0;
-#if GLES && !ANGLE
+#if GLES && !ANGLE && !ANDROID
             GL.GetInteger(GetPName.TextureBinding2D, ref prevTexture);
 #else
             GL.GetInteger(GetPName.TextureBinding2D, out prevTexture);

--- a/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Xna.Framework.Graphics
             GraphicsExtensions.CheckGLError();
 
             var compiled = 0;
-#if GLES && !ANGLE
+#if GLES && !ANGLE && !ANDROID
 			GL.GetShader(_shaderHandle, ShaderParameter.CompileStatus, ref compiled);
 #else
             GL.GetShader(_shaderHandle, ShaderParameter.CompileStatus, out compiled);
@@ -82,7 +82,7 @@ namespace Microsoft.Xna.Framework.Graphics
             GraphicsExtensions.CheckGLError();
             if (compiled == (int)All.False)
             {
-#if GLES && !ANGLE
+#if GLES && !ANGLE && !ANDROID
                 string log = "";
                 int length = 0;
 				GL.GetShader(_shaderHandle, ShaderParameter.InfoLogLength, ref length);

--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             var linked = 0;
 
-#if GLES && !ANGLE
+#if GLES && !ANGLE && !ANDROID
             GL.GetProgram(program, GetProgramParameterName.LinkStatus, ref linked);
 #else
             GL.GetProgram(program, GetProgramParameterName.LinkStatus, out linked);

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -239,7 +239,11 @@ namespace Microsoft.Xna.Framework.Graphics
             // TODO: check for data size and for non renderable formats (formats that can't be attached to FBO)
 
             var framebufferId = 0;
+#if !ANDROID
             GL.GenFramebuffers(1, ref framebufferId);
+#else
+            GL.GenFramebuffers(1, out framebufferId);
+#endif
             GraphicsExtensions.CheckGLError();
             GL.BindFramebuffer(All.Framebuffer, framebufferId);
             GraphicsExtensions.CheckGLError();
@@ -558,7 +562,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (this.glTexture < 0)
             {
-#if IOS || ANDROID
+#if IOS
                 GL.GenTextures(1, ref this.glTexture);
 #else
                 GL.GenTextures(1, out this.glTexture);

--- a/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             Threading.BlockOnUIThread(() =>
             {
-#if IOS || ANDROID
+#if IOS
 			GL.GenTextures(1, ref this.glTexture);
 #else
             GL.GenTextures(1, out this.glTexture);

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 var sizeInBytes = IndexCount * (this.IndexElementSize == IndexElementSize.SixteenBits ? 2 : 4);
 
-#if IOS || ANDROID
+#if IOS
                 GL.GenBuffers(1, ref ibo);
 #else
                 GL.GenBuffers(1, out ibo);

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 //GLExt.Oes.GenVertexArrays(1, out this.vao);
                 //GLExt.Oes.BindVertexArray(this.vao);
-#if IOS || ANDROID
+#if IOS
                 GL.GenBuffers(1, ref this.vbo);
 #else
                 GL.GenBuffers(1, out this.vbo);


### PR DESCRIPTION
Also added Property to Activity to control if the rendering is done on
the UI thread or not. By not rendering on the UI thread we save
a SyncContext.Send call in the underlying AndroidGameView.
This can introduce up to a 100ms delay in a Render call which
can cause a stutter.

By default we will leave RenderOnUIThread = true to maintain
backwards compatability.

The upgrade to OpenTK-1 was required as the fix for this
is not present in the OpenTK 0.9.9.3 version as it is there
for backwards compatabiltiy only.
