### PR TITLE
Change OpenGL resources dispose behavior

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// This allows GL resources to be disposed from other threads, such as the finalizer.
         /// </summary>
         /// <param name="disposeAction">The action to execute for the dispose.</param>
-        static internal void AddDisposeAction(Action disposeAction)
+        static private void AddDisposeAction(Action disposeAction)
         {
             if (disposeAction == null)
                 throw new ArgumentNullException("disposeAction");

--- a/MonoGame.Framework/Graphics/OcclusionQuery.cs
+++ b/MonoGame.Framework/Graphics/OcclusionQuery.cs
@@ -63,11 +63,11 @@ namespace Microsoft.Xna.Framework.Graphics
             if (!IsDisposed)
             {
 #if OPENGL
-                GraphicsDevice.AddDisposeAction(() =>
-                    {
-                        GL.DeleteQueries(1, ref glQueryId);
-                        GraphicsExtensions.CheckGLError();
-                    });
+                Threading.BlockOnUIThread(() =>
+                {
+                    GL.DeleteQueries(1, ref glQueryId);
+                    GraphicsExtensions.CheckGLError();
+                });
 #elif DIRECTX
 #endif
             }

--- a/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (!IsDisposed)
             {
-                GraphicsDevice.AddDisposeAction(() =>
+                Threading.BlockOnUIThread(() =>
                 {
                     this.GraphicsDevice.PlatformDeleteRenderTarget(this);
                 });

--- a/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (!IsDisposed)
             {
-                GraphicsDevice.AddDisposeAction(() =>
+                Threading.BlockOnUIThread(() =>
                 {
                     if (_shaderHandle != -1)
                     {

--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (glTexture > 0)
             {
                 int texture = glTexture;
-                GraphicsDevice.AddDisposeAction(() =>
+                Threading.BlockOnUIThread(() =>
                 {
                     GL.DeleteTextures(1, ref texture);
                     GraphicsExtensions.CheckGLError();

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (!IsDisposed)
             {
-                GraphicsDevice.AddDisposeAction(() =>
+                Threading.BlockOnUIThread(() =>
                 {
                     GL.DeleteBuffers(1, ref ibo);
                     GraphicsExtensions.CheckGLError();

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (!IsDisposed)
             {
-                GraphicsDevice.AddDisposeAction(() =>
+                Threading.BlockOnUIThread(() =>
                 {
                     GL.DeleteBuffers(1, ref vbo);
                     GraphicsExtensions.CheckGLError();


### PR DESCRIPTION
Simplified dispose behavior for opengl resources. It shouldn't be MonoGame's responsibility to delay resource disposal (should be done by a higher level rendering component). This PR should fix #3188

Note that this PR keeps `GraphicsDevice.AddDisposeAction()` to be used by the `GraphicsDevice.PlatformDispose` method. This is on purpose since there might be some corner cases there that I didn't get a chance to test yet.
