### PR TITLE
When a WinStore app becomes hidden, forget any held keys.

### DIFF
--- a/MonoGame.Framework/Windows8/InputEvents.cs
+++ b/MonoGame.Framework/Windows8/InputEvents.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Xna.Framework
             // only arrive here if some other control hasn't gotten it.
             window.KeyDown += CoreWindow_KeyDown;
             window.KeyUp += CoreWindow_KeyUp;
+            window.VisibilityChanged += CoreWindow_VisibilityChanged;
 
             if (inputElement != null)
             {
@@ -271,6 +272,13 @@ namespace Microsoft.Xna.Framework
 
             if (!_keys.Contains(xnaKey))
                 _keys.Add(xnaKey);
+        }
+
+        private void CoreWindow_VisibilityChanged(CoreWindow sender, VisibilityChangedEventArgs args)
+        {
+            //Forget about the held keys when we disappear as we don't receive key events for them while we are in the background
+            if (!args.Visible)
+                _keys.Clear();
         }
     }
 }


### PR DESCRIPTION
If they are released while we aren't active we won't know about it, so we get out of sync.

This can be tested with the platformer sample. Hold `d` to start moving right. Press `alt-tab` to leave the app, release `d`, press `alt-tab` to go back to the app. You'll still be moving to the right

Fixes #3212
