### PR TITLE
DictionaryReader/ListReader Fix

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Xna.Framework.Content
 			{
                 for (uint i = 0; i < count; i++)
                 {
-                    int readerType = input.Read7BitEncodedInt();
+                    var readerType = input.Read7BitEncodedInt();
                 	array[i] = readerType > 0 ? input.ReadObject<T>(input.TypeReaders[readerType - 1]) : default(T);
                 }
 			}

--- a/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
@@ -85,22 +85,22 @@ namespace Microsoft.Xna.Framework.Content
                 	key = input.ReadObject<TKey>(keyReader);
 				}
 				else
-				{
-					int readerType = input.ReadByte();
-                	key = input.ReadObject<TKey>(input.TypeReaders[readerType - 1]);
-				}
+                {
+                    var readerType = input.Read7BitEncodedInt();
+                    key = readerType > 0 ? input.ReadObject<TKey>(input.TypeReaders[readerType - 1]) : default(TKey);
+                }
 
                 if (ReflectionHelpers.IsValueType(valueType))
 				{
                 	value = input.ReadObject<TValue>(valueReader);
 				}
 				else
-				{
-					int readerType = input.ReadByte();
-                	value = input.ReadObject<TValue>(input.TypeReaders[readerType - 1]);
-				}
-				
-				dictionary.Add(key, value);
+                {
+                    var readerType = input.Read7BitEncodedInt();
+                    value = readerType > 0 ? input.ReadObject<TValue>(input.TypeReaders[readerType - 1]) : default(TValue);
+                }
+
+                dictionary.Add(key, value);
             }
             return dictionary;
         }

--- a/MonoGame.Framework/Content/ContentReaders/ListReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ListReader.cs
@@ -56,16 +56,14 @@ namespace Microsoft.Xna.Framework.Content
             if (list == null) list = new List<T>(count);
             for (int i = 0; i < count; i++)
             {
-                // list.Add(input.ReadObject<T>(elementReader));
-				
                 if (ReflectionHelpers.IsValueType(typeof(T)))
 				{
                 	list.Add(input.ReadObject<T>(elementReader));
 				}
 				else
 				{
-					int readerType = input.ReadByte();
-                	list.Add(input.ReadObject<T>(input.TypeReaders[readerType - 1]));
+                    var readerType = input.Read7BitEncodedInt();
+                	list.Add(readerType > 0 ? input.ReadObject<T>(input.TypeReaders[readerType - 1]) : default(T));
 				}
             }
             return list;


### PR DESCRIPTION
This PR fixes the reading of subobjects in `DictionaryReader` and `ListReader` based on the implementation in `ArrayReader`.  This resolved an index out of range exception reading XNA generated XNB files.
