### PR TITLE
Use indexed for loop for nested shared resources

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
@@ -189,8 +189,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
         /// </summary>
         void WriteSharedResources()
         {
-            foreach (var resource in sharedResources)
+            for (int i = 0; i < sharedResources.Count; i++)
+            {
+                var resource = sharedResources[i];
                 WriteObject<object>(resource);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
I am playing around with the content pipeline, trying to convert something I wrote with XNA to it. One of the resources I wrote an importer/processor for calls `WriteSharedResource()` inside its `Write()`. I don't know if that's good or bad but it worked with XNA. With MonoGame it creates an exception since the list of `sharedResources` gets modified inside a loop.

Converting to a simple indexed loop seems to make it work. I don't know much about how to test this part MonoGame beyond what my own code was able to execute.

I'm also fairly new to C# so if there's some better solution don't hestitate to suggest it. Still learning!
