### PR TITLE
check  if graphicsDevice._d3dDevice.NativePointer == null

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1267,15 +1267,15 @@ namespace Microsoft.Xna.Framework.Graphics
         private static GraphicsProfile PlatformGetHighestSupportedGraphicsProfile(GraphicsDevice graphicsDevice)
         {
             FeatureLevel featureLevel;
-            try
+			try
             {
-                if (graphicsDevice == null || graphicsDevice._d3dDevice == null || graphicsDevice._d3dDevice.NativePointer == null)
-                    featureLevel = SharpDX.Direct3D11.Device.GetSupportedFeatureLevel();
-                else
+				if (graphicsDevice == null || graphicsDevice._d3dDevice == null || graphicsDevice._d3dDevice.NativePointer == null) 
+					featureLevel = SharpDX.Direct3D11.Device.GetSupportedFeatureLevel();
+               	else
                 	featureLevel = graphicsDevice._d3dDevice.FeatureLevel;
             }
             catch (SharpDXException)
-            {
+            { 
             	featureLevel = FeatureLevel.Level_9_1; //Minimum defined level
             }
 


### PR DESCRIPTION
fix for issue #3206.
When WP8 resume an WindowsPhoneGameWindow.Page_OrientationChanged event
might occur too early before the device gets updated. In that case
graphicsDevice._d3dDevice.NativePointer is null and
graphicsDevice._d3dDevice.FeatureLevel fails.

I moved outside the try/catch block to make the code readable and to
handle all possible sources of exceptions.
