### PR TITLE
Trigger selection event when left/right arrow keys are used in the UI.

### DIFF
--- a/Tools/Pipeline/Windows/MultiSelectTreeview.cs
+++ b/Tools/Pipeline/Windows/MultiSelectTreeview.cs
@@ -586,7 +586,9 @@ namespace MonoGame.Tools.Pipeline
 			ClearSelectedNodes();
 			ToggleNode( node, true );
 			node.EnsureVisible();
-		}
+
+			OnAfterSelect( new TreeViewEventArgs( _selectedNode ) );
+        }
 
 		private void ToggleNode( TreeNode node, bool bSelectNode )
 		{


### PR DESCRIPTION
This fixes issue #3256.

I was thinking about manually calling this event in the ... if ( e.KeyCode == Keys.Left/Right ) parts of OnKeyDown, but it seems like this should be called every time SelectSingleNode is called. Let me know what to fix/change if needed.
