### PR TITLE
Removed MGCB command trimming, fixes #3130

### DIFF
--- a/Tools/MGCB/CommandLineParser.cs
+++ b/Tools/MGCB/CommandLineParser.cs
@@ -292,7 +292,6 @@ namespace MGCB
                     for (var j = 0; j < commands.Length; j++)
                     {
                         var line = commands[j];
-                        line = line.Trim();
                         if (string.IsNullOrEmpty(line))
                             continue;
                         if (line.StartsWith("#"))


### PR DESCRIPTION
I took a closer look at #3130 

Regarding MGCB, as far as I tested, it already supports optional quotes. `/build:<content_filepath>` works fine in command line and supports white spaces.

Back to the initial issue, @tomspilman is right, the space in `/processorParam:FirstCharacter=` gets trimmed here: https://github.com/mono/MonoGame/blob/edd59dc30cb6c2d376f55a2cd46449c3e5017dd6/Tools/MGCB/CommandLineParser.cs#L295

This issue also affects the pipeline GUI tool since it uses this class to parse .mgcb files. The tool handles white spaces correctly (save/modify) but can't load them due to the parser trimming.

I have checked if it would have any consequences regarding parameter type convertion and everything seems fine.
