### PR TITLE
iOS Song cleanup

### DIFF
--- a/MonoGame.Framework/Media/Song.IOS.cs
+++ b/MonoGame.Framework/Media/Song.IOS.cs
@@ -24,6 +24,12 @@ namespace Microsoft.Xna.Framework.Media
         private NSUrl assetUrl;
         private NSObject playToEndObserver;
 
+        [CLSCompliant(false)]
+        public NSUrl AsserUrl
+        {
+            get { return this.assetUrl; }
+        }
+
         internal Song(Album album, Artist artist, Genre genre, string title, TimeSpan duration, MPMediaItem mediaItem, NSUrl assetUrl)
         {
             this.album = album;
@@ -45,12 +51,6 @@ namespace Microsoft.Xna.Framework.Media
             _sound = AVPlayerItem.FromUrl(url);
             _player = AVPlayer.FromPlayerItem(_sound);
             playToEndObserver = AVPlayerItem.Notifications.ObserveDidPlayToEndTime(OnFinishedPlaying);
-        }
-
-        [CLSCompliant(false)]
-        public Song(NSUrl url)
-        {
-            PlatformInitialize(url);
         }
 
         private void PlatformDispose(bool disposing)
@@ -187,10 +187,6 @@ namespace Microsoft.Xna.Framework.Media
         {
             if (this.mediaItem != null)
                 return this.duration;
-
-            if (_sound != null)
-                return TimeSpan.FromSeconds(_sound.Asset.Duration.Seconds);
-
 
             return _duration;
         }


### PR DESCRIPTION
Removed the pbulic NSUrl constructor for iOS Song in favor of exposing the AsserUrl (it was unused)
Removed the duration return based on the duration of the AVAudioItem as it is null until the song is played
