### PR TITLE
Fixed character region parsing in FontDescription

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/Font/CharacterRegion.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Font/CharacterRegion.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 	[TypeConverter(typeof(CharacterRegionTypeConverter))]
 	public struct CharacterRegion
 	{
-	    public char Start;
-	    public char End;
+	    public int Start;
+	    public int End;
 
 		// Enumerates all characters within the region.        
 	    public IEnumerable<Char> Characters()
 	    {
 	        for (var c = Start; c <= End; c++)
 	        {
-	            yield return c;
+	            yield return (char)c;
 	        }
 	    }
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/FontDescription.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/FontDescription.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         private float spacing;
         private FontDescriptionStyle style;
         private bool useKerning;
-	    private CharacterCollection characters = new CharacterCollection(CharacterRegion.Default.Characters());
+	    private CharacterCollection characters = new CharacterCollection();
 
 		/// <summary>
 		/// Gets or sets the name of the font, such as "Times New Roman" or "Arial". This value cannot be null or empty.
@@ -207,8 +207,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     if (characterRegion.End < characterRegion.Start)
                         throw new ArgumentException("CharacterRegion.End must be greater than CharacterRegion.Start");
 
-                    for (var start = characterRegion.Start; start <= characterRegion.End; start++)
-                        Characters.Add(start);
+                    foreach (var character in characterRegion.Characters())
+                        Characters.Add(character);
                 }
             }
         }


### PR DESCRIPTION
First off, the default ASCII characters were always included.

Second, the CharacterRegion was ignored due to incorrect deserialization.
Example:

```
      <CharacterRegion>
        <Start>32</Start>
        <End>127</End>
      </CharacterRegion>
```

This was deserialized as "add characters from `3` to `1`", which added nothing.

Thanks to these two mistakes the character region was always 32-126.
