### PR TITLE
Resolve looplength bug in xaudio

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Xna.Framework.Audio
                 AudioBytes = count,
                 Flags = BufferFlags.EndOfStream,
                 PlayBegin = loopStart,
-                PlayLength = loopLength,
+                PlayLength = loopLength / (2 * (int)channels),
                 Context = new IntPtr(42),
             };
 
@@ -152,7 +152,7 @@ namespace Microsoft.Xna.Framework.Audio
                 AudioBytes = count,
                 Flags = BufferFlags.EndOfStream,
                 LoopBegin = loopStart,
-                LoopLength = loopLength,
+                LoopLength = loopLength / (2 * (int)channels),
                 LoopCount = AudioBuffer.LoopInfinite,
                 Context = new IntPtr(42),
             };


### PR DESCRIPTION
Xaudio2 requires loop length in samples and takes channels into account so existing was factor of 2 out in mono, factor of 4 out in stereo. Seems the new SoundEffect(byte[] overloads were the only ones effected (fromStream already had correct values)
