### PR TITLE
Handle iOS audio interruption

### DIFF
--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -18,6 +18,10 @@ using Android.Content;
 using Android.Media;
 #endif
 
+#if IOS
+using MonoTouch.AudioToolbox;
+#endif
+
 namespace Microsoft.Xna.Framework.Audio
 {
 	internal sealed class OpenALSoundController : IDisposable
@@ -172,6 +176,21 @@ namespace Microsoft.Xna.Framework.Audio
                     AlcUpdateBuffers, updateBuffers,
                     0
                 };
+#elif IOS
+                AudioSession.Initialize();
+
+                AudioSession.Interrupted += (sender, e) => {
+                    AudioSession.SetActive(false);
+                    Alc.MakeContextCurrent(ContextHandle.Zero);
+                    Alc.SuspendContext(_context);
+                };
+                AudioSession.Resumed += (sender, e) => {
+                    AudioSession.SetActive(true);
+                    Alc.MakeContextCurrent(_context);
+                    Alc.ProcessContext(_context);
+                };
+
+                int[] attribute = new int[0];
 #else
                 int[] attribute = new int[0];
 #endif


### PR DESCRIPTION
Fixes #2285
Updated version of #2938, based on the comment of @MarkoBL
Tested on iOS 7.1 and 8.1.

Note: It gives a couple of warnings as AudioSession has been replaced with AVAudioSession, but using AVAudioSession doesn't work.
