### PR TITLE
Fullscreen on Windows Phone 8.1 

### DIFF
--- a/MonoGame.Framework/Windows8/MetroGamePlatform.cs
+++ b/MonoGame.Framework/Windows8/MetroGamePlatform.cs
@@ -214,11 +214,17 @@ namespace Microsoft.Xna.Framework
         public override void EnterFullScreen()
         {
             // Metro has no concept of fullscreen vs windowed!
+#if WINDOWS_PHONE81
+            StatusBar.GetForCurrentView().HideAsync();
+#endif
         }
 
         public override void ExitFullScreen()
         {
             // Metro has no concept of fullscreen vs windowed!
+#if WINDOWS_PHONE81
+            StatusBar.GetForCurrentView().ShowAsync();
+#endif
         }
         
         public override void EndScreenDeviceChange(string screenDeviceName, int clientWidth, int clientHeight)


### PR DESCRIPTION
Hide and show status bar on Windows Phone 8.1 when entering and exiting fullscreen
