### PR TITLE
Make context menu appear when the Menu key is pressed on the keyboard.

### DIFF
--- a/Tools/Pipeline/Windows/MainView.Designer.cs
+++ b/Tools/Pipeline/Windows/MainView.Designer.cs
@@ -133,6 +133,7 @@ namespace MonoGame.Tools.Pipeline
             _splitTreeProps.TabIndex = 1;
             _splitTreeProps.TabStop = false;
             // 
+            this._treeView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TreeViewOnKeyDown);
             // _propertyGrid
             // 
             this._propertyGrid.Dock = System.Windows.Forms.DockStyle.Fill;

--- a/Tools/Pipeline/Windows/MainView.cs
+++ b/Tools/Pipeline/Windows/MainView.cs
@@ -197,34 +197,39 @@ namespace MonoGame.Tools.Pipeline
                 var node = _treeView.GetNodeAt(p);
                 if (node != null)
                 {
-                    if (!_treeView.SelectedNodes.Contains(node))
-                    {
-                        _treeView.SelectedNode = node;
-                    }
-
-                    if (node.Tag is ContentItem)
-                    {
-                        _treeAddItemMenuItem.Visible = false;
-                        _treeNewItemMenuItem.Visible = false;
-                    }
-                    else
-                    {
-                        _treeAddItemMenuItem.Visible = true;
-                        _treeNewItemMenuItem.Visible = true;
-                    }
-
-                    if (node.Tag is FolderItem)
-                    {
-                        _treeOpenFileMenuItem.Visible = false;
-                    }
-                    else
-                    {
-                        _treeOpenFileMenuItem.Visible = true;
-                    }
-
-                    _treeContextMenu.Show(_treeView, p);
+                    TreeViewShowContextMenu(node, p);
                 }
             }
+        }
+
+        private void TreeViewShowContextMenu(TreeNode node, Point contextMenuLocation)
+        {
+            if (!_treeView.SelectedNodes.Contains(node))
+            {
+                _treeView.SelectedNode = node;
+            }
+
+            if (node.Tag is ContentItem)
+            {
+                _treeAddItemMenuItem.Visible = false;
+                _treeNewItemMenuItem.Visible = false;
+            }
+            else
+            {
+                _treeAddItemMenuItem.Visible = true;
+                _treeNewItemMenuItem.Visible = true;
+            }
+
+            if (node.Tag is FolderItem)
+            {
+                _treeOpenFileMenuItem.Visible = false;
+            }
+            else
+            {
+                _treeOpenFileMenuItem.Visible = true;
+            }
+
+            _treeContextMenu.Show(_treeView, contextMenuLocation);
         }
 
         private void TreeViewOnNodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs args)
@@ -695,6 +700,18 @@ namespace MonoGame.Tools.Pipeline
             {
                 e.Node.ImageIndex = FolderOpenIcon;
                 e.Node.SelectedImageIndex = FolderOpenIcon;
+            }
+        }
+
+        private void TreeViewOnKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Apps)
+            {
+                if (_treeView.SelectedNode != null)
+                {
+                    Point nodeCoords = _treeView.PointToScreen(_treeView.SelectedNode.Bounds.Location);
+                    TreeViewShowContextMenu(_treeView.SelectedNode, nodeCoords);
+                }
             }
         }
 


### PR DESCRIPTION
This fixes issue #3323.

A couple notes:
- When I tested this on my machine, the Keys.Apps key was used when I pressed the Menu key on my keyboard. I assume this will work for other users, since going by these docs (http://msdn.microsoft.com/en-us/library/system.windows.forms.keys%28v=vs.110%29.aspx), Keys.Menu is actually referring to the ALT key.
- I moved most of the common logic into a TreeViewShowContextMenu() method, which I think should work. Let me know if this or anything else needs to be changed.
