### PR TITLE
Fix for BoneWeightCollection.NormalizeWeights

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/BoneWeightCollection.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/BoneWeightCollection.cs
@@ -50,10 +50,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             //
             // Throws InvalidContentException if all weights are zero.
 
-            List<BoneWeight> weights = new List<BoneWeight>(this.Items);
+            var weights = (List<BoneWeight>)Items;
 
             // Sort into descending order
-            weights.Sort((b1, b2) => { return b2.Weight.CompareTo(b1.Weight); });
+            weights.Sort((b1, b2) => b2.Weight.CompareTo(b1.Weight));
 
             // Find the sum to validate we have weights and to normalize the weights
             float sum = 0.0f;


### PR DESCRIPTION
BoneWeightCollection.NormalizeWeights has no effect. The operations are performed on a temporary list instead of the internal list. (And the lamda can be shortened.)
