### PR TITLE
Fix for derived content importers

### DIFF
--- a/Tools/Pipeline/Common/PipelineTypes.cs
+++ b/Tools/Pipeline/Common/PipelineTypes.cs
@@ -249,7 +249,12 @@ namespace MonoGame.Tools.Pipeline
             var cur = 0;
             foreach (var item in _importers)
             {
-                var outputType = item.Type.BaseType.GetGenericArguments()[0];
+                // Find the abstract base class ContentImporter<T>.
+                var baseType = item.Type.BaseType;
+                while (!baseType.IsAbstract)
+                    baseType = baseType.BaseType;
+
+                var outputType = baseType.GetGenericArguments()[0];
                 var desc = new ImporterTypeDescription()
                     {
                         TypeName = item.Type.Name,


### PR DESCRIPTION
Content importers derived from an existing content importer do not work.

For example:

```
class MyTextureImporter : TextureImporter { }
```

This fails because PipelineTypes.Load() only goes up one level in the inheritance hierarchy and reads the generic argument. But in the example above, TextureImporter does not have generic arguments.
