### PR TITLE
Make PvrtcBitmapContent public

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
-    class PvrtcBitmapContent : BitmapContent
+    public class PvrtcBitmapContent : BitmapContent
     {
         internal byte[] _bitmapData;
         internal int _bitsPerPixel;


### PR DESCRIPTION
PvrtcBitmapContent should have the same visibility as Dxt1BitmapContent, Dxt3BitmapContent, etc.
Third-party libraries need to be able to create a PvrtcBitmapContent.
