### PR TITLE
Fix: ContentIdentity of Texture2DContent is not set.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
@@ -70,8 +70,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// <param name="context">Contains information for importing a game asset, such as a logger interface.</param>
         /// <returns>Resulting game asset.</returns>
         public override TextureContent Import (string filename, ContentImporterContext context)
-		{
-			var output = new Texture2DContent ();
+        {
+            var output = new Texture2DContent { Identity = new ContentIdentity(filename) };
 
 #if WINDOWS || MACOS
 


### PR DESCRIPTION
The ContentIdentity should be set by the TextureImporter. The ContentIdentity is needed to create proper error messages in the content processor.
