### PR TITLE
Fix: Creation of ContentTypeReader fails on Android

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/BuiltInContentWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/BuiltInContentWriter.cs
@@ -56,7 +56,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
                     readerClassName += "[";
                     readerClassName += argWriter.GetRuntimeType(targetPlatform);
                     readerClassName += "]";
-                    readerClassName += ", ";
+                    // Important: Do not add a space char after the comma because 
+                    // this will not work with Type.GetType in Xamarin.Android!
+                    readerClassName += ",";
                 }
                 readerClassName = readerClassName.TrimEnd(',', ' ');
                 readerClassName += "]";


### PR DESCRIPTION
ContentTypeReaderManager.LoadAssetReaders() uses Type.GetType(string) to resolve the ContentTypeReader. Type.GetType(string) can fail on Android when the string contains spaces.
