### PR TITLE
Vertex channel conversion

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannelGeneric.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannelGeneric.cs
@@ -2,14 +2,13 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System.Diagnostics;
-using System.Linq;
 using Microsoft.Xna.Framework.Design;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {


### PR DESCRIPTION
In the XNA content pipeline vertex colors are usually imported as `VertexChannel<Vector4>`.
In the MonoGame content pipeline vertex colors seem to be imported as `VertexChannel<Color>`.
That's just a minor difference - no problem so far.

When the mesh is processed in my custom model processor, I call 

```
geometryContent.Vertices.Channels.ConvertChannelContent<Color>(colorChannelIndex);
```

This call fails in MonoGame because `VertexChannel<Color>` cannot be converted to `VertexChannel<Color>`. This commit adds support for this trivial case.
