### PR TITLE
Fix MeshHelper.TransformScene()

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/MeshHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/MeshHelper.cs
@@ -436,6 +436,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             if (transform == Matrix.Identity)
                 return;
 
+            Matrix inverseTransform = Matrix.Invert(transform);
+
             var work = new Stack<NodeContent>();
             work.Push(scene);
 
@@ -443,13 +445,43 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             {
                 var node = work.Pop();
                 foreach (var child in node.Children)
-                    work.Push(child);                    
+                    work.Push(child);
 
                 // Transform the mesh content.
                 var mesh = node as MeshContent;
                 if (mesh != null)
                     mesh.TransformContents(ref transform);
+
+                // Transform local coordinate system using "similarity transform".
+                node.Transform = inverseTransform * node.Transform * transform;
+
+                // Transform animations.
+                foreach (var animationContent in node.Animations.Values)
+                    foreach (var animationChannel in animationContent.Channels.Values)
+                        for (int i = 0; i < animationChannel.Count; i++)
+                            animationChannel[i].Transform = inverseTransform * animationChannel[i].Transform * transform;
             }
+        }
+
+        /// <summary>
+        /// Determines whether the specified transform is left-handed.
+        /// </summary>
+        /// <param name="xform">The transform.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="xform"/> is left-handed; otherwise,
+        /// <see langword="false"/> if <paramref name="xform"/> is right-handed.
+        /// </returns>
+        internal static bool IsLeftHanded(ref Matrix xform)
+        {
+            // Check sign of determinant of upper-left 3x3 matrix:
+            //   positive determinant ... right-handed
+            //   negative determinant ... left-handed
+
+            // Since XNA does not have a 3x3 matrix, use the "scalar triple product"
+            // (see http://en.wikipedia.org/wiki/Triple_product) to calculate the
+            // determinant.
+            float d = Vector3.Dot(xform.Right, Vector3.Cross(xform.Forward, xform.Up));
+            return d < 0.0f;
         }
     }
 }


### PR DESCRIPTION
In the current implementation `MeshHelper.TransformScene` only transforms mesh data. Local transforms, animations, are ignored.

This commit adds the following fixes:
- All nodes in the scene need to be transformed using a "similarity transform". (For example, imagine a model with two separate mesh nodes: A character holding a gun. The model was exported with z-up (3dsmax), but XNA requires y-up. A -90° around the x-axis needs to be applied. If `TransformScene` only rotates the meshes then gun would no longer be attached to the character. `TransformScene` needs to rotate the meshes and correct the local transforms.)
- Animations need to be transformed as well. (Same principle.)
- Normals need to be transformed with the transpose of the inverse. This is relevant when non-uniform scaling is applied. (`Vector3.TransformNormal` doesn't automatically invert/transpose the transform. `TransformNormal` only means that the translation is ignored.)
- When the transform is mirroring the mesh, the winding order needs to be swapped.

I also simplified lines like these

```
channel.Items.CopyTo(geomBuffer, 0);
Vector3.TransformNormal(geomBuffer, ref xform, geomBuffer);
channel.Items.Clear();
foreach (var item in geomBuffer)
    channel.Items.Add(item);
```

to

```
for (int i = 0; i < vector3Channel.Count; i++)
    vector3Channel[i] = Vector3.TransformNormal(vector3Channel[i], inverseTranspose);
```

The second version is easier to maintain. (I assume the original author tried to optimize the operation. But I doubt that the original code is any faster. It requires more heap memory allocations/copies. When `channel.Items.Add(item)` is called each individual Vector3 needs to be boxed/unboxed!)
