### PR TITLE
Fix for building external references

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineBuildEvent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineBuildEvent.cs
@@ -65,10 +65,42 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         [XmlElement("Parameters")]
         public List<Pair> ParametersXml { get; set; }
 
+        /// <summary>
+        /// Gets or sets the dependencies.
+        /// </summary>
+        /// <value>The dependencies.</value>
+        /// <remarks>
+        /// Dependencies are extra files that are required in addition to the <see cref="SourceFile"/>.
+        /// Dependencies are added using <see cref="ContentProcessorContext.AddDependency"/>. Changes
+        /// to the dependent file causes a rebuilt of the content.
+        /// </remarks>
         public List<string> Dependencies { get; set; }
 
+        /// <summary>
+        /// Gets or sets the additional (nested) assets.
+        /// </summary>
+        /// <value>The additional (nested) assets.</value>
+        /// <remarks>
+        /// <para>
+        /// Additional assets are built by using an <see cref="ExternalReference{T}"/> and calling
+        /// <see cref="ContentProcessorContext.BuildAndLoadAsset{TInput,TOutput}(ExternalReference{TInput},string)"/>
+        /// or <see cref="ContentProcessorContext.BuildAsset{TInput,TOutput}(ExternalReference{TInput},string)"/>.
+        /// </para>
+        /// <para>
+        /// Examples: The mesh processor may build textures and effects in addition to the mesh.
+        /// </para>
+        /// </remarks>
         public List<string> BuildAsset { get; set; }
 
+        /// <summary>
+        /// Gets or sets the related output files.
+        /// </summary>
+        /// <value>The related output files.</value>
+        /// <remarks>
+        /// Related output files are non-XNB files that are included in addition to the XNB files.
+        /// Related output files need to be copied to the output folder by a content processor and
+        /// registered by calling <see cref="ContentProcessorContext.AddOutputFile"/>.
+        /// </remarks>
         public List<string> BuildOutput { get; set; }
 
         public static PipelineBuildEvent Load(string filePath)
@@ -86,7 +118,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 return null;
             }
 
-            // Repopulate the parameters from the serialized state.            
+            // Repopulate the parameters from the serialized state.
             foreach (var pair in pipelineEvent.ParametersXml)
                 pipelineEvent.Parameters.Add(pair.Key, pair.Value);
             pipelineEvent.ParametersXml.Clear();
@@ -96,17 +128,14 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
         public void Save(string filePath)
         {
-			var fullFilePath = Path.GetFullPath(filePath);
+            var fullFilePath = Path.GetFullPath(filePath);
             // Make sure the directory exists.
             Directory.CreateDirectory(Path.GetDirectoryName(fullFilePath) + Path.DirectorySeparatorChar);
 
             // Convert the parameters into something we can serialize.
             ParametersXml.Clear();
             foreach (var pair in Parameters)
-            {
-                var converter = TypeDescriptor.GetConverter(pair.Value.GetType());
-                ParametersXml.Add(new Pair { Key = pair.Key, Value = converter.ConvertToString(pair.Value) });
-            }
+                ParametersXml.Add(new Pair { Key = pair.Key, Value = ConvertToString(pair.Value) });
 
             // Serialize our state.
             var serializer = new XmlSerializer(typeof (PipelineBuildEvent));
@@ -152,7 +181,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 return true;
 
             // Did the importer change?
-            // TODO: I need to test the assembly versions here!           
+            // TODO: I need to test the assembly versions here!
             if (cachedEvent.Importer != Importer)
                 return true;
 
@@ -161,35 +190,66 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             if (cachedEvent.Processor != Processor)
                 return true;
 
-            // If the count of parameters is different then we have
-            // to assume the results of processing are different.
-            if (cachedEvent.Parameters.Count != Parameters.Count)
+            // Did the parameters change?
+            if (!AreParametersEqual(cachedEvent.Parameters, Parameters))
                 return true;
 
-            // Finally did any of the processor parameters change?
-            foreach (var pair in cachedEvent.Parameters)
-            {
-                // If the key value doesn't exist... then rebuild.
-                object value;
-                if (!Parameters.TryGetValue(pair.Key, out value))
-                    return true;
+            return false;
+        }
 
-                // If the values are the same type and do not match... rebuild.
-                if (value.GetType().IsInstanceOfType(pair.Value))
-                {
-                    if (!value.Equals(pair.Value))
-                        return true;
-                }
-                else
-                {
-                    var typeConverter = TypeDescriptor.GetConverter(value.GetType());
-                    var converted = typeConverter.ConvertTo(value, pair.Value.GetType());
-                    if (!converted.Equals(pair.Value))
-                        return true;
-                }
+        internal static bool AreParametersEqual(OpaqueDataDictionary parameters0, OpaqueDataDictionary parameters1)
+        {
+            // Same reference or both null?
+            if (parameters0 == parameters1)
+                return true;
+
+            // Are both dictionaries are empty?
+            if ((parameters0 == null || parameters0.Count == 0) && (parameters1 == null || parameters1.Count == 0))
+                return true;
+
+            // Is one dictionary empty?
+            if (parameters0 == null || parameters1 == null)
+                return false;
+
+            // Is number of parameters different?
+            // (This assumes that default values are always set the same way, i.e.
+            // either parameters with default values are set in both dictionaries
+            // or omitted in both dictionaries!)
+            if (parameters0.Count != parameters1.Count)
+                return false;
+
+            // Compare parameter by parameter.
+            foreach (var pair in parameters0)
+            {
+                object value0 = pair.Value;
+                object value1;
+
+                if (!parameters1.TryGetValue(pair.Key, out value1))
+                    return false;
+
+                // Are values equal or both null?
+                if (Equals(value0, value1))
+                    continue;
+
+                // Is one value null?
+                if (value0 == null || value1 == null)
+                    return false;
+
+                // Values are of different type: Compare string representation.
+                if (ConvertToString(value0) != ConvertToString(value1))
+                    return false;
             }
 
-            return false;
+            return true;
+        }
+
+        private static string ConvertToString(object value)
+        {
+            if (value == null)
+                return null;
+
+            var typeConverter = TypeDescriptor.GetConverter(value.GetType());
+            return typeConverter.ConvertToInvariantString(value);
         }
     };
 }

--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -39,6 +39,13 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
         private List<Type> _writers;
 
+        // Keep track of all built assets. (Required to resolve automatic names "AssetName_n".)
+        //   Key = absolute, normalized path of source file
+        //   Value = list of build events
+        // (Note: When using external references, an asset may be built multiple times
+        // with different parameters.)
+        private readonly Dictionary<string, List<PipelineBuildEvent>> _pipelineBuildEvents;
+
         public string ProjectDirectory { get; private set; }
         public string OutputDirectory { get; private set; }
         public string IntermediateDirectory { get; private set; }
@@ -78,6 +85,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
         public PipelineManager(string projectDir, string outputDir, string intermediateDir)
         {
+            _pipelineBuildEvents = new Dictionary<string, List<PipelineBuildEvent>>();
             RethrowExceptions = true;
 
             Assemblies = new List<string>();
@@ -91,9 +99,9 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 	    RegisterCustomConverters ();
         }
 
-	public void AssignTypeConverter<IType, IConverterType> ()
+	public void AssignTypeConverter<TType, TTypeConverter> ()
 	{
-		TypeDescriptor.AddAttributes (typeof (IType), new TypeConverterAttribute (typeof (IConverterType)));
+		TypeDescriptor.AddAttributes (typeof (TType), new TypeConverterAttribute (typeof (TTypeConverter)));
 	}
 
 	private void RegisterCustomConverters ()
@@ -411,7 +419,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             // Record what we're building and how.
             var contentEvent = new PipelineBuildEvent
             {
-                SourceFile = PathHelper.Normalize(sourceFilepath),
+                SourceFile = sourceFilepath,
                 DestFile = outputFilepath,
                 Importer = importerName,
                 Processor = processorName,
@@ -427,12 +435,15 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             return contentEvent;
         }
 
-        public void BuildContent(PipelineBuildEvent pipelineEvent, PipelineBuildEvent cachedEvent, string eventFilepath)
+        private void BuildContent(PipelineBuildEvent pipelineEvent, PipelineBuildEvent cachedEvent, string eventFilepath)
         {
             if (!File.Exists(pipelineEvent.SourceFile))
                 throw new PipelineException("The source file '{0}' does not exist!", pipelineEvent.SourceFile);
 
-            Logger.PushFile(pipelineEvent.SourceFile);            
+            Logger.PushFile(pipelineEvent.SourceFile);
+
+            // Keep track of all build events. (Required to resolve automatic names "AssetName_n".)
+            TrackPipelineBuildEvent(pipelineEvent);
 
             var rebuild = pipelineEvent.NeedsRebuild(cachedEvent);
             if (!rebuild)
@@ -500,9 +511,6 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             var importer = CreateImporter(pipelineEvent.Importer);
             if (importer == null)
                 throw new PipelineException("Failed to create importer '{0}'", pipelineEvent.Importer);
-            var processor = CreateProcessor(pipelineEvent.Processor, pipelineEvent.Parameters);
-            if (processor == null)
-                throw new PipelineException("Failed to create processor '{0}'", pipelineEvent.Processor);
 
             // Try importing the content.
             object importedObject;
@@ -527,6 +535,15 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 var importContext = new PipelineImporterContext(this);
                 importedObject = importer.Import(pipelineEvent.SourceFile, importContext);
             }
+
+            // The pipelineEvent.Processor can be null or empty. In this case the
+            // asset should be imported but not processed.
+            if (string.IsNullOrEmpty(pipelineEvent.Processor))
+                return importedObject;
+
+            var processor = CreateProcessor(pipelineEvent.Processor, pipelineEvent.Parameters);
+            if (processor == null)
+                throw new PipelineException("Failed to create processor '{0}'", pipelineEvent.Processor);
 
             // Make sure the input type is valid.
             if (!processor.InputType.IsAssignableFrom(importedObject.GetType()))
@@ -579,6 +596,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
             if (cachedEvent != null)
             {
+                // Recursively clean additional (nested) assets.
                 foreach (var asset in cachedEvent.BuildAsset)
                 {
                     string assetEventFilepath;
@@ -587,15 +605,19 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                     if (assetCachedEvent == null)
                     {
                         Logger.LogMessage("Cleaning {0}", asset);
+
+                        // Remove asset (.xnb file) from output folder.
                         FileHelper.DeleteIfExists(asset);
+
+                        // Remove event file (.mgcontent file) from intermediate folder.
                         FileHelper.DeleteIfExists(assetEventFilepath);
                         continue;
                     }
 
-                    // Give the asset a chance to rebuild.                    
                     CleanContent(string.Empty, asset);
                 }
 
+                // Remove related output files (non-XNB files) that were copied to the output folder.
                 foreach (var asset in cachedEvent.BuildOutput)
                 {
                     Logger.LogMessage("Cleaning {0}", asset);
@@ -604,8 +626,14 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             }
 
             Logger.LogMessage("Cleaning {0}", outputFilepath);
+
+            // Remove asset (.xnb file) from output folder.
             FileHelper.DeleteIfExists(outputFilepath);
+
+            // Remove event file (.mgcontent file) from intermediate folder.
             FileHelper.DeleteIfExists(eventFilepath);
+
+            _pipelineBuildEvents.Remove(sourceFilepath);
         }
 
         private void WriteXnb(object content, PipelineBuildEvent pipelineEvent)
@@ -625,6 +653,131 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             // Store the last write time of the output XNB here
             // so we can verify it hasn't been tampered with.
             pipelineEvent.DestTime = File.GetLastWriteTime(pipelineEvent.DestFile);
+        }
+
+        /// <summary>
+        /// Stores the pipeline build event (in memory) if no matching event is found.
+        /// </summary>
+        /// <param name="pipelineEvent">The pipeline build event.</param>
+        private void TrackPipelineBuildEvent(PipelineBuildEvent pipelineEvent)
+        {
+            List<PipelineBuildEvent> pipelineBuildEvents;
+            if (!_pipelineBuildEvents.TryGetValue(pipelineEvent.SourceFile, out pipelineBuildEvents))
+            {
+                pipelineBuildEvents = new List<PipelineBuildEvent>();
+                _pipelineBuildEvents.Add(pipelineEvent.SourceFile, pipelineBuildEvents);
+            }
+
+            if (FindMatchingEvent(pipelineBuildEvents, pipelineEvent.Importer, pipelineEvent.Processor, pipelineEvent.Parameters) == null)
+                pipelineBuildEvents.Add(pipelineEvent);
+        }
+
+        /// <summary>
+        /// Gets an automatic asset name, such as "AssetName_0".
+        /// </summary>
+        /// <param name="sourceFileName">The source file name.</param>
+        /// <param name="importerName">The name of the content importer. Can be <see langword="null"/>.</param>
+        /// <param name="processorName">The name of the content processor. Can be <see langword="null"/>.</param>
+        /// <param name="processorParameters">The processor parameters. Can be <see langword="null"/>.</param>
+        /// <returns>The asset name.</returns>
+        public string GetAssetName(string sourceFileName, string importerName, string processorName, OpaqueDataDictionary processorParameters)
+        {
+            Debug.Assert(Path.IsPathRooted(sourceFileName), "Absolute path expected.");
+
+            // Get source file name, which is used for lookup in _pipelineBuildEvents.
+            sourceFileName = PathHelper.Normalize(sourceFileName);
+            string relativeSourceFileName = PathHelper.GetRelativePath(ProjectDirectory, sourceFileName);
+
+            List<PipelineBuildEvent> pipelineBuildEvents;
+            if (_pipelineBuildEvents.TryGetValue(sourceFileName, out pipelineBuildEvents))
+            {
+                // This source file has already been build.
+                // --> Compare pipeline build events.
+                ResolveImporterAndProcessor(sourceFileName, ref importerName, ref processorName);
+
+                var matchingEvent = FindMatchingEvent(pipelineBuildEvents, importerName, processorName, processorParameters);
+                if (matchingEvent != null)
+                {
+                    // Matching pipeline build event found.
+                    string existingName = matchingEvent.DestFile;
+                    existingName = PathHelper.GetRelativePath(OutputDirectory, existingName);
+                    existingName = existingName.Substring(0, existingName.Length - 4);   // Remove ".xnb".
+                    return existingName;
+                }
+
+                Logger.LogMessage(string.Format("Warning: Asset {0} built multiple times with different settings.", relativeSourceFileName));
+            }
+
+            // No pipeline build event with matching settings found.
+            // Get default asset name (= output file name relative to output folder without ".xnb").
+            string directoryName = Path.GetDirectoryName(relativeSourceFileName);
+            string fileName = Path.GetFileNameWithoutExtension(relativeSourceFileName);
+            string assetName = Path.Combine(directoryName, fileName);
+            assetName = PathHelper.Normalize(assetName);
+            return AppendAssetNameSuffix(assetName);
+        }
+
+        /// <summary>
+        /// Determines whether the specified list contains a matching pipeline build event.
+        /// </summary>
+        /// <param name="pipelineBuildEvents">The list of pipeline build events.</param>
+        /// <param name="importerName">The name of the content importer. Can be <see langword="null"/>.</param>
+        /// <param name="processorName">The name of the content processor. Can be <see langword="null"/>.</param>
+        /// <param name="processorParameters">The processor parameters. Can be <see langword="null"/>.</param>
+        /// <returns>
+        /// The matching pipeline build event, or <see langword="null"/>.
+        /// </returns>
+        private static PipelineBuildEvent FindMatchingEvent(List<PipelineBuildEvent> pipelineBuildEvents, string importerName, string processorName, OpaqueDataDictionary processorParameters)
+        {
+            foreach (var existingBuildEvent in pipelineBuildEvents)
+            {
+                if (existingBuildEvent.Importer == importerName
+                    && existingBuildEvent.Processor == processorName
+                    && PipelineBuildEvent.AreParametersEqual(existingBuildEvent.Parameters, processorParameters))
+                {
+                    return existingBuildEvent;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the asset name including a suffix, such as "_0". (The number is incremented
+        /// automatically.
+        /// </summary>
+        /// <param name="baseAssetName">
+        /// The asset name without suffix (relative to output folder).
+        /// </param>
+        /// <returns>The asset name with suffix.</returns>
+        private string AppendAssetNameSuffix(string baseAssetName)
+        {
+            int index = 0;
+            string assetName = baseAssetName + "_0";
+            while (IsAssetNameUsed(assetName))
+            {
+                index++;
+                assetName = baseAssetName + '_' + index;
+            }
+
+            return assetName;
+        }
+
+        /// <summary>
+        /// Determines whether the specified asset name is already used.
+        /// </summary>
+        /// <param name="assetName">The asset name (relative to output folder).</param>
+        /// <returns>
+        /// <see langword="true"/> if the asset name is already used; otherwise,
+        /// <see langword="false"/> if the name is available.
+        /// </returns>
+        private bool IsAssetNameUsed(string assetName)
+        {
+            string destFile = Path.Combine(OutputDirectory, assetName + ".xnb");
+
+            return _pipelineBuildEvents.SelectMany(pair => pair.Value)
+                                       .Select(pipelineEvent => pipelineEvent.DestFile)
+                                       .Any(existingDestFile => destFile.Equals(existingDestFile, StringComparison.OrdinalIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
A few changes were required to build my existing XNA content.

`ContentProcessorContext.BuildAndLoadAsset` can be called with `processorName = null`. In this case XNA imports the asset, but does not process it. This is for example used in http://blogs.msdn.com/b/shawnhar/archive/2010/06/18/merging-animation-files.aspx.

`ContentProcessorContext.BuildAsset` does not yet generate automatic names, such as "AssetName_i". The name is currently hardcoded as "AssetName_0". But in our content project, we have multiple multiple assets with the same name. For example: a model "House.fbx" uses a material "House.drmat", which references a texture "House.tga". In this case MGCB should create "House.xnb", "House_0.xnb", "House_1.xnb". 
A texture "House.tga" may be referenced by multiple materials. Sometimes "House.tga" needs to be processed multiple times with different settings. In this case multiple files need to be created ("House_1.xnb", House_2.xnb", "House_3.xnb"). When the "House.tga" is processed multiple times with the same settings, the file should be reused (create only "House_1.xnb").
I have added the necessary changes. All PipelineBuildEvents are now tracked in a dictionary. When a new asset is build, asset name and processor parameters are compared with the previous pipeline build events.

While working through the code I repeatedly got confused by "Dependencies" vs. "BuildAsset" vs. "BuildOutput" and how they relate to the XNA pipeline. I have added some code comments.

If you need more info, let me know. I have tested the new MGCB on a fairly large and complex content project.
