### PR TITLE
Calculate line height smaller than line spacing correctly

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (c == '\n')
                 {
                     fullLineCount++;
-                    finalLineHeight = LineSpacing;
+                    finalLineHeight = 0;
 
                     offset.X = 0;
                     offset.Y = LineSpacing * fullLineCount;

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 defaultGlyph = _glyphs[DefaultCharacter.Value];
 
 			var width = 0.0f;
-			var finalLineHeight = (float)LineSpacing;
+			var finalLineHeight = 0;
 			var fullLineCount = 0;
             var currentGlyph = Glyph.Empty;
 			var offset = Vector2.Zero;


### PR DESCRIPTION
When using SpriteFont textures, LineSpacing is the height of the tallest sprite (untrimmed).

MeasureString works incorrectly because it initializes the `finalLineHeight` variable with LineSpacing, then looks for taller sprites:

``` C#
if (currentGlyph.Cropping.Height > finalLineHeight)
    finalLineHeight = currentGlyph.Cropping.Height;
```

This will obviously never happen with SpriteFont textures. This PR modifies MeasureString so it initializes `finalLineHeight` with 0 and resets it to 0 at a line break.

I haven't tested it with SpriteFont descriptions where LineSpacing might be a correct value, so please test it. 

The biggest change is when you measure small characters, like a space which is represented as a 1x1 transparent pixel. It will return a height of 1:
`this.font.MeasureString(" ")` -> {18, 1}

How is the result of MeasureString "definied"?
