### PR TITLE
Android orientation lock

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameActivity.cs
+++ b/MonoGame.Framework/Android/AndroidGameActivity.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Xna.Framework
 
         public bool AutoPauseAndResumeMediaPlayer = true;
         public bool RenderOnUIThread = true; 
+        public bool PreventRotation { get; set; }
 
 		/// <summary>
 		/// OnCreate called when the activity is launched from cold or after the app

--- a/MonoGame.Framework/Android/OrientationListener.cs
+++ b/MonoGame.Framework/Android/OrientationListener.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Xna.Framework
             if (ScreenReceiver.ScreenLocked)
                 return;
 
+            if (Game.Activity.PreventRotation)
+                return;
+
             var disporientation = AndroidCompatibility.GetAbsoluteOrientation(orientation);
 
             // Only auto-rotate if target orientation is supported and not current


### PR DESCRIPTION
Simple and useful feature. Many Android devices are very sensitive when it comes to rotation. If the user shakes the device the rotation might change, so this is very useful if you use accelerometer in your game. Just lock the rotation while the game is playing and unlock once the game is paused/stopped.
