### PR TITLE
[WP8] fix memory leak when Resume game

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Xna.Framework.Content
 		private IServiceProvider serviceProvider;
 		private IGraphicsDeviceService graphicsDeviceService;
         private Dictionary<string, object> loadedAssets = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        internal Dictionary<string, object> loadedSharedResources = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 		private List<IDisposable> disposableAssets = new List<IDisposable>();
         private bool disposed;
         private byte[] scratchBuffer;
@@ -446,6 +447,7 @@ namespace Microsoft.Xna.Framework.Content
 		    }
 			disposableAssets.Clear();
 		    loadedAssets.Clear();
+		    loadedSharedResources.Clear();
 		}
 
 		public string RootDirectory

--- a/MonoGame.Framework/Content/ContentReader.cs
+++ b/MonoGame.Framework/Content/ContentReader.cs
@@ -105,7 +105,16 @@ namespace Microsoft.Xna.Framework.Content
 
             var sharedResources = new object[sharedResourceCount];
             for (var i = 0; i < sharedResourceCount; ++i)
-                sharedResources[i] = InnerReadObject<object>(null);
+            {
+                object existingInstance;
+                string key = assetName.Replace('\\', '/') +"_SharedResource_" + i;                
+                contentManager.loadedSharedResources.TryGetValue(key, out existingInstance);
+                
+                sharedResources[i] = InnerReadObject<object>(existingInstance);
+
+                if (existingInstance == null)
+                    contentManager.loadedSharedResources[key] = sharedResources[i];
+            }
 
             // Fixup shared resources by calling each registered action
             foreach (var fixup in sharedResourceFixups)

--- a/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Xna.Framework.Content
         {
             var effect = existingInstance;
             
-            int dataSize = input.ReadInt32();
+            int dataSize = (int)input.ReadUInt32();
             byte[] data = input.ContentManager.GetScratchBuffer(dataSize);
             input.Read(data, 0, dataSize);
 

--- a/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
@@ -14,10 +14,14 @@ namespace Microsoft.Xna.Framework.Content
 
         protected internal override Effect Read(ContentReader input, Effect existingInstance)
         {
+            var effect = existingInstance;
+            
             int dataSize = input.ReadInt32();
             byte[] data = input.ContentManager.GetScratchBuffer(dataSize);
             input.Read(data, 0, dataSize);
-            var effect = new Effect(input.GraphicsDevice, data, 0, dataSize);
+
+            if (effect == null)
+                effect = new Effect(input.GraphicsDevice, data, 0, dataSize);
             effect.Name = input.AssetName;
             return effect;
         }

--- a/MonoGame.Framework/Content/ContentReaders/SongReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SongReader.cs
@@ -14,7 +14,9 @@ namespace Microsoft.Xna.Framework.Content
 	{
 		protected internal override Song Read(ContentReader input, Song existingInstance)
 		{
-			var path = input.ReadString();
+            var song = existingInstance;
+
+            var path = input.ReadString();
 			
 			if (!String.IsNullOrEmpty(path))
 			{
@@ -27,7 +29,9 @@ namespace Microsoft.Xna.Framework.Content
 			
 			var durationMs = input.ReadObject<int>();
 
-            return new Song(path, durationMs); 
+            if (song == null)
+                song = new Song(path, durationMs); 
+            return song;
 		}
 	}
 }

--- a/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
@@ -50,6 +50,8 @@ namespace Microsoft.Xna.Framework.Content
             // Create the effect.
             var effect = new SoundEffect(header, data, dataSize, durationMs, loopStart, loopLength);
 
+            if(existingInstance != null)
+                return existingInstance;
             // Store the original asset name for debugging later.
             effect.Name = input.AssetName;
 

--- a/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
@@ -11,13 +11,16 @@ namespace Microsoft.Xna.Framework.Content
     {
         protected internal override VertexBuffer Read(ContentReader input, VertexBuffer existingInstance)
         {
+			var buffer = existingInstance;
+
             var declaration = input.ReadRawObject<VertexDeclaration>();
             var vertexCount = (int)input.ReadUInt32();
             int dataSize = vertexCount * declaration.VertexStride;
             byte[] data = input.ContentManager.GetScratchBuffer(dataSize);
             input.Read(data, 0, dataSize);
 
-            var buffer = new VertexBuffer(input.GraphicsDevice, declaration, vertexCount, BufferUsage.None);
+            if(buffer == null)
+                buffer = new VertexBuffer(input.GraphicsDevice, declaration, vertexCount, BufferUsage.None);
             buffer.SetData(data, 0, dataSize);
             return buffer;
         }


### PR DESCRIPTION
ContentManager & ContentReaders create new instances during
AssetReload(). The problem was with SoundEffectReader,
and with Shared resources like VertexBuffer, IndexBuffer,
Effect.

http://community.monogame.net/t/sharpdx-crashing-the-app-after-having-resumed-a-few-times/813/5
#1771
#3048
