### PR TITLE
Have project selected initially after opening a project.

### DIFF
--- a/Tools/Pipeline/Windows/MainView.cs
+++ b/Tools/Pipeline/Windows/MainView.cs
@@ -26,6 +26,7 @@ namespace MonoGame.Tools.Pipeline
 
         private bool _treeUpdating;
         private bool _treeSort;
+        private bool _projectLoading;
 
         private const string MonoGameContentProjectFileFilter = "MonoGame Content Build Files (*.mgcb)|*.mgcb";
         private const string XnaContentProjectFileFilter = "XNA Content Projects (*.contentproj)|*.contentproj";
@@ -76,6 +77,9 @@ namespace MonoGame.Tools.Pipeline
             _controller.OnBuildFinished += invokeUpdateMenus;
             _controller.OnProjectLoading += invokeUpdateMenus;
             _controller.OnProjectLoaded += invokeUpdateMenus;
+
+            _controller.OnProjectLoading += OnProjectLoading;
+            _controller.OnProjectLoaded += OnProjectLoaded;
 
             var updateUndoRedo = new CanUndoRedoChanged(UpdateUndoRedo);
             var invokeUpdateUndoRedo = new CanUndoRedoChanged((u, r) => Invoke(updateUndoRedo, u, r));
@@ -409,7 +413,8 @@ namespace MonoGame.Tools.Pipeline
             node.ImageIndex = iconIdx;
             node.SelectedImageIndex = iconIdx;
 
-            _treeView.SelectedNode = node;
+            if (!_projectLoading)
+                _treeView.SelectedNode = node;
 
             root.Expand();
         }
@@ -764,6 +769,16 @@ namespace MonoGame.Tools.Pipeline
       
             UpdateUndoRedo(_controller.CanUndo, _controller.CanRedo);
             UpdateRecentProjectList();
+        }
+
+        private void OnProjectLoading()
+        {
+            _projectLoading = true;
+        }
+
+        private void OnProjectLoaded()
+        {
+            _projectLoading = true;
         }
         
         private void UpdateUndoRedo(bool canUndo, bool canRedo)

--- a/Tools/Pipeline/Windows/MainView.cs
+++ b/Tools/Pipeline/Windows/MainView.cs
@@ -778,7 +778,7 @@ namespace MonoGame.Tools.Pipeline
 
         private void OnProjectLoaded()
         {
-            _projectLoading = true;
+            _projectLoading = false;
         }
         
         private void UpdateUndoRedo(bool canUndo, bool canRedo)


### PR DESCRIPTION
Upon opening a content project, the Pipeline Tool will now have the project selected (its properties displayed within the property grid) rather than the last-added content item.

Note: this is a windows-view-specific fix.
