### PR TITLE
Sound instance pool optimization to look for matching format in the pool

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -166,6 +166,17 @@ namespace Microsoft.Xna.Framework.Audio
             inst.InitializeSound();
             inst.BindDataBuffer(_data, Format, Size, (int)Rate);
         }
+		
+		/// <summary>
+        /// Test if a SoundEffectInstance is compatible (i.e. same sampling rate, number of channels, etc.) with the SoundEffect.
+        /// This method is used by the SoundEffectInstancePool to re-use instances efficiently.
+        /// </summary>
+        /// <param name="inst">The SoundEffectInstance to test</param>
+        /// <returns>True if compatible, false otherwise</returns>
+        internal bool PlatformIsInstanceCompatible(SoundEffectInstance inst)
+        {
+            return true; // OpenAL don't care about that
+        }
 
         #endregion
 

--- a/MonoGame.Framework/Audio/SoundEffect.Web.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.Web.cs
@@ -29,6 +29,17 @@ namespace Microsoft.Xna.Framework.Audio
         private void PlatformSetupInstance(SoundEffectInstance instance)
         {
         }
+		
+		/// <summary>
+        /// Test if a SoundEffectInstance is compatible (i.e. same sampling rate, number of channels, etc.) with the SoundEffect.
+        /// This method is used by the SoundEffectInstancePool to re-use instances efficiently.
+        /// </summary>
+        /// <param name="inst">The SoundEffectInstance to test</param>
+        /// <returns>True if compatible, false otherwise</returns>
+        internal bool PlatformIsInstanceCompatible(SoundEffectInstance inst)
+        {
+            return true;
+        }
 
         private void PlatformDispose(bool disposing)
         {

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -183,28 +183,6 @@ namespace Microsoft.Xna.Framework.Audio
             // already have a valid voice assigned.
             var voice = inst._voice;
 
-            if (voice != null)
-            {
-                // TODO: This really shouldn't be here.  Instead we should fix the 
-                // SoundEffectInstancePool to internally to look for a compatible
-                // instance or return a new instance without a voice.
-                //
-                // For now we do the same test that the pool should be doing here.
-             
-                if (!ReferenceEquals(inst._format, _format))
-                {
-                    if (inst._format.Encoding != _format.Encoding ||
-                        inst._format.Channels != _format.Channels ||
-                        inst._format.SampleRate != _format.SampleRate ||
-                        inst._format.BitsPerSample != _format.BitsPerSample)
-                    {
-                        voice.DestroyVoice();
-                        voice.Dispose();
-                        voice = null;
-                    }
-                }
-            }
-
             if (voice == null && Device != null)
                 voice = new SourceVoice(Device, _format, VoiceFlags.None, XAudio2.MaximumFrequencyRatio);
 

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -183,11 +183,6 @@ namespace Microsoft.Xna.Framework.Audio
             // already have a valid voice assigned.
             var voice = inst._voice;
 
-            if (voice != null)
-            {
-                System.Diagnostics.Debug.Assert(PlatformIsInstanceCompatible(inst));
-            }
-
             if (voice == null && Device != null)
                 voice = new SourceVoice(Device, _format, VoiceFlags.None, XAudio2.MaximumFrequencyRatio);
 

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -212,6 +212,28 @@ namespace Microsoft.Xna.Framework.Audio
             inst._format = _format;
         }
 
+        /// <summary>
+        /// Test if a SoundEffectInstance is compatible (i.e. same sampling rate, number of channels, etc.) with the SoundEffect.
+        /// This method is used by the SoundEffectInstancePool to re-use instances efficiently.
+        /// </summary>
+        /// <param name="inst">The SoundEffectInstance to test</param>
+        /// <returns>True if compatible, false otherwise</returns>
+        internal bool PlatformIsInstanceCompatible(SoundEffectInstance inst)
+        {
+            if (inst != null)
+            {
+                if (ReferenceEquals(inst._format, _format) ||
+                    (inst._format.Encoding == _format.Encoding &&
+                    inst._format.Channels == _format.Channels &&
+                    inst._format.SampleRate == _format.SampleRate &&
+                    inst._format.BitsPerSample == _format.BitsPerSample))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         #endregion
 
         private void PlatformDispose(bool disposing)

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -183,6 +183,11 @@ namespace Microsoft.Xna.Framework.Audio
             // already have a valid voice assigned.
             var voice = inst._voice;
 
+            if (voice != null)
+            {
+                System.Diagnostics.Debug.Assert(PlatformIsInstanceCompatible(inst));
+            }
+
             if (voice == null && Device != null)
                 voice = new SourceVoice(Device, _format, VoiceFlags.None, XAudio2.MaximumFrequencyRatio);
 

--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Xna.Framework.Audio
             if (!SoundEffectInstancePool.SoundsAvailable)
                 return null;
 
-            var inst = SoundEffectInstancePool.GetInstance(forXAct);
+            var inst = SoundEffectInstancePool.GetInstance(this, forXAct);
             inst._effect = this;
             PlatformSetupInstance(inst);
 

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -90,32 +90,43 @@ namespace Microsoft.Xna.Framework.Audio
         /// SoundEffectInstance if the pool is empty.
         /// </summary>
         /// <returns>The SoundEffectInstance.</returns>
-        internal static SoundEffectInstance GetInstance(bool forXAct)
+        internal static SoundEffectInstance GetInstance(SoundEffect effect, bool forXAct)
         {
             SoundEffectInstance inst = null;
             var count = _pooledInstances.Count;
             if (count > 0)
             {
-                // Grab the item at the end of the list so the remove doesn't copy all
-                // the list items down one slot.
-                inst = _pooledInstances[count - 1];
-                _pooledInstances.RemoveAt(count - 1);
+                // look for a compatible sound instance
+                for (int i = count - 1; i >= 0; i--)
+                {
+                    inst = _pooledInstances[i];
+                    if (effect.PlatformIsInstanceCompatible(inst))
+                    {
+                        // swap the instance to the end of the pool so that the List doesn't
+                        // copy all the items down one slot when removing it
+                        SoundEffectInstance tmpInst = _pooledInstances[count - 1];
+                        _pooledInstances[count - 1] = inst;
+                        _pooledInstances[i] = tmpInst;
+                        _pooledInstances.RemoveAt(count - 1);
 
-                // Reset used instance to the "default" state.
-                inst._isPooled = true;
-                inst._isXAct = forXAct;
-                inst.Volume = 1.0f;
-                inst.Pan = 0.0f;
-                inst.Pitch = 0.0f;
-                inst.IsLooped = false;
-            }
-            else
-            {
-                inst = new SoundEffectInstance();
-                inst._isPooled = true;
-                inst._isXAct = forXAct;
+                        // Reset used instance to the "default" state.
+                        inst._isPooled = true;
+                        inst._isXAct = forXAct;
+                        inst.Volume = 1.0f;
+                        inst.Pan = 0.0f;
+                        inst.Pitch = 0.0f;
+                        inst.IsLooped = false;
+
+                        return inst;
+                    }                   
+                }
             }
 
+            // no comptible instance found, let's return a new one
+            inst = new SoundEffectInstance();
+            inst._isPooled = true;
+            inst._isXAct = forXAct;
+            
             return inst;
         }
 


### PR DESCRIPTION
This is a follow up to #4155 where @tomspilman suggested this optimization.

It checks if there is any `SoundEffectInstance` with the same format of the given `SoundEffect` in the pool to efficiently re-use instances.
This only impacts XAudio for now.

It would be cool to document this in the documentation to warn that using too many different `SoundEffect` formats may impact performance (or the opposite, that using the same format for all sounds is best).

In our project, all sounds have the same format, hence it would be nice to test this PR against more varied projects.
