### PR TITLE
Fix ContentExtensions.GetAllProperties for Win10 when Native toolchain enabled

### DIFF
--- a/MonoGame.Framework/Content/ContentExtensions.cs
+++ b/MonoGame.Framework/Content/ContentExtensions.cs
@@ -33,8 +33,7 @@ namespace Microsoft.Xna.Framework.Content
 #if WINRT
             PropertyInfo[] infos= type.GetTypeInfo().DeclaredProperties.ToArray();
             var nonStaticPropertyInfos = from p in infos
-                                         where (p.GetMethod != null) && (!p.GetMethod.IsStatic) &&
-                                         (p.GetMethod == p.GetMethod.GetRuntimeBaseDefinition())
+                                         where (p.GetMethod != null) && (!p.GetMethod.IsStatic)
                                          select p;
             return nonStaticPropertyInfos.ToArray();
 #else


### PR DESCRIPTION
I  found that loading Xml from content files works incorrect for Win10 in release mode (or to be more precise when native toolchain is enabled).
It looks like `ContentExtensions.GetAllProperties` always return empty array due to condition `(p.GetMethod == p.GetMethod.GetRuntimeBaseDefinition())` (which is true without native toolchain, and false with) .
I am not sure what exactly should check this code, but in my case it works as expected without it.
