### PR TITLE
Getting the Content Pipeline through NuGet

### DIFF
--- a/NuGetPackages/MonoGame.Framework.Content.Pipeline.Build.nuspec
+++ b/NuGetPackages/MonoGame.Framework.Content.Pipeline.Build.nuspec
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+    <metadata>
+        <id>MonoGame.Framework.Content.Pipeline.Build</id>
+        <version>0.0.0.0</version>
+        <title>MonoGame.Framework.Content.Pipeline.Build</title>
+        <authors>MonoGameTeam</authors>
+        <owners>MonoGameTeam</owners>
+        <licenseUrl>https://github.com/mono/MonoGame/blob/develop/LICENSE.txt#L2</licenseUrl>
+        <projectUrl>http://monogame.net/</projectUrl>
+        <iconUrl>https://pbs.twimg.com/profile_images/487954549441691649/O3KsHAsb_400x400.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>MonoGame is an open source implementation of the Microsoft XNA 4.x Framework.
+      The goal is to make it easy for XNA developers to create cross-platform games with extremely high code reuse. We currently support iOS, Android, Windows (both OpenGL and DirectX), Mac OS X, Linux, Windows 8 Store, Windows Phone 8, PlayStation Mobile, and the OUYA console.</description>
+        <summary>MonoGame is an open source cross platform implementation of Microsoft's XNA 4.x Framework</summary>
+        <releaseNotes></releaseNotes>
+        <copyright>Copyright  2015</copyright>
+        <language>en-US</language>
+	</metadata>
+    <files>
+    
+        <!-- NuGet files -->
+        <file src="..\..\NuGetPackages\build\MonoGame.Framework.Content.Pipeline.Build\MonoGame.Framework.Content.Pipeline.Build.targets" target="build\" />
+        
+        <!-- platform independent files -->
+        <file src="..\..\MonoGame.Framework.Content.Pipeline\MonoGame.Content.Builder.targets" target="tools\" />
+        
+        <!-- Windows specific files -->
+        <file src="..\..\Tools\MGCB\bin\Windows\AnyCPU\Release\*.exe" target="tools\Windows\" />
+        <file src="..\..\Tools\MGCB\bin\Windows\AnyCPU\Release\*.dll" target="tools\Windows\" />
+        <file src="..\..\Tools\2MGFX\bin\Windows\AnyCPU\Release\2MGFX.exe" target="tools\Windows\" />
+        <file src="..\..\Tools\2MGFX\bin\Windows\AnyCPU\Release\2MGFX.xml" target="tools\Windows\" />
+        <file src="..\..\Tools\Pipeline\bin\Windows\AnyCPU\Release\Pipeline.exe" target="tools\Windows\" />
+        <file src="..\..\Tools\Pipeline\bin\Windows\AnyCPU\Release\Pipeline.exe.config" target="tools\Windows\" />
+        <file src="..\..\Tools\Pipeline\bin\Windows\AnyCPU\Release\Pipeline.xml" target="tools\Windows\" />
+        <file src="..\..\Tools\Pipeline\bin\Windows\AnyCPU\Release\Templates\*" target="tools\Windows\Templates\" />
+        
+    </files>
+</package>

--- a/NuGetPackages/Readme-Build.txt
+++ b/NuGetPackages/Readme-Build.txt
@@ -13,3 +13,4 @@ NuGet pack MonoGame.Framework.WindowsDX.nuspec -BasePath ..\MonoGame.Framework\b
 NuGet pack MonoGame.Framework.WindowsGL.nuspec -BasePath ..\MonoGame.Framework\bin -OutputDirectory packages
 NuGet pack MonoGame.Framework.WindowsPhone8.nuspec -BasePath ..\MonoGame.Framework\bin -OutputDirectory packages
 NuGet pack MonoGame.Framework.WindowsPhone81.nuspec -BasePath ..\MonoGame.Framework\bin -OutputDirectory packages
+NuGet pack MonoGame.Framework.Content.Pipeline.Build.nuspec -BasePath ..\MonoGame.Framework\bin -OutputDirectory packages

--- a/NuGetPackages/build/MonoGame.Framework.Content.Pipeline.Build/MonoGame.Framework.Content.Pipeline.Build.targets
+++ b/NuGetPackages/build/MonoGame.Framework.Content.Pipeline.Build/MonoGame.Framework.Content.Pipeline.Build.targets
@@ -1,0 +1,16 @@
+<!--
+  MonoGame - Copyright (C) The MonoGame Team
+  This file is subject to the terms and conditions defined in
+  file 'LICENSE.txt', which is part of this source code package.
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Condition="'$(MonoGameContentBuilderExe)' == ''">
+      <MonoGameContentBuilderExe Condition=" '$(OS)' == 'Windows_NT' ">$(MSBuildThisFileDirectory)..\tools\Windows\MGCB.exe</MonoGameContentBuilderExe>
+      <MonoGameContentBuilderExe Condition=" '$(OS)' != 'Windows_NT' ">$(MSBuildThisFileDirectory)..\tools\MacOS\MGCB.exe</MonoGameContentBuilderExe>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\tools\MonoGame.Content.Builder.targets" />
+  
+</Project>


### PR DESCRIPTION
This is still a major WIP. Only tested on Windows.

When installing this package, NuGet automatically adds this to the bottom of the file:

```
<Import Project="..\packages\MonoGame.Framework.Content.Pipeline.Build.0.0.0.0\build\MonoGame.Framework.Content.Pipeline.Build.targets" Condition="Exists('..\packages\MonoGame.Framework.Content.Pipeline.Build.0.0.0.0\build\MonoGame.Framework.Content.Pipeline.Build.targets')" />
<Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
    <PropertyGroup>
        <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
    </PropertyGroup>
    <Error Condition="!Exists('..\packages\MonoGame.Framework.Content.Pipeline.Build.0.0.0.0\build\MonoGame.Framework.Content.Pipeline.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MonoGame.Framework.Content.Pipeline.Build.0.0.0.0\build\MonoGame.Framework.Content.Pipeline.Build.targets'))" />
</Target>
```

I am not sure how the NuGets are built via TeamCity
