### PR TITLE
[Direct3D] Fix setting fullscreen state while device not being ready

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -717,7 +717,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     // Entering fullscreen mode may raise a SharpDXException with HRESULT 0x887A0022 [DXGI_ERROR_NOT_CURRENTLY_AVAILABLE/NotCurrentlyAvailable] if the device is not yet ready to do so.
                     // The DXGI documention states that "when this error is returned, an application can continue to run in windowed mode and try to switch to full-screen mode later"
                     // See https://msdn.microsoft.com/en-us/library/windows/desktop/bb174579(v=vs.85).aspx
-                    // Another error may be raised here, 0x887A0004 [DXGI_ERROR_UNSUPPORTED/Unsupported], upon which we disable fullscreen state
+                    // Another error may be raised here, 0x887A0004 [DXGI_ERROR_UNSUPPORTED/Unsupported], upon which we fall back to borberless in EnterFullScreen()
                     try
                     {
                         _swapChain.SetFullscreenState(PresentationParameters.IsFullScreen, null);
@@ -726,13 +726,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     catch (SharpDXException ex)
                     {
                         if (ex.ResultCode.Code == unchecked((int)0x887A0022)) // [DXGI_ERROR_NOT_CURRENTLY_AVAILABLE/NotCurrentlyAvailable]
-                            _shouldRetrySettingFullscreen = true;
-                        else if (ex.ResultCode.Code == unchecked((int)0x887A0004)) // [DXGI_ERROR_UNSUPPORTED/Unsupported]
-                        {
-                            PresentationParameters.IsFullScreen = false;
-                        }
+                            _shouldRetrySettingFullscreen = true;   
                         else
-                            throw ex;
+                            throw;
                     }
                 }
 
@@ -986,7 +982,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 // Exception related to the device not being ready shall be silent because it can safely retry to set the fullscreen mode later
                 if (!_shouldRetrySettingFullscreen || ex.ResultCode.Code != unchecked((int)0x887A0022))
-                    throw ex;
+                    throw;
 
                 // TODO: How should we deal with a device lost case here?
             }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -724,7 +724,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
                     catch (SharpDXException ex)
                     {
-                        if (unchecked((uint)ex.ResultCode.Code) == 0x887A0022)
+                        if (ex.ResultCode.Code == unchecked((int)0x887A0022))
                             _shouldRetrySettingFullscreen = true;
                         else
                             throw ex;
@@ -980,7 +980,7 @@ namespace Microsoft.Xna.Framework.Graphics
             catch (SharpDX.SharpDXException ex)
             {
                 // Exception related to the device not being ready shall be silent because it can safely retry to set the fullscreen mode later
-                if (_shouldRetrySettingFullscreen && unchecked((uint)ex.ResultCode.Code) != 0x887A0022)
+                if (!_shouldRetrySettingFullscreen || ex.ResultCode.Code != unchecked((int)0x887A0022))
                     throw ex;
 
                 // TODO: How should we deal with a device lost case here?

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -175,6 +175,13 @@ namespace MonoGame.Framework
                  Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
                  Game.GraphicsDevice.CreateSizeDependentResources(true);
                  Game.GraphicsDevice.ApplyRenderTargets(null);
+                 // if IsFullScreen is false after CreateSizeDependentResources, it means that it encountered a [DXGI_ERROR_UNSUPPORTED/Unsupported]
+                 if (Game.GraphicsDevice.PresentationParameters.IsFullScreen == false)
+                 {
+                     // falling back to borderless mode
+                     Game.graphicsDeviceManager.HardwareModeSwitch = false;
+                     _window.IsBorderless = true;
+                 }
                 _window._form.WindowState = FormWindowState.Maximized;
             }
             else

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -173,15 +173,21 @@ namespace MonoGame.Framework
             if (Game.graphicsDeviceManager.HardwareModeSwitch)
             {
                  Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
-                 Game.GraphicsDevice.CreateSizeDependentResources(true);
-                 Game.GraphicsDevice.ApplyRenderTargets(null);
-                 // if IsFullScreen is false after CreateSizeDependentResources, it means that it encountered a [DXGI_ERROR_UNSUPPORTED/Unsupported]
-                 if (Game.GraphicsDevice.PresentationParameters.IsFullScreen == false)
+                 try
                  {
-                     // falling back to borderless mode
-                     Game.graphicsDeviceManager.HardwareModeSwitch = false;
-                     _window.IsBorderless = true;
+                     // may fail is fullscreen is not supported for this PresentationParameters
+                     Game.GraphicsDevice.CreateSizeDependentResources(true);
                  }
+                 catch (SharpDX.SharpDXException ex)
+                 {
+                     if (ex.ResultCode.Code == unchecked((int)0x887A0004)) // [DXGI_ERROR_UNSUPPORTED/Unsupported]
+                     {
+                         // falling back to borderless
+                         _window.IsBorderless = true;
+                         Game.graphicsDeviceManager.HardwareModeSwitch = false;
+                     }
+                 }
+                 Game.GraphicsDevice.ApplyRenderTargets(null);                 
                 _window._form.WindowState = FormWindowState.Maximized;
             }
             else


### PR DESCRIPTION
Fixes #4148

I'm not 100% confident about this one. What should be checked:
- if it uses the correct method to compare exception's HRESULT
- if it is safe to retry setting the fullscreen state after `_swapChain.Present(syncInterval, PresentFlags.None);`

This bug is really hard to reproduce, so I'm going to roll this PR out to our game today and will check if the problem is still referenced in our crash reports DB over the week. I've never been able to observe it locally, but we're typically getting about 1 of these crashes per day, so I'll be able to monitor its occurrence.
