### PR TITLE
Add stream-based content import

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/DdsLoader.cs
+++ b/MonoGame.Framework.Content.Pipeline/DdsLoader.cs
@@ -212,12 +212,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             return pitch * rows;
         }
 
-        static internal TextureContent Import(string filename, ContentImporterContext context)
+        static internal TextureContent Import(Stream input, string virtualFilename, ContentImporterContext context)
         {
-            var identity = new ContentIdentity(filename);
+            var identity = new ContentIdentity(virtualFilename);
             TextureContent output = null;
 
-            using (var reader = new BinaryReader(new FileStream(filename, FileMode.Open, FileAccess.Read)))
+            using (var reader = new BinaryReader(input))
             {
                 // Read signature ("DDS ")
                 var valid = reader.ReadByte() == 0x44;

--- a/MonoGame.Framework.Content.Pipeline/EffectImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/EffectImporter.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System.IO;
+using System.Text;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline
@@ -28,9 +29,24 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// <returns>Resulting game asset.</returns>
         public override EffectContent Import(string filename, ContentImporterContext context)
         {
+            using (var stream = new FileStream(filename, FileMode.Open, FileAccess.Read))
+            {
+                return Import(stream, filename, context);
+            }
+        }
+
+        /// <summary>
+        /// Called by third-party systems when importing an .fx file to be used as a game asset.
+        /// </summary>
+        /// <param name="input">The stream to read the asset from.</param>
+        /// <param name="virtualFilename">For importers that depend on filenames (such as file extensions), this provides a virtual filename for those importers.</param>
+        /// <param name="context">Contains information for importing a game asset, such as a logger interface.</param>
+        /// <returns>Resulting game asset.</returns>
+        public override EffectContent Import(Stream input, string virtualFilename, ContentImporterContext context)
+        {
             var effect = new EffectContent();
-            effect.Identity = new ContentIdentity(filename);
-            using (var reader = new StreamReader(filename))
+            effect.Identity = new ContentIdentity(virtualFilename);
+            using (var reader = new StreamReader(input, Encoding.UTF8, true, 1024, true))
                 effect.EffectCode = reader.ReadToEnd();
             return effect;
         }

--- a/MonoGame.Framework.Content.Pipeline/FbxImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/FbxImporter.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.IO;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline
@@ -20,6 +21,16 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             };
 
             return importer.Import(filename, context);
+        }
+
+        public override NodeContent Import(Stream input, string virtualFilename, ContentImporterContext context)
+        {
+            var importer = new OpenAssetImporter
+            {
+                ImporterName = "FbxImporter",
+            };
+
+            return importer.Import(input, virtualFilename, context);
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/FontDescriptionImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/FontDescriptionImporter.cs
@@ -40,5 +40,17 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 
 	        return fontDescription;
 	    }
+
+	    public override FontDescription Import(Stream input, string virtualFilename, ContentImporterContext context)
+        {
+            FontDescription fontDescription = null;
+
+            using (var xmlInput = XmlReader.Create(input))
+                fontDescription = IntermediateSerializer.Deserialize<FontDescription>(xmlInput, virtualFilename);
+
+            fontDescription.Identity = new ContentIdentity(virtualFilename, "FontDescriptionImporter");
+
+            return fontDescription;
+        }
 	}
 }

--- a/MonoGame.Framework.Content.Pipeline/H264Importer.cs
+++ b/MonoGame.Framework.Content.Pipeline/H264Importer.cs
@@ -2,6 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+using System.IO;
+
 namespace Microsoft.Xna.Framework.Content.Pipeline
 {
     [ContentImporter(".mp4", DisplayName = "H.264 Video - MonoGame", DefaultProcessor = "VideoProcessor")]
@@ -15,6 +18,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         {
             var content = new VideoContent(filename);
             return content;
+        }
+
+        public override VideoContent Import(Stream input, string virtualFilename, ContentImporterContext context)
+        {
+            throw new NotSupportedException("Video content must be stored on disk, not imported from a stream.");
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Mp3Importer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Mp3Importer.cs
@@ -40,5 +40,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             var content = new AudioContent(filename, AudioFileType.Mp3);
             return content;
         }
+
+        public override AudioContent Import(Stream input, string virtualFilename, ContentImporterContext context)
+        {
+            throw new NotSupportedException("MP3 content must be stored on disk, not imported from a stream.");
+        }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/OggImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/OggImporter.cs
@@ -33,5 +33,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             var content = new AudioContent(filename, AudioFileType.Ogg);
             return content;
         }
+
+        public override AudioContent Import(Stream input, string virtualFilename, ContentImporterContext context)
+        {
+            throw new NotSupportedException("OGG content must be stored on disk, not imported from a stream.");
+        }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/WavImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/WavImporter.cs
@@ -41,5 +41,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             
             return content;
         }
+
+        public override AudioContent Import(Stream input, string virtualFilename, ContentImporterContext context)
+        {
+            throw new NotSupportedException("WAV content must be stored on disk, not imported from a stream.");
+        }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/WmaImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/WmaImporter.cs
@@ -40,5 +40,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             var content = new AudioContent(filename, AudioFileType.Wma);
             return content;
         }
+
+        public override AudioContent Import(Stream input, string virtualFilename, ContentImporterContext context)
+        {
+            throw new NotSupportedException("WMA content must be stored on disk, not imported from a stream.");
+        }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/WmvImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/WmvImporter.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.IO;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline
@@ -30,6 +31,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         {
             var content = new VideoContent(filename);
             return content;
+        }
+
+        public override VideoContent Import(Stream input, string virtualFilename, ContentImporterContext context)
+        {
+            throw new NotSupportedException("WMV content must be stored on disk, not imported from a stream.");
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/XImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/XImporter.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.IO;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline
@@ -33,6 +34,16 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                 ImporterName = "XImporter",
             };
             return importer.Import(filename, context);
+        }
+
+        public override NodeContent Import(Stream input, string virtualFilename, ContentImporterContext context)
+        {
+            var importer = new OpenAssetImporter
+            {
+                ImporterName = "XImporter",
+            };
+
+            return importer.Import(input, virtualFilename, context);
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/XmlImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/XmlImporter.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.IO;
 using System.Xml;
 using Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate;
 
@@ -25,6 +26,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         {
             using (var reader = XmlReader.Create(filename))
                 return IntermediateSerializer.Deserialize<object>(reader, filename);
+        }
+
+        public override object Import(Stream input, string virtualFilename, ContentImporterContext context)
+        {
+            using (var reader = XmlReader.Create(input))
+                return IntermediateSerializer.Deserialize<object>(reader, virtualFilename);
         }
     }
 }


### PR DESCRIPTION
This adds a stream-based content importing API.  As per #4342, our asset importing system is primarily stream based, because we might be sourcing content from non-file based streams (like over the network).  Right now whenever we import content we have to take the stream (which might already be loaded from a file), write it out to disk somewhere, pass that filename into MonoGame (which might then read a stream again) to perform the content import.

By providing a stream-based content importing API, it removes the requirement to have a temporary file on-disk, and makes importing assets from in-memory or network sources easier.
