### PR TITLE
[android] Fix Android Orientation

### DIFF
--- a/MonoGame.Framework/Android/AndroidGamePlatform.cs
+++ b/MonoGame.Framework/Android/AndroidGamePlatform.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Xna.Framework
         public override void BeforeInitialize()
         {
             var currentOrientation = AndroidCompatibility.GetAbsoluteOrientation();
-
+            Android.Util.Log.Debug("MonoGame", " BeforeInitialize currentOrientation = " + currentOrientation);
+            Android.Util.Log.Debug("MonoGame", " BeforeInitialize Game.Activity.Resources.Configuration.Orientation = " + Game.Activity.Resources.Configuration.Orientation);
             switch (Game.Activity.Resources.Configuration.Orientation)
             {
                 case Android.Content.Res.Orientation.Portrait:

--- a/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Xna.Framework
         private readonly AndroidTouchEventManager _touchManager;
 
         public bool IsResuming { get; private set; }
+        public DisplayOrientation CurrentOrientation { get; set; }
         private bool _lostContext;
 #if !OUYA
         private bool backPressed;
@@ -37,6 +38,7 @@ namespace Microsoft.Xna.Framework
             _gameWindow = androidGameWindow;
 			_game = game;
             _touchManager = new AndroidTouchEventManager(androidGameWindow);
+            CurrentOrientation = DisplayOrientation.Unknown;
         }
 
         public bool TouchEnabled
@@ -93,7 +95,7 @@ namespace Microsoft.Xna.Framework
                     }
                 }
             }
-
+            Android.Util.Log.Debug("MonoGame", "MonoGameAndroidGameView.SurfaceChanged: format = " + format + ", width = " + width + ", height = " + height);
             // When the game is resumed from a portrait orientation it may receive a portrait surface at first.
             // If the game does not support portrait we should ignore it because we will receive the landscape surface a moment later.
             if (width < height && (_game.graphicsDeviceManager.SupportedOrientations & DisplayOrientation.Portrait) == 0)
@@ -112,10 +114,17 @@ namespace Microsoft.Xna.Framework
             manager.ApplyChanges();
 
             SurfaceChanged(holder, format, width, height);
-            Android.Util.Log.Debug("MonoGame", "MonoGameAndroidGameView.SurfaceChanged: format = " + format + ", width = " + width + ", height = " + height);
 
             if (_game.GraphicsDevice != null)
+            {
                 _game.graphicsDeviceManager.ResetClientBounds();
+
+                if (CurrentOrientation != _gameWindow.CurrentOrientation)
+                {
+                    Android.Util.Log.Debug("MonoGame", "CurrentOrientation = " + CurrentOrientation);
+                    _gameWindow.SetOrientation(CurrentOrientation, true);
+                }
+            }
         }
 
         void ISurfaceHolderCallback.SurfaceDestroyed(ISurfaceHolder holder)

--- a/MonoGame.Framework/Android/OrientationListener.cs
+++ b/MonoGame.Framework/Android/OrientationListener.cs
@@ -32,9 +32,11 @@ namespace Microsoft.Xna.Framework
             // Only auto-rotate if target orientation is supported and not current
             AndroidGameWindow gameWindow = (AndroidGameWindow)Game.Instance.Window;
             if ((gameWindow.GetEffectiveSupportedOrientations() & disporientation) != 0 &&
-                disporientation != gameWindow.CurrentOrientation)
+                disporientation != gameWindow.GameView.CurrentOrientation)
             {
-                gameWindow.SetOrientation(disporientation, true);
+                Android.Util.Log.Debug("MonoGame", "OnOrientationChanged ( " + disporientation + " )");
+                gameWindow.GameView.CurrentOrientation = disporientation;
+                gameWindow.SetDisplayOrientation(disporientation);
             }
         }
     }

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -278,11 +278,6 @@ namespace Microsoft.Xna.Framework
 
 			_game.applyChanges(this);
 #else
-
-#if ANDROID
-            // Trigger a change in orientation in case the supported orientations have changed
-            ((AndroidGameWindow)_game.Window).SetOrientation(_game.Window.CurrentOrientation, false);
-#endif
             // Ensure the presentation parameter orientation and buffer size matches the window
             _graphicsDevice.PresentationParameters.DisplayOrientation = _game.Window.CurrentOrientation;
 


### PR DESCRIPTION
The OrientationChanged Event was occuring too early. It was
happening BEFORE the change had occured as a result the
Viewport property was completely wrong and had the old values.
