### PR TITLE
[Ready to Test] Spritefont styles

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -162,7 +162,7 @@
     <Compile Include="ContentPipeline\EffectProcessorTests.cs">
         <Platforms>Windows</Platforms>
     </Compile>
-	<Compile Include="ContentPipeline\EnumConformingTest.cs"> 
+	<Compile Include="ContentPipeline\PipelineEnumConformingTest.cs"> 
 		<Platforms>Windows,MacOS,Linux</Platforms>
 	</Compile>
     <Compile Include="ContentPipeline\FontDescriptionTests.cs">

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -162,6 +162,9 @@
     <Compile Include="ContentPipeline\EffectProcessorTests.cs">
         <Platforms>Windows</Platforms>
     </Compile>
+	<Compile Include="ContentPipeline\EnumConformingTest.cs"> 
+		<Platforms>Windows,MacOS,Linux</Platforms>
+	</Compile>
     <Compile Include="ContentPipeline\FontDescriptionTests.cs">
         <Platforms>Windows,MacOS,Linux</Platforms>
     </Compile>

--- a/MonoGame.Framework.Content.Pipeline/Graphics/FontDescriptionStyle.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/FontDescriptionStyle.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
     public enum FontDescriptionStyle
     {
         /// <summary>
+        /// Normal text.
+        /// </summary>
+        Regular=0,
+
+        /// <summary>
         /// Bold text.
         /// </summary>
         Bold,
@@ -22,10 +27,5 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         /// Italic text.
         /// </summary>
         Italic,
-
-        /// <summary>
-        /// Normal text.
-        /// </summary>
-        Regular,
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -333,6 +333,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             return split [0];
         }
 
+#endif
         private class FileInfoComparer : IEqualityComparer<FileInfo>
         {
             public bool Equals(FileInfo x, FileInfo y)
@@ -345,6 +346,5 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                 return obj.FullName.GetHashCode();
             }
         }
-#endif
     }
 }

--- a/Test/ContentPipeline/EnumConformingTest.cs
+++ b/Test/ContentPipeline/EnumConformingTest.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+
+namespace MonoGame.Tests.ContentPipeline
+{
+    [TestFixture]
+    public class EnumConformingTest
+    {
+        [Test]
+        public void ContainmentTypeEnum()
+        {
+            Assert.AreEqual(0, (int) FontDescriptionStyle.Regular);
+            Assert.AreEqual(1, (int) FontDescriptionStyle.Bold);
+            Assert.AreEqual(2, (int) FontDescriptionStyle.Italic);
+        }
+    }
+}

--- a/Test/ContentPipeline/PipelineEnumConformingTest.cs
+++ b/Test/ContentPipeline/PipelineEnumConformingTest.cs
@@ -9,10 +9,10 @@ using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 namespace MonoGame.Tests.ContentPipeline
 {
     [TestFixture]
-    public class EnumConformingTest
+    public class PipelineEnumConformingTest
     {
         [Test]
-        public void ContainmentTypeEnum()
+        public void FontDescriptionStyleTest()
         {
             Assert.AreEqual(0, (int) FontDescriptionStyle.Regular);
             Assert.AreEqual(1, (int) FontDescriptionStyle.Bold);

--- a/Test/ContentPipeline/PipelineEnumConformingTest.cs
+++ b/Test/ContentPipeline/PipelineEnumConformingTest.cs
@@ -11,12 +11,13 @@ namespace MonoGame.Tests.ContentPipeline
     [TestFixture]
     public class PipelineEnumConformingTest
     {
-        [Test]
-        public void FontDescriptionStyleTest()
+        [TestCase(0, FontDescriptionStyle.Regular)]
+        [TestCase(1, FontDescriptionStyle.Bold)]
+        [TestCase(2, FontDescriptionStyle.Italic)]
+        [TestCase(3, FontDescriptionStyle.Italic |FontDescriptionStyle.Bold)]
+        public void FontDescriptionStyleTest(int expected, FontDescriptionStyle style)
         {
-            Assert.AreEqual(0, (int) FontDescriptionStyle.Regular);
-            Assert.AreEqual(1, (int) FontDescriptionStyle.Bold);
-            Assert.AreEqual(2, (int) FontDescriptionStyle.Italic);
+            Assert.AreEqual(expected, (int) style);
         }
     }
 }

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -87,7 +87,7 @@
     <Compile Include="ContentPipeline\AssetTestClasses.cs" />
     <Compile Include="ContentPipeline\AssetTestUtility.cs" />
     <Compile Include="ContentPipeline\BitmapContentTests.cs" />
-	<Compile Include="ContentPipeline\EnumConformingTest.cs" />
+	<Compile Include="ContentPipeline\PipelineEnumConformingTest.cs" />
     <Compile Include="ContentPipeline\FontDescriptionTests.cs" />
     <Compile Include="ContentPipeline\IntermediateDeserializerTest.cs" />
     <Compile Include="ContentPipeline\IntermediateSerializerTest.cs" />

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -87,6 +87,7 @@
     <Compile Include="ContentPipeline\AssetTestClasses.cs" />
     <Compile Include="ContentPipeline\AssetTestUtility.cs" />
     <Compile Include="ContentPipeline\BitmapContentTests.cs" />
+	<Compile Include="ContentPipeline\EnumConformingTest.cs" />
     <Compile Include="ContentPipeline\FontDescriptionTests.cs" />
     <Compile Include="ContentPipeline\IntermediateDeserializerTest.cs" />
     <Compile Include="ContentPipeline\IntermediateSerializerTest.cs" />


### PR DESCRIPTION
**As of 20/02/2016 this is ready to test**
I'm working on enabling the style tag of the spritefonts as talked in #4149. At this time i can find the font based on its filename or its family name if it is an installed font in Windows.
The changes at this time include:
- Add 3 private fields to `FontDescriptionProcessor` that contains the supported font extensions, possible terminations of bold font files, and the possible terminations of italic font files.
- Add method `FontDescriptionProcessor.FindFontByFileName`: Considers the fontname as the filename of the font, and tries to find the font file that better matches the name and the style (for example if the users wants "arial" bold, this finds "arialb.ttf"), the method relays heavily on LINQ and I have added comments in each step at least for now, but I don't mind removing them in future.
- Add private class `FontDescriptionProcessor.FileInfoComparer`: Required in method `FontDescriptionProcessor.FindFontByFileName`
- Update method `FontDescriptionProcessor.FindFontFileFromFontName` for Windows: Added style information to the method call and updated its logic.
- Simplified method `FontDescriptionProcessor.Process`: Reworked the method to remove an `if` embedded inside an `#if` and make the procedure simpler.
- Reorder the elements of `FontDescriptionStyle`, now Regular is 0, bold is 1, italic is 2, and by extension bold and italic is 3. Before Bold was 0, italic was 1 and regular was 2.

Both methods look for the best match for the users intentions, giving preference to the italic fonts (if requested).

The code  in `FontDescriptionProcessor.FindFontByFileName` is tested, and linked inside `FontDescriptionProcessor.Process`, but it's result is not used at this time as I want to make the other procedures needed.

I'll need guidance with the following things:
- To search in every folder using family names and to see what styles are available inside each font file i'll need to use SharpFont to read that data, but it feels wrong using it outside `SharpFontImporter`. The problem is that if I do this inside `SharpFontImporter` i'll have to move code from `FontDescriptionProcessor` to `SharpFontImporter`, i'm not sure what option is better.
- Related to the previous point, for rendering the font styles manually I'm gonna need to have information about the found font to know what treatment it needs to get the expected style, and I can do it when retrieving each glyph from the font inside `SharpFontImporter` or after that when back in `FontDescriptionProcessor`
- Also, to review the linux method `FontDescriptionProcessor.FindFontFileFromFontName` i'll need to have an example of the data retrieved in: [line of code](https://github.com/Tzenchor/MonoGame/commit/067476c80767113dd4cd8001b203148a70c649bf#diff-4e98352b3c096b0bf2a04d8f61626bc3L316) from anyone on linux and/or mac
