### PR TITLE
Allow disabling Content Pipeline tests

### DIFF
--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#if !NO_CONTENTPIPELINE
+
 using System;
 using System.Collections;
 using Microsoft.Xna.Framework;
@@ -536,7 +538,7 @@ class StructArrayNoElements
 
 namespace MonoGame.Tests.ContentPipeline
 {
-    #region Namespaces
+#region Namespaces
     public class NamespaceHelper
     {
         public bool Value;
@@ -577,9 +579,9 @@ namespace MonoGame.Tests.ContentPipeline
             }
         }
     }
-    #endregion
+#endregion
 
-    #region CustomFormatting
+#region CustomFormatting
     public class CustomFormatting<T, U>
     {
         public T A;
@@ -587,7 +589,7 @@ namespace MonoGame.Tests.ContentPipeline
         public string EmptyString;
         public U Rectangle;
     }
-    #endregion
+#endregion
 }
 
 namespace MonoGame.Tests.SomethingElse.ContentPipeline
@@ -597,3 +599,5 @@ namespace MonoGame.Tests.SomethingElse.ContentPipeline
         public bool Value;
     }
 }
+
+#endif

--- a/Test/ContentPipeline/AssetTestUtility.cs
+++ b/Test/ContentPipeline/AssetTestUtility.cs
@@ -4,10 +4,12 @@
 
 using System;
 using System.IO;
-#if !WINDOWS || DIRECTX || XNA
+#if (!WINDOWS || DIRECTX || XNA) && !NO_CONTENTPIPELINE
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Content.Pipeline.Processors;
+#else
+using NUnit.Framework;
 #endif
 using Microsoft.Xna.Framework.Graphics;
 
@@ -17,7 +19,7 @@ namespace MonoGame.Tests.ContentPipeline
     {
         public static Effect CompileEffect(GraphicsDevice graphicsDevice, params string[] pathParts)
         {
-#if !WINDOWS || DIRECTX || XNA
+#if (!WINDOWS || DIRECTX || XNA) && !NO_CONTENTPIPELINE
             var effectProcessor = new EffectProcessor();
             var context = new TestProcessorContext(TargetPlatform.Windows, "notused.xnb");
             var effectPath = Paths.Effect(pathParts);
@@ -28,8 +30,9 @@ namespace MonoGame.Tests.ContentPipeline
             }, context);
 
             return new Effect(graphicsDevice, compiledEffect.GetEffectCode());
-#else // OpenGL
-            throw new NotImplementedException();
+#else // OpenGL or NO_CONTENTPIPELINE
+            Assert.Inconclusive("Content Pipeline support disabled");
+            return null; // This line is never actually reached, since the Assert throws an exception
 #endif
         }
     }

--- a/Test/ContentPipeline/BitmapContentTests.cs
+++ b/Test/ContentPipeline/BitmapContentTests.cs
@@ -1,4 +1,10 @@
-﻿using Microsoft.Xna.Framework;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#if !NO_CONTENTPIPELINE
+
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
 using NUnit.Framework;
@@ -121,3 +127,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/EffectProcessorTests.cs
+++ b/Test/ContentPipeline/EffectProcessorTests.cs
@@ -1,3 +1,9 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#if !NO_CONTENTPIPELINE
+
 using System;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using NUnit.Framework;
@@ -123,3 +129,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/FontDescriptionTests.cs
+++ b/Test/ContentPipeline/FontDescriptionTests.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#if !NO_CONTENTPIPELINE
+
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using NUnit.Framework;
@@ -98,3 +104,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/FontTextureProcessorTests.cs
+++ b/Test/ContentPipeline/FontTextureProcessorTests.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#if !NO_CONTENTPIPELINE
+
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
@@ -96,3 +98,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#if !NO_CONTENTPIPELINE
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -33,12 +35,12 @@ namespace MonoGame.Tests.ContentPipeline
             {
                 public GraphicsDevice GraphicsDevice { get; private set; }
 
-                #pragma warning disable 67
+#pragma warning disable 67
                 public event EventHandler<EventArgs> DeviceCreated;
                 public event EventHandler<EventArgs> DeviceDisposing;
                 public event EventHandler<EventArgs> DeviceReset;
                 public event EventHandler<EventArgs> DeviceResetting;
-                #pragma warning restore 67
+#pragma warning restore 67
             }
 
             class FakeServiceProvider : IServiceProvider
@@ -595,3 +597,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#if !NO_CONTENTPIPELINE
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -33,12 +35,12 @@ namespace MonoGame.Tests.ContentPipeline
             {
                 public GraphicsDevice GraphicsDevice { get; private set; }
 
-                #pragma warning disable 67
+#pragma warning disable 67
                 public event EventHandler<EventArgs> DeviceCreated;
                 public event EventHandler<EventArgs> DeviceDisposing;
                 public event EventHandler<EventArgs> DeviceReset;
                 public event EventHandler<EventArgs> DeviceResetting;
-                #pragma warning restore 67
+#pragma warning restore 67
             }
 
             class FakeServiceProvider : IServiceProvider
@@ -496,3 +498,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/ModelProcessorTests.cs
+++ b/Test/ContentPipeline/ModelProcessorTests.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#if !NO_CONTENTPIPELINE
+
 using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline;
@@ -283,3 +285,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/TestContentBuildLogger.cs
+++ b/Test/ContentPipeline/TestContentBuildLogger.cs
@@ -1,4 +1,10 @@
-﻿using Microsoft.Xna.Framework.Content.Pipeline;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#if !NO_CONTENTPIPELINE
+
+using Microsoft.Xna.Framework.Content.Pipeline;
 
 namespace MonoGame.Tests.ContentPipeline
 {
@@ -17,3 +23,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/TestImporterContext.cs
+++ b/Test/ContentPipeline/TestImporterContext.cs
@@ -1,4 +1,10 @@
-﻿using Microsoft.Xna.Framework.Content.Pipeline;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#if !NO_CONTENTPIPELINE
+
+using Microsoft.Xna.Framework.Content.Pipeline;
 using System;
 using System.Collections.Generic;
 
@@ -45,3 +51,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/TestProcessorContext.cs
+++ b/Test/ContentPipeline/TestProcessorContext.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#if !NO_CONTENTPIPELINE
+
+using System;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
@@ -89,3 +95,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/TextureContentTests.cs
+++ b/Test/ContentPipeline/TextureContentTests.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#if !NO_CONTENTPIPELINE
+
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using NUnit.Framework;
@@ -124,3 +130,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/TextureImporterTests.cs
+++ b/Test/ContentPipeline/TextureImporterTests.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#if !NO_CONTENTPIPELINE
+
+using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework;
@@ -212,3 +218,5 @@ namespace MonoGame.Tests.ContentPipeline
         }
     }
 }
+
+#endif

--- a/Test/ContentPipeline/TextureProcessorTests.cs
+++ b/Test/ContentPipeline/TextureProcessorTests.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#if !NO_CONTENTPIPELINE
+
+using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework;
@@ -221,3 +227,5 @@ namespace MonoGame.Tests.ContentPipeline
 #endif
     }
 }
+
+#endif

--- a/Test/README.md
+++ b/Test/README.md
@@ -13,8 +13,13 @@ Currently, on Windows, the tests can be run using NUnit and target
 either XNA or MonoGame.  On Mac OS X and Linux, the tests target
 MonoGame and are implemented in an executable assembly that can be run
 and debugged directly.  After execution using the custom test runner,
-and HTML report of the results will be loaded in your default browser,
+an HTML report of the results will be loaded in your default browser,
 and a log of stdout can be found in bin\$(Configuration)\stdout.txt.
+
+If the full XNA Framework is not installed, the XNA Content Pipeline tests
+fail to compile. Define NO_CONTENTPIPELINE compilation symbol in project
+properties to disable these tests and allow building the XNA tests. The
+remaining tests can be built against the XNA redistributable version.
 
 *Note: Currently there is no way to skip or select certain tests to run
 using the custom runner.  This functionality is coming soon.*


### PR DESCRIPTION
First off, I'm not sure if this issue actually affects more people, but I've found myself doing these changes repeatedly. Feel free to close if this seems not worth the trouble.

I don't have the full XNA framework on my dev computer, since I'm not too keen on installing an old VS version just to get the bits. The unit tests run nicely against the XNA redistributable, save for those involving the Content Pipeline, which is only included in the full framework. The missing types cause a build failure. This PR adds support for using `NO_CONTENTPIPELINE` symbol to disable all Content Pipeline tests/utilities and get the test project building.

Also added missing license headers to the files I touched. Visual Studio changed indentation on a couple of lines, sorry for that.
