### PR TITLE
Render faster if possible on fixed time step

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -447,12 +447,25 @@ namespace Microsoft.Xna.Framework
                 // NOTE: While sleep can be inaccurate in general it is 
                 // accurate enough for frame limiting purposes if some
                 // fluctuation is an acceptable result.
+                if (!graphicsDeviceManager.RenderMultipleFramesPerStep)
+                {
+                    // NOTE: While sleep can be inaccurate in general it is 
+                    // accurate enough for frame limiting purposes if some
+                    // fluctuation is an acceptable result.
 #if WINRT
-                Task.Delay(sleepTime).Wait();
+                    Task.Delay(sleepTime).Wait();
 #else
-                System.Threading.Thread.Sleep(sleepTime);
+                    System.Threading.Thread.Sleep(sleepTime);
 #endif
-                goto RetryTick;
+                    goto RetryTick;
+                }
+                else
+                {
+                    // Draw until we have used up our time.
+                    DoDraw(_gameTime);
+
+                    goto RetryTick;
+                }
             }
 
             // Do not allow any update to take longer than our maximum.

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -582,6 +582,18 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Allows the game to call <see cref="Game.Draw"/> multiple times per step, that is
+        /// it allows the game to render faster than the vertical refresh rate of the screen.
+        /// <para>
+        /// This is a separate option to <see cref="SynchronizeWithVerticalRetrace"/>, because
+        /// you may want to disable vsync, but still only call <see cref="Game.Draw"/> once.  For
+        /// this option to be useful, you need to set <see cref="SynchronizeWithVerticalRetrace"/>
+        /// to <c>false</c>.
+        /// </para>
+        /// </summary>
+        public bool RenderMultipleFramesPerStep { get; set; }
+
+        /// <summary>
         /// This method is used by MonoGame Android to adjust the game's drawn to area to fill
         /// as much of the screen as possible whilst retaining the aspect ratio inferred from
         /// aspectRatio = (PreferredBackBufferWidth / PreferredBackBufferHeight)


### PR DESCRIPTION
Follow up from #2651 with the changes requested.

Currently when MonoGame is using a fixed time step, it won't ever render faster than 60FPS, despite the GPUs capability to do so.

This modifies the tick so that if `RenderMultipleFramesPerStep` is on, it will continue to render frames until the time is used up (instead of sleeping).

This is useful for diagnosing whether rendering is responsible for causing slow frames by giving an accurate representation of how fast the current frame can be rendered.
