### PR TITLE
Multisampling and RenderTarget2D

### DIFF
--- a/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 return;
 
             // Setup the multisampling description.
-            var depthStencilViewDimension = DepthStencilViewDimension.Texture2DArray;
+            var depthStencilViewDimension = DepthStencilViewDimension.Texture2D;
             var multisampleDesc = new SharpDX.DXGI.SampleDescription(1, 0);
             if (MultiSampleCount > 1)
             {

--- a/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
@@ -17,6 +17,15 @@ namespace Microsoft.Xna.Framework.Graphics
             GenerateIfRequired();
         }
 
+        internal override Resource CreateTexture()
+        {
+            if (MultiSampleCount > 1)
+                return new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice,
+                    GetTextureDescription(MultiSampleCount,
+                        (int) StandardMultisampleQualityLevels.StandardMultisamplePattern));
+            return base.CreateTexture();
+        }
+
         private void GenerateIfRequired()
         {
             if (_renderTargetViews != null)

--- a/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
@@ -57,11 +57,13 @@ namespace Microsoft.Xna.Framework.Graphics
                 return;
 
             // Setup the multisampling description.
+            var depthStencilViewDimension = DepthStencilViewDimension.Texture2DArray;
             var multisampleDesc = new SharpDX.DXGI.SampleDescription(1, 0);
             if (MultiSampleCount > 1)
             {
                 multisampleDesc.Count = MultiSampleCount;
                 multisampleDesc.Quality = (int)StandardMultisampleQualityLevels.StandardMultisamplePattern;
+                depthStencilViewDimension = DepthStencilViewDimension.Texture2DMultisampled;
             }
 
             // Create a descriptor for the depth/stencil buffer.
@@ -83,7 +85,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     new DepthStencilViewDescription()
                     {
                         Format = SharpDXHelper.ToFormat(DepthStencilFormat),
-                        Dimension = DepthStencilViewDimension.Texture2D
+                        Dimension = depthStencilViewDimension
                     });
             }
         }

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -369,21 +369,25 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #endif
 
-        internal override SharpDX.Direct3D11.Resource CreateTexture()
-		{
-            // TODO: Move this to SetData() if we want to make Immutable textures!
-            var desc = new SharpDX.Direct3D11.Texture2DDescription();
-            desc.Width = width;
-            desc.Height = height;
-            desc.MipLevels = _levelCount;
-            desc.ArraySize = ArraySize;
-            desc.Format = SharpDXHelper.ToFormat(_format);
-            desc.BindFlags = SharpDX.Direct3D11.BindFlags.ShaderResource;
-            desc.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.None;
-            desc.SampleDescription.Count = 1;
-            desc.SampleDescription.Quality = 0;
-            desc.Usage = SharpDX.Direct3D11.ResourceUsage.Default;
-            desc.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
+        protected SharpDX.Direct3D11.Texture2DDescription GetTextureDescription(int msCount = 1, int msQuality = 0)
+        {
+            var desc = new SharpDX.Direct3D11.Texture2DDescription
+            {
+                Width = width,
+                Height = height,
+                MipLevels = _levelCount,
+                ArraySize = ArraySize,
+                Format = SharpDXHelper.ToFormat(_format),
+                BindFlags = SharpDX.Direct3D11.BindFlags.ShaderResource,
+                CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.None,
+                SampleDescription =
+                {
+                    Count = msCount,
+                    Quality = msQuality
+                },
+                Usage = SharpDX.Direct3D11.ResourceUsage.Default,
+                OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None
+            };
 
             if (_renderTarget)
             {
@@ -399,7 +403,13 @@ namespace Microsoft.Xna.Framework.Graphics
             if (_shared)
                 desc.OptionFlags |= SharpDX.Direct3D11.ResourceOptionFlags.Shared;
 
-            return new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc);
+            return desc;
+        }
+
+        internal override SharpDX.Direct3D11.Resource CreateTexture()
+		{
+            // TODO: Move this to SetData() if we want to make Immutable textures!
+            return new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, GetTextureDescription());
         }
 
         private void PlatformReload(Stream textureStream)


### PR DESCRIPTION
I have spent a lot of time debugging this bug and finally cracked it with DebugView and DirectX Debug Layer. You cannot create a depth stencil view with multisampling if you do not set the underlying texture dimension. This only affects the DirectX version of RenderTarget2D I think.
