### PR TITLE
UWP Targets and Rooted File Access

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Xna.Framework.Content
                 // This is primarily for editor support. 
                 // Setting the RootDirectory to an absolute path is useful in editor
                 // situations, but TitleContainer can ONLY be passed relative paths.                
-#if DESKTOPGL || MONOMAC || WINDOWS || WINRT
+#if DESKTOPGL || MONOMAC || WINDOWS || WINDOWS_UAP
                 if (Path.IsPathRooted(assetPath))                
                     stream = File.OpenRead(assetPath);                
                 else

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Xna.Framework.Content
                 // This is primarily for editor support. 
                 // Setting the RootDirectory to an absolute path is useful in editor
                 // situations, but TitleContainer can ONLY be passed relative paths.                
-#if DESKTOPGL || MONOMAC || WINDOWS
+#if DESKTOPGL || MONOMAC || WINDOWS || WINRT
                 if (Path.IsPathRooted(assetPath))                
                     stream = File.OpenRead(assetPath);                
                 else


### PR DESCRIPTION
In addition to TitleContainer file system access, UWP apps fully support
read and write access to ApplicationData.Current.LocalFolder and
KnownFolder directories (Music Library, Pictures) with package declarations.  Not sure 
it is the role of MonoGame to restrict access to the TitleContainer subfolder
exclusively if a rooted path is requested on the the UWP platform.
If access to a rooted folder is invalid an access denied exception is always
thrown for UWP platform targets (Windows 8, Windows 10, Windows Phone,
XB1) due to sandboxing.  This proposed code change adds WINDOWS_UAP to the list of platform
targets which allow rooted file system access.
