### PR TITLE
Update SDL Platform to Enable/Disable Screensaver of it loose/gain focus.

### DIFF
--- a/MonoGame.Framework/SDL/SDL2.cs
+++ b/MonoGame.Framework/SDL/SDL2.cs
@@ -149,6 +149,9 @@ internal static class Sdl
     [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_DisableScreenSaver")]
     public static extern void DisableScreenSaver();
 
+    [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_EnableScreenSaver")]
+    public static extern void EnableScreenSaver ();
+
     [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GetVersion")]
     public static extern void GetVersion(out Version version);
 

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -165,11 +165,15 @@ namespace Microsoft.Xna.Framework
                 else if (ev.Type == Sdl.EventType.WindowEvent)
                 {
                     if (ev.Window.EventID == Sdl.Window.EventId.Resized || ev.Window.EventID == Sdl.Window.EventId.SizeChanged)
-                        _view.ClientResize(ev.Window.Data1, ev.Window.Data2);
-                    else if (ev.Window.EventID == Sdl.Window.EventId.FocusGained)
+                        _view.ClientResize (ev.Window.Data1, ev.Window.Data2);
+                    else if (ev.Window.EventID == Sdl.Window.EventId.FocusGained) {
                         IsActive = true;
-                    else if (ev.Window.EventID == Sdl.Window.EventId.FocusLost)
+                        Sdl.DisableScreenSaver ();
+                        _view.SetCursorVisible (_game.IsMouseVisible);
+                    } else if (ev.Window.EventID == Sdl.Window.EventId.FocusLost) {
                         IsActive = false;
+                        Sdl.EnableScreenSaver ();
+                    }
                 }
             }
         }


### PR DESCRIPTION
We really shouldn't be Disabling the screen saver completely.
If the user switches to another app the screen saver should be
re-enabled. As a result we also need to make sure we re-disable
it if we get focus again.

Additionally we need to make sure the Cursor is set because sometimes
on MacOS it looses the setting when switching windows
