### PR TITLE
Fix issues with modifying presentation parameters with multisampling enabled

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -1051,10 +1051,16 @@ namespace Microsoft.Xna.Framework.Graphics
         {
            return GraphicsProfile.HiDef;
         }
-
+        
         private static Rectangle PlatformGetTitleSafeArea(int x, int y, int width, int height)
         {
             return new Rectangle(x, y, width, height);
+        }
+        
+        internal void PlatformSetMultiSamplingToMaximum(PresentationParameters presentationParameters, out int quality)
+        {
+            presentationParameters.MultiSampleCount = 4;
+            quality = 0;
         }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
@@ -99,10 +99,16 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             return GraphicsProfile.HiDef;
         }
-
+        
         private static Rectangle PlatformGetTitleSafeArea(int x, int y, int width, int height)
         {
             return new Rectangle(x, y, width, height);
+        }
+        
+        internal void PlatformSetMultiSamplingToMaximum(PresentationParameters presentationParameters, out int quality)
+        {
+            presentationParameters.MultiSampleCount = 0;
+            quality = 0;
         }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #if DEBUG
             if (DisplayMode == null)
             {
-                throw new ApplicationException(
+                throw new Exception(
                     "Unable to determine the current display mode.  This can indicate that the " +
                     "game is not configured to be HiDPI aware under Windows 10 or later.  See " +
                     "https://github.com/MonoGame/MonoGame/issues/5040 for more information.");

--- a/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 for (var i = 0; i < ArraySize; i++)
                 {
                     var renderTargetViewDescription = new RenderTargetViewDescription();
-                    if (MultiSampleCount > 1)
+                    if (GetTextureSampleDescription().Count > 1)
                     {
                         renderTargetViewDescription.Dimension = RenderTargetViewDimension.Texture2DMultisampledArray;
                         renderTargetViewDescription.Texture2DMSArray.ArraySize = 1;
@@ -56,13 +56,11 @@ namespace Microsoft.Xna.Framework.Graphics
             if (DepthStencilFormat == DepthFormat.None)
                 return;
 
-            // Setup the multisampling description.
-            var multisampleDesc = new SharpDX.DXGI.SampleDescription(1, 0);
-            if (MultiSampleCount > 1)
-            {
-                multisampleDesc.Count = MultiSampleCount;
-                multisampleDesc.Quality = (int)StandardMultisampleQualityLevels.StandardMultisamplePattern;
-            }
+            // The depth stencil view's multisampling configuration must strictly
+            // match the texture's multisampling configuration.  Ignore whatever parameters
+            // were provided and use the texture's configuration so that things are
+            // guarenteed to work.
+            var multisampleDesc = GetTextureSampleDescription();
 
             // Create a descriptor for the depth/stencil buffer.
             // Allocate a 2-D surface as the depth/stencil buffer.
@@ -83,7 +81,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     new DepthStencilViewDescription()
                     {
                         Format = SharpDXHelper.ToFormat(DepthStencilFormat),
-                        Dimension = DepthStencilViewDimension.Texture2D
+                        Dimension = GetTextureSampleDescription().Count > 1 ? DepthStencilViewDimension.Texture2DMultisampled : DepthStencilViewDimension.Texture2D
                     });
             }
         }

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using MonoGame.Utilities.Png;
+using SharpDX.DXGI;
 
 #if WINDOWS_PHONE
 using System.Threading;
@@ -27,6 +28,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private bool _renderTarget;
         private bool _mipmap;
+
+        private SampleDescription _sampleDescription;
+
         private void PlatformConstruct(int width, int height, bool mipmap, SurfaceFormat format, SurfaceType type, bool shared)
         {
             _shared = shared;
@@ -120,6 +124,9 @@ namespace Microsoft.Xna.Framework.Graphics
             desc.SampleDescription.Quality = 0;
             desc.Usage = SharpDX.Direct3D11.ResourceUsage.Staging;
             desc.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
+
+            // Save sampling description.
+            _sampleDescription = desc.SampleDescription;
 
             var d3dContext = GraphicsDevice._d3dContext;
             using (var stagingTex = new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc))
@@ -399,7 +406,15 @@ namespace Microsoft.Xna.Framework.Graphics
             if (_shared)
                 desc.OptionFlags |= SharpDX.Direct3D11.ResourceOptionFlags.Shared;
 
+            // Save sampling description.
+            _sampleDescription = desc.SampleDescription;
+
             return new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc);
+        }
+
+        internal SampleDescription GetTextureSampleDescription()
+        {
+            return _sampleDescription;
         }
 
         private void PlatformReload(Stream textureStream)

--- a/MonoGame.Framework/Graphics/Texture3D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.DirectX.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Runtime.InteropServices;
 using SharpDX;
 using SharpDX.Direct3D11;
+using SharpDX.DXGI;
+using MapFlags = SharpDX.Direct3D11.MapFlags;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -14,6 +16,7 @@ namespace Microsoft.Xna.Framework.Graphics
 	{
         private bool renderTarget;
         private bool mipMap;
+	    private SampleDescription _sampleDescription;
 
         private void PlatformConstruct(GraphicsDevice graphicsDevice, int width, int height, int depth, bool mipMap, SurfaceFormat format, bool renderTarget)
         {
@@ -58,7 +61,7 @@ namespace Microsoft.Xna.Framework.Graphics
             return new SharpDX.Direct3D11.Texture3D(GraphicsDevice._d3dDevice, description);
         }
 
-        private void PlatformSetData<T>(int level,
+	    private void PlatformSetData<T>(int level,
                                      int left, int top, int right, int bottom, int front, int back,
                                      T[] data, int startIndex, int elementCount, int width, int height, int depth)
         {

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -217,10 +217,25 @@ namespace Microsoft.Xna.Framework
             presentationParameters.DisplayOrientation = _game.Window.CurrentOrientation;
             presentationParameters.DeviceWindowHandle = _game.Window.Handle;
 
-            // TODO: This isn't correct... we need to query the hardware
-            // to see what the max quality level supported is for the current
-            // device and back buffer format.
-            presentationParameters.MultiSampleCount = _preferMultiSampling ? 4 : 0;
+            if (_preferMultiSampling)
+            {
+                if (_graphicsDevice == null)
+                {
+                    // We can't determine the multisampling level by calling PlatformSetMultiSamplingToMaximum yet.
+                    // Once the device initializes, it will call CreateSizeDependentResources which will perform
+                    // a call to PlatformSetMultiSamplingToMaximum.
+                    presentationParameters.MultiSampleCount = 32;
+                }
+                else
+                {
+                    int quality;
+                    _graphicsDevice.PlatformSetMultiSamplingToMaximum(presentationParameters, out quality);
+                }
+            }
+            else
+            {
+                presentationParameters.MultiSampleCount = 0;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
When you enable multisampling at game startup, it determines the maximum multisampling count allowed by the hardware and configured both the swap chain and depth stencil view with it.

However, when you `ApplyChanges` at runtime, it had a hard-coded value of 4 if multisampling was enabled.  Due to this, if you modified the presentation parameters (in my specific case it was enabling window resizing), it would cause the multisampling count of the swap chain (now 4) and the multisampling count of the depth stencil view (still 16 in my case) to get out of sync, which is not permitted in DirectX.  The end result of this was that instead of rendering working correctly, the window would be entirely black, with nothing rendered.

This moved the maximum multisampling count logic into a platform-specific method on the `GraphicsDevice`, and ensures that method is called whenever the multisampling count needs to be adjusted by MonoGame.

It also addresses a scenario where a `RenderTarget` could be created with a different multisampling count on the depth stencil view than the underlying texture resource.  This update texture to keep track of the sample description used when creating the resource, and forces the logic to use the same parameters when creating the depth stencil view, to avoid the same scenario occurring on render targets as was occurring on the swap chain.