### PR TITLE
Add interfaces to Effect classes

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -578,6 +578,15 @@
     <Compile Include="Graphics\Effect\EnvironmentMapEffect.cs">
 		<ExcludePlatforms>Web</ExcludePlatforms>
     </Compile>
+    <Compile Include="Graphics\Effect\IEffect.cs" />
+    <Compile Include="Graphics\Effect\IEffectAnnotation.cs" />
+    <Compile Include="Graphics\Effect\IEffectAnnotationCollection.cs" />
+    <Compile Include="Graphics\Effect\IEffectParameter.cs" />
+    <Compile Include="Graphics\Effect\IEffectParameterCollection.cs" />
+    <Compile Include="Graphics\Effect\IEffectPass.cs" />
+    <Compile Include="Graphics\Effect\IEffectPassCollection.cs" />
+    <Compile Include="Graphics\Effect\IEffectTechnique.cs" />
+    <Compile Include="Graphics\Effect\IEffectTechniqueCollection.cs" />
     <Compile Include="Graphics\Effect\IEffectFog.cs" />
     <Compile Include="Graphics\Effect\IEffectLights.cs" />
     <Compile Include="Graphics\Effect\IEffectMatrices.cs" />

--- a/MonoGame.Framework/Graphics/Effect/Effect.cs
+++ b/MonoGame.Framework/Graphics/Effect/Effect.cs
@@ -8,7 +8,7 @@ using System.IO;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	public class Effect : GraphicsResource
+	public class Effect : GraphicsResource, IEffect
     {
         struct MGFXHeader 
         {
@@ -41,6 +41,21 @@ namespace Microsoft.Xna.Framework.Graphics
         public EffectTechnique CurrentTechnique { get; set; }
   
         internal ConstantBuffer[] ConstantBuffers { get; private set; }
+
+        IEffectParameterCollection IEffect.Parameters
+        {
+            get { return Parameters; }
+        }
+
+        IEffectTechniqueCollection IEffect.Techniques
+        {
+            get { return Techniques; }
+        }
+
+        IEffectTechnique IEffect.CurrentTechnique
+        {
+            get { return CurrentTechnique; }
+        }
 
         private Shader[] _shaders;
 

--- a/MonoGame.Framework/Graphics/Effect/EffectAnnotation.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectAnnotation.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     // TODO: This class needs to be finished!
 
-	public class EffectAnnotation
+	public class EffectAnnotation : IEffectAnnotation
 	{
 		internal EffectAnnotation (
 			EffectParameterClass class_,

--- a/MonoGame.Framework/Graphics/Effect/EffectAnnotationCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectAnnotationCollection.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	public class EffectAnnotationCollection : IEnumerable<EffectAnnotation>
+	public class EffectAnnotationCollection : IEnumerable<EffectAnnotation>, IEffectAnnotationCollection
 	{
         internal static readonly EffectAnnotationCollection Empty = new EffectAnnotationCollection(new EffectAnnotation[0]);
 
@@ -45,6 +45,25 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             return _annotations.GetEnumerator();
         }
-	}
+
+        #region Interface Members
+
+        IEffectAnnotation IEffectAnnotationCollection.this[int index]
+        {
+            get { return this[index]; }
+        }
+
+        IEffectAnnotation IEffectAnnotationCollection.this[string name]
+        {
+            get { return this[name]; }
+        }
+
+        IEnumerable<IEffectAnnotation> IEffectAnnotationCollection.Interfaces
+        {
+            get { return this; }
+        }
+
+        #endregion
+    }
 }
 

--- a/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
@@ -6,8 +6,8 @@ using System.Diagnostics;
 namespace Microsoft.Xna.Framework.Graphics
 {
     [DebuggerDisplay("{DebugDisplayString}")]
-	public class EffectParameter
-	{
+	public class EffectParameter : IEffectParameter
+    {
         /// <summary>
         /// The next state key used when an effect parameter
         /// is updated by any of the 'set' methods.
@@ -881,6 +881,55 @@ namespace Microsoft.Xna.Framework.Graphics
             for (var i = 0; i < value.Length; i++)
 				Elements[i].SetValue (value[i]);
             StateKey = unchecked(NextStateKey++);
-		}
-	}    
+        }
+
+        #region Interface Members
+
+        string IEffectParameter.Name
+        {
+            get { return Name; }
+        }
+
+        string IEffectParameter.Semantic
+        {
+            get { return Semantic; }
+        }
+
+        EffectParameterClass IEffectParameter.ParameterClass
+        {
+            get { return ParameterClass; }
+        }
+
+        EffectParameterType IEffectParameter.ParameterType
+        {
+            get { return ParameterType; }
+        }
+
+        int IEffectParameter.RowCount
+        {
+            get { return RowCount; }
+        }
+
+        int IEffectParameter.ColumnCount
+        {
+            get { return ColumnCount; }
+        }
+
+        IEffectParameterCollection IEffectParameter.Elements
+        {
+            get { return Elements; }
+        }
+
+        IEffectParameterCollection IEffectParameter.StructureMembers
+        {
+            get { return StructureMembers; }
+        }
+
+        IEffectAnnotationCollection IEffectParameter.Annotations
+        {
+            get { return Annotations; }
+        }
+
+        #endregion
+    }    
 }

--- a/MonoGame.Framework/Graphics/Effect/EffectParameterCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectParameterCollection.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-    public class EffectParameterCollection : IEnumerable<EffectParameter>
+    public class EffectParameterCollection : IEnumerable<EffectParameter>, IEffectParameterCollection
     {
         internal static readonly EffectParameterCollection Empty = new EffectParameterCollection(new EffectParameter[0]);
 
@@ -34,8 +34,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			get { return _parameters[index]; }
 		}
-		
-		public EffectParameter this[string name]
+
+        public EffectParameter this[string name]
         {
             get 
             {
@@ -59,5 +59,24 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             return _parameters.GetEnumerator();
         }
+
+        #region Interface Members
+
+        IEffectParameter IEffectParameterCollection.this[string name]
+        {
+            get { return this[name]; }
+        }
+
+        IEffectParameter IEffectParameterCollection.this[int index]
+        {
+            get { return this[index]; }
+        }
+
+        IEnumerable<IEffectParameter> IEffectParameterCollection.Interfaces
+        {
+            get { return this; }
+        }
+
+        #endregion
     }
 }

--- a/MonoGame.Framework/Graphics/Effect/EffectPass.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectPass.cs
@@ -1,8 +1,9 @@
+using System;
 using System.Diagnostics;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-    public class EffectPass
+    public class EffectPass : IEffectPass
     {
         private readonly Effect _effect;
 
@@ -131,5 +132,24 @@ namespace Microsoft.Xna.Framework.Graphics
                     samplerStates[sampler.samplerSlot] = sampler.state;
             }
         }
+
+        #region Interface Members
+
+        string IEffectPass.Name
+        {
+            get { return Name; }
+        }
+
+        IEffectAnnotationCollection IEffectPass.Annotations
+        {
+            get { return Annotations; }
+        }
+
+        void IEffectPass.Apply()
+        {
+            Apply();
+        }
+
+        #endregion
     }
 }

--- a/MonoGame.Framework/Graphics/Effect/EffectPassCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectPassCollection.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-    public class EffectPassCollection : IEnumerable<EffectPass>
+    public class EffectPassCollection : IEnumerable<EffectPass>, IEffectPassCollection
     {
 		private readonly EffectPass[] _passes;
 
@@ -112,5 +112,30 @@ namespace Microsoft.Xna.Framework.Graphics
                 _current = null;
             }
         }
+
+        #region Interface Members
+        
+        int IEffectPassCollection.Count
+        {
+            get { return Count; }
+        }
+
+        IEffectPass IEffectPassCollection.this[string name]
+        {
+            get { return this[name]; }
+        }
+
+        IEffectPass IEffectPassCollection.this[int index]
+        {
+            get { return this[index]; }
+        }
+
+        IEnumerable<IEffectPass> IEffectPassCollection.Interfaces
+        {
+            get { return this; }
+        }
+
+        #endregion
+
     }
 }

--- a/MonoGame.Framework/Graphics/Effect/EffectTechnique.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectTechnique.cs
@@ -1,7 +1,7 @@
 using System;
 namespace Microsoft.Xna.Framework.Graphics
 {
-	public class EffectTechnique
+	public class EffectTechnique : IEffectTechnique
 	{
         public EffectPassCollection Passes { get; private set; }
 
@@ -25,6 +25,25 @@ namespace Microsoft.Xna.Framework.Graphics
             Passes = passes;
             Annotations = annotations;
         }
+
+        #region Interface Members
+        
+        IEffectPassCollection IEffectTechnique.Passes
+        {
+            get { return Passes; }
+        }
+
+        IEffectAnnotationCollection IEffectTechnique.Annotations
+        {
+            get { return Annotations; }
+        }
+
+        string IEffectTechnique.Name
+        {
+            get { return Name; }
+        }
+
+        #endregion
     }
 
 

--- a/MonoGame.Framework/Graphics/Effect/EffectTechniqueCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectTechniqueCollection.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-    public class EffectTechniqueCollection : IEnumerable<EffectTechnique>
+    public class EffectTechniqueCollection : IEnumerable<EffectTechnique>, IEffectTechniqueCollection
     {
 		private readonly EffectTechnique[] _techniques;
 
@@ -51,5 +51,18 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             return _techniques.GetEnumerator();
         }
+
+        #region Interface Members
+
+        IEffectTechnique IEffectTechniqueCollection.this[string name] { get { return this[name]; } }
+
+        IEffectTechnique IEffectTechniqueCollection.this[int index] { get { return this[index]; } }
+
+        IEnumerable<IEffectTechnique> IEffectTechniqueCollection.Interfaces
+        {
+            get { return this; }
+        }
+
+        #endregion
     }
 }

--- a/MonoGame.Framework/Graphics/Effect/IEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/IEffect.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public interface IEffect : IDisposable
+    {
+        IEffectParameterCollection Parameters { get; }
+
+        IEffectTechniqueCollection Techniques { get; }
+
+        IEffectTechnique CurrentTechnique { get; }
+    }
+}

--- a/MonoGame.Framework/Graphics/Effect/IEffectAnnotation.cs
+++ b/MonoGame.Framework/Graphics/Effect/IEffectAnnotation.cs
@@ -1,0 +1,19 @@
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public interface IEffectAnnotation
+    {
+        EffectParameterClass ParameterClass { get; }
+
+        EffectParameterType ParameterType { get; }
+
+        string Name { get; }
+
+        int RowCount { get; }
+
+        int ColumnCount { get; }
+
+        string Semantic { get; }
+    }
+}

--- a/MonoGame.Framework/Graphics/Effect/IEffectAnnotationCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/IEffectAnnotationCollection.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public interface IEffectAnnotationCollection
+    {
+        int Count { get; }
+
+        IEffectAnnotation this[int index] { get; }
+
+        IEffectAnnotation this[string name] { get; }
+
+        IEnumerable<IEffectAnnotation> Interfaces { get; }
+    }
+}

--- a/MonoGame.Framework/Graphics/Effect/IEffectParameter.cs
+++ b/MonoGame.Framework/Graphics/Effect/IEffectParameter.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public interface IEffectParameter
+    {
+        string Name { get; }
+
+        string Semantic { get; }
+
+        EffectParameterClass ParameterClass { get; }
+
+        EffectParameterType ParameterType { get; }
+
+        int RowCount { get; }
+
+        int ColumnCount { get; }
+
+        IEffectParameterCollection Elements { get; }
+
+        IEffectParameterCollection StructureMembers { get; }
+
+        IEffectAnnotationCollection Annotations { get; }
+
+        bool GetValueBoolean();
+        int GetValueInt32();
+        Matrix GetValueMatrix();
+        Matrix[] GetValueMatrixArray(int count);
+        Quaternion GetValueQuaternion();
+        Single GetValueSingle();
+        Single[] GetValueSingleArray();
+        string GetValueString();
+        Texture2D GetValueTexture2D();
+
+#if !GLES
+        Texture3D GetValueTexture3D();
+#endif
+
+        TextureCube GetValueTextureCube();
+        Vector2 GetValueVector2();
+        Vector2[] GetValueVector2Array();
+        Vector3 GetValueVector3();
+        Vector3[] GetValueVector3Array();
+        Vector4 GetValueVector4();
+        Vector4[] GetValueVector4Array();
+        void SetValue(bool value);
+        void SetValue(int value);
+        void SetValue(Matrix value);
+        void SetValueTranspose(Matrix value);
+        void SetValue(Matrix[] value);
+        void SetValue(Quaternion value);
+        void SetValue(Single value);
+        void SetValue(Single[] value);
+        void SetValue(Texture value);
+        void SetValue(Vector2 value);
+        void SetValue(Vector2[] value);
+        void SetValue(Vector3 value);
+        void SetValue(Vector3[] value); 
+        void SetValue(Vector4 value);
+        void SetValue(Vector4[] value);
+    }
+}

--- a/MonoGame.Framework/Graphics/Effect/IEffectParameterCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/IEffectParameterCollection.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public interface IEffectParameterCollection
+    {
+        IEffectParameter this[int index] { get; }
+
+        IEffectParameter this[string name] { get; }
+
+        IEnumerable<IEffectParameter> Interfaces { get; }
+    }
+}

--- a/MonoGame.Framework/Graphics/Effect/IEffectPass.cs
+++ b/MonoGame.Framework/Graphics/Effect/IEffectPass.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public interface IEffectPass
+    {
+        string Name { get; }
+
+        IEffectAnnotationCollection Annotations { get; }
+
+        void Apply();
+    }
+}

--- a/MonoGame.Framework/Graphics/Effect/IEffectPassCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/IEffectPassCollection.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public interface IEffectPassCollection
+    {
+        IEffectPass this[int index] { get; }
+
+        IEffectPass this[string name] { get; }
+
+        int Count { get; }
+
+        IEnumerable<IEffectPass> Interfaces { get; }
+    }
+}

--- a/MonoGame.Framework/Graphics/Effect/IEffectTechnique.cs
+++ b/MonoGame.Framework/Graphics/Effect/IEffectTechnique.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Xna.Framework.Graphics
+{
+    public interface IEffectTechnique
+    {
+        IEffectPassCollection Passes { get; }
+
+        IEffectAnnotationCollection Annotations { get; }
+
+        string Name { get; }
+    }
+}

--- a/MonoGame.Framework/Graphics/Effect/IEffectTechniqueCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/IEffectTechniqueCollection.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public interface IEffectTechniqueCollection
+    {
+        IEffectTechnique this[int index] { get; }
+
+        IEffectTechnique this[string name] { get; }
+
+        IEnumerable<IEffectTechnique> Interfaces { get; }
+    }
+}


### PR DESCRIPTION
Resolves #5057.  This adds new interfaces to the Effect classes, so that engines that want to emulate the effect interface can do so.

In my particular use case, I'm using it to track parameters set against effects so that I can automatically batch rendering later.