### PR TITLE
GraphicsDeviceManager fixes

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -141,7 +141,9 @@
     <Compile Include="Framework\Graphics\BlendStateTest.cs" />
     <Compile Include="Framework\Graphics\EffectTest.cs" />
     <Compile Include="Framework\Graphics\GraphicsAdapterTest.cs" />
-    <Compile Include="Framework\Graphics\GraphicsDeviceTest.cs" />
+    <Compile Include="Framework\Graphics\GraphicsDeviceTest.cs">
+        <Platforms>Windows</Platforms>
+    </Compile>
     <Compile Include="Framework\Graphics\MiscellaneousTests.cs" />
     <Compile Include="Framework\Graphics\GraphicsDeviceTestFixtureBase.cs" />
     <Compile Include="Framework\Graphics\IndexBufferTest.cs" />

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -521,7 +521,7 @@ namespace Microsoft.Xna.Framework
 
         protected virtual void Initialize()
         {
-            // TODO: We shouldn't need to do this here.
+            // TODO: This should be removed once all platforms use the new GraphicsDeviceManager
             applyChanges(graphicsDeviceManager);
 
             // According to the information given on MSDN (see link below), all
@@ -534,9 +534,6 @@ namespace Microsoft.Xna.Framework
             _graphicsDeviceService = (IGraphicsDeviceService)
                 Services.GetService(typeof(IGraphicsDeviceService));
 
-            // FIXME: If this test fails, is LoadContent ever called?  This
-            //        seems like a condition that warrants an exception more
-            //        than a silent failure.
             if (_graphicsDeviceService != null &&
                 _graphicsDeviceService.GraphicsDevice != null)
             {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -544,6 +544,17 @@ namespace Microsoft.Xna.Framework.Graphics
             PresentationParameters = presentationParameters;
             Reset();
         }
+#else
+        // TODO: implement these
+        public void Reset()
+        {
+            
+        }
+
+        public void Reset(PresentationParameters presentationParameters)
+        {
+
+        }
 #endif
 
         /*

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -186,7 +186,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </exception>
         public GraphicsDevice(GraphicsAdapter adapter, GraphicsProfile graphicsProfile, PresentationParameters presentationParameters)
         {
-            // TODO what to do when adapter is null, I'm not sure this always throws in XNA
+            if (adapter == null)
+                throw new ArgumentNullException("adapter");
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
             Adapter = adapter;
@@ -514,26 +515,13 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             throw new NotImplementedException();
         }
-
-        public void Reset()
-        {
-            // Manually resetting the device is not currently supported.
-            throw new NotImplementedException();
-        }
         */
 
 #if WINDOWS && DIRECTX
-        public void Reset(PresentationParameters presentationParameters)
+        public void Reset()
         {
             if (DeviceResetting != null)
                 DeviceResetting(this, EventArgs.Empty);
-
-            if (presentationParameters == null)
-                throw new ArgumentNullException("presentationParameters");
-            if (presentationParameters.DeviceWindowHandle == IntPtr.Zero)
-                throw new ArgumentException("PresentationParameters.DeviceWindowHandle must not be null.");
-
-            PresentationParameters = presentationParameters;
 
             // Update the back buffer.
             CreateSizeDependentResources();
@@ -544,6 +532,17 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (DeviceLost != null)
                 DeviceLost(this, EventArgs.Empty);
+        }
+
+        public void Reset(PresentationParameters presentationParameters)
+        {
+            if (presentationParameters == null)
+                throw new ArgumentNullException("presentationParameters");
+            if (presentationParameters.DeviceWindowHandle == IntPtr.Zero)
+                throw new ArgumentException("PresentationParameters.DeviceWindowHandle must not be null.");
+
+            PresentationParameters = presentationParameters;
+            Reset();
         }
 #endif
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -119,15 +119,6 @@ namespace Microsoft.Xna.Framework.Graphics
 		public event EventHandler<ResourceDestroyedEventArgs> ResourceDestroyed;
         public event EventHandler<EventArgs> Disposing;
 
-        private bool SuppressEventHandlerWarningsUntilEventsAreProperlyImplemented()
-        {
-            return
-                DeviceLost != null &&
-                ResourceCreated != null &&
-                ResourceDestroyed != null &&
-                Disposing != null;
-        }
-
         private int _maxVertexBufferSlots;
         internal int MaxTextureSlots;
         internal int MaxVertexTextureSlots;
@@ -171,14 +162,8 @@ namespace Microsoft.Xna.Framework.Graphics
         public GraphicsMetrics Metrics { get { return _graphicsMetrics; } set { _graphicsMetrics = value; } }
 
         internal GraphicsDevice(GraphicsDeviceInformation gdi)
+            : this(gdi.Adapter, gdi.GraphicsProfile, gdi.PresentationParameters)
         {
-            if (gdi.PresentationParameters == null)
-                throw new ArgumentNullException("presentationParameters");
-            PresentationParameters = gdi.PresentationParameters;
-            Setup();
-            GraphicsCapabilities = new GraphicsCapabilities(this);
-            GraphicsProfile = gdi.GraphicsProfile;
-            Initialize();
         }
 
         internal GraphicsDevice ()
@@ -201,9 +186,10 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </exception>
         public GraphicsDevice(GraphicsAdapter adapter, GraphicsProfile graphicsProfile, PresentationParameters presentationParameters)
         {
-            Adapter = adapter;
+            // TODO what to do when adapter is null, I'm not sure this always throws in XNA
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
+            Adapter = adapter;
             PresentationParameters = presentationParameters;
             Setup();
             GraphicsCapabilities = new GraphicsCapabilities(this);
@@ -495,6 +481,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 _isDisposed = true;
+
+                if (Disposing != null)
+                    Disposing(this, EventArgs.Empty);
             }
         }
 
@@ -536,11 +525,25 @@ namespace Microsoft.Xna.Framework.Graphics
 #if WINDOWS && DIRECTX
         public void Reset(PresentationParameters presentationParameters)
         {
+            if (DeviceResetting != null)
+                DeviceResetting(this, EventArgs.Empty);
+
+            if (presentationParameters == null)
+                throw new ArgumentNullException("presentationParameters");
+            if (presentationParameters.DeviceWindowHandle == IntPtr.Zero)
+                throw new ArgumentException("PresentationParameters.DeviceWindowHandle must not be null.");
+
             PresentationParameters = presentationParameters;
 
             // Update the back buffer.
             CreateSizeDependentResources();
             ApplyRenderTargets(null);
+
+            if (DeviceReset != null)
+                DeviceReset(this, EventArgs.Empty);
+
+            if (DeviceLost != null)
+                DeviceLost(this, EventArgs.Empty);
         }
 #endif
 

--- a/MonoGame.Framework/Graphics/RenderTargetCube.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
@@ -39,6 +41,9 @@ namespace Microsoft.Xna.Framework.Graphics
             get { return size; }
         }
 
+		public bool IsContentLost { get { return false; } }
+		public event EventHandler<EventArgs> ContentLost;
+		
         /// <summary>
         /// Initializes a new instance of the <see cref="RenderTargetCube"/> class.
         /// </summary>

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Xna.Framework
     {
         private readonly Game _game;
         private GraphicsDevice _graphicsDevice;
+        private bool _initialized = false;
+
         private int _preferredBackBufferHeight;
         private int _preferredBackBufferWidth;
         private SurfaceFormat _preferredBackBufferFormat;
@@ -26,6 +28,9 @@ namespace Microsoft.Xna.Framework
         private bool _disposed;
         private bool _hardwareModeSwitch = true;
         private bool _wantFullScreen;
+        private GraphicsProfile _graphicsProfile;
+        // dirty flag for ApplyChanges
+        private bool _shouldApplyChanges;
 
         /// <summary>
         /// The default back buffer width.
@@ -94,14 +99,32 @@ namespace Microsoft.Xna.Framework
             Dispose(false);
         }
 
-        public void CreateDevice()
+        private void CreateDevice()
         {
             if (_graphicsDevice != null)
                 return;
 
-            Initialize();
+            if (!_initialized)
+                Initialize();
+
+            var gdi = DoPreparingDeviceSettings();
+            CreateDevice(gdi);
+        }
+
+        private void CreateDevice(GraphicsDeviceInformation gdi)
+        {
+            if (_graphicsDevice != null)
+                return;
+
+            _graphicsDevice = new GraphicsDevice(gdi);
+            _shouldApplyChanges = false;
 
             OnDeviceCreated(EventArgs.Empty);
+        }
+
+        void IGraphicsDeviceManager.CreateDevice()
+        {
+            CreateDevice();
         }
 
         public bool BeginDraw()
@@ -129,33 +152,49 @@ namespace Microsoft.Xna.Framework
         public event EventHandler<EventArgs> DeviceReset;
         public event EventHandler<EventArgs> DeviceResetting;
         public event EventHandler<PreparingDeviceSettingsEventArgs> PreparingDeviceSettings;
+        public event EventHandler<EventArgs> Disposed;
 
-        // FIXME: Why does the GraphicsDeviceManager not know enough about the
-        //        GraphicsDevice to raise these events without help?
-        internal void OnDeviceDisposing(EventArgs e)
+        protected void OnDeviceDisposing(EventArgs e)
         {
             Raise(DeviceDisposing, e);
         }
 
-        // FIXME: Why does the GraphicsDeviceManager not know enough about the
-        //        GraphicsDevice to raise these events without help?
-        internal void OnDeviceResetting(EventArgs e)
+        protected void OnDeviceResetting(EventArgs e)
         {
             Raise(DeviceResetting, e);
         }
 
-        // FIXME: Why does the GraphicsDeviceManager not know enough about the
-        //        GraphicsDevice to raise these events without help?
-        internal void OnDeviceReset(EventArgs e)
+        protected void OnDeviceReset(EventArgs e)
         {
             Raise(DeviceReset, e);
         }
 
-        // FIXME: Why does the GraphicsDeviceManager not know enough about the
-        //        GraphicsDevice to raise these events without help?
-        internal void OnDeviceCreated(EventArgs e)
+        protected void OnDeviceCreated(EventArgs e)
         {
             Raise(DeviceCreated, e);
+        }
+
+        /// <summary>
+        /// This populates a GraphicsDeviceInformation instance and invokes PreparingDeviceSettings to
+        /// allow users to change the settings. Then returns that GraphicsDeviceInformation.
+        /// Throws NullReferenceException if users set GraphicsDeviceInformation.PresentationParameters to null.
+        /// </summary>
+        private GraphicsDeviceInformation DoPreparingDeviceSettings()
+        {
+            var gdi = new GraphicsDeviceInformation();
+            PrepareGraphicsDeviceInformation(gdi);
+
+            if (PreparingDeviceSettings != null)
+            {
+                // this allows users to overwrite settings through the argument
+                var args = new PreparingDeviceSettingsEventArgs(gdi);
+                PreparingDeviceSettings(this, args);
+
+                if (gdi.PresentationParameters == null || gdi.Adapter == null)
+                    throw new NullReferenceException("Members should not be set to null in PreparingDeviceSettingsEventArgs");
+            }
+
+            return gdi;
         }
 
         private void Raise<TEventArgs>(EventHandler<TEventArgs> handler, TEventArgs e)
@@ -188,6 +227,8 @@ namespace Microsoft.Xna.Framework
                     }
                 }
                 _disposed = true;
+                if (Disposed != null)
+                    Disposed(this, EventArgs.Empty);
             }
         }
 
@@ -212,6 +253,15 @@ namespace Microsoft.Xna.Framework
             presentationParameters.MultiSampleCount = _preferMultiSampling ? 4 : 0;
         }
 
+        private void PrepareGraphicsDeviceInformation(GraphicsDeviceInformation gdi)
+        {
+            gdi.Adapter = GraphicsAdapter.DefaultAdapter;
+            gdi.GraphicsProfile = GraphicsProfile;
+            var pp = new PresentationParameters();
+            PreparePresentationParameters(pp);
+            gdi.PresentationParameters = pp;
+        }
+
         /// <summary>
         /// Applies any pending property changes to the graphics device.
         /// </summary>
@@ -219,21 +269,37 @@ namespace Microsoft.Xna.Framework
         {
             // If the device hasn't been created then create it now.
             if (_graphicsDevice == null)
+            {
                 CreateDevice();
+            }
+
+            if (!_shouldApplyChanges)
+                return;
 
             _game.Window.SetSupportedOrientations(_supportedOrientations);
-
-            PreparePresentationParameters(_graphicsDevice.PresentationParameters);
-
-            // TODO: Should this trigger some sort of device reset?
-            _graphicsDevice.GraphicsProfile = GraphicsProfile;
 
             // Allow for optional platform specific behavior.
             PlatformApplyChanges();
 
+            // populates a gdi with settings in this gdm and allows users to override them with
+            // PrepareDeviceSettings event this information should be applied to the GraphicsDevice
+            var gdi = DoPreparingDeviceSettings();
+
+            if (gdi.GraphicsProfile != GraphicsDevice.GraphicsProfile)
+            {
+                // if the GraphicsProfile changed we need to create a new GraphicsDevice
+                DisposeGraphicsDevice();
+                CreateDevice(gdi);
+                return;
+            }
+
+            ResetGraphicsDevice(gdi.PresentationParameters);
+
             // Update the graphics device and then the platform window.
             _graphicsDevice.OnPresentationChanged();
             _game.Platform.OnPresentationChanged();
+
+            _shouldApplyChanges = false;
 
             // Set the new display size on the touch panel.
             //
@@ -243,6 +309,24 @@ namespace Microsoft.Xna.Framework
             //
             TouchPanel.DisplayWidth = _graphicsDevice.PresentationParameters.BackBufferWidth;
             TouchPanel.DisplayHeight = _graphicsDevice.PresentationParameters.BackBufferHeight;
+            TouchPanel.DisplayOrientation = _graphicsDevice.PresentationParameters.DisplayOrientation;
+        }
+
+        private void DisposeGraphicsDevice()
+        {
+            _graphicsDevice.Dispose();
+
+            if (DeviceDisposing != null)
+                DeviceDisposing(this, EventArgs.Empty);
+
+            _graphicsDevice = null;
+        }
+
+        private void ResetGraphicsDevice(PresentationParameters pp)
+        {
+            OnDeviceResetting(EventArgs.Empty);
+            GraphicsDevice.Reset(pp);
+            OnDeviceReset(EventArgs.Empty);
         }
 
         partial void PlatformInitialize(PresentationParameters presentationParameters);
@@ -257,31 +341,7 @@ namespace Microsoft.Xna.Framework
             // Allow for any per-platform changes to the presentation.
             PlatformInitialize(presentationParameters);
 
-            // TODO: Implement multisampling (aka anti-alising) for all platforms!
-            if (PreparingDeviceSettings != null)
-            {
-                var gdi = new GraphicsDeviceInformation();
-                gdi.GraphicsProfile = GraphicsProfile; // Microsoft defaults this to Reach.
-                gdi.Adapter = GraphicsAdapter.DefaultAdapter;
-                gdi.PresentationParameters = presentationParameters;
-                var pe = new PreparingDeviceSettingsEventArgs(gdi);
-                PreparingDeviceSettings(this, pe);
-                presentationParameters = pe.GraphicsDeviceInformation.PresentationParameters;
-                GraphicsProfile = pe.GraphicsDeviceInformation.GraphicsProfile;
-            }
-
-            // Create and initialize the graphics device.
-            _graphicsDevice = new GraphicsDevice(GraphicsAdapter.DefaultAdapter, GraphicsProfile, presentationParameters);
-
-            // Set the new display size on the touch panel.
-            //
-            // TODO: In XNA this seems to be done as part of the 
-            // GraphicsDevice.DeviceReset event... we need to get 
-            // those working.
-            //
-            TouchPanel.DisplayWidth = _graphicsDevice.PresentationParameters.BackBufferWidth;
-            TouchPanel.DisplayHeight = _graphicsDevice.PresentationParameters.BackBufferHeight;
-            TouchPanel.DisplayOrientation = _graphicsDevice.PresentationParameters.DisplayOrientation;
+            _initialized = true;
         }
 
         /// <summary>
@@ -299,7 +359,18 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// The profile which determines the graphics feature level.
         /// </summary>
-        public GraphicsProfile GraphicsProfile { get; set; }
+        public GraphicsProfile GraphicsProfile
+        {
+            get
+            {
+                return _graphicsProfile;
+            }
+            set
+            {
+                _shouldApplyChanges = true;
+                _graphicsProfile = value;
+            }
+        }
 
         /// <summary>
         /// Returns the graphics device for this manager.
@@ -325,6 +396,7 @@ namespace Microsoft.Xna.Framework
             get { return _wantFullScreen; }
             set
             {
+                _shouldApplyChanges = true;
                 _wantFullScreen = value;
             }
         }
@@ -339,6 +411,7 @@ namespace Microsoft.Xna.Framework
             get { return _hardwareModeSwitch;}
             set
             {
+                _shouldApplyChanges = true;
                 _hardwareModeSwitch = value;
             }
         }
@@ -358,6 +431,7 @@ namespace Microsoft.Xna.Framework
             }
             set
             {
+                _shouldApplyChanges = true;
                 _preferMultiSampling = value;
             }
         }
@@ -377,6 +451,7 @@ namespace Microsoft.Xna.Framework
             }
             set
             {
+                _shouldApplyChanges = true;
                 _preferredBackBufferFormat = value;
             }
         }
@@ -396,6 +471,7 @@ namespace Microsoft.Xna.Framework
             }
             set
             {
+                _shouldApplyChanges = true;
                 _preferredBackBufferHeight = value;
             }
         }
@@ -415,6 +491,7 @@ namespace Microsoft.Xna.Framework
             }
             set
             {
+                _shouldApplyChanges = true;
                 _preferredBackBufferWidth = value;
             }
         }
@@ -435,6 +512,7 @@ namespace Microsoft.Xna.Framework
             }
             set
             {
+                _shouldApplyChanges = true;
                 _preferredDepthStencilFormat = value;
             }
         }
@@ -455,6 +533,7 @@ namespace Microsoft.Xna.Framework
             }
             set
             {
+                _shouldApplyChanges = true;
                 _synchronizedWithVerticalRetrace = value;
             }
         }
@@ -475,6 +554,7 @@ namespace Microsoft.Xna.Framework
             }
             set
             {
+                _shouldApplyChanges = true;
                 _supportedOrientations = value;
             }
         }

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -159,12 +159,13 @@ namespace Microsoft.Xna.Framework
             Raise(DeviceDisposing, e);
         }
 
-        protected void OnDeviceResetting(EventArgs e)
+        // TODO these should be made protected, but currently WP calls these in SurfaceUpdateHandler
+        public void OnDeviceResetting(EventArgs e)
         {
             Raise(DeviceResetting, e);
         }
 
-        protected void OnDeviceReset(EventArgs e)
+        public void OnDeviceReset(EventArgs e)
         {
             Raise(DeviceReset, e);
         }

--- a/Test/Framework/Graphics/GraphicsDeviceManagerTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceManagerTest.cs
@@ -37,10 +37,65 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        public void InitializeEventCount()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+
+            var resettingCount = 0;
+            var resetCount = 0;
+            var preparingCount = 0;
+            var createdCount = 0;
+            var devDispCount = 0;
+            var dispCount = 0;
+
+            gdm.DeviceResetting += (s, a) => resettingCount++;
+            gdm.DeviceReset += (s, a) => resetCount++;
+            gdm.PreparingDeviceSettings += (s, a) => preparingCount++;
+            gdm.DeviceCreated += (s, a) => createdCount++;
+            gdm.DeviceDisposing += (s, a) => devDispCount++;
+            gdm.Disposed += (s, a) => dispCount++;
+
+            game.InitializeOnly();
+
+            Assert.AreEqual(0, resettingCount);
+            Assert.AreEqual(0, resetCount);
+            Assert.AreEqual(1, preparingCount);
+            Assert.AreEqual(1, createdCount);
+            Assert.AreEqual(0, devDispCount);
+            Assert.AreEqual(0, dispCount);
+
+            game.Dispose();
+        }
+
+        [Test]
+        public void DoNotModifyPresentationParametersDirectly()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+
+            game.InitializeWith += (sender, args) =>
+            {
+                var gd = game.GraphicsDevice;
+
+                var oldpp = gd.PresentationParameters;
+                gdm.PreferredBackBufferWidth = 100;
+                gdm.ApplyChanges();
+                var newpp = gd.PresentationParameters;
+                Assert.AreNotSame(oldpp, newpp);
+            };
+
+            game.InitializeOnly();
+            game.Dispose();
+        }
+
+        [Test]
         public void PreparingDeviceSettings()
         {
             var game = new TestGameBase();
             var gdm = new GraphicsDeviceManager(game);
+
+            var count = 0;
 
             gdm.PreparingDeviceSettings += (sender, args) =>
             {
@@ -63,11 +118,204 @@ namespace MonoGame.Tests.Graphics
                 Assert.AreEqual(DisplayOrientation.Default, pp.DisplayOrientation);
                 Assert.AreEqual(RenderTargetUsage.DiscardContents, pp.RenderTargetUsage);
                 Assert.AreEqual(0, pp.MultiSampleCount);
+
+                count++;
             };
 
-            game.ExitCondition = x => x.DrawNumber > 1;
-            game.Run();
+            game.InitializeOnly();
+            Assert.AreEqual(1, count);
             game.Dispose();
+        }
+
+        [Test]
+        public void PreparingDeviceSettingsEventChangeGraphicsProfile()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+
+            Assert.AreEqual(GraphicsProfile.Reach, gdm.GraphicsProfile);
+
+            game.InitializeOnly();
+
+            var invoked = false;
+            gdm.PreparingDeviceSettings += (s, a) =>
+            {
+                a.GraphicsDeviceInformation.GraphicsProfile = GraphicsProfile.HiDef;
+                invoked = true;
+            };
+
+            // make sure that changing the graphics profile creates a new device and does not reset
+            var creationCount = 0;
+            gdm.DeviceCreated += (sender, args) => creationCount++;
+            var resetCount = 0;
+            gdm.DeviceReset += (sender, args) => resetCount++;
+
+            // make a change so ApplyChanges actually does something
+            gdm.PreferredBackBufferWidth = 100;
+            gdm.ApplyChanges();
+
+            // assert that PreparingDeviceSettings is invoked, but the GraphicsProfile of the gdm did not change
+            Assert.That(invoked);
+            Assert.AreEqual(GraphicsProfile.Reach, gdm.GraphicsProfile);
+            Assert.AreEqual(GraphicsProfile.HiDef, gdm.GraphicsDevice.GraphicsProfile);
+
+            Assert.AreEqual(creationCount, 1);
+            Assert.AreEqual(resetCount, 0);
+
+            game.Dispose();
+        }
+
+        [Test]
+        public void PreparingDeviceSettingsArgsPresentationParametersAreApplied()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+
+            var invoked = false;
+
+            game.PreInitializeWith += (sender, args) =>
+            {
+                Assert.AreEqual(RenderTargetUsage.DiscardContents,
+                    gdm.GraphicsDevice.PresentationParameters.RenderTargetUsage);
+
+                gdm.PreparingDeviceSettings += (s, a) =>
+                {
+                    a.GraphicsDeviceInformation.GraphicsProfile = GraphicsProfile.HiDef;
+                    a.GraphicsDeviceInformation.PresentationParameters.RenderTargetUsage = RenderTargetUsage.PreserveContents;
+                    invoked = true;
+                };
+            };
+
+            game.InitializeOnly();
+
+            // make a change so ApplyChanges actually does something
+            gdm.PreferredBackBufferWidth = 100;
+            gdm.ApplyChanges();
+
+            Assert.That(invoked);
+            Assert.AreEqual(RenderTargetUsage.PreserveContents, gdm.GraphicsDevice.PresentationParameters.RenderTargetUsage);
+
+            game.Dispose();
+        }
+
+        [Test]
+        public void PreparingDeviceSettingsArgsThrowsWhenPPSetToNull()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+
+            var invoked = false;
+
+            gdm.PreparingDeviceSettings += (s, a) =>
+            {
+                a.GraphicsDeviceInformation.PresentationParameters = null;
+                invoked = true;
+            };
+
+            Assert.Throws<NullReferenceException>(() => game.InitializeOnly());
+            Assert.That(invoked);
+
+            game.Dispose();
+        }
+
+        public void ApplyChangesReturnsWhenNoSetterCalled()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+
+            var invoked = false;
+
+            game.PreInitializeWith += (sender, args) =>
+            {
+                gdm.PreparingDeviceSettings += (s, a) =>
+                {
+                    invoked = true;
+                };
+            };
+
+            game.InitializeOnly();
+
+            gdm.ApplyChanges();
+            Assert.IsFalse(invoked);
+
+            // this proves that XNA does not check for equality, but just registers that setters are used
+            gdm.PreferredBackBufferWidth = gdm.PreferredBackBufferWidth;
+
+            gdm.ApplyChanges();
+            Assert.That(invoked);
+
+            game.Dispose();
+        }
+
+        [Test]
+        public void ApplyChangesInvokesPreparingDeviceSettings()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+
+            var invoked = false;
+
+            game.InitializeWith += (sender, args) =>
+            {
+                gdm.PreparingDeviceSettings += (s, a) =>
+                {
+                    invoked = true;
+                };
+            };
+
+            game.InitializeOnly();
+
+            gdm.PreferredBackBufferWidth = gdm.PreferredBackBufferWidth;
+            gdm.ApplyChanges();
+            Assert.That(invoked);
+
+            game.Dispose();
+        }
+
+        [Test]
+        public void ApplyChangesResetsDevice()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+
+            var count = 0;
+
+            gdm.DeviceReset += (sender, args) => count++;
+
+            game.InitializeOnly();
+
+            gdm.PreferredBackBufferWidth = gdm.PreferredBackBufferWidth;
+            gdm.ApplyChanges();
+            Assert.AreEqual(1, count);
+
+            game.Dispose();
+        }
+
+        [Test]
+        public void DeviceDisposingInvokedAfterDeviceDisposed()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+
+            var invoked = false;
+
+            gdm.DeviceDisposing += (sender, args) =>
+            {
+                invoked = true;
+                Assert.IsTrue(gdm.GraphicsDevice.IsDisposed);
+            };
+
+            game.InitializeOnly();
+
+            Assert.IsFalse(gdm.GraphicsDevice.IsDisposed);
+            Assert.IsFalse(invoked);
+            // change the graphics profile so the current device needs to be disposed
+            gdm.GraphicsProfile = GraphicsProfile.HiDef;
+            gdm.ApplyChanges();
+            Assert.IsTrue(invoked);
+
+            game.Dispose();
+
         }
 
         [TestCase(false)]

--- a/Test/Framework/Graphics/GraphicsDeviceManagerTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceManagerTest.cs
@@ -54,7 +54,10 @@ namespace MonoGame.Tests.Graphics
             gdm.PreparingDeviceSettings += (s, a) => preparingCount++;
             gdm.DeviceCreated += (s, a) => createdCount++;
             gdm.DeviceDisposing += (s, a) => devDispCount++;
+            // TODO: re-add this when DesktopGL platfrom uses the new GDM
+#if !DESKTOPGL
             gdm.Disposed += (s, a) => dispCount++;
+#endif
 
             game.InitializeOnly();
 

--- a/Test/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceTest.cs
@@ -14,6 +14,100 @@ namespace MonoGame.Tests.Graphics
     [TestFixture]
     internal class GraphicsDeviceTest : GraphicsDeviceTestFixtureBase
     {
+        [Test]
+        public void CtorAdapterNull()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new GraphicsDevice(null, GraphicsProfile.Reach, new PresentationParameters()));
+        }
+
+        [Test]
+        public void CtorPresentationParametersNull()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new GraphicsDevice(GraphicsAdapter.DefaultAdapter, GraphicsProfile.Reach, null));
+        }
+
+        [Test]
+        public void DisposedWhenDisposingInvoked()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+            ((IGraphicsDeviceManager) gdm).CreateDevice();
+
+            var gd = gdm.GraphicsDevice;
+
+            var count = 0;
+
+            gd.Disposing += (sender, args) =>
+            {
+                Assert.IsTrue(gd.IsDisposed);
+                count++;
+            };
+
+            gd.Dispose();
+            Assert.AreEqual(1, count);
+
+            // Disposing should not be invoked more than once
+            gd.Dispose();
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void ResetInvokedBeforeDeviceLost()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+
+            game.InitializeOnly();
+
+            var gd = game.GraphicsDevice;
+
+            var resetCount = 0;
+            var devLostCount = 0;
+
+            var lostCount = 0;
+            var tex = new RenderTarget2D(gdm.GraphicsDevice, 5, 5);
+            tex.ContentLost += (sender, args) => lostCount++;
+
+            gd.DeviceReset += (sender, args) =>
+            {
+                resetCount++;
+                Assert.AreEqual(0, devLostCount);
+            };
+
+            gd.DeviceLost += (sender, args) =>
+            {
+                devLostCount++;
+                Assert.AreEqual(1, resetCount);
+            };
+
+#if XNA
+            gd.Reset();
+#else
+            gd.Reset(new PresentationParameters());
+#endif
+
+            Assert.AreEqual(1, lostCount);
+
+            tex.Dispose();
+
+            game.Dispose();
+        }
+
+        [Test]
+        public void ResetWindowHandleNullThrowsException()
+        {
+            var game = new TestGameBase();
+            new GraphicsDeviceManager(game);
+            game.InitializeOnly();
+
+            var gd = game.GraphicsDevice;
+            Assert.Throws<ArgumentException>(() => gd.Reset(new PresentationParameters()));
+
+            game.Dispose();
+        }
+
 		[Test]
 		public void Clear()
 		{

--- a/Test/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceTest.cs
@@ -71,7 +71,8 @@ namespace MonoGame.Tests.Graphics
             Assert.AreEqual(1, devLostCount);
         }
 
-        [Test]
+        // TODO Make sure dynamic graphics resources are notified when graphics device is lost
+        [Test, Ignore]
         public void ContentLostResources()
         {
             // https://blogs.msdn.microsoft.com/shawnhar/2007/12/12/virtualizing-the-graphicsdevice-in-xna-game-studio-2-0/
@@ -94,6 +95,11 @@ namespace MonoGame.Tests.Graphics
 
             Assert.IsTrue(rtc.IsContentLost);
             Assert.IsFalse(rtc.IsDisposed);
+
+            rt.Dispose();
+            vb.Dispose();
+            ib.Dispose();
+            rtc.Dispose();
         }
 
         [Test]

--- a/Test/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceTest.cs
@@ -31,12 +31,6 @@ namespace MonoGame.Tests.Graphics
         [Test]
         public void DisposedWhenDisposingInvoked()
         {
-            var game = new TestGameBase();
-            var gdm = new GraphicsDeviceManager(game);
-            ((IGraphicsDeviceManager) gdm).CreateDevice();
-
-            var gd = gdm.GraphicsDevice;
-
             var count = 0;
 
             gd.Disposing += (sender, args) =>
@@ -56,19 +50,8 @@ namespace MonoGame.Tests.Graphics
         [Test]
         public void ResetInvokedBeforeDeviceLost()
         {
-            var game = new TestGameBase();
-            var gdm = new GraphicsDeviceManager(game);
-
-            game.InitializeOnly();
-
-            var gd = game.GraphicsDevice;
-
             var resetCount = 0;
             var devLostCount = 0;
-
-            var lostCount = 0;
-            var tex = new RenderTarget2D(gdm.GraphicsDevice, 5, 5);
-            tex.ContentLost += (sender, args) => lostCount++;
 
             gd.DeviceReset += (sender, args) =>
             {
@@ -82,30 +65,41 @@ namespace MonoGame.Tests.Graphics
                 Assert.AreEqual(1, resetCount);
             };
 
-#if XNA
             gd.Reset();
-#else
-            gd.Reset(new PresentationParameters());
-#endif
 
-            Assert.AreEqual(1, lostCount);
+            Assert.AreEqual(1, resetCount);
+            Assert.AreEqual(1, devLostCount);
+        }
 
-            tex.Dispose();
+        [Test]
+        public void ContentLostResources()
+        {
+            // https://blogs.msdn.microsoft.com/shawnhar/2007/12/12/virtualizing-the-graphicsdevice-in-xna-game-studio-2-0/
 
-            game.Dispose();
+            var rt = new RenderTarget2D(gdm.GraphicsDevice, 5, 5);
+            var vb = new DynamicVertexBuffer(gd, VertexPositionColor.VertexDeclaration, 1, BufferUsage.None);
+            var ib = new DynamicIndexBuffer(gd, IndexElementSize.SixteenBits, 1, BufferUsage.None);
+            var rtc = new RenderTargetCube(gd, 1, false, SurfaceFormat.Color, DepthFormat.Depth16);
+
+            gd.Reset();
+
+            Assert.IsTrue(rt.IsContentLost);
+            Assert.IsFalse(rt.IsDisposed);
+
+            Assert.IsTrue(vb.IsContentLost);
+            Assert.IsFalse(vb.IsDisposed);
+
+            Assert.IsTrue(ib.IsContentLost);
+            Assert.IsFalse(ib.IsDisposed);
+
+            Assert.IsTrue(rtc.IsContentLost);
+            Assert.IsFalse(rtc.IsDisposed);
         }
 
         [Test]
         public void ResetWindowHandleNullThrowsException()
         {
-            var game = new TestGameBase();
-            new GraphicsDeviceManager(game);
-            game.InitializeOnly();
-
-            var gd = game.GraphicsDevice;
             Assert.Throws<ArgumentException>(() => gd.Reset(new PresentationParameters()));
-
-            game.Dispose();
         }
 
 		[Test]

--- a/Test/Framework/Graphics/Texture3DNonVisualTest.cs
+++ b/Test/Framework/Graphics/Texture3DNonVisualTest.cs
@@ -24,11 +24,7 @@ namespace MonoGame.Tests.Graphics
             _game = new Game();
             var graphicsDeviceManager = new GraphicsDeviceManager(_game);
             graphicsDeviceManager.GraphicsProfile = GraphicsProfile.HiDef;
-#if XNA
             graphicsDeviceManager.ApplyChanges();
-#else
-            graphicsDeviceManager.CreateDevice();
-#endif
 
             t = new Texture3D(_game.GraphicsDevice, w, h, d, false, SurfaceFormat.Color);
             for (int layer = 0; layer < d; layer++)

--- a/Test/Framework/TestGameBase.cs
+++ b/Test/Framework/TestGameBase.cs
@@ -145,6 +145,16 @@ namespace MonoGame.Tests {
 				handler (this, new FrameInfoEventArgs(FrameInfo));
 		}
 
+	    public void InitializeOnly()
+	    {
+            if (GraphicsDevice == null)
+            {
+                var graphicsDeviceManager = Services.GetService(typeof(IGraphicsDeviceManager)) as IGraphicsDeviceManager;
+                graphicsDeviceManager.CreateDevice();
+            }
+            Initialize();
+	    }
+
 		protected override void Initialize ()
 		{
 			SafeRaise (PreInitializeWith);


### PR DESCRIPTION
This is not finished yet, but I'm sharing so people that are interested and/or worried can follow progress and advise. This is a start to getting GraphicsDevice and GraphicsDeviceManager events right and handling PresentationParameters the same as in XNA.

I may have done a seperate PR for this, but I also added a simple method to TestGameBase that initializes the game without creating a window. This can speed up a lot of test that are 'visual' but don't need to be. I already fixed a couple that just needed a GraphicsDevice, but not necessarily a window... Actually, most tests don't **really** need a window, right? Note that we can't get around that for XNA tests. Other tests that can benefit are RasterizerState and Viewport among others.

There's more testing to be done and GraphicsDevice events also needs its events fixed, but that might be better to do in a seperate PR. I did do the Disposed event though, because of how easy it was and I couldn't resist :p

This fixes at least (I'll add issues here as I find them)
- fixes #539
- fixes #4433
- fixes #3114