### PR TITLE
Fix crash when DynamicSoundEffectInstance not disposed

### DIFF
--- a/MonoGame.Framework/Audio/DynamicSoundEffectInstanceManager.cs
+++ b/MonoGame.Framework/Audio/DynamicSoundEffectInstanceManager.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Xna.Framework.Audio
         {
             for (int i = _playingInstances.Count - 1; i >= 0; i--)
             {
-                if (_playingInstances[i].IsAlive)
+                var target = _playingInstances[i].Target as DynamicSoundEffectInstance;
+                if (target != null)
                 {
-                    var target = (DynamicSoundEffectInstance)_playingInstances[i].Target;
                     if (!target.IsDisposed)
                         target.UpdateQueue();
                 }

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -350,7 +350,6 @@ namespace Microsoft.Xna.Framework.Audio
 
             if (MasterVoice != null)
             {
-                MasterVoice.DestroyVoice();
                 MasterVoice.Dispose();
                 MasterVoice = null;
             }

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -339,8 +339,6 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal static void PlatformShutdown()
         {
-            SoundEffectInstancePool.Shutdown();
-
             if (_reverbVoice != null)
             {
                 _reverbVoice.DestroyVoice();

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -155,23 +155,5 @@ namespace Microsoft.Xna.Framework.Audio
             }
         }
 
-        internal static void Shutdown()
-        {
-            // We need to dispose all SoundEffectInstances before shutdown,
-            // so as to destroy all SourceVoice instances,
-            // before we can destroy our XAudio MasterVoice instance.
-            // Otherwise XAudio shutdown fails, causing intermittent crashes.
-            foreach (var inst in _playingInstances)
-            {
-                inst.Dispose();
-            }
-            _playingInstances.Clear();
-
-            foreach (var inst in _pooledInstances)
-            {
-                inst.Dispose();
-            }
-            _pooledInstances.Clear();
-        }
     }
 }

--- a/Test/Framework/Audio/SoundEffectTest.cs
+++ b/Test/Framework/Audio/SoundEffectTest.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
 using NUnit.Framework;
 
@@ -266,6 +267,21 @@ namespace MonoGame.Tests.Audio
             Assert.DoesNotThrow(() => new SoundEffect(new byte[2], 0, 2, 8000, AudioChannels.Mono, 0, 1));
             Assert.Throws<ArgumentException>(() => new SoundEffect(new byte[2], 0, 2, 8000, AudioChannels.Mono, 0, 2));
             Assert.Throws<ArgumentException>(() => new SoundEffect(new byte[2], 0, 2, 8000, AudioChannels.Mono, 0, int.MaxValue));
+        }
+
+        public void InstanceNotDisposedWhenGameDisposed()
+        {
+            var game = new Game();
+            var s = new SoundEffectInstance();
+            var d = new DynamicSoundEffectInstance(44100, AudioChannels.Stereo);
+
+            game.Dispose();
+
+            Assert.IsFalse(s.IsDisposed);
+            Assert.IsFalse(d.IsDisposed);
+
+            s.Dispose();
+            d.Dispose();
         }
 
         private byte[] LoadRiff(string filename, out int sampleRate, out AudioChannels channels)

--- a/Test/Framework/Audio/SoundEffectTest.cs
+++ b/Test/Framework/Audio/SoundEffectTest.cs
@@ -7,7 +7,7 @@ using System.IO;
 using Microsoft.Xna.Framework.Audio;
 using NUnit.Framework;
 
-namespace MonoGame.Tests.Framework.Audio
+namespace MonoGame.Tests.Audio
 {
     public class SoundEffectTests
     {

--- a/Test/Framework/Audio/XactTest.cs
+++ b/Test/Framework/Audio/XactTest.cs
@@ -7,7 +7,7 @@ using System.IO;
 using Microsoft.Xna.Framework.Audio;
 using NUnit.Framework;
 
-namespace MonoGame.Tests.Framework.Audio
+namespace MonoGame.Tests.Audio
 {
     [TestFixture]
     public class XactTests


### PR DESCRIPTION
I had a look at the following SharpDX sample 
https://github.com/sharpdx/SharpDX-Samples/blob/master/Desktop/XAudio2/PlaySound/Program.cs#L42

and MasteringVoice is just disposed without calling `MasteringVoice.DestroyVoice`. This avoids the crash when other SFX are not disposed. I did a test for XNA and disposing a Game does not dispose of sound effects that are not yet disposed, so it's left to the user there too. If this is the right way of shutting down XAudio2 we can also remove `SoundEffect.PlatformShutdown` in `Game.Dispose`.

fixes #5064, fixes #5070 