### PR TITLE
Allow #line directives to be used in .fx files

### DIFF
--- a/Tools/2MGFX/Preprocessor.cs
+++ b/Tools/2MGFX/Preprocessor.cs
@@ -24,6 +24,8 @@ namespace TwoMGFX
             foreach (var define in defines)
                 pp.addMacro(define.Key, define.Value);
 
+            effectCode = effectCode.Replace("#line", "//--WORKAROUND#line");
+
             pp.addInput(new MGStringLexerSource(effectCode, true, fullPath));
 
             var result = new StringBuilder();
@@ -38,6 +40,10 @@ namespace TwoMGFX
                         endOfStream = true;
                         break;
                     case CppNet.Token.CPPCOMMENT:
+                        if (token.getText().StartsWith("//--WORKAROUND#line"))
+                        {
+                            result.Append(token.getText().Replace("//--WORKAROUND#line", "#line"));
+                        }
                         break;
                     case CppNet.Token.CCOMMENT:
                     {


### PR DESCRIPTION
This allows `#line` directives to be used in effect files.

As part of Protogame, we have our own asset system which underneath passes effect code to MonoGame's content pipeline for compilation.  To do this, we write the effect code to a temporary file on disk, and tell the effect processor to compile that file.  We preemptively resolve includes on the string in memory before we pass the effect code to MonoGame, so there are no external dependencies on other files.

Right now, the CppNet preprocessor strips out any `#line` directives in the source code, even though they are recognised by the underlying shader compiler.  We want to use `#line` directives when we pass the content into MonoGame's content pipeline so that the filenames and line numbers match with our actual source files, and don't just have the temporary filename on disk (and incorrectly offset line numbers due to includes).

This change detects `#line` directives before they are passed into CppNet, and encodes them as a comment.  When reading the output from the preprocessor, they then get transformed back into `#line` directives again so that they exist for the underlying shader compiler.

