### PR TITLE
Do not omit filename and line number information from the first error during effect compilation

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                     if (identity == null)
                     {
                         identity = new ContentIdentity(fileName, input.Identity.SourceTool, lineAndColumn);
-                        allErrorsAndWarnings = message + Environment.NewLine;
+                        allErrorsAndWarnings = errorsAndWarningArray[i] + Environment.NewLine;
                     }
                     else
                         allErrorsAndWarnings += errorsAndWarningArray[i] + Environment.NewLine;


### PR DESCRIPTION
Currently effect compilation exceptions result in a message like this: (this is with #5077 applied)

```
warning X3206: implicit truncation of vector type
C:\Users\June\Documents\Projects\Protogame\Protogame.Resources\effect.BuiltinSurface.fx(432,20): warning X3206: implicit truncation of vector type
C:\Users\June\Documents\Projects\Protogame\Protogame.Resources\effect.BuiltinSurface.fx(306,2): error X4000: variable 'output' used without having been completely initialized
```

This fixes the code so it always includes the filename and line number reported by the shader compiler as the location of the error:

```
C:\Users\June\Documents\Projects\Protogame\Protogame.Resources\effect.BuiltinSurface.fx(432,20): warning X3206: implicit truncation of vector type
C:\Users\June\Documents\Projects\Protogame\Protogame.Resources\effect.BuiltinSurface.fx(432,20): warning X3206: implicit truncation of vector type
C:\Users\June\Documents\Projects\Protogame\Protogame.Resources\effect.BuiltinSurface.fx(306,2): error X4000: variable 'output' used without having been completely initialized
```