### PR TITLE
DX11 Multisample Quality fix

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -714,7 +714,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     PresentationParameters.MultiSampleCount = maxLevel;
 
                 multisampleDesc.Count = PresentationParameters.MultiSampleCount;
-                multisampleDesc.Quality = qualityLevels - 1;
+                // Get the quality level for the selected multisample count, which may be
+                // lower than the maximum found above.
+                multisampleDesc.Quality = _d3dDevice.CheckMultisampleQualityLevels(format, PresentationParameters.MultiSampleCount) - 1;
             }
 
             int vSyncFrameLatency = PresentationParameters.PresentationInterval.GetFrameLatency();


### PR DESCRIPTION
DX11 Multisample Quality was being set to the maximum, even if the desired multisample quality was lower.  For example, the dev selects a multisample count of 4.  The code checks for the maximum available, which in my case was 8.  This returns a quality level of 33.  The code previously was setting multisampleDesc.Count to 4 but multisampleDesc.Quality was being set to 32 (quality level - 1 for a multisample count of 8).  This resulted in an incorrect argument HRESULT when creating the swapchain.

The change here now calculates the quality level for the selected multisample count, not the highest.