### PR TITLE
Fix Android launch (no EFX)

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -42,10 +42,10 @@
       <Platform Name="Android">TRACE;ANDROID;GLES;OPENGL;OPENAL</Platform>
       <Platform Name="iOS">IOS;GLES;OPENGL;OPENAL</Platform>
       <Platform Name="tvOS">IOS;TVOS;GLES;OPENGL;OPENAL</Platform>
-      <Platform Name="Linux">TRACE;LINUX;OPENGL;OPENAL;DESKTOPGL</Platform>
-      <Platform Name="MacOS">MONOMAC;OPENGL;OPENAL</Platform>
+      <Platform Name="Linux">TRACE;LINUX;OPENGL;OPENAL;DESKTOPGL;SUPPORTS_EFX</Platform>
+      <Platform Name="MacOS">MONOMAC;OPENGL;OPENAL;SUPPORTS_EFX</Platform>
       <Platform Name="Ouya">TRACE;ANDROID;GLES;OPENGL;OUYA;OPENAL</Platform>
-      <Platform Name="WindowsGL">TRACE;WINDOWS;DESKTOPGL</Platform>
+      <Platform Name="WindowsGL">TRACE;WINDOWS;DESKTOPGL;SUPPORTS_EFX</Platform>
       <Platform Name="Windows">TRACE;WINDOWS;DIRECTX;WINDOWS_MEDIA_SESSION</Platform>
       <Platform Name="Windows8">TRACE;NETFX_CORE;WINRT;WINDOWS_STOREAPP;DIRECTX;DIRECTX11_1;WINDOWS_MEDIA_ENGINE</Platform>
       <Platform Name="WindowsPhone">TRACE;SILVERLIGHT;WINDOWS_PHONE;WINRT;DIRECTX</Platform>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -43,7 +43,7 @@
       <Platform Name="iOS">IOS;GLES;OPENGL;OPENAL</Platform>
       <Platform Name="tvOS">IOS;TVOS;GLES;OPENGL;OPENAL</Platform>
       <Platform Name="Linux">TRACE;LINUX;OPENGL;OPENAL;DESKTOPGL;SUPPORTS_EFX</Platform>
-      <Platform Name="MacOS">MONOMAC;OPENGL;OPENAL;SUPPORTS_EFX</Platform>
+      <Platform Name="MacOS">MONOMAC;OPENGL;OPENAL</Platform>
       <Platform Name="Ouya">TRACE;ANDROID;GLES;OPENGL;OUYA;OPENAL</Platform>
       <Platform Name="WindowsGL">TRACE;WINDOWS;DESKTOPGL;SUPPORTS_EFX</Platform>
       <Platform Name="Windows">TRACE;WINDOWS;DIRECTX;WINDOWS_MEDIA_SESSION</Platform>

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -35,10 +35,6 @@ using AudioToolbox;
 using AVFoundation;
 #endif
 
-#if !MONOMAC && !GLES
-#define SUPPORTS_EFX
-#endif
-
 namespace Microsoft.Xna.Framework.Audio
 {
     internal static class ALHelper

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -35,6 +35,10 @@ using AudioToolbox;
 using AVFoundation;
 #endif
 
+#if !MONOMAC && !GLES
+#define SUPPORTS_EFX
+#endif
+
 namespace Microsoft.Xna.Framework.Audio
 {
     internal static class ALHelper
@@ -57,7 +61,7 @@ namespace Microsoft.Xna.Framework.Audio
 	internal sealed class OpenALSoundController : IDisposable
     {
         private static OpenALSoundController _instance = null;
-#if !MONOMAC
+#if SUPPORTS_EFX
         private static EffectsExtension _efx = null;
 #endif
         private IntPtr _device;
@@ -125,7 +129,7 @@ namespace Microsoft.Xna.Framework.Audio
 			AL.GenSources(allSourcesArray);
             ALHelper.CheckError("Failed to generate sources.");
             Filter = 0;
- #if !MONOMAC
+#if SUPPORTS_EFX
             if (Efx.IsInitialized) {
                 Filter = Efx.GenFilter ();
             }
@@ -298,7 +302,7 @@ namespace Microsoft.Xna.Framework.Audio
 				return _instance;
 			}
 		}
-#if !MONOMAC
+#if SUPPORTS_EFX
         public static EffectsExtension Efx {
             get {
                 if (_efx == null)
@@ -394,10 +398,10 @@ namespace Microsoft.Xna.Framework.Audio
                             AL.DeleteSource(allSourcesArray[i]);
                             ALHelper.CheckError("Failed to delete source.");
                         }
-#if !MONOMAC
+#if SUPPORTS_EFX
                         if (Filter != 0 && Efx.IsInitialized)
                             Efx.DeleteFilter (Filter);
-#endif           
+#endif
                         CleanUpOpenAL();
                     }
                 }

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -25,6 +25,10 @@ using Foundation;
 #endif
 #endif
 
+#if !MONOMAC && !GLES
+#define SUPPORTS_EFX
+#endif
+
 namespace Microsoft.Xna.Framework.Audio
 {
     public sealed partial class SoundEffect : IDisposable
@@ -195,7 +199,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal static void PlatformSetReverbSettings(ReverbSettings reverbSettings)
         {
-#if !MONOMAC
+#if SUPPORTS_EFX
             if (!OpenALSoundController.Efx.IsInitialized)
                 return;
 
@@ -252,7 +256,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal static void PlatformShutdown()
         {
-#if !MONOMAC
+#if SUPPORTS_EFX
             if (ReverbEffect != 0) {
                 OpenALSoundController.Efx.DeleteAuxiliaryEffectSlot ((int)ReverbSlot);
                 OpenALSoundController.Efx.DeleteEffect ((int)ReverbEffect);

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -25,10 +25,6 @@ using Foundation;
 #endif
 #endif
 
-#if !MONOMAC && !GLES
-#define SUPPORTS_EFX
-#endif
-
 namespace Microsoft.Xna.Framework.Audio
 {
     public sealed partial class SoundEffect : IDisposable

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -17,6 +17,10 @@ using OpenTK.Audio.OpenAL;
 using OpenAL;
 #endif
 
+#if !MONOMAC && !GLES
+#define SUPPORTS_EFX
+#endif
+
 namespace Microsoft.Xna.Framework.Audio
 {
     public partial class SoundEffectInstance : IDisposable
@@ -28,7 +32,7 @@ namespace Microsoft.Xna.Framework.Audio
 		internal int SourceId;
         private float reverb = 0f;
         bool applyFilter = false;
-#if !MONOMAC
+#if SUPPORTS_EFX
         EfxFilterType filterType;
 #endif
         float filterQ;
@@ -143,10 +147,8 @@ namespace Microsoft.Xna.Framework.Audio
 			// Pitch
 			AL.Source (SourceId, ALSourcef.Pitch, XnaPitchToAlPitch(_pitch));
             ALHelper.CheckError("Failed to set source pitch.");
-#if !MONOMAC
-
+#if SUPPORTS_EFX
             ApplyReverb ();
-
             ApplyFilter ();
 #endif
             AL.SourcePlay(SourceId);
@@ -191,15 +193,14 @@ namespace Microsoft.Xna.Framework.Audio
                 AL.SourceStop(SourceId);
                 ALHelper.CheckError("Failed to stop source.");
 
-#if !MONOMAC
+#if SUPPORTS_EFX
                 // Reset the SendFilter to 0 if we are NOT using revert since 
                 // sources are recyled
                 OpenALSoundController.Efx.BindSourceToAuxiliarySlot (SourceId, 0, 0, 0);
                 ALHelper.CheckError ("Failed to unset reverb.");
-#endif
                 AL.Source (SourceId, ALSourcei.EfxDirectFilter, 0);
                 ALHelper.CheckError ("Failed to unset filter.");
-
+#endif
                 AL.Source(SourceId, ALSourcei.Buffer, 0);
                 ALHelper.CheckError("Failed to free source from buffer.");
 
@@ -282,7 +283,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal void PlatformSetReverbMix(float mix)
         {
-#if !MONOMAC
+#if SUPPORTS_EFX
             if (!OpenALSoundController.Efx.IsInitialized)
                 return;
             reverb = mix;
@@ -293,7 +294,7 @@ namespace Microsoft.Xna.Framework.Audio
 #endif
         }
 
-#if !MONOMAC
+#if SUPPORTS_EFX
         void ApplyReverb ()
         {
             if (reverb > 0f && SoundEffect.ReverbSlot != 0) {
@@ -334,7 +335,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal void PlatformSetFilter(FilterMode mode, float filterQ, float frequency)
         {
-#if !MONOMAC
+#if SUPPORTS_EFX
             if (!OpenALSoundController.Efx.IsInitialized)
                 return;
 
@@ -361,7 +362,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal void PlatformClearFilter()
         {
-#if !MONOMAC
+#if SUPPORTS_EFX
             if (!OpenALSoundController.Efx.IsInitialized)
                 return;
 

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -17,10 +17,6 @@ using OpenTK.Audio.OpenAL;
 using OpenAL;
 #endif
 
-#if !MONOMAC && !GLES
-#define SUPPORTS_EFX
-#endif
-
 namespace Microsoft.Xna.Framework.Audio
 {
     public partial class SoundEffectInstance : IDisposable


### PR DESCRIPTION
The code assumed that EFX was available if it wasn't built for MONOMAC.  Replaced that with a SUPPORTS_EFX symbol that is defined if it is not MONOMAC and not GLES because the GLES platforms still use OpenTK.OpenAL.