### PR TITLE
[xact] Make sure the Cue is properly reset

### DIFF
--- a/MonoGame.Framework/Audio/Xact/Cue.cs
+++ b/MonoGame.Framework/Audio/Xact/Cue.cs
@@ -113,7 +113,8 @@ namespace Microsoft.Xna.Framework.Audio
         {
             IsDisposed = false;
             IsCreated = false;
-            IsPrepared = true;            
+            IsPrepared = true;
+            _curSound = null;
         }
 
         /// <summary>Pauses playback.</summary>

--- a/Test/Framework/Audio/XactTest.cs
+++ b/Test/Framework/Audio/XactTest.cs
@@ -191,6 +191,20 @@ namespace MonoGame.Tests.Framework.Audio
             Assert.False(cue.IsStopped);
             Assert.False(cue.IsStopping);
 
+            cue.Play ();
+            cue.Stop (AudioStopOptions.Immediate);
+
+            cue = _soundBank.GetCue ("blast_mono");
+
+            // Make sure the initial state is reset
+            Assert.False(cue.IsCreated);
+            Assert.False(cue.IsPreparing);
+            Assert.True(cue.IsPrepared);
+            Assert.False(cue.IsPlaying);
+            Assert.False(cue.IsPaused);
+            Assert.False(cue.IsStopped);
+            Assert.False(cue.IsStopping);
+
             cue.Dispose();
 
             // Make sure the disposed state is correct.


### PR DESCRIPTION
When using GetCue in XNA the Cue is always
returned in its initial state. There was a bug
where the Cue would be returned with a IsStopped
value of 'true' if the cue had been played before.
This did not match the expected XNA behaviour.