### PR TITLE
Set session state to proper value when resuming.

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.WME.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WME.cs
@@ -147,6 +147,7 @@ namespace Microsoft.Xna.Framework.Media
         {
             if (_sessionState == SessionState.Stopped)
                 return;
+            _sessionState = SessionState.Stopped;
             _mediaEngineEx.Source = null;
         }
     }

--- a/MonoGame.Framework/Media/MediaPlayer.WME.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WME.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Xna.Framework.Media
         {
             if (_sessionState != SessionState.Paused)
                 return;
+            _sessionState = SessionState.Started;
             _mediaEngineEx.Play();
         }
 


### PR DESCRIPTION
On windows uwp platform when resuming a song, sessionState was not
reset to started, which resulted in failing to pause a song later
