### PR TITLE
Add manifest to templates to be dpi aware

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
@@ -21,7 +21,6 @@
     <Import file="templates/Common/Icon.ico" />
     <Import file="templates/Common/Program.cs" />
     <Import file="templates/Common/Content.mgcb" />
-    <Import file="templates/Common/app.manifest" />
     <Import file="templates/Common/OpenTK.dll.config" />
     <Import file="templates/Common/Tao.Sdl.dll.config" />
     <Import file="templates/Common/MonoGame.Framework.dll.config" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
@@ -21,6 +21,7 @@
     <Import file="templates/Common/Icon.ico" />
     <Import file="templates/Common/Program.cs" />
     <Import file="templates/Common/Content.mgcb" />
+    <Import file="templates/Common/app.manifest" />
     <Import file="templates/Common/OpenTK.dll.config" />
     <Import file="templates/Common/Tao.Sdl.dll.config" />
     <Import file="templates/Common/MonoGame.Framework.dll.config" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/app.manifest
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <assemblyIdentity version="1.0.0.0" name="${ProjectName}"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/app.manifest
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/app.manifest
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on and is
+           is designed to work with. Uncomment the appropriate elements and Windows will 
+           automatically selected the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
+
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
+</assembly>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/app.manifest
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/app.manifest
@@ -35,7 +35,7 @@
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
     </windowsSettings>
   </application>
 

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameProject.xpt.xml
@@ -28,7 +28,7 @@
 			<Files>
 				<File name="Game1.cs" src="Common/Game1.cs" />
 				<File name="Program.cs" src="Common/Program.cs" />
-				<RawFile name="app.manifest" src="Common/app.manifest" />
+				<File name="app.manifest" src="Common/app.manifest" />
 				<RawFile name="Icon.png" src="Common/Icon-md.png"/>
 				<RawFile name="Icon.ico" src="Common/Icon.ico" BuildAction="EmbeddedResource"/>
 				<Directory name="Properties">

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameProject.xpt.xml
@@ -28,6 +28,7 @@
 			<Files>
 				<File name="Game1.cs" src="Common/Game1.cs" />
 				<File name="Program.cs" src="Common/Program.cs" />
+				<RawFile name="app.manifest" src="Common/app.manifest" />
 				<RawFile name="Icon.png" src="Common/Icon-md.png"/>
 				<RawFile name="Icon.ico" src="Common/Icon.ico" BuildAction="EmbeddedResource"/>
 				<Directory name="Properties">

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameWindowsProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameWindowsProject.xpt.xml
@@ -28,7 +28,7 @@
 			<Files>
 				<File name="Game1.cs" src="Common/Game1.cs" />
 				<File name="Program.cs" src="Common/Program.cs" />
-				<RawFile name="app.manifest" src="Common/app.manifest />
+				<File name="app.manifest" src="Common/app.manifest />
 				<RawFile name="Icon.png" src="Common/Icon-md.png" />
 				<Directory name="Properties">
 					<File name="AssemblyInfo.cs" src="Common/AssemblyInfo.cs" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameWindowsProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameWindowsProject.xpt.xml
@@ -28,6 +28,7 @@
 			<Files>
 				<File name="Game1.cs" src="Common/Game1.cs" />
 				<File name="Program.cs" src="Common/Program.cs" />
+				<RawFile name="app.manifest" src="Common/app.manifest />
 				<RawFile name="Icon.png" src="Common/Icon-md.png" />
 				<Directory name="Properties">
 					<File name="AssemblyInfo.cs" src="Common/AssemblyInfo.cs" />

--- a/ProjectTemplates/VisualStudio2010/DesktopGL/MonoGameDesktopGL.vstemplate
+++ b/ProjectTemplates/VisualStudio2010/DesktopGL/MonoGameDesktopGL.vstemplate
@@ -22,6 +22,7 @@
       <ProjectItem ReplaceParameters="false" TargetFileName="Icon.ico">Icon.ico</ProjectItem>
 	  <ProjectItem ReplaceParameters="false" TargetFileName="Icon.bmp">Icon.bmp</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="Program.cs">Program.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="app.manifest">app.manifest</ProjectItem>
       <Folder Name="Properties" TargetFolderName="Properties">
         <ProjectItem ReplaceParameters="true" TargetFileName="AssemblyInfo.cs">AssemblyInfo.cs</ProjectItem>
       </Folder>

--- a/ProjectTemplates/VisualStudio2010/DesktopGL/MonoGameDesktopGLApplication.csproj
+++ b/ProjectTemplates/VisualStudio2010/DesktopGL/MonoGameDesktopGLApplication.csproj
@@ -38,6 +38,9 @@
   <PropertyGroup>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Game1.cs" />
     <Compile Include="Program.cs" />
@@ -100,6 +103,7 @@
       <Link>MonoGame.Framework.dll.config</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="app.manifest" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Content.Builder.targets" />

--- a/ProjectTemplates/VisualStudio2010/DesktopGL/app.manifest
+++ b/ProjectTemplates/VisualStudio2010/DesktopGL/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <assemblyIdentity version="1.0.0.0" name="$safeprojectname$"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/ProjectTemplates/VisualStudio2010/DesktopGL/app.manifest
+++ b/ProjectTemplates/VisualStudio2010/DesktopGL/app.manifest
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on and is
+           is designed to work with. Uncomment the appropriate elements and Windows will 
+           automatically selected the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
+
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
+</assembly>

--- a/ProjectTemplates/VisualStudio2010/DesktopGL/app.manifest
+++ b/ProjectTemplates/VisualStudio2010/DesktopGL/app.manifest
@@ -35,7 +35,7 @@
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
     </windowsSettings>
   </application>
 

--- a/ProjectTemplates/VisualStudio2010/Windows/MonoGameWindows.vstemplate
+++ b/ProjectTemplates/VisualStudio2010/Windows/MonoGameWindows.vstemplate
@@ -20,6 +20,7 @@
       <ProjectItem ReplaceParameters="true" TargetFileName="Game1.cs">Game1.cs</ProjectItem>
       <ProjectItem ReplaceParameters="false" TargetFileName="Icon.ico">Icon.ico</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="Program.cs">Program.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="app.manifest">app.manifest</ProjectItem>
       <Folder Name="Properties" TargetFolderName="Properties">
         <ProjectItem ReplaceParameters="true" TargetFileName="AssemblyInfo.cs">AssemblyInfo.cs</ProjectItem>
       </Folder>

--- a/ProjectTemplates/VisualStudio2010/Windows/MonoGameWindowsApplication.csproj
+++ b/ProjectTemplates/VisualStudio2010/Windows/MonoGameWindowsApplication.csproj
@@ -37,6 +37,9 @@
   <PropertyGroup>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Game1.cs" />
     <Compile Include="Program.cs" />
@@ -54,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <MonoGameContentReference Include="Content\Content.mgcb" />
+    <None Include="app.manifest" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Content.Builder.targets" />

--- a/ProjectTemplates/VisualStudio2010/Windows/app.manifest
+++ b/ProjectTemplates/VisualStudio2010/Windows/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <assemblyIdentity version="1.0.0.0" name="$safeprojectname$"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/ProjectTemplates/VisualStudio2010/Windows/app.manifest
+++ b/ProjectTemplates/VisualStudio2010/Windows/app.manifest
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on and is
+           is designed to work with. Uncomment the appropriate elements and Windows will 
+           automatically selected the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
+
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
+</assembly>

--- a/ProjectTemplates/VisualStudio2010/Windows/app.manifest
+++ b/ProjectTemplates/VisualStudio2010/Windows/app.manifest
@@ -35,7 +35,7 @@
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
     </windowsSettings>
   </application>
 


### PR DESCRIPTION
@mrhelmut This fixes #5040 and should also fix #5092. A couple things:
- The manifest still needs to be set as ApplicationManifest in MD templates, but I don't know where that should go. It's just added to the project as a file now and nothing more. @dellis1972 Can you give me some pointers here?
- This only needs to be done for WindowsDX and DesktopGL right?
- Should the name be {NameOfProject}.manifest? I don't know how to replace the name of the file itself.

Sorry, I've never worked on templates before so there's a lot I don't know :/