### PR TITLE
Fixed OpenAL CallingConvention on Function Pointers #5100

### DIFF
--- a/MonoGame.Framework/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Audio/OpenAL.cs
@@ -495,6 +495,7 @@ namespace OpenAL
         private int StorageHardware;
         private int StorageAccessible;
 
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate bool SetBufferModeDelegate (int n, ref int buffers, int value);
 
         private SetBufferModeDelegate setBufferMode;
@@ -539,20 +540,33 @@ namespace OpenAL
     {
         /* Effect API */
 
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate void alGenEffectsDelegate (int n, out uint effect);
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate void alDeleteEffectsDelegate (int n, ref int effect);
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate bool alIsEffectDelegate (uint effect);
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate void alEffectfDelegate (uint effect, EfxEffectf param, float value);
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate void alEffectiDelegate (uint effect, EfxEffecti param, int value);
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate void alGenAuxiliaryEffectSlotsDelegate (int n, out uint effectslots);
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate void alDeleteAuxiliaryEffectSlotsDelegate (int n, ref int effectslots);
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate void alAuxiliaryEffectSlotiDelegate (uint slot, EfxEffecti type, uint effect);
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate void alAuxiliaryEffectSlotfDelegate (uint slot, EfxEffectSlotf param, float value);
 
         /* Filter API */
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private unsafe delegate void alGenFiltersDelegate (int n, [Out] uint* filters);
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate void alFilteriDelegate (uint fid, EfxFilteri param, int value);
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private delegate void alFilterfDelegate (uint fid, EfxFilterf param, float value);
+        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         private unsafe delegate void alDeleteFiltersDelegate (int n, [In] uint* filters);
 
 

--- a/MonoGame.Framework/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Audio/OpenAL.cs
@@ -136,6 +136,11 @@ namespace OpenAL
         SlotEffect = 0x0001,
     }
 
+    public enum EfxEffectSlotf
+    {
+        EffectSlotGain = 0x0002,
+    }
+
     public enum EfxEffectf
     {
         EaxReverbDensity = 0x0001,
@@ -542,6 +547,7 @@ namespace OpenAL
         private delegate void alGenAuxiliaryEffectSlotsDelegate (int n, out uint effectslots);
         private delegate void alDeleteAuxiliaryEffectSlotsDelegate (int n, ref int effectslots);
         private delegate void alAuxiliaryEffectSlotiDelegate (uint slot, EfxEffecti type, uint effect);
+        private delegate void alAuxiliaryEffectSlotfDelegate (uint slot, EfxEffectSlotf param, float value);
 
         /* Filter API */
         private unsafe delegate void alGenFiltersDelegate (int n, [Out] uint* filters);
@@ -558,6 +564,7 @@ namespace OpenAL
         private alGenAuxiliaryEffectSlotsDelegate alGenAuxiliaryEffectSlots;
         private alDeleteAuxiliaryEffectSlotsDelegate alDeleteAuxiliaryEffectSlots;
         private alAuxiliaryEffectSlotiDelegate alAuxiliaryEffectSloti;
+        private alAuxiliaryEffectSlotfDelegate alAuxiliaryEffectSlotf;
         private alGenFiltersDelegate alGenFilters;
         private alFilteriDelegate alFilteri;
         private alFilterfDelegate alFilterf;
@@ -587,6 +594,7 @@ namespace OpenAL
             alGenAuxiliaryEffectSlots = (alGenAuxiliaryEffectSlotsDelegate)Marshal.GetDelegateForFunctionPointer (AL.GetProcAddress ("alGenAuxiliaryEffectSlots"), typeof (alGenAuxiliaryEffectSlotsDelegate));
             alDeleteAuxiliaryEffectSlots = (alDeleteAuxiliaryEffectSlotsDelegate)Marshal.GetDelegateForFunctionPointer (AL.GetProcAddress ("alDeleteAuxiliaryEffectSlots"), typeof (alDeleteAuxiliaryEffectSlotsDelegate));
             alAuxiliaryEffectSloti = (alAuxiliaryEffectSlotiDelegate)Marshal.GetDelegateForFunctionPointer (AL.GetProcAddress ("alAuxiliaryEffectSloti"), typeof (alAuxiliaryEffectSlotiDelegate));
+            alAuxiliaryEffectSlotf = (alAuxiliaryEffectSlotfDelegate)Marshal.GetDelegateForFunctionPointer (AL.GetProcAddress ("alAuxiliaryEffectSlotf"), typeof (alAuxiliaryEffectSlotfDelegate));
 
             alGenFilters = (alGenFiltersDelegate)Marshal.GetDelegateForFunctionPointer (AL.GetProcAddress ("alGenFilters"), typeof (alGenFiltersDelegate));
             alFilteri = (alFilteriDelegate)Marshal.GetDelegateForFunctionPointer (AL.GetProcAddress ("alFilteri"), typeof (alFilteriDelegate));
@@ -628,10 +636,16 @@ alEffecti (effect, EfxEffecti.FilterType, (int)EfxEffectType.Reverb);
             alDeleteEffects (1, ref effect);
         }
 
-        public void BindEffectToAuxiliarySlot (uint effect, uint slot)
+        public void BindEffectToAuxiliarySlot (uint slot, uint effect)
         {
             alAuxiliaryEffectSloti (slot,EfxEffecti.SlotEffect, effect);
             ALHelper.CheckError ("Failed to bind Effect");
+        }
+
+        public void AuxiliaryEffectSlot (uint slot, EfxEffectSlotf param, float value)
+        {
+            alAuxiliaryEffectSlotf (slot, param, value);
+            ALHelper.CheckError ("Failes to set " + param + " " + value);
         }
 
         public void BindSourceToAuxiliarySlot (int SounceId, int slot, int slotnumber, int filter)

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -207,6 +207,7 @@ namespace Microsoft.Xna.Framework.Audio
             efx.GenEffect (out ReverbEffect);
             efx.Effect (ReverbEffect, EfxEffecti.EffectType, (int)EfxEffectType.Reverb);
             efx.Effect (ReverbEffect, EfxEffectf.EaxReverbReflectionsDelay, reverbSettings.ReflectionsDelayMs / 1000.0f);
+            efx.Effect (ReverbEffect, EfxEffectf.LateReverbDelay, reverbSettings.ReverbDelayMs / 1000.0f);
             // map these from range 0-15 to 0-1
             efx.Effect (ReverbEffect, EfxEffectf.EaxReverbDiffusion, reverbSettings.EarlyDiffusion / 15f);
             efx.Effect (ReverbEffect, EfxEffectf.EaxReverbDiffusion, reverbSettings.LateDiffusion / 15f);
@@ -214,11 +215,12 @@ namespace Microsoft.Xna.Framework.Audio
             efx.Effect (ReverbEffect, EfxEffectf.EaxReverbLFReference, (reverbSettings.LowEqCutoff * 50f) + 50f);
             efx.Effect (ReverbEffect, EfxEffectf.EaxReverbGainHF, XactHelpers.ParseVolumeFromDecibels (reverbSettings.HighEqGain - 8f));
             efx.Effect (ReverbEffect, EfxEffectf.EaxReverbHFReference, (reverbSettings.HighEqCutoff * 500f) + 1000f);
-            efx.Effect (ReverbEffect, EfxEffectf.EaxReverbReflectionsGain, Math.Min (XactHelpers.ParseVolumeFromDecibels (reverbSettings.ReflectionsGainDb), 1.0f));
+            // According to Xamarin docs EaxReverbReflectionsGain Unit: Linear gain Range [0.0f .. 3.16f] Default: 0.05f
+            efx.Effect (ReverbEffect, EfxEffectf.EaxReverbReflectionsGain, Math.Min (XactHelpers.ParseVolumeFromDecibels (reverbSettings.ReflectionsGainDb), 3.16f));
             efx.Effect (ReverbEffect, EfxEffectf.EaxReverbGain, Math.Min (XactHelpers.ParseVolumeFromDecibels (reverbSettings.ReverbGainDb), 1.0f));
             // map these from 0-100 down to 0-1
             efx.Effect (ReverbEffect, EfxEffectf.EaxReverbDensity, reverbSettings.DensityPct / 100f);
-            efx.Effect (ReverbEffect, EfxEffectf.EaxReverbGain, reverbSettings.WetDryMixPct / 100f);
+            efx.AuxiliaryEffectSlot (ReverbSlot, EfxEffectSlotf.EffectSlotGain, reverbSettings.WetDryMixPct / 200f);
 
             // Dont know what to do with these EFX has no mapping for them. Just ignore for now
             // we can enable them as we go. 
@@ -233,7 +235,7 @@ namespace Microsoft.Xna.Framework.Audio
             //efx.SetEffectParam (ReverbEffect, EfxEffectf.LowFrequencyReference, reverbSettings.DecayTimeSec);
             //efx.SetEffectParam (ReverbEffect, EfxEffectf.LowFrequencyReference, reverbSettings.RoomSizeFeet);
 
-            efx.BindEffectToAuxiliarySlot (ReverbEffect, ReverbSlot);
+            efx.BindEffectToAuxiliarySlot (ReverbSlot, ReverbEffect);
 #endif
         }
 


### PR DESCRIPTION
The function pointers for OpenAL effects/filters were using
the platform default calling convention. On Mac and Linux
this is Cdecl, but on Windows it is StdCall.

OpenAL soft is built on windows using cdecl. As a result the
calls to these methods would either crash or produce unexpected
behaviour.