### PR TITLE
Misc tool fixes

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -114,6 +114,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// </remarks>
         private static string FindCommand(string command)
         {
+            // Expand any environment variables.
+            command = Environment.ExpandEnvironmentVariables(command);
+
             // If we have a full path just pass it through.
             if (File.Exists(command))
                 return command;

--- a/MonoGame.Framework.Content.Pipeline/LoadedTypeCollection.cs
+++ b/MonoGame.Framework.Content.Pipeline/LoadedTypeCollection.cs
@@ -21,6 +21,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 
         public LoadedTypeCollection()
         {
+            // Scan the already loaded assemblies.
+            if (_all == null)
+            {
+                var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+                foreach (var ass in assemblies)
+                    ScanAssembly(ass);
+            }
+
             // Hook into assembly loading events to gather any new
             // enumeration types that are found.
             AppDomain.CurrentDomain.AssemblyLoad += (sender, args) => ScanAssembly(args.LoadedAssembly);            
@@ -55,13 +63,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 
         public IEnumerator<T> GetEnumerator()
         {
-            if (_all == null)
-            {
-                var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-                foreach (var ass in assemblies)
-                    ScanAssembly(ass);
-            }
-
             return _all.GetEnumerator();
         }
 


### PR DESCRIPTION
- We now expand environment variables in paths passed to `ExternalTool.Run`.
- Easier to debug and more logical to scan assemblies on construction of `LoadedTypeCollection<>`.
