### PR TITLE
Added SamplerState.TextureFilterMode to correctly support comparison filtering

### DIFF
--- a/Build/Projects/2MGFX.definition
+++ b/Build/Projects/2MGFX.definition
@@ -106,6 +106,9 @@
     <Compile Include="..\..\MonoGame.Framework\Graphics\States\TextureFilter.cs">
       <Link>MonoGame.Framework\TextureFilter.cs</Link>
     </Compile>
+    <Compile Include="..\..\MonoGame.Framework\Graphics\States\TextureFilterMode.cs">
+      <Link>MonoGame.Framework\TextureFilterMode.cs</Link>
+    </Compile>
     <Compile Include="..\..\MonoGame.Framework\Graphics\Vertices\VertexElementUsage.cs">
       <Link>MonoGame.Framework\VertexElementUsage.cs</Link>
     </Compile>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -814,6 +814,7 @@
     <Compile Include="Graphics\States\TargetBlendState.cs" />
     <Compile Include="Graphics\States\TextureAddressMode.cs" />
     <Compile Include="Graphics\States\TextureFilter.cs" />
+    <Compile Include="Graphics\States\TextureFilterMode.cs" />
     <Compile Include="Graphics\SurfaceFormat.cs" />
     <Compile Include="Graphics\SwapChainRenderTarget.cs">
       <Platforms>Windows</Platforms>

--- a/MonoGame.Framework/Graphics/States/SamplerState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.DirectX.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #else
 				desc.BorderColor = BorderColor.ToColor4();
 #endif
-				desc.Filter = GetFilter(Filter, ComparisonFunction != CompareFunction.Never);
+				desc.Filter = GetFilter(Filter, FilterMode);
                 desc.MaximumAnisotropy = MaxAnisotropy;
                 desc.MipLodBias = MipMapLevelOfDetailBias;
                 desc.ComparisonFunction = ComparisonFunction.ToComparison();
@@ -58,77 +58,78 @@ namespace Microsoft.Xna.Framework.Graphics
             return _state;
         }
 
-        private static SharpDX.Direct3D11.Filter GetFilter(TextureFilter filter, bool comparison)
+        private static SharpDX.Direct3D11.Filter GetFilter(TextureFilter filter, TextureFilterMode mode)
         {
-            if (comparison)
+            switch (mode)
             {
-                switch (filter)
-                {
-                    case TextureFilter.Anisotropic:
-                        return SharpDX.Direct3D11.Filter.ComparisonAnisotropic;
+                case TextureFilterMode.Comparison:
+                    switch (filter)
+                    {
+                        case TextureFilter.Anisotropic:
+                            return SharpDX.Direct3D11.Filter.ComparisonAnisotropic;
 
-                    case TextureFilter.Linear:
-                        return SharpDX.Direct3D11.Filter.ComparisonMinMagMipLinear;
+                        case TextureFilter.Linear:
+                            return SharpDX.Direct3D11.Filter.ComparisonMinMagMipLinear;
 
-                    case TextureFilter.LinearMipPoint:
-                        return SharpDX.Direct3D11.Filter.ComparisonMinMagLinearMipPoint;
+                        case TextureFilter.LinearMipPoint:
+                            return SharpDX.Direct3D11.Filter.ComparisonMinMagLinearMipPoint;
 
-                    case TextureFilter.MinLinearMagPointMipLinear:
-                        return SharpDX.Direct3D11.Filter.ComparisonMinLinearMagPointMipLinear;
+                        case TextureFilter.MinLinearMagPointMipLinear:
+                            return SharpDX.Direct3D11.Filter.ComparisonMinLinearMagPointMipLinear;
 
-                    case TextureFilter.MinLinearMagPointMipPoint:
-                        return SharpDX.Direct3D11.Filter.ComparisonMinLinearMagMipPoint;
+                        case TextureFilter.MinLinearMagPointMipPoint:
+                            return SharpDX.Direct3D11.Filter.ComparisonMinLinearMagMipPoint;
 
-                    case TextureFilter.MinPointMagLinearMipLinear:
-                        return SharpDX.Direct3D11.Filter.ComparisonMinPointMagMipLinear;
+                        case TextureFilter.MinPointMagLinearMipLinear:
+                            return SharpDX.Direct3D11.Filter.ComparisonMinPointMagMipLinear;
 
-                    case TextureFilter.MinPointMagLinearMipPoint:
-                        return SharpDX.Direct3D11.Filter.ComparisonMinPointMagLinearMipPoint;
+                        case TextureFilter.MinPointMagLinearMipPoint:
+                            return SharpDX.Direct3D11.Filter.ComparisonMinPointMagLinearMipPoint;
 
-                    case TextureFilter.Point:
-                        return SharpDX.Direct3D11.Filter.ComparisonMinMagMipPoint;
+                        case TextureFilter.Point:
+                            return SharpDX.Direct3D11.Filter.ComparisonMinMagMipPoint;
 
-                    case TextureFilter.PointMipLinear:
-                        return SharpDX.Direct3D11.Filter.ComparisonMinMagPointMipLinear;
+                        case TextureFilter.PointMipLinear:
+                            return SharpDX.Direct3D11.Filter.ComparisonMinMagPointMipLinear;
 
-                    default:
-                        throw new ArgumentException("Invalid texture filter!");
-                }
-            }
-            else
-            {
-                switch (filter)
-                {
-                    case TextureFilter.Anisotropic:
-                        return SharpDX.Direct3D11.Filter.Anisotropic;
+                        default:
+                            throw new ArgumentException("Invalid texture filter!");
+                    }
+                case TextureFilterMode.Default:
+                    switch (filter)
+                    {
+                        case TextureFilter.Anisotropic:
+                            return SharpDX.Direct3D11.Filter.Anisotropic;
 
-                    case TextureFilter.Linear:
-                        return SharpDX.Direct3D11.Filter.MinMagMipLinear;
+                        case TextureFilter.Linear:
+                            return SharpDX.Direct3D11.Filter.MinMagMipLinear;
 
-                    case TextureFilter.LinearMipPoint:
-                        return SharpDX.Direct3D11.Filter.MinMagLinearMipPoint;
+                        case TextureFilter.LinearMipPoint:
+                            return SharpDX.Direct3D11.Filter.MinMagLinearMipPoint;
 
-                    case TextureFilter.MinLinearMagPointMipLinear:
-                        return SharpDX.Direct3D11.Filter.MinLinearMagPointMipLinear;
+                        case TextureFilter.MinLinearMagPointMipLinear:
+                            return SharpDX.Direct3D11.Filter.MinLinearMagPointMipLinear;
 
-                    case TextureFilter.MinLinearMagPointMipPoint:
-                        return SharpDX.Direct3D11.Filter.MinLinearMagMipPoint;
+                        case TextureFilter.MinLinearMagPointMipPoint:
+                            return SharpDX.Direct3D11.Filter.MinLinearMagMipPoint;
 
-                    case TextureFilter.MinPointMagLinearMipLinear:
-                        return SharpDX.Direct3D11.Filter.MinPointMagMipLinear;
+                        case TextureFilter.MinPointMagLinearMipLinear:
+                            return SharpDX.Direct3D11.Filter.MinPointMagMipLinear;
 
-                    case TextureFilter.MinPointMagLinearMipPoint:
-                        return SharpDX.Direct3D11.Filter.MinPointMagLinearMipPoint;
+                        case TextureFilter.MinPointMagLinearMipPoint:
+                            return SharpDX.Direct3D11.Filter.MinPointMagLinearMipPoint;
 
-                    case TextureFilter.Point:
-                        return SharpDX.Direct3D11.Filter.MinMagMipPoint;
+                        case TextureFilter.Point:
+                            return SharpDX.Direct3D11.Filter.MinMagMipPoint;
 
-                    case TextureFilter.PointMipLinear:
-                        return SharpDX.Direct3D11.Filter.MinMagPointMipLinear;
+                        case TextureFilter.PointMipLinear:
+                            return SharpDX.Direct3D11.Filter.MinMagPointMipLinear;
 
-                    default:
-                        throw new ArgumentException("Invalid texture filter!");
-                }
+                        default:
+                            throw new ArgumentException("Invalid texture filter!");
+                    }
+                default:
+                    throw new ArgumentException("Invalid texture filter mode!");
             }
         }
 

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -164,17 +164,20 @@ namespace Microsoft.Xna.Framework.Graphics
             GL.TexParameter(target, TextureParameterName.TextureLodBias, MipMapLevelOfDetailBias);
             GraphicsExtensions.CheckGLError();
             // Comparison samplers are not supported in OpenGL ES 2.0 (without an extension, anyway)
-            if (ComparisonFunction != CompareFunction.Never)
+            switch (FilterMode)
             {
-                GL.TexParameter(target, TextureParameterName.TextureCompareMode, (int) TextureCompareMode.CompareRefToTexture);
-                GraphicsExtensions.CheckGLError();
-                GL.TexParameter(target, TextureParameterName.TextureCompareFunc, (int) ComparisonFunction.GetDepthFunction());
-                GraphicsExtensions.CheckGLError();
-            }
-            else
-            {
-                GL.TexParameter(target, TextureParameterName.TextureCompareMode, (int) TextureCompareMode.None);
-                GraphicsExtensions.CheckGLError();
+                case TextureFilterMode.Comparison:
+                    GL.TexParameter(target, TextureParameterName.TextureCompareMode, (int) TextureCompareMode.CompareRefToTexture);
+                    GraphicsExtensions.CheckGLError();
+                    GL.TexParameter(target, TextureParameterName.TextureCompareFunc, (int) ComparisonFunction.GetDepthFunction());
+                    GraphicsExtensions.CheckGLError();
+                    break;
+                case TextureFilterMode.Default:
+                    GL.TexParameter(target, TextureParameterName.TextureCompareMode, (int) TextureCompareMode.None);
+                    GraphicsExtensions.CheckGLError();
+                    break;
+                default:
+                    throw new InvalidOperationException("Invalid filter mode!");
             }
 #endif
             if (GraphicsDevice.GraphicsCapabilities.SupportsTextureMaxLevel)

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private int _maxAnisotropy;
         private int _maxMipLevel;
         private float _mipMapLevelOfDetailBias;
+        private TextureFilterMode _filterMode;
         private CompareFunction _comparisonFunction;
 
         public TextureAddressMode AddressU
@@ -127,6 +128,16 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        public TextureFilterMode FilterMode
+        {
+            get { return _filterMode; }
+            set
+            {
+                ThrowIfBound();
+                _filterMode = value;
+            }
+        }
+
         internal void BindToGraphicsDevice(GraphicsDevice device)
         {
             if (_defaultStateObject)
@@ -155,6 +166,7 @@ namespace Microsoft.Xna.Framework.Graphics
             MaxMipLevel = 0;
             MipMapLevelOfDetailBias = 0.0f;
             ComparisonFunction = CompareFunction.Never;
+            FilterMode = TextureFilterMode.Default;
         }
 
         private SamplerState(string name, TextureFilter filter, TextureAddressMode addressMode)
@@ -180,6 +192,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _maxMipLevel = cloneSource._maxMipLevel;
             _mipMapLevelOfDetailBias = cloneSource._mipMapLevelOfDetailBias;
             _comparisonFunction = cloneSource._comparisonFunction;
+            _filterMode = cloneSource._filterMode;
         }
 
         internal SamplerState Clone()

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -118,6 +118,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// When using comparison sampling, also set <see cref="FilterMode"/> to <see cref="TextureFilterMode.Comparison"/>.
+        /// </summary>
         public CompareFunction ComparisonFunction
         {
             get { return _comparisonFunction; }

--- a/MonoGame.Framework/Graphics/States/TextureFilterMode.cs
+++ b/MonoGame.Framework/Graphics/States/TextureFilterMode.cs
@@ -1,5 +1,12 @@
-﻿namespace Microsoft.Xna.Framework.Graphics
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Filtering modes for texture samplers.
+    /// </summary>
     public enum TextureFilterMode
     {
         Default,

--- a/MonoGame.Framework/Graphics/States/TextureFilterMode.cs
+++ b/MonoGame.Framework/Graphics/States/TextureFilterMode.cs
@@ -1,0 +1,8 @@
+﻿namespace Microsoft.Xna.Framework.Graphics
+{
+    public enum TextureFilterMode
+    {
+        Default,
+        Comparison
+    }
+}

--- a/Test/Framework/Graphics/SamplerStateTest.cs
+++ b/Test/Framework/Graphics/SamplerStateTest.cs
@@ -115,7 +115,7 @@ namespace MonoGame.Tests.Graphics
 #endif
 
 #if !XNA
-        [Test, Ignore]
+        [Test]
         public void VisualTestComparisonFunction()
         {
             PrepareFrameCapture();
@@ -150,7 +150,8 @@ namespace MonoGame.Tests.Graphics
                     AddressU = TextureAddressMode.Clamp,
                     AddressV = TextureAddressMode.Clamp,
                     AddressW = TextureAddressMode.Clamp,
-                    ComparisonFunction = compares[i]
+                    ComparisonFunction = compares[i],
+                    FilterMode = TextureFilterMode.Comparison
                 };
 
             var customEffect = AssetTestUtility.CompileEffect(gd, 


### PR DESCRIPTION
@tomspilman This adds a property to SamplerState so the user can explicitly set the TextureFilterMode to Compare and leaves room for more TextureFilterModes in the future. We no longer use CompareFunction.Never to indicate we don't want to use a CompareFunction. Instead it can be used like any other CompareFunction when SamplerState.FilterMode is set to TextureFilterMode.Compare. Discussion about this started in #5072 