### PR TITLE
Optimized and added additional constructors to Color

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -263,10 +263,19 @@ namespace Microsoft.Xna.Framework
         public Color(int r, int g, int b)
         {
             _packedValue = 0;
-            R = (byte)MathHelper.Clamp(r, Byte.MinValue, Byte.MaxValue);
-            G = (byte)MathHelper.Clamp(g, Byte.MinValue, Byte.MaxValue);
-            B = (byte)MathHelper.Clamp(b, Byte.MinValue, Byte.MaxValue);
-            A = (byte)255;
+            if (((r | g | b) & 0xFFFFFF00) != 0)
+            {
+                R = (byte)MathHelper.Clamp(r, Byte.MinValue, Byte.MaxValue);
+                G = (byte)MathHelper.Clamp(g, Byte.MinValue, Byte.MaxValue);
+                B = (byte)MathHelper.Clamp(b, Byte.MinValue, Byte.MaxValue);
+            }
+            else
+            {
+                R = (byte)r;
+                G = (byte)g;
+                B = (byte)b;
+            }
+            A = 255;
         }
 
         /// <summary>
@@ -279,10 +288,20 @@ namespace Microsoft.Xna.Framework
         public Color(int r, int g, int b, int alpha)
         {
             _packedValue = 0;
-            R = (byte)MathHelper.Clamp(r, Byte.MinValue, Byte.MaxValue);
-            G = (byte)MathHelper.Clamp(g, Byte.MinValue, Byte.MaxValue);
-            B = (byte)MathHelper.Clamp(b, Byte.MinValue, Byte.MaxValue);
-            A = (byte)MathHelper.Clamp(alpha, Byte.MinValue, Byte.MaxValue);
+            if (((r | g | b | alpha) & 0xFFFFFF00) != 0)
+            {
+                R = (byte)MathHelper.Clamp(r, Byte.MinValue, Byte.MaxValue);
+                G = (byte)MathHelper.Clamp(g, Byte.MinValue, Byte.MaxValue);
+                B = (byte)MathHelper.Clamp(b, Byte.MinValue, Byte.MaxValue);
+                A = (byte)MathHelper.Clamp(alpha, Byte.MinValue, Byte.MaxValue);
+            }
+            else
+            {
+                R = (byte)r;
+                G = (byte)g;
+                B = (byte)b;
+                A = (byte)alpha;
+            }
         }
 
         /// <summary>

--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -165,7 +165,13 @@ namespace Microsoft.Xna.Framework
 	// ARGB
         private uint _packedValue;
 	  
-        private Color(uint packedValue)
+        /// <summary>
+        /// Constructs an RGBA color from a packed value.
+        /// The value is a 32-bit unsigned integer, with R in the least significant octet.
+        /// </summary>
+        /// <param name="packedValue">The packed value.</param>
+        [CLSCompliant(false)]
+        public Color(uint packedValue)
         {
             _packedValue = packedValue;
 			// ARGB
@@ -233,7 +239,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Constructs an RGBA color from scalars which representing red, green and blue values. Alpha value will be opaque.
+        /// Constructs an RGBA color from scalars representing red, green and blue values. Alpha value will be opaque.
         /// </summary>
         /// <param name="r">Red component value from 0.0f to 1.0f.</param>
         /// <param name="g">Green component value from 0.0f to 1.0f.</param>
@@ -249,7 +255,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Constructs an RGBA color from scalars which representing red, green and blue values. Alpha value will be opaque.
+        /// Constructs an RGBA color from scalars representing red, green and blue values. Alpha value will be opaque.
         /// </summary>
         /// <param name="r">Red component value from 0 to 255.</param>
         /// <param name="g">Green component value from 0 to 255.</param>
@@ -264,7 +270,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Constructs an RGBA color from scalars which representing red, green, blue and alpha values.
+        /// Constructs an RGBA color from scalars representing red, green, blue and alpha values.
         /// </summary>
         /// <param name="r">Red component value from 0 to 255.</param>
         /// <param name="g">Green component value from 0 to 255.</param>
@@ -280,7 +286,26 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Constructs an RGBA color from scalars which representing red, green, blue and alpha values.
+        /// Constructs an RGBA color from scalars representing red, green, blue and alpha values.
+        /// </summary>
+        /// <remarks>
+        /// This overload sets the values directly without clamping, and may therefore be faster than the other overloads.
+        /// </remarks>
+        /// <param name="r"></param>
+        /// <param name="g"></param>
+        /// <param name="b"></param>
+        /// <param name="alpha"></param>
+        public Color(byte r, byte g, byte b, byte alpha)
+        {
+            _packedValue = 0;
+            R = r;
+            G = g;
+            B = b;
+            A = alpha;
+        }
+
+        /// <summary>
+        /// Constructs an RGBA color from scalars representing red, green, blue and alpha values.
         /// </summary>
         /// <param name="r">Red component value from 0.0f to 1.0f.</param>
         /// <param name="g">Green component value from 0.0f to 1.0f.</param>

--- a/Test/Framework/ColorTest.cs
+++ b/Test/Framework/ColorTest.cs
@@ -52,6 +52,50 @@ namespace MonoGame.Tests.Framework
             Assert.That(color.A, Is.EqualTo(32));
         }
 #endif
+        
+        [Test]
+        public void FromNonPremultiplied_Int()
+        {
+            var color = Color.FromNonPremultiplied(255, 128, 64, 128);
+            Assert.That(color.R, Is.EqualTo(128).Within(1));
+            Assert.That(color.G, Is.EqualTo(64).Within(1));
+            Assert.That(color.B, Is.EqualTo(32).Within(1));
+            Assert.That(color.A, Is.EqualTo(128).Within(0));
+
+            var overflow = Color.FromNonPremultiplied(280, 128, -10, 128);
+            Assert.That(overflow.R, Is.EqualTo(140).Within(1));
+            Assert.That(overflow.G, Is.EqualTo(64).Within(1));
+            Assert.That(overflow.B, Is.EqualTo(0).Within(1));
+            Assert.That(overflow.A, Is.EqualTo(128).Within(0));
+
+            var overflow2 = Color.FromNonPremultiplied(255, 128, 64, 280);
+            Assert.That(overflow2.R, Is.EqualTo(255).Within(1));
+            Assert.That(overflow2.G, Is.EqualTo(140).Within(1));
+            Assert.That(overflow2.B, Is.EqualTo(70).Within(1));
+            Assert.That(overflow2.A, Is.EqualTo(255).Within(0));
+        }
+
+        [Test]
+        public void FromNonPremultiplied_Float()
+        {
+            var color = Color.FromNonPremultiplied(new Vector4(1.0f, 0.5f, 0.25f, 0.5f));
+            Assert.That(color.R, Is.EqualTo(128).Within(1));
+            Assert.That(color.G, Is.EqualTo(64).Within(1));
+            Assert.That(color.B, Is.EqualTo(32).Within(1));
+            Assert.That(color.A, Is.EqualTo(128).Within(1));
+
+            var overflow = Color.FromNonPremultiplied(new Vector4(1.1f, 0.5f, -0.1f, 0.5f));
+            Assert.That(overflow.R, Is.EqualTo(140).Within(1));
+            Assert.That(overflow.G, Is.EqualTo(64).Within(1));
+            Assert.That(overflow.B, Is.EqualTo(0).Within(1));
+            Assert.That(overflow.A, Is.EqualTo(128).Within(1));
+
+            var overflow2 = Color.FromNonPremultiplied(new Vector4(1f, 0.5f, 0.25f, 1.1f));
+            Assert.That(overflow2.R, Is.EqualTo(255).Within(1));
+            Assert.That(overflow2.G, Is.EqualTo(140).Within(1));
+            Assert.That(overflow2.B, Is.EqualTo(70).Within(1));
+            Assert.That(overflow2.A, Is.EqualTo(255).Within(1));
+        }
 
         [Test]
         public void Multiply()

--- a/Test/Framework/ColorTest.cs
+++ b/Test/Framework/ColorTest.cs
@@ -10,16 +10,24 @@ namespace MonoGame.Tests.Framework
         {
 #if !XNA
             new object[] { new Color(new Color(64, 128, 192), 32), 64, 128, 192, 32 },
+            new object[] { new Color(new Color(64, 128, 192), 256), 64, 128, 192, 255 },
             new object[] { new Color(new Color(64, 128, 192), 0.125f), 64, 128, 192, 32 },
+            new object[] { new Color(new Color(64, 128, 192), 1.1f), 64, 128, 192, 255 },
             new object[] { new Color((byte)64, (byte)128, (byte)192, (byte)32), 64, 128, 192, 32 },
 #endif
             new object[] { new Color(), 0, 0, 0, 0 },
             new object[] { new Color(64, 128, 192), 64, 128, 192, 255 },
+            new object[] { new Color(256, 256, -1), 255, 255, 0, 255},
             new object[] { new Color(64, 128, 192, 32), 64, 128, 192, 32 },
+            new object[] { new Color(256, 256, -1, 256), 255, 255, 0, 255},
             new object[] { new Color(0.25f, 0.5f, 0.75f), 64, 128, 192, 255 },
+            new object[] { new Color(1.1f, 1.1f, -0.1f), 255, 255, 0, 255 },
             new object[] { new Color(0.25f, 0.5f, 0.75f, 0.125f), 64, 128, 192, 32 },
+            new object[] { new Color(1.1f, 1.1f, -0.1f, -0.1f), 255, 255, 0, 0 },
             new object[] { new Color(new Vector3(0.25f, 0.5f, 0.75f)), 64, 128, 192, 255 },
-            new object[] { new Color(new Vector4(0.25f, 0.5f, 0.75f, 0.125f)), 64, 128, 192, 32 }
+            new object[] { new Color(new Vector3(1.1f, 1.1f, -0.1f)), 255, 255, 0, 255 },
+            new object[] { new Color(new Vector4(0.25f, 0.5f, 0.75f, 0.125f)), 64, 128, 192, 32 },
+            new object[] { new Color(new Vector4(1.1f, 1.1f, -0.1f, -0.1f)), 255, 255, 0, 0 }
         };
 
         [Test, TestCaseSource("_ctorTestCases")]

--- a/Test/Framework/ColorTest.cs
+++ b/Test/Framework/ColorTest.cs
@@ -5,6 +5,46 @@ namespace MonoGame.Tests.Framework
 {
     class ColorTest
     {
+        // Contains a test case for each constructor type
+        private object[] _ctorTestCases =
+        {
+#if !XNA
+            new object[] { new Color(new Color(64, 128, 192), 32), 64, 128, 192, 32 },
+            new object[] { new Color(new Color(64, 128, 192), 0.125f), 64, 128, 192, 32 },
+            new object[] { new Color((byte)64, (byte)128, (byte)192, (byte)32), 64, 128, 192, 32 },
+#endif
+            new object[] { new Color(), 0, 0, 0, 0 },
+            new object[] { new Color(64, 128, 192), 64, 128, 192, 255 },
+            new object[] { new Color(64, 128, 192, 32), 64, 128, 192, 32 },
+            new object[] { new Color(0.25f, 0.5f, 0.75f), 64, 128, 192, 255 },
+            new object[] { new Color(0.25f, 0.5f, 0.75f, 0.125f), 64, 128, 192, 32 },
+            new object[] { new Color(new Vector3(0.25f, 0.5f, 0.75f)), 64, 128, 192, 255 },
+            new object[] { new Color(new Vector4(0.25f, 0.5f, 0.75f, 0.125f)), 64, 128, 192, 32 }
+        };
+
+        [Test, TestCaseSource("_ctorTestCases")]
+        public void Ctor_Explicit(Color color, int expectedR, int expectedG, int expectedB, int expectedA)
+        {
+            // Account for rounding differences with float constructors
+            Assert.That(color.R, Is.EqualTo(expectedR).Within(1));
+            Assert.That(color.G, Is.EqualTo(expectedG).Within(1));
+            Assert.That(color.B, Is.EqualTo(expectedB).Within(1));
+            Assert.That(color.A, Is.EqualTo(expectedA).Within(1));
+        }
+
+#if !XNA
+        [Test]
+        public void Ctor_Packed()
+        {
+            var color = new Color(0x20C08040);
+
+            Assert.That(color.R, Is.EqualTo(64));
+            Assert.That(color.G, Is.EqualTo(128));
+            Assert.That(color.B, Is.EqualTo(192));
+            Assert.That(color.A, Is.EqualTo(32));
+        }
+#endif
+
         [Test]
         public void Multiply()
         {


### PR DESCRIPTION
Fixes #4824. Added the `Color(byte, byte, byte, byte)` constructor and made `Color(uint)` public. Also added some simple unit tests for the constructors and corrected a minor typo.

In the issue, there was some discussion about a separate `Color.FromBytes()` method, but I opted for another constructor overload, since the parameters must be `byte`s in either case. I did not add a `Color(byte, byte, byte)` overload with constant alpha to avoid excessive overloads - this is a more "advanced" overload after all. This can be changed if it makes the API cleaner, of course.

As expected, the new `byte` overload is clearly (40-60%) faster than the `int` version in a quick microbenchmark.