### PR TITLE
Fix SpriteEffect half pixel offset

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var projection = Matrix.CreateOrthographicOffCenter(0, viewport.Width, viewport.Height, 0, 0, 1);
             var halfPixelOffset = Matrix.CreateTranslation(0, 0, 0);
 
-            if (NeedsHalfPixelOffset){
+            if (SpriteBatch.NeedsHalfPixelOffset){
                 halfPixelOffset += Matrix.CreateTranslation(-0.5f, -0.5f, 0);
             }
 

--- a/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
@@ -64,7 +64,11 @@ namespace Microsoft.Xna.Framework.Graphics
             var viewport = GraphicsDevice.Viewport;
 
             var projection = Matrix.CreateOrthographicOffCenter(0, viewport.Width, viewport.Height, 0, 0, 1);
-            var halfPixelOffset = Matrix.CreateTranslation(-0.5f, -0.5f, 0);
+            var halfPixelOffset = Matrix.CreateTranslation(0, 0, 0);
+
+            if (NeedsHalfPixelOffset){
+                halfPixelOffset += Matrix.CreateTranslation(-0.5f, -0.5f, 0);
+            }
 
             matrixParam.SetValue(halfPixelOffset * projection);
         }


### PR DESCRIPTION
Fixed the issue #4939 when the NeedsHalfPixelOffset tag was not being used in the SpriteEffect class.