### PR TITLE
Add a null reference check on DisplayMode for #5040

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -213,8 +213,18 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void Setup()
         {
-			// Initialize the main viewport
-			_viewport = new Viewport (0, 0,
+#if DEBUG
+            if (DisplayMode == null)
+            {
+                throw new ApplicationException(
+                    "Unable to determine the current display mode.  This can indicate that the " +
+                    "game is not configured to be HiDPI aware under Windows 10 or later.  See " +
+                    "https://github.com/MonoGame/MonoGame/issues/5040 for more information.");
+            }
+#endif
+
+            // Initialize the main viewport
+            _viewport = new Viewport (0, 0,
 			                         DisplayMode.Width, DisplayMode.Height);
 			_viewport.MaxDepth = 1.0f;
 


### PR DESCRIPTION
There's currently a fix for #5040 in the form of adjusting templates, however this only assists developers creating new projects going forward.  For existing developers, they need to add or create an `app.manifest` file in their project.

We wasted about 6 hours remotely debugging this issue before we realised it was that Windows 10 configures a 125% DPI by default, and that on this particular machine that setting hadn't been changed to be 100%.  We then found #5040 which then documented the issue.

This adds a null check in `DEBUG` builds so that if DisplayMode is null, the developer gets a much more useful exception around the potential issue that might be occurring.