### PR TITLE
WinDX: Implemented a more reliable keyboard input method

### DIFF
--- a/MonoGame.Framework/Input/Keyboard.Windows.cs
+++ b/MonoGame.Framework/Input/Keyboard.Windows.cs
@@ -4,21 +4,57 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Input
 {
     public static partial class Keyboard
     {
-        static List<Keys> _keys;
+        private static readonly Keys[] DefinedKeys;
+
+        private static readonly byte[] _keyState = new byte[256];
+        private static readonly List<Keys> _keys = new List<Keys>(10);
+
+        private static bool _isActive;
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetKeyboardState(byte[] lpKeyState);
+
+        private static readonly Predicate<Keys> IsKeyReleasedPredicate = key => !IsKeyPressed(key);
+
+        static Keyboard()
+        {
+            DefinedKeys = Enum.GetValues(typeof(Keys)).Cast<Keys>()
+                .Where(k => ((int)k >= 1) && ((int)k <= 255))
+                .ToArray();
+        }
 
         private static KeyboardState PlatformGetState()
         {
+            if (_isActive && GetKeyboardState(_keyState))
+            {
+                _keys.RemoveAll(IsKeyReleasedPredicate);
+
+                foreach (var key in DefinedKeys)
+                    if (IsKeyPressed(key) && !_keys.Contains(key))
+                        _keys.Add(key);
+            }
+
             return new KeyboardState(_keys, Console.CapsLock, Console.NumberLock);
         }
 
-        internal static void SetKeys(List<Keys> keys)
+        private static bool IsKeyPressed(Keys key)
         {
-            _keys = keys;
+            return ((_keyState[(int)key] & 0x80) != 0);
+        }
+
+        internal static void SetActive(bool isActive)
+        {
+            _isActive = isActive;
+            if (!_isActive)
+                _keys.Clear();
         }
     }
 }

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -3,14 +3,11 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using Microsoft.Xna.Framework;
 using System.Windows.Forms;
 using Microsoft.Xna.Framework.Input;
-using XnaKeys = Microsoft.Xna.Framework.Input.Keys;
-
 
 namespace MonoGame.Framework
 {
@@ -19,16 +16,11 @@ namespace MonoGame.Framework
         //internal static string LaunchParameters;
 
         private WinFormsGameWindow _window;
-        private readonly List<XnaKeys> _keyState;
 
         public WinFormsGamePlatform(Game game)
             : base(game)
         {
-            _keyState = new List<XnaKeys>();
-            Keyboard.SetKeys(_keyState);
-
             _window = new WinFormsGameWindow(this);
-            _window.KeyState = _keyState;
 
             Mouse.Window = _window._form;
 
@@ -187,7 +179,6 @@ namespace MonoGame.Framework
                 }
                 Microsoft.Xna.Framework.Media.MediaManagerState.CheckShutdown();
             }
-            Keyboard.SetKeys(null);
 
             base.Dispose(disposing);
         }


### PR DESCRIPTION
Fixes #5122

As discussed in issue #5122, this replaces DirectX RawInput with Windows GetKeyboardState for retrieving keyboard input.

This resolves "stuck" key issues when opening the Steam overlay, and should eliminate any other potential for stuck keys.