### PR TITLE
Throw NoSuitableGraphicsDeviceException if graphics device creation fails

### DIFF
--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -99,7 +99,18 @@ namespace Microsoft.Xna.Framework
             if (_graphicsDevice != null)
                 return;
 
-            Initialize();
+            try
+            {
+                Initialize();
+            }
+            catch (NoSuitableGraphicsDeviceException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new NoSuitableGraphicsDeviceException("Failed to create graphics device!", ex);
+            }
 
             OnDeviceCreated(EventArgs.Empty);
         }


### PR DESCRIPTION
Resolves #5123

As per issue #5123, this catches any exceptions during graphics device creation and wraps them in a `NoSuitableGraphicsDeviceException`. This allows the MonoGame user to catch this exception and handle appropriately (e.g. informing the user to check that their graphics device is compatible and that drivers are up to date).