### PR TITLE
Fix SoundEffect disposal test to not use internal constructor

### DIFF
--- a/Test/Framework/Audio/SoundEffectTest.cs
+++ b/Test/Framework/Audio/SoundEffectTest.cs
@@ -272,15 +272,12 @@ namespace MonoGame.Tests.Audio
         public void InstanceNotDisposedWhenGameDisposed()
         {
             var game = new Game();
-            var s = new SoundEffectInstance();
             var d = new DynamicSoundEffectInstance(44100, AudioChannels.Stereo);
 
             game.Dispose();
 
-            Assert.IsFalse(s.IsDisposed);
             Assert.IsFalse(d.IsDisposed);
 
-            s.Dispose();
             d.Dispose();
         }
 

--- a/Test/Framework/Audio/SoundEffectTest.cs
+++ b/Test/Framework/Audio/SoundEffectTest.cs
@@ -270,7 +270,7 @@ namespace MonoGame.Tests.Audio
         }
 
         // TODO creating/disposing a Game should not create/dispose the master voice
-        [Test]
+        [Test, Ignore]
         public void InstanceNotDisposedWhenGameDisposed()
         {
             var game = new Game();

--- a/Test/Framework/Audio/SoundEffectTest.cs
+++ b/Test/Framework/Audio/SoundEffectTest.cs
@@ -269,15 +269,22 @@ namespace MonoGame.Tests.Audio
             Assert.Throws<ArgumentException>(() => new SoundEffect(new byte[2], 0, 2, 8000, AudioChannels.Mono, 0, int.MaxValue));
         }
 
+        // TODO creating/disposing a Game should not create/dispose the master voice
+        [Test]
         public void InstanceNotDisposedWhenGameDisposed()
         {
             var game = new Game();
+
+            var se = new SoundEffect(new byte[16000], 8000, AudioChannels.Mono);
+            var s = se.CreateInstance();
             var d = new DynamicSoundEffectInstance(44100, AudioChannels.Stereo);
 
             game.Dispose();
 
+            Assert.IsFalse(s.IsDisposed);
             Assert.IsFalse(d.IsDisposed);
 
+            s.Dispose();
             d.Dispose();
         }
 


### PR DESCRIPTION
XNA tests didn't compile because an internal SoundEffectInstance constructor was used in the InstanceNotDisposed test. This test was also not run because it was missing the "Test" attribute. 

After adding it in, the test ran fine in XNA but failed in MG because when Game is disposed the master voice is also disposed and you don't have access to the subvoices after that. I don't think XNA disposes of the master voice when game is disposed because trying to use a SFX after disposing game will work in XNA. The 'fix' in the first commit here is crap, because it doesn't solve anything, but I only just realised that :p 

I think Game really shouln't be involved in this to keep things nicely separated. It would be nice if you could run Audio through MG without creating a Game (just using MG as an audio wrapper). So I'd like to expose functions to setup audio (automatically done when creating a game) and dispose of all audio (not called by game) so the user has more control and game disposal doesn't kill all audio (compliant with XNA behaviour). Thoughts?
