### PR TITLE
Added Localized Resource Processing and Loading.

### DIFF
--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -105,6 +105,7 @@
     <Compile Include="Graphics\Etc1BitmapContent.cs" />
     <Compile Include="Graphics\FontDescription.cs" />
     <Compile Include="Graphics\FontDescriptionStyle.cs" />
+    <Compile Include="Graphics\LocalizedFontDescription.cs" />
     <Compile Include="Graphics\GeometryContent.cs" />
     <Compile Include="Graphics\GeometryContentCollection.cs" />
     <Compile Include="Graphics\Font\Glyph.cs" />
@@ -149,6 +150,7 @@
     <Compile Include="Processors\EffectProcessor.cs" />
     <Compile Include="Processors\EffectProcessorDebugMode.cs" />
     <Compile Include="Processors\FontDescriptionProcessor.cs" />
+    <Compile Include="Processors\LocalizedFontProcessor.cs" />
     <Compile Include="Processors\FontTextureProcessor.cs" />
     <Compile Include="Processors\MaterialProcessor.cs" />
     <Compile Include="Processors\MaterialProcessorDefaultEffect.cs" />

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -1086,6 +1086,12 @@
     <Content Include="Assets\Textures\Surge.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Fonts\Localized.spritefont">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\Fonts\Strings.resx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
 
     <Content Include="Assets\Effects\DirectX\Bevels.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -334,6 +334,12 @@
     <Content Include="Templates\SpriteFont.template">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Templates\LocalizedSpriteFont.spritefont">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\LocalizedSpriteFont.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
 
     <BundleResource Include="Resources\App.icns">
       <Platforms>MacOS</Platforms>

--- a/Documentation/config.xml
+++ b/Documentation/config.xml
@@ -35,7 +35,7 @@
         <topic id="Using_The_Pipeline_Tool" name="Using The Pipeline Tool" filename="using_pipeline_tool.md"/>
         <topic id="Custom_Effects" name="Custom Effects" filename="custom_effects.md"/>
         <topic id="Using_TrueType_Fonts" name="Using TrueType Fonts" filename="adding_ttf_fonts.md"/>
-	<topic id="Localization" name="Localization" filename="localization.md" />
+    <topic id="Localization" name="Localization" filename="localization.md" />
     </topic>
 
     <topic id="Tools" name="Tools" filename="tools.md">

--- a/Documentation/config.xml
+++ b/Documentation/config.xml
@@ -35,6 +35,7 @@
         <topic id="Using_The_Pipeline_Tool" name="Using The Pipeline Tool" filename="using_pipeline_tool.md"/>
         <topic id="Custom_Effects" name="Custom Effects" filename="custom_effects.md"/>
         <topic id="Using_TrueType_Fonts" name="Using TrueType Fonts" filename="adding_ttf_fonts.md"/>
+	<topic id="Localization" name="Localization" filename="localization.md" />
     </topic>
 
     <topic id="Tools" name="Tools" filename="tools.md">

--- a/Documentation/localization.md
+++ b/Documentation/localization.md
@@ -144,5 +144,5 @@ These values are retrieved from
 	CultureInfo.CurrentCulture.TwoLetterISOLanguageName     // eg. "en"
 ```
 
-which are part of the System.Globalization namespace. On a side not you can also use the `LoadLocalized` to load language 
+which are part of the System.Globalization namespace. On a side note you can also use the `LoadLocalized` to load language 
 specific SpriteFonts. They just need to be named in the same way as we have described above.

--- a/Documentation/localization.md
+++ b/Documentation/localization.md
@@ -93,7 +93,7 @@ You should end up with a .spritefont file like this
     <CharacterRegions>
       <CharacterRegion>
         <Start>&#32;</Start>
-        <End>&#126;</End>
+        <End>&#32;</End>
       </CharacterRegion>
     </CharacterRegions>
     <ResourceFiles>
@@ -120,7 +120,7 @@ SpriteFont.
 
 # Other Localized assets
 
-Note all localized assets will be fonts. In certain situtions you might need to swap out an entire texture or spritesheet.
+Not all localized assets will be fonts. In certain situtions you might need to swap out an entire texture or spritesheet.
 For these cases a new method has been added to the ContentManager, LoadLocalized. The idea behind this method is that it will
 look for localized files BEFORE loading the default one. 
 
@@ -144,4 +144,5 @@ These values are retrieved from
 	CultureInfo.CurrentCulture.TwoLetterISOLanguageName     // eg. "en"
 ```
 
-which are part of the System.Globalization namespace.
+which are part of the System.Globalization namespace. On a side not you can also use the `LoadLocalized` to load language 
+specific SpriteFonts. They just need to be named in the same way as we have described above.

--- a/Documentation/localization.md
+++ b/Documentation/localization.md
@@ -1,0 +1,147 @@
+Localization is an important part of any game. While it can be possible to design a
+game that is region independent, its quite hard. At some point you will need to 
+produce localized text and graphics. 
+
+MonoGame has a simple localization system built in. If you want to develop your own
+system you are still able to do so. But the default system should be good enough for
+most use cases.
+
+# Creating resx files.
+
+MonoGame runs on .net/Mono on most platforms. Localization is handled by those platforms
+via the use of resx files. There are walkthroughs on [MSDN](https://msdn.microsoft.com/en-us/library/aa992030(v=vs.100).aspx)
+which walk you through the process. A simplified version is presented here.
+
+Create a .resx file in the IDE e.g Foo.resx and add it to your game project. Note this needs to be added to the 
+main app projects. The Foo.resx file should have an Action of EmbeddedResouce and a Generator value of ResXFileCodeGenerator. 
+There is a snippet from the .csproj
+
+```xml
+    <EmbeddedResource Include="Foo.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Foo.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+```
+
+Add any string resources to that file. These are in the form of a Key/Value pair. You can use the built in editor 
+or manually edit the .resx file by hand. Its an xml file so you can view the contents easily.
+
+```xml
+	<data name="Wall_Style" xml:space="preserve">
+		<value>Wall Style : {0}</value>
+	</data>
+```
+
+What happens when the resx is processed by the generator and produces a Foo.Designer.cs file which is then 
+included in your project. You can then access the "string" value by using code as follows
+
+```csharp
+	var s = MyProject.Foo.Wall_Style;
+```
+
+Note in the example we have a place holder ({0}) for additional text. You can still use te property of Foo.Wall_Style with
+things like string.Format.
+
+```csharp
+	int i = 1;
+	var s = string.Format (MyProject.Foo.Wall_Style, i);
+```
+
+All this means you dont need to hard the string directly. When accessing MyProject.Foo.Wall_Style the code will lookup the value from 
+the embedded resx file. 
+
+You can add support for a new language by adding a new resx file which uses the language/region code e.g Foo.de-DE.resx.
+This new file will contain the translations for that language/region. In the example we are targetting German.
+ 
+## Universal Windows Platform (UWP) considerations.
+
+Unfortunately UWP does not support resx files anymore. They have a new file called resw. The format is similar but 
+incompatible. As a result you will need to duplicate the data into a set of resw files to get the to work on UWP. The 
+process is like the standrd resx process.
+
+# Upgrading your SpriteFont files
+
+By default the SpriteFont processor uses a limited set of characters to generate the font. While this is fine for english 
+languages it would probably not include special characters needed for other languages (French, Arabic, Korean etc).
+
+As a result MonoGame has a LocalizedFontProcessor which does something slightly different. The process looks at the resx 
+files you provide it with and generates an optimized spritefont which only contains the characters your game uses. 
+
+To make use of this functionality you ned to tell the spritefont which resx files to use. Open the .spritefont with a 
+xml/text editor and add lines like this inside the Asset node
+
+```xml
+<ResourceFiles>
+      <Resx>..\Foo.resx</Resx>
+      <Resx>..\Foo.de-DE.resx</Resx>
+</ResourceFiles>
+```
+
+Note the paths are relative to the .spritefont directory. In the example above the resx files are in the directory
+above the .spritefont.
+
+You should end up with a .spritefont file like this
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<XnaContent xmlns:Graphics="Microsoft.Xna.Framework.Content.Pipeline.Graphics">
+  <Asset Type="Graphics:FontDescription">
+    <FontName>Verdana</FontName>
+    <Size>14</Size>
+    <Spacing>1</Spacing>
+    <Style>Regular</Style>
+    <CharacterRegions>
+      <CharacterRegion>
+        <Start>&#32;</Start>
+        <End>&#126;</End>
+      </CharacterRegion>
+    </CharacterRegions>
+    <ResourceFiles>
+      <Resx>..\Foo.resx</Resx>
+      <Resx>..\Foo.de-DE.resx</Resx>
+    </ResourceFiles>
+  </Asset>
+</XnaContent>
+```
+
+Once that is done you then need to change the .mgcb file so that the SpriteFontProcessor is replaced with 
+the LocalizedFontProcessor. This can be done by editing the .mgcb file or using the Pipeline tool. After
+that you can just compile your content as normal. If the processor has any trouble resolving or reading the
+resx files you will get an error.
+
+# Loading the Font
+
+Loading the font can be done in the normal way. The end result of the process is a .xnb file containing a normal
+SpriteFont. 
+
+```csharp
+	var font = Content.Load<SpriteFont>("Foo");
+```
+
+# Other Localized assets
+
+Note all localized assets will be fonts. In certain situtions you might need to swap out an entire texture or spritesheet.
+For these cases a new method has been added to the ContentManager, LoadLocalized. The idea behind this method is that it will
+look for localized files BEFORE loading the default one. 
+
+So for example say you have an asset, MyCharacter. You have a MyCharacter.xnb file which contains the data for that item. You 
+can also has a MyCharacter.de-DE.xnb file which contains the German version of that asset. This asset could be a Texture, Audio
+or any other game asset. You can then use LoadLocalized to load the localized version of the asset.
+
+```csharp
+var myCharacter = Content.LoadLocalized<Texture2D>("MyCharacter");
+```
+
+The decision on which localized asset to load is made by looking for a file with the following patterns
+
+	<AssetName>.<CurrentCulture.Name>
+	<AssetName>.<CurrentCulture.TwoLetterISOLanguageName>
+
+These values are retrieved from 
+
+```csharp
+	CultureInfo.CurrentCulture.Name                        // eg. "en-US"
+	CultureInfo.CurrentCulture.TwoLetterISOLanguageName     // eg. "en"
+```
+
+which are part of the System.Globalization namespace.

--- a/MonoGame.Framework.Content.Pipeline/Graphics/LocalizedFontDescription.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/LocalizedFontDescription.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
     /// custom font description class, deriving from the built in FontDescription
     /// type, and adding a new property to store the resource filenames.
     /// </summary>
-    class LocalizedFontDescription : FontDescription
+    public class LocalizedFontDescription : FontDescription
     {
         /// <summary>
         /// Constructor.

--- a/MonoGame.Framework.Content.Pipeline/Graphics/LocalizedFontDescription.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/LocalizedFontDescription.cs
@@ -1,0 +1,53 @@
+﻿#region File Description
+//-----------------------------------------------------------------------------
+// LocalizedFontDescription.cs
+//
+// Microsoft XNA Community Game Platform
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//-----------------------------------------------------------------------------
+#endregion
+
+#region Using Statements
+using System.Collections.Generic;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+#endregion
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
+{
+    /// <summary>
+    /// Normally, when you add a .spritefont file to your project, this data is
+    /// deserialized into a FontDescription object, which is then built into a
+    /// SpriteFontContent by the FontDescriptionProcessor. But to localize the
+    /// font, we want to add some additional data, so our custom processor can
+    /// know what .resx files it needs to scan. We do this by defining our own
+    /// custom font description class, deriving from the built in FontDescription
+    /// type, and adding a new property to store the resource filenames.
+    /// </summary>
+    class LocalizedFontDescription : FontDescription
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public LocalizedFontDescription()
+            : base("Arial", 14, 0)
+        {
+        }
+
+
+        /// <summary>
+        /// Add a new property to our font description, which will allow us to
+        /// include a ResourceFiles element in the .spritefont XML. We use the
+        /// ContentSerializer attribute to mark this as optional, so existing
+        /// .spritefont files that do not include this ResourceFiles element
+        /// can be imported as well.
+        /// </summary>
+        [ContentSerializer(Optional = true, CollectionItemName = "Resx")]
+        public List<string> ResourceFiles
+        {
+            get { return resourceFiles; }
+        }
+
+        List<string> resourceFiles = new List<string>();
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Processors/LocalizedFontProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/LocalizedFontProcessor.cs
@@ -1,0 +1,79 @@
+#region File Description
+//-----------------------------------------------------------------------------
+// LocalizedFontProcessor.cs
+//
+// Microsoft XNA Community Game Platform
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//-----------------------------------------------------------------------------
+#endregion
+
+#region Using Statements
+using System.IO;
+using System.Xml;
+using Microsoft.Xna.Framework.Content.Pipeline;
+using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+using Microsoft.Xna.Framework.Content.Pipeline.Processors;
+#endregion
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
+{
+    /// <summary>
+    /// Custom processor extends the SpriteFont build process to scan over the resource
+    /// strings used by the game, automatically adding whatever characters it finds in
+    /// them to the font. This makes sure the game will always have all the characters
+    /// it needs, no matter what languages it is localized into, while still producing
+    /// an efficient font that does not waste space on unnecessary characters. This is
+    /// especially useful for languages such as Japanese and Korean, which have
+    /// potentially thousands of different characters, although games typically only
+    /// use a small fraction of these. Building only the characters we need is far more
+    /// efficient than if we tried to include the entire CJK character region.
+    /// </summary>
+    [ContentProcessor]
+    class LocalizedFontProcessor : ContentProcessor<LocalizedFontDescription,
+                                                    SpriteFontContent>
+    {
+        /// <summary>
+        /// Converts a font description into SpriteFont format.
+        /// </summary>
+        public override SpriteFontContent Process(LocalizedFontDescription input,
+                                                  ContentProcessorContext context)
+        {
+            // Scan each .resx file in turn.
+            foreach (string resourceFile in input.ResourceFiles)
+            {
+                string absolutePath = Path.GetFullPath(resourceFile);
+
+                // Make sure the .resx file really does exist.
+                if (!File.Exists(absolutePath))
+                {
+                    throw new InvalidContentException("Can't find " + absolutePath);
+                }
+
+                // Load the .resx data.
+                XmlDocument xmlDocument = new XmlDocument();
+
+                xmlDocument.Load(absolutePath);
+
+                // Scan each string from the .resx file.
+                foreach (XmlNode xmlNode in xmlDocument.SelectNodes("root/data/value"))
+                {
+                    string resourceString = xmlNode.InnerText;
+
+                    // Scan each character of the string.
+                    foreach (char usedCharacter in resourceString)
+                    {
+                        input.Characters.Add(usedCharacter);
+                    }
+                }
+
+                // Mark that this font should be rebuilt if the resource file changes.
+                context.AddDependency(absolutePath);
+            }
+
+            // After adding the necessary characters, we can use the built in
+            // FontDescriptionProcessor to do the hard work of building the font for us.
+            return context.Convert<FontDescription,
+                                   SpriteFontContent>(input, "FontDescriptionProcessor");
+        }
+    }
+}

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Reflection;
 using Microsoft.Xna.Framework.Utilities;
 using Microsoft.Xna.Framework.Graphics;
+using System.Globalization;
 
 #if !WINRT
 using Microsoft.Xna.Framework.Audio;
@@ -194,6 +195,29 @@ namespace Microsoft.Xna.Framework.Content
 				disposed = true;
 			}
 		}
+
+        public virtual T LoadLocalized<T> (string assetName)
+        {
+            string [] cultureNames =
+            {
+                CultureInfo.CurrentCulture.Name,                        // eg. "en-US"
+                CultureInfo.CurrentCulture.TwoLetterISOLanguageName     // eg. "en"
+            };
+
+            // Look first for a specialized language-country version of the asset,
+            // then if that fails, loop back around to see if we can find one that
+            // specifies just the language without the country part.
+            foreach (string cultureName in cultureNames) {
+                string localizedAssetName = assetName + '.' + cultureName;
+
+                try {
+                    return Load<T> (localizedAssetName);
+                } catch (ContentLoadException) { }
+            }
+
+            // If we didn't find any localized asset, fall back to the default name.
+            return Load<T> (assetName);
+        }
 
 		public virtual T Load<T>(string assetName)
 		{

--- a/Test/Assets/Fonts/Localized.spritefont
+++ b/Test/Assets/Fonts/Localized.spritefont
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file contains an xml description of a font, and will be read by the XNA
+Framework Content Pipeline. Follow the comments to customize the appearance
+of the font in your game, and to change the characters which are available to draw
+with.
+-->
+<XnaContent xmlns:Graphics="Microsoft.Xna.Framework.Content.Pipeline.Graphics">
+  <Asset Type="Graphics:LocalizedFontDescription">
+
+    <!--
+    Modify this string to change the font that will be imported.
+    -->
+    <FontName>Arial</FontName>
+
+    <!--
+    Size is a float value, measured in points. Modify this value to change
+    the size of the font.
+    -->
+    <Size>10</Size>
+
+    <!--
+    Spacing is a float value, measured in pixels. Modify this value to change
+    the amount of spacing in between characters.
+    -->
+    <Spacing>2</Spacing>
+
+    <!--
+    UseKerning controls the layout of the font. If this value is true, kerning information
+    will be used when placing characters.
+    -->
+    <UseKerning>true</UseKerning>
+
+    <!--
+    Style controls the style of the font. Valid entries are "Regular", "Bold", "Italic",
+    and "Bold, Italic", and are case sensitive.
+    -->
+    <Style>Regular</Style>
+
+    <!--
+    If you uncomment this line, the default character will be substituted if you draw
+    or measure text that contains characters which were not included in the font.
+    -->
+    <!-- <DefaultCharacter>*</DefaultCharacter> -->
+
+    <!--
+    CharacterRegions control what letters are available in the font. Every
+    character from Start to End will be built and made available for drawing. The
+    default range is from 32, (ASCII space), to 126, ('~'), covering the basic Latin
+    character set. The characters are ordered according to the Unicode standard.
+    See the documentation for more information.
+    -->
+    <CharacterRegions>
+      <CharacterRegion>
+        <Start>&#32;</Start>
+        <End>&#32;</End>
+      </CharacterRegion>
+    </CharacterRegions>
+    <ResourceFiles>
+      <Resx>Assets\Fonts\Strings.resx</Resx>
+    </ResourceFiles>
+  </Asset>
+</XnaContent>

--- a/Test/Assets/Fonts/Strings.resx
+++ b/Test/Assets/Fonts/Strings.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>MonoGame Rocks!</value>
+  </data>
+</root>

--- a/Test/ContentPipeline/TestProcessorContext.cs
+++ b/Test/ContentPipeline/TestProcessorContext.cs
@@ -85,6 +85,19 @@ namespace MonoGame.Tests.ContentPipeline
             if (typeof(TOutput) == typeof(MaterialContent) && typeof(TInput).IsAssignableFrom(typeof(MaterialContent)))
                 return (TOutput)((object)input);
 
+            var processor = (ContentProcessor<TInput, TOutput>)typeof(ContentProcessor<TInput, TOutput>).Assembly.CreateInstance("Microsoft.Xna.Framework.Content.Pipeline.Processors."+ processorName);
+            if (processor != null) {
+                var type = processor.GetType();
+                foreach (var kvp in processorParameters)
+                {
+                    var property = type.GetProperty(kvp.Key);
+                    if (property == null)
+                        continue;
+                    property.SetValue(processor, kvp.Value);
+                }
+                return processor.Process(input, this);
+            }
+
             throw new NotImplementedException();
         }
     }

--- a/Tools/Pipeline/Templates/LocalizedSpriteFont.spritefont
+++ b/Tools/Pipeline/Templates/LocalizedSpriteFont.spritefont
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file contains an xml description of a font, and will be read by the XNA
+Framework Content Pipeline. Follow the comments to customize the appearance
+of the font in your game, and to change the characters which are available to draw
+with.
+-->
+<XnaContent xmlns:Graphics="Microsoft.Xna.Framework.Content.Pipeline.Graphics">
+  <Asset Type="Graphics:LocalizedFontDescription">
+
+    <!--
+    Modify this string to change the font that will be imported.
+    -->
+    <FontName>Arial</FontName>
+
+    <!--
+    Size is a float value, measured in points. Modify this value to change
+    the size of the font.
+    -->
+    <Size>12</Size>
+
+    <!--
+    Spacing is a float value, measured in pixels. Modify this value to change
+    the amount of spacing in between characters.
+    -->
+    <Spacing>0</Spacing>
+
+    <!--
+    UseKerning controls the layout of the font. If this value is true, kerning information
+    will be used when placing characters.
+    -->
+    <UseKerning>true</UseKerning>
+
+    <!--
+    Style controls the style of the font. Valid entries are "Regular", "Bold", "Italic",
+    and "Bold, Italic", and are case sensitive.
+    -->
+    <Style>Regular</Style>
+
+    <!--
+    If you uncomment this line, the default character will be substituted if you draw
+    or measure text that contains characters which were not included in the font.
+    -->
+    <!-- <DefaultCharacter>*</DefaultCharacter> -->
+
+    <!--
+    CharacterRegions control what letters are available in the font. Every
+    character from Start to End will be built and made available for drawing. The
+    default range is from 32, (ASCII space), to 126, ('~'), covering the basic Latin
+    character set. The characters are ordered according to the Unicode standard.
+    See the documentation for more information.
+    For localized fonts you can leave this empty as the character range will be picked up
+    from the Resource Files.
+    -->
+    <CharacterRegions>
+      <CharacterRegion>
+        <Start>&#32;</Start>
+        <End>&#32;</End>
+      </CharacterRegion>
+    </CharacterRegions>
+    <!--
+    ResourceFiles control the charaters which will be in the font. It does this
+    by scanning the text in each of the resource files and adding those specific
+    characters to the font. 
+    -->
+    <ResourceFiles>
+        <!-- <Resx>Strings.resx</Resx> -->
+    </ResourceFiles>
+  </Asset>
+</XnaContent>

--- a/Tools/Pipeline/Templates/LocalizedSpriteFont.template
+++ b/Tools/Pipeline/Templates/LocalizedSpriteFont.template
@@ -1,0 +1,5 @@
+﻿LocalizedSpriteFont Description
+Font.png
+FontDescriptionImporter
+LocalizedFontDescriptionProcessor
+LocalizedSpriteFont.spritefont


### PR DESCRIPTION
Fixes #5136

When localizing games you sometimes need to load localized
assets as well as text. This commit includes the sample
XNA processors and ContentManager code into the core of the
MonoGame system. This means that people no longer need to
implement this stuff themselves.

Usage:

Define all of the "string" resources in standard .resx resource
files. Add these to the .spritefont file

```
   <ResourceFiles>
      <Resx>..\Strings.resx</Resx>
      <Resx>..\Strings.da.resx</Resx>
      <Resx>..\Strings.fr.resx</Resx>
      <Resx>..\Strings.ja.resx</Resx>
      <Resx>..\Strings.ko.resx</Resx>
    </ResourceFiles>
```

Change the .spritefont over to use the LocalizedFontProcessor.
Load the font as normal.

For other localized assets you can make use of the new

``````
```Content.LoadLocalized<T>```
``````

method. This will attempt to load assets which contain a culture
extension e.g

```
Texture1.fr.xnb
Texture1.en-gb.xnb
```

Note either the Name or the TwoLetterISOLanguageName can be used.
