### PR TITLE
[XAudio] bugfix: read adpcm blockAlign as int16

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Xna.Framework.Audio
             var format = BitConverter.ToInt16(header, 0);
             var channels = BitConverter.ToInt16(header, 2);
             var sampleRate = BitConverter.ToInt32(header, 4);
-            var blockAlignment = BitConverter.ToInt32(header, 12);
+            var blockAlignment = BitConverter.ToInt16(header, 12);
 
             WaveFormat waveFormat;
             if (format == 1)


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/windows/desktop/dd757713(v=vs.85).aspx

https://github.com/MonoGame/MonoGame/blob/3713daf5e632395a1837f681e2d56299eb0e99b4/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs#L24-L33