### PR TITLE
[Pipeline Tool] General Fixes

### DIFF
--- a/Tools/Pipeline/Controls/ProjectControl.cs
+++ b/Tools/Pipeline/Controls/ProjectControl.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Xwt;
 using Xwt.Drawing;
 
@@ -48,8 +49,25 @@ namespace MonoGame.Tools.Pipeline
 
         private void Handle_ButtonReleased(object sender, ButtonEventArgs e)
         {
-            if (e.Button == PointerButton.Right && _showContextMenu && _contextMenu.Items.Count > 0)
-                _contextMenu.Show(TreeView.ToEto());
+            if (e.Button == PointerButton.Right)
+            {
+#if WINDOWS
+                var crow = TreeView.GetRowAtPosition(e.X, e.Y);
+
+                if (crow == null)
+                    return;
+
+                if (!TreeView.SelectedRows.ToList().Contains(crow))
+                {
+                    TreeView.UnselectAll();
+                    TreeView.SelectRow(crow);
+                    TreeView.FocusedRow = crow;
+                }
+#endif
+
+                if (_showContextMenu && _contextMenu.Items.Count > 0)
+                    _contextMenu.Show(TreeView.ToEto());
+            }
         }
 
         private void ProjectControl_SelectionChanged(object sender, System.EventArgs e)
@@ -81,6 +99,8 @@ namespace MonoGame.Tools.Pipeline
                 _rootExists = false;
 
                 _showContextMenu = false;
+                PipelineController.Instance.SelectionChanged(new List<IProjectItem>());
+
                 return;
             }
 

--- a/Tools/Pipeline/Controls/PropertyCells/CellCombo.cs
+++ b/Tools/Pipeline/Controls/PropertyCells/CellCombo.cs
@@ -67,7 +67,7 @@ namespace MonoGame.Tools.Pipeline
                     return;
 
                 if (_type.IsSubclassOf(typeof(Enum)))
-                    _eventHandler(Enum.Parse(Value.GetType(), combo.SelectedValue.ToString()), EventArgs.Empty);
+                    _eventHandler(Enum.Parse(_type, combo.SelectedValue.ToString()), EventArgs.Empty);
                 else if (_type == typeof(ImporterTypeDescription))
                     _eventHandler(PipelineTypes.Importers[combo.SelectedIndex], EventArgs.Empty);
                 else

--- a/Tools/Pipeline/Controls/PropertyGridTable.cs
+++ b/Tools/Pipeline/Controls/PropertyGridTable.cs
@@ -281,11 +281,11 @@ namespace MonoGame.Tools.Pipeline
 #if LINUX
             // force size realocation
             drawable.Width = pixel1.Width - 2;
-#endif
 
             foreach (var child in pixel1.Children)
                 if (child != drawable)
                     child.Width = drawable.Width - _separatorPos;
+#endif
 
             drawable.Invalidate();
         }
@@ -297,6 +297,10 @@ namespace MonoGame.Tools.Pipeline
             {
                 var scrollsize = (_height >= Height) ? System.Windows.SystemParameters.VerticalScrollBarWidth : 0.0;
                 drawable.Width = (int)(Width - scrollsize - System.Windows.SystemParameters.BorderWidth * 2);
+
+                foreach (var child in pixel1.Children)
+                    if (child != drawable)
+                        child.Width = drawable.Width - _separatorPos;
             });
 
             (drawable.ControlObject as System.Windows.Controls.Canvas).Dispatcher.BeginInvoke(action,

--- a/Tools/Pipeline/Dialogs/NewItemDialog.cs
+++ b/Tools/Pipeline/Dialogs/NewItemDialog.cs
@@ -31,14 +31,8 @@ namespace MonoGame.Tools.Pipeline
             while (enums.MoveNext())
             {
                 var ret = new ImageListItem();
-                ret.Text = enums.Current.Label;
+                ret.Text = enums.Current.Label + " (" + Path.GetExtension(enums.Current.TemplateFile) + ")";
                 ret.Tag = enums.Current;
-                
-                try
-                {
-                    ret.Image = new Bitmap(new Bitmap(Path.Combine(Path.GetDirectoryName(enums.Current.TemplateFile), enums.Current.Icon)), 16, 16);
-                }
-                catch { }
 
                 list1.Items.Add(ret);
             }

--- a/Tools/Pipeline/MainWindow.cs
+++ b/Tools/Pipeline/MainWindow.cs
@@ -99,9 +99,9 @@ namespace MonoGame.Tools.Pipeline
         {
             var result = MessageBox.Show(this, "Do you want to save the project first?", "Save Project", MessageBoxButtons.YesNoCancel, MessageBoxType.Question);
 
-            if (result == Eto.Forms.DialogResult.Yes)
+            if (result == DialogResult.Yes)
                 return AskResult.Yes;
-            if (result == Eto.Forms.DialogResult.No)
+            if (result == DialogResult.No)
                 return AskResult.No;
 
             return AskResult.Cancel;
@@ -208,13 +208,13 @@ namespace MonoGame.Tools.Pipeline
         public bool ShowDeleteDialog(List<IProjectItem> items)
         {
             var dialog = new DeleteDialog(PipelineController.Instance, items);
-            return dialog.Run(this) == Eto.Forms.DialogResult.Ok;
+            return dialog.Run(this) == DialogResult.Ok;
         }
 
         public bool ShowEditDialog(string title, string text, string oldname, bool file, out string newname)
         {
             var dialog = new EditDialog(title, text, oldname, file);
-            var result = dialog.Run(this) == Eto.Forms.DialogResult.Ok;
+            var result = dialog.Run(this) == DialogResult.Ok;
 
             newname = dialog.Text;
 
@@ -384,25 +384,6 @@ namespace MonoGame.Tools.Pipeline
             cmdOpenItemWith.Enabled = info.OpenItemWith;
             cmdOpenItemLocation.Enabled = info.OpenItemLocation;
             cmdRebuildItem.Enabled = info.RebuildItem;
-
-            // ToolBar
-
-            if (info.Build && toolbar.Items.Contains(toolCancelBuild))
-            {
-                toolbar.Items.Remove(toolCancelBuild);
-
-                toolbar.Items.Insert(12, toolBuild);
-                toolbar.Items.Insert(13, toolRebuild);
-                toolbar.Items.Insert(14, toolClean);
-            }
-            else if (info.Cancel && toolbar.Items.Contains(toolBuild))
-            {
-                toolbar.Items.Remove(toolBuild);
-                toolbar.Items.Remove(toolRebuild);
-                toolbar.Items.Remove(toolClean);
-
-                toolbar.Items.Insert(12, toolCancelBuild);
-            }
 
             // Visibility of menu items can't be changed so 
             // we need to recreate the context menu each time.

--- a/Tools/Pipeline/MainWindow.eto.cs
+++ b/Tools/Pipeline/MainWindow.eto.cs
@@ -371,7 +371,7 @@ namespace MonoGame.Tools.Pipeline
             ToolBar.Items.Add(toolBuild);
             ToolBar.Items.Add(toolRebuild);
             ToolBar.Items.Add(toolClean);
-            ToolBar.Items.Add(new SeparatorToolItem());
+            toolbar.Items.Add(toolCancelBuild);
         }
     }
 }

--- a/Tools/Pipeline/Styles.Linux.cs
+++ b/Tools/Pipeline/Styles.Linux.cs
@@ -274,7 +274,7 @@ namespace MonoGame.Tools.Pipeline
 
             Style.Add<DropDownHandler>("OverrideSize", h =>
             {
-                var cell = (h.Control.Child as Gtk.ComboBox).Cells[0] as Gtk.CellRendererText;
+                var cell = (h.Control.Child as Gtk.CellView).Cells[0] as Gtk.CellRendererText;
                 cell.Ellipsize = Pango.EllipsizeMode.End;
             });
 


### PR DESCRIPTION
Stuff done:
 - fixed propertygrid crash on Linux/Mac due to incorrect cast of an object
   - new Eto Forms dll changed some combobox stuff so that broke it
 - fixed not being able to change property of multiple items (fixes #5160)
 - fixed closing project not clearing propertygrid
 - fixed right clicking an item on Windows not selecting the current item
 - fixed propertygrid sizing for windows sometimes showing left/right scrollbar
 - improved appearence of items in new item dialog, they now show extension of the template and an icon is no longer displayed
 - improved toolbar, now all items are always visible, with showing/hiding items there was a chance for a misclick