### PR TITLE
[MGCB] changes to output for Visual Studio

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
@@ -63,6 +63,17 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         }
 
         /// <summary>
+        /// Gets the the current PushFile for use in warning and error messages.
+        /// </summary>
+        /// <returns>Name of the file being processed.</returns>
+        protected string PeekFile()
+        {
+            if (filenames.Count == 0)
+                throw new InvalidOperationException("'filenames' is empty.\r\nCalls to PopFile() has to be paired with calls to PushFile().");
+            return filenames.Peek();
+        }
+
+        /// <summary>
         /// Outputs a high-priority status message from a content importer or processor.
         /// </summary>
         /// <param name="message">Message being reported.</param>

--- a/Tools/MGCB/BuildContent.cs
+++ b/Tools/MGCB/BuildContent.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Framework.Content.Pipeline.Builder;
@@ -341,8 +342,15 @@ namespace MGCB
                     }
                     else
                         message = c.SourceFile + " ";
-                    message += ": error : ";
-                    message += ex.Message;
+                    message += ": error ";
+
+                    // extract errorCode from MGFX message
+                    var match = Regex.Match(ex.Message, @"([A-Z]*[0-9]*):(.*)");
+                    if (match.Success || match.Groups.Count == 2)
+                        message += match.Groups[1].Value + " : " + match.Groups[2].Value;
+                    else
+                        message += ": " + ex.Message;
+
                     Console.WriteLine(message);
                     ++errorCount;
                 }

--- a/Tools/MGCB/BuildContent.cs
+++ b/Tools/MGCB/BuildContent.cs
@@ -336,22 +336,26 @@ namespace MGCB
                         message = ex.ContentIdentity.SourceFilename;
                         if (!string.IsNullOrEmpty(ex.ContentIdentity.FragmentIdentifier))
                             message += "(" + ex.ContentIdentity.FragmentIdentifier + ")";
-                        message += ": error: ";
+                        else
+                            message += " ";
                     }
+                    else
+                        message = c.SourceFile + " ";
+                    message += ": error : ";
                     message += ex.Message;
                     Console.WriteLine(message);
                     ++errorCount;
                 }
                 catch (PipelineException ex)
                 {
-                    Console.Error.WriteLine("{0}: error: {1}", c.SourceFile, ex.Message);
+                    Console.Error.WriteLine("{0} : error : {1}", c.SourceFile, ex.Message);
                     if (ex.InnerException != null)
                         Console.Error.WriteLine(ex.InnerException.ToString());
                     ++errorCount;
                 }
                 catch (Exception ex)
                 {
-                    Console.Error.WriteLine("{0}: error: {1}", c.SourceFile, ex.Message);
+                    Console.Error.WriteLine("{0} : error : {1}", c.SourceFile, ex.Message);
                     if (ex.InnerException != null)
                         Console.Error.WriteLine(ex.InnerException.ToString());
                     ++errorCount;

--- a/Tools/MGCB/BuildContent.cs
+++ b/Tools/MGCB/BuildContent.cs
@@ -336,7 +336,7 @@ namespace MGCB
                         message = ex.ContentIdentity.SourceFilename;
                         if (!string.IsNullOrEmpty(ex.ContentIdentity.FragmentIdentifier))
                             message += "(" + ex.ContentIdentity.FragmentIdentifier + ")";
-                        message += ": ";
+                        message += ": error: ";
                     }
                     message += ex.Message;
                     Console.WriteLine(message);

--- a/Tools/MGCB/ConsoleLogger.cs
+++ b/Tools/MGCB/ConsoleLogger.cs
@@ -28,8 +28,12 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 warning = contentIdentity.SourceFilename;
                 if (!string.IsNullOrEmpty(contentIdentity.FragmentIdentifier))
                     warning += "(" + contentIdentity.FragmentIdentifier + ")";
-                warning += ": warning : ";
+                else
+                    warning += " ";
             }
+            else
+                warning = PeekFile() + " "; 
+            warning += ": warning : ";
             
             if (messageArgs != null && messageArgs.Length != 0)
                 warning += string.Format(message, messageArgs);

--- a/Tools/MGCB/ConsoleLogger.cs
+++ b/Tools/MGCB/ConsoleLogger.cs
@@ -28,7 +28,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 warning = contentIdentity.SourceFilename;
                 if (!string.IsNullOrEmpty(contentIdentity.FragmentIdentifier))
                     warning += "(" + contentIdentity.FragmentIdentifier + ")";
-                warning += ": ";
+                warning += ": warning : ";
             }
             
             if (messageArgs != null && messageArgs.Length != 0)

--- a/Tools/MGCB/ConsoleLogger.cs
+++ b/Tools/MGCB/ConsoleLogger.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Text.RegularExpressions;
 using Microsoft.Xna.Framework.Content.Pipeline;
 
 namespace MonoGame.Framework.Content.Pipeline.Builder
@@ -33,8 +34,18 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             }
             else
                 warning = PeekFile() + " "; 
-            warning += ": warning : ";
+            warning += ": warning ";
             
+            // extract errorCode from MGFX message
+            var match = Regex.Match(message, @"([A-Z]*[0-9]*):(.*)");
+            if (match.Success || match.Groups.Count == 2)
+            {
+                warning += match.Groups[1].Value + " ";
+                message = match.Groups[2].Value;
+            }
+
+            warning += ": ";
+
             if (messageArgs != null && messageArgs.Length != 0)
                 warning += string.Format(message, messageArgs);
             else if (!string.IsNullOrEmpty(message))

--- a/Tools/Pipeline/Common/OutputParser.cs
+++ b/Tools/Pipeline/Common/OutputParser.cs
@@ -39,8 +39,9 @@ namespace MonoGame.Tools.Pipeline
         Regex _reSkipping = new Regex(@"^(Skipping)\W(?<filename>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildAsset = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildError = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\W*?:\W*?error\W*?:\W*(?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        Regex _reFileErrorWithLineNum   = new Regex(@"^(?<filename>.+?)(\((?<line>[0-9]+),(?<column>[0-9]+)(-(?<columnEnd>[0-9]+))?\))?:\W*?(error)\W*(?<errorCode>[A-Z][0-9]+):\W*(?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        Regex _reFileWarningWithLineNum = new Regex(@"^(?<filename>.+?)(\((?<line>[0-9]+),(?<column>[0-9]+)(-(?<columnEnd>[0-9]+))?\))?:\W*?(warning)\W*(?<warningCode>[A-Z][0-9]+):\W*(?<warningMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reFileWarning = new Regex(@"^(?<filename>.+?):\W*?(warning)\W*:\W*(?<warningMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reFileErrorWithLineNum   = new Regex(@"^(?<filename>.+?)(\((?<line>[0-9]+),(?<column>[0-9]+)(-(?<columnEnd>[0-9]+))?\))?:\W*?(error)\W*(?<errorCode>[A-Z][0-9]+)\W*:\W*(?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reFileWarningWithLineNum = new Regex(@"^(?<filename>.+?)(\((?<line>[0-9]+),(?<column>[0-9]+)(-(?<columnEnd>[0-9]+))?\))?:\W*?(warning)\W*(?<warningCode>[A-Z][0-9]+)\W*:\W*(?<warningMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reFileError = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\W*?: (?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildEnd = new Regex(@"^(Build)\W+(?<buildInfo>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildTime = new Regex(@"^(Time elapsed)\W+(?<buildElapsedTime>.*?)\.\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -165,6 +166,13 @@ namespace MonoGame.Tools.Pipeline
                 var errorCode = m.Groups["warningCode"];
                 Filename = m.Groups["filename"].Value.Replace("\\\\", "/").Replace("\\", "/");
                 ErrorMessage = string.Format("{0} ({1},{2}): {3}", errorCode, lineNum, column, m.Groups["warningMessage"].Value);
+            }
+            else if (_reFileWarning.IsMatch(line))
+            {
+                State = OutputState.BuildWarning;
+                var m = _reFileWarning.Match(line);
+                Filename = m.Groups["filename"].Value.Replace("\\\\", "/").Replace("\\", "/");
+                ErrorMessage = m.Groups["warningMessage"].Value;
             }
             else if (_reFileError.IsMatch(line))
             {


### PR DESCRIPTION
Formatting the Output of a Custom Build Step or Build Event
https://msdn.microsoft.com/en-us/library/yxkt8b26.aspx

_Before_
![mgerrorlist0](https://cloud.githubusercontent.com/assets/3018589/18378922/7948567a-7678-11e6-8b04-4f9ee9f123b4.png)

```
3>  P:/TestContentBuildLogger/MG/Content/test.fbx
3>      LogMessage
3>  LogWarning0
3>  P:/TestContentBuildLogger/MG/Content/test.fbx: LogWarning
3>  P:/TestContentBuildLogger/MG/Content/test.fbx(64,4): LogWarningWithLineNum
3>  P:/TestContentBuildLogger/MG/Content/test.fbx(64,4): LogWarningWithLink
3>  P:/TestContentBuildLogger/MG/Content/test.fbx(64,4): LogWarningWithNewLine
3>  WinNewLine
3>      LogImportantMessage
3>      LogImportantMessageWithNewLine
3>  WinNewLine
3>  Console.WriteLine
3>  Error.WriteLine
3>  P:/TestContentBuildLogger/MG/Content/test.fbx(42,8): TestInvalidContentException
3>  Newline1
3>  Newline2
3>  Return1
3>  Return2
3>  NewlineAgain
3>  WinNewLine
3>  P:/TestContentBuildLogger/MG/Content/test1.fbx
3>P:/TestContentBuildLogger/MG/Content/test1.fbx : error : Processor 'GpuSkinnedModelProcessor' had unexpected failure!
3>  System.NullReferenceException: test1_NullReferenceException
3>     at tainicom.ProtonType.Content.Pipeline.GpuSkinnedModelProcessor.Process(NodeContent input, ContentProcessorContext context) in p:\tainicom\Pinball_League\EspressoRub\trunk\Skinning\SkinnedModelImporter\GpuSkinnedModelProcessor.cs:line 43
3>     at Microsoft.Xna.Framework.Content.Pipeline.ContentProcessor`2.Microsoft.Xna.Framework.Content.Pipeline.IContentProcessor.Process(Object input, ContentProcessorContext context) in P:\MonoGame\MonoGame.Framework.Content.Pipeline\ContentProcessor.cs:line 60
3>     at MonoGame.Framework.Content.Pipeline.Builder.PipelineManager.ProcessContent(PipelineBuildEvent pipelineEvent) in P:\MonoGame\MonoGame.Framework.Content.Pipeline\Builder\PipelineManager.cs:line 696
3>C:\Program Files (x86)\MSBuild\MonoGame\v3.0\MonoGame.Content.Builder.targets(91,5): error MSB3073: The command ""C:\Program Files (x86)\MSBuild\MonoGame\v3.0\Tools\MGCB.exe" /@:"P:\TestContentBuildLogger\MG\Content\Content.mgcb" /platform:Windows /outputDir:"P:\TestContentBuildLogger\MG\Content\bin\Windows" /intermediateDir:"P:\TestContentBuildLogger\MG\Content\obj\Windows" /quiet" exited with code 2.
```

_after_
![mgerrorlist1](https://cloud.githubusercontent.com/assets/3018589/18378951/9c474ef6-7678-11e6-9f83-10f796dab200.png)

```
3>P:/TestContentBuildLogger/MG/Content/test.fbx
3>      LogMessage
3>P:/TestContentBuildLogger/MG/Content/test.fbx : warning : LogWarning0
3>P:/TestContentBuildLogger/MG/Content/test.fbx : warning : LogWarning
3>P:/TestContentBuildLogger/MG/Content/test.fbx(64,4): warning : LogWarningWithLineNum
3>P:/TestContentBuildLogger/MG/Content/test.fbx(64,4): warning : LogWarningWithLink
3>P:/TestContentBuildLogger/MG/Content/test.fbx(64,4): warning : LogWarningWithNewLine
3>  WinNewLine
3>      LogImportantMessage
3>      LogImportantMessageWithNewLine
3>  WinNewLine
3>  Console.WriteLine
3>  Error.WriteLine
3>P:/TestContentBuildLogger/MG/Content/test.fbx : error : TestInvalidContentException
3>  Newline1
3>  Newline2
3>  Return1
3>  Return2
3>  NewlineAgain
3>  WinNewLine
3>  P:/TestContentBuildLogger/MG/Content/test1.fbx
3>P:/TestContentBuildLogger/MG/Content/test1.fbx : error : Processor 'GpuSkinnedModelProcessor' had unexpected failure!
3>  System.NullReferenceException: test1_NullReferenceException
3>     at tainicom.ProtonType.Content.Pipeline.GpuSkinnedModelProcessor.Process(NodeContent input, ContentProcessorContext context) in p:\tainicom\Pinball_League\EspressoRub\trunk\Skinning\SkinnedModelImporter\GpuSkinnedModelProcessor.cs:line 39
3>     at Microsoft.Xna.Framework.Content.Pipeline.ContentProcessor`2.Microsoft.Xna.Framework.Content.Pipeline.IContentProcessor.Process(Object input, ContentProcessorContext context) in P:\MonoGame\MonoGame.Framework.Content.Pipeline\ContentProcessor.cs:line 60
3>     at MonoGame.Framework.Content.Pipeline.Builder.PipelineManager.ProcessContent(PipelineBuildEvent pipelineEvent) in P:\MonoGame\MonoGame.Framework.Content.Pipeline\Builder\PipelineManager.cs:line 696
3>C:\Program Files (x86)\MSBuild\MonoGame\v3.0\MonoGame.Content.Builder.targets(91,5): error MSB3073: The command ""C:\Program Files (x86)\MSBuild\MonoGame\v3.0\Tools\MGCB.exe" /@:"P:\TestContentBuildLogger\MG\Content\Content.mgcb" /platform:Windows /outputDir:"P:\TestContentBuildLogger\MG\Content\bin\Windows" /intermediateDir:"P:\TestContentBuildLogger\MG\Content\obj\Windows" /quiet" exited with code 2.
```

_XNA output_
![xnaerrorlist](https://cloud.githubusercontent.com/assets/3018589/18379006/db8a0522-7678-11e6-8439-376f305ee48c.png)

```
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx : warning : The skeleton root, "PIVOT", has been pulled out of the scene hierarchy and made into a child of the root node. One of the skeleton root's old parents, "PersonSupervisor", has an animation named "Base Stack" which will not be reflected on the skeleton root.
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx : warning : Fragment identifier "PersonSupervisor".
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx : warning : LogWarning0
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx : warning : LogWarning
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx(64,4): warning : LogWarningWithLineNum
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx(64,4): warning : LogWarningWithLink
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx(64,4): warning : LogWarningWithNewLine
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx(64,4): warning : WinNewLine
  LogImportantMessage
  LogImportantMessageWithNewLine
  WinNewLine
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx : error : TestInvalidContentException
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx : error : Newline1
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx : error : Newline2
Return1
Return2
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx : error : NewlineAgain
P:\TestContentBuildLogger\XNA\ContentTest\ContentTestContent\test.fbx : error : WinNewLine
```

_test code_

```
            if(input.Identity.SourceFilename.Contains("test1"))
                throw new System.NullReferenceException("test1_NullReferenceException");
            context.Logger.LogMessage("LogMessage");
            context.Logger.LogWarning(null, null, "LogWarning0");
            context.Logger.LogWarning(null, input.Identity, "LogWarning");
            input.Identity.FragmentIdentifier = "64,4";
            context.Logger.LogWarning(null, input.Identity, "LogWarningWithLineNum");
            context.Logger.LogWarning("http://www.monogame.net/", input.Identity, "LogWarningWithLink");
            context.Logger.LogWarning("http://www.monogame.net/", input.Identity, "LogWarningWithNewLine\r\nWinNewLine");
            context.Logger.LogImportantMessage("LogImportantMessage");
            context.Logger.LogImportantMessage("LogImportantMessageWithNewLine\r\nWinNewLine");
            System.Console.WriteLine("Console.WriteLine");            
            System.Console.Error.WriteLine("Error.WriteLine");

            input.Identity.FragmentIdentifier = "42,8";
            input.Identity.SourceTool = "customTool v 0.45a";
            if (input.Identity.SourceFilename.Contains("test"))
                throw new InvalidContentException("TestInvalidContentException\nNewline1\nNewline2\rReturn1\rReturn2\nNewlineAgain\r\nWinNewLine", input.Identity);
```
