### PR TITLE
Throw ObjectDisposedException on disposed resources

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -140,6 +140,9 @@ namespace Microsoft.Xna.Framework.Audio
         /// <remarks>Throws an exception if more sounds are playing than the platform allows.</remarks>
         public virtual void Play()
         {
+            if (_isDisposed)
+                throw new ObjectDisposedException("SoundEffectInstance");
+
             if (State == SoundState.Playing)
                 return;
 

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Xna.Framework.Graphics
         public unsafe void DrawBatch(SpriteSortMode sortMode, Effect effect)
 		{
             if (effect != null && effect.IsDisposed)
-                throw new ObjectDisposedException(nameof(effect));
+                throw new ObjectDisposedException("effect");
 
 			// nothing to do
             if (_batchItemCount == 0)

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -146,6 +146,9 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="effect">The custom effect to apply to the drawn geometry</param>
         public unsafe void DrawBatch(SpriteSortMode sortMode, Effect effect)
 		{
+            if (effect != null && effect.IsDisposed)
+                throw new ObjectDisposedException(nameof(effect));
+
 			// nothing to do
             if (_batchItemCount == 0)
 				return;

--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Xna.Framework.Media
         private static void PlaySong(Song song, TimeSpan? startPosition)
         {
             if (song != null && song.IsDisposed)
-                throw new ObjectDisposedException(nameof(song));
+                throw new ObjectDisposedException("song");
 
             PlatformPlaySong(song, startPosition);
             State = MediaState.Playing;

--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -155,6 +155,9 @@ namespace Microsoft.Xna.Framework.Media
 
         private static void PlaySong(Song song, TimeSpan? startPosition)
         {
+            if (song != null && song.IsDisposed)
+                throw new ObjectDisposedException(nameof(song));
+
             PlatformPlaySong(song, startPosition);
             State = MediaState.Playing;
         }


### PR DESCRIPTION
(https://github.com/MonoGame/MonoGame/issues/5164)

- Avoid a NullReferenceException on SpriteBatch.End() and throw a more
descriptive exception when the effect passed into SpriteBatch.Begin()
has been disposed.
- MediaPlayer gave no feedback and did not play a song when calling
Play() with a disposed song.
- SoundEffectInstance has the same effect as MediaPlayer (no reaction,
no sound playing)

There are most likely more places where this behavior is desired, these are the ones I came up with, it's a start.