### PR TITLE
avoid the case where normalizing 0,0 results in NaN,NaN and instead default to 0,0

### DIFF
--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -756,9 +756,11 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Normalize()
         {
-            float val = 1.0f / (float)Math.Sqrt((X * X) + (Y * Y));
-            X *= val;
-            Y *= val;
+			var magnitude = (float)Math.Sqrt((X * X) + (Y * Y));
+			if(magnitude > 1E-05f)
+				this /= magnitude;
+			else
+				X = Y = 0;
         }
 
         /// <summary>


### PR DESCRIPTION
minor fix for Vector2.Normalize to avoid it returning NaN,NaN when passed 0,0