### PR TITLE
Implement GraphicsDevice.BlendFactor

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1182,6 +1182,20 @@ namespace Microsoft.Xna.Framework.Graphics
             Debug.Assert(_d3dContext != null, "The d3d context is null!");
         }
 
+        private void PlatformApplyBlendFactor()
+        {
+#if WINDOWS_UAP
+			_d3dContext.OutputMerger.BlendFactor =
+				new SharpDX.Mathematics.Interop.RawColor4(
+					BlendFactor.R / 255.0f,
+					BlendFactor.G / 255.0f,
+					BlendFactor.B / 255.0f,
+					BlendFactor.A / 255.0f);
+#else
+			_d3dContext.OutputMerger.BlendFactor = BlendFactor.ToColor4();
+#endif
+        }
+
         internal void PlatformApplyState(bool applyShaders)
         {
             // NOTE: This code assumes _d3dContext has been locked by the caller.

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -298,6 +298,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Force reseting states
             this.BlendState.PlatformApplyState(this, true);
+            this.PlatformApplyBlendFactor(true);
             this.DepthStencilState.PlatformApplyState(this, true);
             this.RasterizerState.PlatformApplyState(this, true);            
 
@@ -840,6 +841,20 @@ namespace Microsoft.Xna.Framework.Graphics
         internal void PlatformBeginApplyState()
         {
             Threading.EnsureUIThread();
+        }
+
+        private void PlatformApplyBlendFactor(bool force = false)
+        {
+            if (force || BlendFactor != _lastBlendState.BlendFactor)
+            {
+                GL.BlendColor(
+                    this.BlendFactor.R / 255.0f,
+                    this.BlendFactor.G / 255.0f,
+                    this.BlendFactor.B / 255.0f,
+                    this.BlendFactor.A / 255.0f);
+                GraphicsExtensions.CheckGLError();
+                _lastBlendState.BlendFactor = this.BlendFactor;
+            }
         }
 
         internal void PlatformApplyState(bool applyShaders)

--- a/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
@@ -67,6 +67,10 @@ namespace Microsoft.Xna.Framework.Graphics
         {
         }
 
+        private void PlatformApplyBlendFactor()
+        {
+        }
+
         internal void PlatformApplyState(bool applyShaders)
         {
         }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -341,6 +341,13 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// The color used as blend factor when alpha blending.
+        /// </summary>
+        /// <remarks>
+        /// When only changing BlendFactor, use this rather than <see cref="Graphics.BlendState.BlendFactor"/> to
+        /// only update BlendFactor so the whole BlendState does not have to be updated.
+        /// </remarks>
         public Color BlendFactor
         {
             get { return _blendFactor; }
@@ -431,6 +438,12 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 _actualBlendState.PlatformApplyState(this);
                 _blendStateDirty = false;
+            }
+
+            if (_blendFactorDirty)
+            {
+                PlatformApplyBlendFactor();
+                _blendFactorDirty = false;
             }
 
             if (_depthStencilStateDirty)

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private bool _isDisposed;
 
+        private Color _blendFactor = Color.White;
+        private bool _blendFactorDirty;
+
         private BlendState _blendState;
         private BlendState _actualBlendState;
         private bool _blendStateDirty;
@@ -338,6 +341,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        public Color BlendFactor
+        {
+            get { return _blendFactor; }
+            set
+            {
+                if (_blendFactor == value)
+                    return;
+                _blendFactor = value;
+                _blendFactorDirty = true;
+            }
+        }
+
         public BlendState BlendState
         {
 			get { return _blendState; }
@@ -369,6 +384,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 newBlendState.BindToGraphicsDevice(this);
 
                 _actualBlendState = newBlendState;
+
+                BlendFactor = _actualBlendState.BlendFactor;
 
                 _blendStateDirty = true;
             }

--- a/MonoGame.Framework/Graphics/States/BlendState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.DirectX.cs
@@ -42,17 +42,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			// locked the d3dContext for us to use.
 
 			// Apply the state!
-#if WINDOWS_UAP
-			device._d3dContext.OutputMerger.SetBlendState(_state,
-				new SharpDX.Mathematics.Interop.RawColor4(
-					_blendFactor.R / 255.0f,
-					_blendFactor.G / 255.0f,
-					_blendFactor.B / 255.0f,
-					_blendFactor.A / 255.0f));
-#else
-			device._d3dContext.OutputMerger.SetBlendState(_state, _blendFactor.ToColor4());
-#endif
-		}
+			device._d3dContext.OutputMerger.BlendState = _state;
+        }
 
         protected override void Dispose(bool disposing)
         {

--- a/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
@@ -34,17 +34,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 device._lastBlendEnable = blendEnabled;
             }
 
-            if (force || this.BlendFactor != device._lastBlendState.BlendFactor)
-            {
-                GL.BlendColor(
-                    this.BlendFactor.R / 255.0f,      
-                    this.BlendFactor.G / 255.0f, 
-                    this.BlendFactor.B / 255.0f, 
-                    this.BlendFactor.A / 255.0f);
-                GraphicsExtensions.CheckGLError();
-                device._lastBlendState.BlendFactor = this.BlendFactor;
-            }
-
             if (force || 
                 this.ColorBlendFunction != device._lastBlendState.ColorBlendFunction || 
                 this.AlphaBlendFunction != device._lastBlendState.AlphaBlendFunction)

--- a/MonoGame.Framework/Graphics/States/BlendState.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.cs
@@ -145,6 +145,13 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// The color used as blend factor when alpha blending.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="GraphicsDevice.BlendFactor"/> is set to this value when this <see cref="BlendState"/>
+        /// is bound to a GraphicsDevice.
+        /// </remarks>
 	    public Color BlendFactor
 	    {
 	        get { return _blendFactor; }
@@ -177,6 +184,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 _independentBlendEnable = value;
             }
         }
+
 
         public static readonly BlendState Additive;
         public static readonly BlendState AlphaBlend;

--- a/Test/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceTest.cs
@@ -14,6 +14,26 @@ namespace MonoGame.Tests.Graphics
     [TestFixture]
     internal class GraphicsDeviceTest : GraphicsDeviceTestFixtureBase
     {
+        [Test]
+        public void BlendFactor()
+        {
+            Assert.AreEqual(Color.White, gd.BlendFactor);
+
+            var blend = new BlendState
+            {
+                BlendFactor = Color.Crimson
+            };
+
+            gd.BlendState = blend;
+            Assert.AreEqual(Color.Crimson, gd.BlendFactor);
+
+            gd.BlendFactor = Color.CornflowerBlue;
+            Assert.AreEqual(Color.Crimson, gd.BlendState.BlendFactor);
+            Assert.AreEqual(Color.CornflowerBlue, gd.BlendFactor);
+
+            blend.Dispose();
+        }
+
 		[Test]
 		public void Clear()
 		{


### PR DESCRIPTION
Fixes #5175. Details and discussion is in the issue. When handling this I noticed the `force` boolean and _last<RenderState> variables in GraphicsDevice.OpenGL. Do we need those? We already have dirty flags. Or do we have to apply state before the first call to ApplyChanges maybe?