### PR TITLE
Fix some compiler warnings

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -59,7 +59,6 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         public string IntermediateDirectory { get; private set; }
 
         private ContentCompiler _compiler;
-        private MethodInfo _compileMethod;
 
         public ContentBuildLogger Logger { get; set; }
 

--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                 foreach (var outfile in shaderInfo.AdditionalOutputFiles)
                     context.AddOutputFile(outfile);
             }
-            catch (ShaderCompilerException ex)
+            catch (ShaderCompilerException)
             {
                 // This will log any warnings and errors and throw.
                 ProcessErrorsAndWarnings(true, shaderErrorsAndWarnings, input, context);

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NamespaceAliasHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NamespaceAliasHelper.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
         }
 
         /// <summary>
-        /// Returns just the portion <paramref name="@namespace"/> relative to <paramref name="namespaceParent"/>.
+        /// Returns just the portion <paramref name="namespace"/> relative to <paramref name="namespaceParent"/>.
         /// For example, given namespaceParent=Foo.Bar and @namespace=Foo.Bar.Baz, will return Baz.
         /// </summary>
         private static string GetRelativeNamespace(string namespaceParent, string @namespace)

--- a/MonoGame.Framework/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Audio/OpenAL.cs
@@ -325,7 +325,6 @@ namespace OpenAL
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSourceStop")]
         public static extern void SourceStop (int sourceId);
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSourcei")]
         internal static extern void Source (int sourceId, int i, int a);
 

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -406,12 +406,11 @@ namespace Microsoft.Xna.Framework.Audio
 		}
 
         /// <summary>
-        /// Reserves the given sound buffer. If there are no available sources then false is
-        /// returned, otherwise true will be returned and the sound buffer can be played. If
-        /// the controller was not able to setup the hardware, then false will be returned.
+        /// Reserves a sound buffer and return its identifier. If there are no available sources
+        /// or the controller was not able to setup the hardware then an
+        /// <see cref="InstancePlayLimitException"/> is thrown.
         /// </summary>
-        /// <param name="soundBuffer">The sound buffer you want to play</param>
-        /// <returns>True if the buffer can be played, and false if not.</returns>
+        /// <returns>The source number of the reserved sound buffer.</returns>
 		public int ReserveSource()
 		{
             if (!CheckInitState())

--- a/MonoGame.Framework/Audio/Xact/ReverbSettings.cs
+++ b/MonoGame.Framework/Audio/Xact/ReverbSettings.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Xna.Framework.Audio
     {
         private readonly DspParameter[] _parameters = new DspParameter[22];
 
-        private bool _dirty;
-
         public ReverbSettings(BinaryReader reader)
         {
             _parameters[0] = new DspParameter(reader); // ReflectionsDelayMs

--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1788,7 +1788,7 @@ namespace Microsoft.Xna.Framework
             return new Vector4(R / 255.0f, G / 255.0f, B / 255.0f, A / 255.0f);
         }
 	
-	/// <summary>
+        /// <summary>
         /// Gets or sets packed value of this <see cref="Color"/>.
         /// </summary>
         [CLSCompliant(false)]

--- a/MonoGame.Framework/Graphics/ClearOptions.cs
+++ b/MonoGame.Framework/Graphics/ClearOptions.cs
@@ -7,7 +7,7 @@ using System;
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
-    /// Defines the buffers for clearing when calling <see cref="GraphicsDevice.Clear"/> operation.
+    /// Defines the buffers for clearing when calling <see cref="GraphicsDevice.Clear(ClearOptions, Color, float, int)"/> operation.
     /// </summary>
     [Flags]
     public enum ClearOptions

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 {
                     displayModes = monitor.GetDisplayModeList(formatTranslation.Key, 0);
                 }
-                catch (SharpDX.SharpDXException ex)
+                catch (SharpDX.SharpDXException)
                 {
                     var mode = new DisplayMode(desktopWidth, desktopHeight, SurfaceFormat.Color);
                     modes.Add(mode);

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -733,7 +733,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 unchecked
                 {
-                    _graphicsMetrics._targetCount += (ulong)renderTargetCount;
+                    _graphicsMetrics._targetCount += renderTargetCount;
                 }
             }
         }
@@ -927,7 +927,7 @@ namespace Microsoft.Xna.Framework.Graphics
             unchecked
             {
                 _graphicsMetrics._drawCount++;
-                _graphicsMetrics._primitiveCount += (ulong)primitiveCount;
+                _graphicsMetrics._primitiveCount += primitiveCount;
             }
         }
 
@@ -963,7 +963,7 @@ namespace Microsoft.Xna.Framework.Graphics
             unchecked
             {
                 _graphicsMetrics._drawCount++;
-                _graphicsMetrics._primitiveCount += (ulong) primitiveCount;
+                _graphicsMetrics._primitiveCount += primitiveCount;
             }
         }
 
@@ -985,7 +985,7 @@ namespace Microsoft.Xna.Framework.Graphics
             unchecked
             {
                 _graphicsMetrics._drawCount++;
-                _graphicsMetrics._primitiveCount += (ulong) primitiveCount;
+                _graphicsMetrics._primitiveCount +=  primitiveCount;
             }
         }
 
@@ -1031,7 +1031,7 @@ namespace Microsoft.Xna.Framework.Graphics
             unchecked
             {
                 _graphicsMetrics._drawCount++;
-                _graphicsMetrics._primitiveCount += (ulong) primitiveCount;
+                _graphicsMetrics._primitiveCount +=  primitiveCount;
             }
         }
 
@@ -1077,7 +1077,7 @@ namespace Microsoft.Xna.Framework.Graphics
             unchecked
             {
                 _graphicsMetrics._drawCount++;
-                _graphicsMetrics._primitiveCount += (ulong) primitiveCount;
+                _graphicsMetrics._primitiveCount +=  primitiveCount;
             }
         }
 
@@ -1101,7 +1101,7 @@ namespace Microsoft.Xna.Framework.Graphics
             unchecked
             {
                 _graphicsMetrics._drawCount++;
-                _graphicsMetrics._primitiveCount += (ulong)(primitiveCount * instanceCount);
+                _graphicsMetrics._primitiveCount += (primitiveCount * instanceCount);
             }
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsMetrics.cs
+++ b/MonoGame.Framework/Graphics/GraphicsMetrics.cs
@@ -9,54 +9,54 @@ namespace Microsoft.Xna.Framework.Graphics
     /// </summary>
     public struct GraphicsMetrics
     {
-        internal ulong _clearCount;
-        internal ulong _drawCount;
-        internal ulong _pixelShaderCount;
-        internal ulong _primitiveCount;
-        internal ulong _spriteCount;
-        internal ulong _targetCount;
-        internal ulong _textureCount;
-        internal ulong _vertexShaderCount;
+        internal long _clearCount;
+        internal long _drawCount;
+        internal long _pixelShaderCount;
+        internal long _primitiveCount;
+        internal long _spriteCount;
+        internal long _targetCount;
+        internal long _textureCount;
+        internal long _vertexShaderCount;
 
         /// <summary>
         /// Number of times Clear was called.
         /// </summary>
-        public ulong ClearCount { get { return _clearCount; } }
+        public long ClearCount { get { return _clearCount; } }
 
         /// <summary>
         /// Number of times Draw was called.
         /// </summary>
-        public ulong DrawCount { get { return _drawCount; } }
+        public long DrawCount { get { return _drawCount; } }
 
         /// <summary>
         /// Number of times the pixel shader was changed on the GPU.
         /// </summary>
-        public ulong PixelShaderCount { get { return _pixelShaderCount; } }
+        public long PixelShaderCount { get { return _pixelShaderCount; } }
 
         /// <summary>
         /// Number of rendered primitives.
         /// </summary>
-        public ulong PrimitiveCount { get { return _primitiveCount; } }
+        public long PrimitiveCount { get { return _primitiveCount; } }
 
         /// <summary>
         /// Number of sprites and text characters rendered via <see cref="SpriteBatch"/>.
         /// </summary>
-        public ulong SpriteCount { get { return _spriteCount; } }
+        public long SpriteCount { get { return _spriteCount; } }
 
         /// <summary>
         /// Number of times a target was changed on the GPU.
         /// </summary>
-        public ulong TargetCount {get { return _targetCount; } }
+        public long TargetCount {get { return _targetCount; } }
 
         /// <summary>
         /// Number of times a texture was changed on the GPU.
         /// </summary>
-        public ulong TextureCount { get { return _textureCount; } }
+        public long TextureCount { get { return _textureCount; } }
 
         /// <summary>
         /// Number of times the vertex shader was changed on the GPU.
         /// </summary>
-        public ulong VertexShaderCount { get { return _vertexShaderCount; } }
+        public long VertexShaderCount { get { return _vertexShaderCount; } }
 
         /// <summary>
         /// Returns the difference between two sets of metrics.

--- a/MonoGame.Framework/Graphics/ModelMesh.cs
+++ b/MonoGame.Framework/Graphics/ModelMesh.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     for (int j = 0; j < effect.CurrentTechnique.Passes.Count; j++)
                     {
 						effect.CurrentTechnique.Passes[j].Apply ();
-						this.graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, part.VertexOffset, 0, part.NumVertices, part.StartIndex, part.PrimitiveCount);
+						graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, part.VertexOffset, part.StartIndex, part.PrimitiveCount);
 					}
 				}
 			}

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Xna.Framework.Graphics
             
             unchecked
             {
-                _device._graphicsMetrics._spriteCount += (ulong)batchCount;
+                _device._graphicsMetrics._spriteCount += batchCount;
             }
 
             // Iterate through the batches, doing short.MaxValue sets of vertices only.

--- a/MonoGame.Framework/Graphics/States/Blend.cs
+++ b/MonoGame.Framework/Graphics/States/Blend.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
 		InverseDestinationAlpha,
 	    /// <summary>
-        /// Each component of the color is multiplied by a constant in the <see cref="GraphicsDevice.BlendFactor"/>.
+        /// Each component of the color is multiplied by a constant in the <see cref="Microsoft.Xna.Framework.Graphics.GraphicsDevice.BlendFactor"/>.
 	    /// </summary>
 		BlendFactor,
         /// <summary>

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -322,7 +322,6 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
 #if !WINDOWS_PHONE
 
-        [CLSCompliant(false)]
         static SharpDX.Direct3D11.Texture2D CreateTex2DFromBitmap(SharpDX.WIC.BitmapSource bsource, GraphicsDevice device)
         {
 

--- a/MonoGame.Framework/Graphics/Texture3D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.DirectX.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Runtime.InteropServices;
 using SharpDX;
 using SharpDX.Direct3D11;
-using SharpDX.DXGI;
 using MapFlags = SharpDX.Direct3D11.MapFlags;
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -16,7 +15,6 @@ namespace Microsoft.Xna.Framework.Graphics
 	{
         private bool renderTarget;
         private bool mipMap;
-	    private SampleDescription _sampleDescription;
 
         private void PlatformConstruct(GraphicsDevice graphicsDevice, int width, int height, int depth, bool mipMap, SurfaceFormat format, bool renderTarget)
         {

--- a/MonoGame.Framework/Input/GamePad.XInput.cs
+++ b/MonoGame.Framework/Input/GamePad.XInput.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Xna.Framework.Input
                 packetNumber = xistate.PacketNumber;
                 gamepad = xistate.Gamepad;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
             }
 

--- a/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
+++ b/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
@@ -8378,7 +8378,7 @@ namespace MonoGame.Utilities
         /// </summary>
         /// <remarks>
         ///   <para>
-        ///     Set this at any point before calling <see cref="Close()"/>.
+        ///     Set this at any point before calling <see cref="Stream.Close"/>.
         ///   </para>
         /// </remarks>
         internal bool LeaveOpen

--- a/Test/ContentPipeline/AudioContentTests.cs
+++ b/Test/ContentPipeline/AudioContentTests.cs
@@ -192,10 +192,8 @@ namespace MonoGame.Tests.ContentPipeline
                     if (bitsPerSample == 32)
                         return -2;
                     return 1;
-                    break;
                 case ConversionFormat.Adpcm:
                     return 2;
-                    break;
                 case ConversionFormat.WindowsMedia:
                 case ConversionFormat.Xma:
                 default:

--- a/Test/Framework/TestGameBase.cs
+++ b/Test/Framework/TestGameBase.cs
@@ -166,7 +166,7 @@ namespace MonoGame.Tests {
 			SafeRaise (UnloadContentWith);
 		}
 
-		public new void Run (Predicate<FrameInfo> until = null)
+		public void Run (Predicate<FrameInfo> until = null)
 		{
 			if (until != null)
 				ExitCondition = until;

--- a/Test/Runner/Interface/CommandLineInterface.cs
+++ b/Test/Runner/Interface/CommandLineInterface.cs
@@ -121,7 +121,7 @@ namespace MonoGame.Tests
 				resultWriter.SaveTestResult (result);
 
 				if (_runOptions.PerformXslTransform) {
-					var transform = new XslTransform ();
+					var transform = new XslCompiledTransform();
 					transform.Load (_runOptions.XslTransformPath);
 					transform.Transform (_runOptions.XmlResultsPath, _runOptions.TransformedResultsPath);
 				}

--- a/Tools/2MGFX/Properties/AssemblyInfo.cs
+++ b/Tools/2MGFX/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -13,6 +14,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright (C) The MonoGame Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+
+// Mark the assembly as CLS compliant so it can be safely used in other .NET languages
+[assembly: CLSCompliant(true)]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Tools/Pipeline/Common/PipelineController.ExcludeAction.cs
+++ b/Tools/Pipeline/Common/PipelineController.ExcludeAction.cs
@@ -53,7 +53,7 @@ namespace MonoGame.Tools.Pipeline
                             else
                                 File.Delete(_con.GetFullPath(item.OriginalPath));
                         }
-                        catch (FileNotFoundException ex)
+                        catch (FileNotFoundException)
                         {
                             // No error needed in case file is not found
                         }

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -271,7 +271,7 @@ namespace MonoGame.Tools.Pipeline
                 PipelineSettings.Default.Save();
                 View.UpdateRecentList(PipelineSettings.Default.ProjectHistory);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 View.ShowError("Open Project", "Failed to open project!");
                 return;


### PR DESCRIPTION
Helps out with #2433. Most of these were wrong references in comments and unused variables/parameters. I only built Windows and WindowsGL solutions. The bulk of the leftover warnings for those platforms are about a DrawIndexedPrimitives overload being obsolete in tests, but that overload is what we need to use for XNA and I didn't feel like #ifdeffing around all of them :p Then there's some warnings thrown in NVorbis and code generated by TinyPG that I didn't fix (about CLS-compliance), there's some about GraphicsDevice.BlendFactor missing which will be fixed by #5176. There are some warnings about variables not being assigned, but I left those in and some about variables not being used in tests, but I glanced over and it seemed like they were used for reflection tests. 
