### PR TITLE
[Pipeline Tool] Use attributes if available

### DIFF
--- a/Tools/Pipeline/Common/PipelineTypes.cs
+++ b/Tools/Pipeline/Common/PipelineTypes.cs
@@ -61,8 +61,10 @@ namespace MonoGame.Tools.Pipeline
         public struct Property
         {
             public string Name;
+            public string DisplayName;
             public Type Type;
             public object DefaultValue;
+            public bool Browsable;
 
             public override string ToString()
             {
@@ -287,14 +289,28 @@ namespace MonoGame.Tools.Pipeline
                 var properties = new List<ProcessorTypeDescription.Property>();
                 foreach (var i in typeProperties)
                 {
-                    // TODO:
-                    //p.GetCustomAttribute(typeof(ContentPipelineIgnore))
+                    var attrs = i.GetCustomAttributes(true);
+                    var name = i.Name;
+                    var browsable = true;
+                    var defvalue = i.GetValue(obj, null);
+
+                    foreach (var a in attrs)
+                    {
+                        if (a is BrowsableAttribute)
+                            browsable = (a as BrowsableAttribute).Browsable;
+                        else if (a is DisplayNameAttribute)
+                            name = (a as DisplayNameAttribute).DisplayName;
+                        else if (a is DefaultValueAttribute)
+                            defvalue = (a as DefaultValueAttribute).Value;
+                    }
 
                     var p = new ProcessorTypeDescription.Property()
                         {
                             Name = i.Name,
+                            DisplayName = name,
                             Type = i.PropertyType,
-                            DefaultValue = i.GetValue(obj, null),
+                            DefaultValue = defvalue,
+                            Browsable = browsable
                         };
                     properties.Add(p);
                 }

--- a/Tools/Pipeline/Controls/PropertyGridControl.cs
+++ b/Tools/Pipeline/Controls/PropertyGridControl.cs
@@ -90,6 +90,7 @@ namespace MonoGame.Tools.Pipeline
             foreach (var p in props)
             {
                 var attrs = p.GetCustomAttributes(true);
+                var name = p.Name;
                 var browsable = true;
                 var category = "Mics";
 
@@ -99,6 +100,8 @@ namespace MonoGame.Tools.Pipeline
                         browsable = (a as BrowsableAttribute).Browsable;
                     else if (a is CategoryAttribute)
                         category = (a as CategoryAttribute).Category;
+                    else if (a is DisplayNameAttribute)
+                        name = (a as DisplayNameAttribute).DisplayName;
                 }
 
                 object value = p.GetValue(objects[0], null);
@@ -114,7 +117,7 @@ namespace MonoGame.Tools.Pipeline
                 if (!browsable)
                     continue;
 
-                propertyTable.AddEntry(category, p.Name, value, p.PropertyType, (sender, e) =>
+                propertyTable.AddEntry(category, name, value, p.PropertyType, (sender, e) =>
                 {
                     var action = new UpdatePropertyAction(MainWindow.Instance, objects, p, sender);
                     PipelineController.Instance.AddAction(action);
@@ -130,6 +133,9 @@ namespace MonoGame.Tools.Pipeline
         {
             foreach (var p in objects[0].Processor.Properties)
             {
+                if (!p.Browsable)
+                    continue;
+
                 object value = objects[0].ProcessorParams[p.Name];
                 foreach (ContentItem o in objects)
                 {
@@ -140,7 +146,7 @@ namespace MonoGame.Tools.Pipeline
                     }
                 }
 
-                propertyTable.AddEntry("Processor Parameters", p.Name, value, p.Type, (sender, e) =>
+                propertyTable.AddEntry("Processor Parameters", p.DisplayName, value, p.Type, (sender, e) =>
                 {
                     var action = new UpdateProcessorAction(MainWindow.Instance, objects.Cast<ContentItem>().ToList(), p.Name, sender);
                     PipelineController.Instance.AddAction(action);


### PR DESCRIPTION
Stuff done:
 - properties will use `DisplayName` if available
 - properties will use `DefaultValue` for the starting value if available
 - properties will not be shown if `Browsable` attribute is set to false
   - under TODO I noticed there was an idea to use `ContentPipelineIgnore` (which does not exist) but we would just be creating a pointless attribute considering there already is an attribute for that exact purpose