### PR TITLE
Fix a crash when loading ADPCM data from a WaveBank.

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             if (codec == MiniFormatTag.Adpcm)
             {
-                PlatformInitializeAdpcm(buffer, 0, buffer.Length, sampleRate, (AudioChannels)channels, blockAlignment, loopStart, loopLength);
+                PlatformInitializeAdpcm(buffer, 0, buffer.Length, sampleRate, (AudioChannels)channels, (blockAlignment + 16) * 2, loopStart, loopLength);
                 duration = TimeSpan.FromSeconds(SoundBuffer.Duration);
                 return;
             }

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Xna.Framework.Audio
             var format = BitConverter.ToInt16(header, 0);
             var channels = BitConverter.ToInt16(header, 2);
             var sampleRate = BitConverter.ToInt32(header, 4);
-            var blockAlignment = BitConverter.ToInt32(header, 12);
+            var blockAlignment = BitConverter.ToInt16(header, 12);
 
             // We need to decode MSADPCM.
             var supportsADPCM = OpenALSoundController.GetInstance.SupportsADPCM;


### PR DESCRIPTION
In a previous commit the code was refactored. The adjustments
to the blockAlignent was overlooked. As a result when loading
the ADPCM data under openal the blockAlignment is incorrect.
This causes a crash.