### PR TITLE
DdsLoader Write Helper

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/DdsLoader.cs
+++ b/MonoGame.Framework.Content.Pipeline/DdsLoader.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
@@ -14,6 +15,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
     /// </summary>
     class DdsLoader
     {
+        [Flags]
         enum Ddsd : uint
         {
             Caps = 0x1,             // Required in every DDS file
@@ -26,6 +28,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             Depth = 0x800000,       // Required in a depth texture
         }
 
+        [Flags]
         enum DdsCaps : uint
         {
             Complex = 0x8,       // Optional; must be used on any file that contains more than one surface (a mipmap, a cubic environment map, or mipmapped volume texture)
@@ -33,6 +36,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             Texture = 0x1000,    // Required
         }
 
+        [Flags]
         enum DdsCaps2 : uint
         {
             Cubemap = 0x200,
@@ -47,6 +51,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             CubemapAllFaces = Cubemap | CubemapPositiveX | CubemapNegativeX | CubemapPositiveY | CubemapNegativeY | CubemapPositiveZ | CubemapNegativeZ,
         }
 
+        [Flags]
         enum Ddpf : uint
         {
             AlphaPixels = 0x1,
@@ -373,6 +378,86 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                 var b = bytes[i + 1] & 0x1F;
                 bytes[i] = (byte)((bytes[i] & 0x07) | (b << 3));
                 bytes[i + 1] = (byte)((bytes[i + 1] & 0xE0) | r);
+            }
+        }
+
+        internal static void WriteUncompressed(string filename, BitmapContent bitmapContent)
+        {
+            using (var writer = new BinaryWriter(new FileStream(filename, FileMode.Create, FileAccess.Write)))
+            {
+                // Write signature ("DDS ")
+                writer.Write((byte)0x44);
+                writer.Write((byte)0x44);
+                writer.Write((byte)0x53);
+                writer.Write((byte)0x20);
+
+                var header = new DdsHeader();
+                header.dwSize = 124;
+                header.dwFlags = Ddsd.Caps | Ddsd.Width | Ddsd.Height | Ddsd.Pitch | Ddsd.PixelFormat;
+                header.dwWidth = (uint)bitmapContent.Width;
+                header.dwHeight = (uint)bitmapContent.Height;
+                header.dwPitchOrLinearSize = (uint)(bitmapContent.Width * 4);
+                header.dwDepth = (uint)0;
+                header.dwMipMapCount = (uint)0;
+                
+                writer.Write((uint)header.dwSize);
+                writer.Write((uint)header.dwFlags);
+                writer.Write((uint)header.dwHeight);
+                writer.Write((uint)header.dwWidth);
+                writer.Write((uint)header.dwPitchOrLinearSize);
+                writer.Write((uint)header.dwDepth);
+                writer.Write((uint)header.dwMipMapCount);
+
+                // 11 unsed and reserved DWORDS.
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+
+                SurfaceFormat format;
+                if (!bitmapContent.TryGetFormat(out format) || format != SurfaceFormat.Color)
+                    throw new NotSupportedException("Unsupported bitmap content!");
+
+                header.ddspf.dwSize = 32;
+                header.ddspf.dwFlags = Ddpf.AlphaPixels | Ddpf.Rgb;
+                header.ddspf.dwFourCC = 0;
+                header.ddspf.dwRgbBitCount = 32;
+                header.ddspf.dwRBitMask = 0x000000ff;
+                header.ddspf.dwGBitMask = 0x0000ff00;
+                header.ddspf.dwBBitMask = 0x00ff0000;
+                header.ddspf.dwABitMask = 0xff000000;
+
+                // Write the DDS_PIXELFORMAT
+                writer.Write((uint)header.ddspf.dwSize);
+                writer.Write((uint)header.ddspf.dwFlags);
+                writer.Write((uint)header.ddspf.dwFourCC);
+                writer.Write((uint)header.ddspf.dwRgbBitCount);
+                writer.Write((uint)header.ddspf.dwRBitMask);
+                writer.Write((uint)header.ddspf.dwGBitMask);
+                writer.Write((uint)header.ddspf.dwBBitMask);
+                writer.Write((uint)header.ddspf.dwABitMask);
+
+                header.dwCaps = DdsCaps.Texture;
+                header.dwCaps2 = 0;
+
+                // Continue reading DDS_HEADER
+                writer.Write((uint)header.dwCaps);
+                writer.Write((uint)header.dwCaps2);
+
+                // More reserved unused DWORDs.
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+                writer.Write((uint)0);
+
+                // Write out the face data.
+                writer.Write(bitmapContent.GetPixelData());
             }
         }
     }


### PR DESCRIPTION
A basic uncompressed DDS writing for exporting content for use with different console command line tools.

This could be expanded in the future for other pipeline uses if needed.