### PR TITLE
ConstantBufferData constructor

### DIFF
--- a/Tools/2MGFX/ConstantBufferData.cs
+++ b/Tools/2MGFX/ConstantBufferData.cs
@@ -14,6 +14,15 @@ namespace TwoMGFX
 
         public List<EffectObject.d3dx_parameter> Parameters { get; private set; }
 
+        public ConstantBufferData(string name)
+        {
+            Name = name;
+
+            ParameterIndex = new List<int>();
+            ParameterOffset = new List<int>();
+            Parameters = new List<EffectObject.d3dx_parameter>();
+            Size = 0;
+        }
 
         public bool SameAs(ConstantBufferData other)
         {


### PR DESCRIPTION
I added a common constructor for `ConstantBufferData` used by multiple console platforms.