### PR TITLE
Improve setting BlendState in DX

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1182,17 +1182,29 @@ namespace Microsoft.Xna.Framework.Graphics
             Debug.Assert(_d3dContext != null, "The d3d context is null!");
         }
 
-        private void PlatformApplyBlendFactor()
+        private void PlatformApplyBlend()
+        {
+            if (_blendFactorDirty || _blendStateDirty)
+            {
+                var state = _actualBlendState.GetDxState(this);
+                var factor = GetBlendFactor();
+                _d3dContext.OutputMerger.SetBlendState(state, factor);
+
+                _blendFactorDirty = false;
+                _blendStateDirty = false;
+            }
+        }
+
+        private Color4 GetBlendFactor()
         {
 #if WINDOWS_UAP
-			_d3dContext.OutputMerger.BlendFactor =
-				new SharpDX.Mathematics.Interop.RawColor4(
+			return new SharpDX.Mathematics.Interop.RawColor4(
 					BlendFactor.R / 255.0f,
 					BlendFactor.G / 255.0f,
 					BlendFactor.B / 255.0f,
 					BlendFactor.A / 255.0f);
 #else
-			_d3dContext.OutputMerger.BlendFactor = BlendFactor.ToColor4();
+			return BlendFactor.ToColor4();
 #endif
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1195,18 +1195,21 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        private Color4 GetBlendFactor()
-        {
 #if WINDOWS_UAP
+        private SharpDX.Mathematics.Interop.RawColor4 GetBlendFactor()
+        {
 			return new SharpDX.Mathematics.Interop.RawColor4(
 					BlendFactor.R / 255.0f,
 					BlendFactor.G / 255.0f,
 					BlendFactor.B / 255.0f,
 					BlendFactor.A / 255.0f);
-#else
-			return BlendFactor.ToColor4();
-#endif
         }
+#else
+        private Color4 GetBlendFactor()
+        {
+			return BlendFactor.ToColor4();
+        }
+#endif
 
         internal void PlatformApplyState(bool applyShaders)
         {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -296,9 +296,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     "Try updating your graphics drivers.");
             }
 
-            // Force reseting states
-            this.BlendState.PlatformApplyState(this, true);
-            this.PlatformApplyBlendFactor(true);
+            // Force resetting states
+            this.PlatformApplyBlend(true);
             this.DepthStencilState.PlatformApplyState(this, true);
             this.RasterizerState.PlatformApplyState(this, true);            
 
@@ -843,15 +842,21 @@ namespace Microsoft.Xna.Framework.Graphics
             Threading.EnsureUIThread();
         }
 
-        private void PlatformApplyBlendFactor(bool force = false)
+        private void PlatformApplyBlend(bool force = false)
+        {
+            _actualBlendState.PlatformApplyState(this, force);
+            ApplyBlendFactor(force);
+        }
+
+        private void ApplyBlendFactor(bool force)
         {
             if (force || BlendFactor != _lastBlendState.BlendFactor)
             {
                 GL.BlendColor(
-                    this.BlendFactor.R / 255.0f,
-                    this.BlendFactor.G / 255.0f,
-                    this.BlendFactor.B / 255.0f,
-                    this.BlendFactor.A / 255.0f);
+                    this.BlendFactor.R/255.0f,
+                    this.BlendFactor.G/255.0f,
+                    this.BlendFactor.B/255.0f,
+                    this.BlendFactor.A/255.0f);
                 GraphicsExtensions.CheckGLError();
                 _lastBlendState.BlendFactor = this.BlendFactor;
             }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
         }
 
-        private void PlatformApplyBlendFactor()
+        private void PlatformApplyBlend()
         {
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -434,17 +434,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             PlatformBeginApplyState();
 
-            if (_blendStateDirty)
-            {
-                _actualBlendState.PlatformApplyState(this);
-                _blendStateDirty = false;
-            }
-
-            if (_blendFactorDirty)
-            {
-                PlatformApplyBlendFactor();
-                _blendFactorDirty = false;
-            }
+            PlatformApplyBlend();
 
             if (_depthStencilStateDirty)
             {

--- a/MonoGame.Framework/Graphics/States/BlendState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.DirectX.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class BlendState
     {
-        SharpDX.Direct3D11.BlendState _state;
+        private SharpDX.Direct3D11.BlendState _state;
 
         protected internal override void GraphicsDeviceResetting()
         {
@@ -16,7 +16,7 @@ namespace Microsoft.Xna.Framework.Graphics
             base.GraphicsDeviceResetting();
         }
 
-        internal void PlatformApplyState(GraphicsDevice device)
+        internal SharpDX.Direct3D11.BlendState GetDxState(GraphicsDevice device)
         {
             if (_state == null)
             {
@@ -38,11 +38,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
             Debug.Assert(GraphicsDevice == device, "The state was created for a different device!");
 
-			// NOTE: We make the assumption here that the caller has
-			// locked the d3dContext for us to use.
-
 			// Apply the state!
-			device._d3dContext.OutputMerger.BlendState = _state;
+			return _state;
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
We used the BlendState and BlendFactor setters which both called SetBlendState internally. I changed this to check if either BlendState or BlendFactor is dirty and calling SetBlendState from our code so only 1 call is done. Discussed in #5176 
cc @tomspilman 