### PR TITLE
WinDX: ClientSizeChanged / backbuffer resizing bug fixes

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -47,6 +47,8 @@ namespace MonoGame.Framework
         {
             var gdm = Game.graphicsDeviceManager;
 
+            _window.EnableClientSizeChangedEvent(false); // Disable ClientSizeChanged event while the window is initialised
+
             _window.Initialize(gdm.PreferredBackBufferWidth, gdm.PreferredBackBufferHeight);
 
             base.BeforeInitialize();
@@ -55,6 +57,8 @@ namespace MonoGame.Framework
                 EnterFullScreen();
             else
                 ExitFullScreen();
+
+            _window.EnableClientSizeChangedEvent(true); // Re-enable (and trigger) ClientSizeChanged event
         }
 
         public override void RunLoop()
@@ -94,14 +98,13 @@ namespace MonoGame.Framework
             {
                 Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
                 Game.GraphicsDevice.SetHardwareFullscreen();
-
-                _window._form.WindowState = FormWindowState.Maximized;
             }
             else
             {
                 _window.IsBorderless = true;
-                _window._form.WindowState = FormWindowState.Maximized;
             }
+
+            _window._form.WindowState = FormWindowState.Maximized;
 
             _alreadyInWindowedMode = false;
             _alreadyInFullScreenMode = true;
@@ -114,22 +117,16 @@ namespace MonoGame.Framework
 
             if (Game.graphicsDeviceManager.HardwareModeSwitch)
             {
-
                 Game.GraphicsDevice.PresentationParameters.IsFullScreen = false;
                 Game.GraphicsDevice.SetHardwareFullscreen();
-
-                _window._form.WindowState = FormWindowState.Normal;
-
-                Game.GraphicsDevice.PresentationParameters.BackBufferWidth = Game.graphicsDeviceManager.PreferredBackBufferWidth;
-                Game.GraphicsDevice.PresentationParameters.BackBufferHeight = Game.graphicsDeviceManager.PreferredBackBufferHeight;
-
-                Game.GraphicsDevice.OnPresentationChanged();
             }
             else
             {
-                _window._form.WindowState = FormWindowState.Normal;
                 _window.IsBorderless = false;
             }
+
+            _window._form.WindowState = FormWindowState.Normal;
+            _window.ChangeClientSize(new Size(Game.graphicsDeviceManager.PreferredBackBufferWidth, Game.graphicsDeviceManager.PreferredBackBufferHeight));
 
             _alreadyInWindowedMode = true;
             _alreadyInFullScreenMode = false;
@@ -137,16 +134,16 @@ namespace MonoGame.Framework
 
         internal override void OnPresentationChanged()
         {
-            var presentationParameters = Game.GraphicsDevice.PresentationParameters;
-            
-            if (presentationParameters.IsFullScreen)
+            _window.EnableClientSizeChangedEvent(false); // Disable ClientSizeChanged event while the window is resized
+
+            if (Game.GraphicsDevice.PresentationParameters.IsFullScreen)
                 EnterFullScreen();
             else
-                ExitFullScreen();                
-            
-            _window.ChangeClientSize(new Size(presentationParameters.BackBufferWidth, presentationParameters.BackBufferHeight));
+                ExitFullScreen();
+
+            _window.EnableClientSizeChangedEvent(true); // Re-enable (and trigger) ClientSizeChanged event
         }
-        
+
         public override void EndScreenDeviceChange(string screenDeviceName, int clientWidth, int clientHeight)
         {
         }

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -126,7 +126,6 @@ namespace MonoGame.Framework
             }
 
             _window._form.WindowState = FormWindowState.Normal;
-            _window.ChangeClientSize(new Size(Game.graphicsDeviceManager.PreferredBackBufferWidth, Game.graphicsDeviceManager.PreferredBackBufferHeight));
 
             _alreadyInWindowedMode = true;
             _alreadyInFullScreenMode = false;
@@ -137,9 +136,14 @@ namespace MonoGame.Framework
             _window.EnableClientSizeChangedEvent(false); // Disable ClientSizeChanged event while the window is resized
 
             if (Game.GraphicsDevice.PresentationParameters.IsFullScreen)
+            {
                 EnterFullScreen();
+            }
             else
+            {
                 ExitFullScreen();
+                _window.ChangeClientSize(new Size(Game.graphicsDeviceManager.PreferredBackBufferWidth, Game.graphicsDeviceManager.PreferredBackBufferHeight));
+            }
 
             _window.EnableClientSizeChangedEvent(true); // Re-enable (and trigger) ClientSizeChanged event
         }

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -37,6 +37,8 @@ namespace MonoGame.Framework
 
         private bool _isMouseInBounds;
 
+        private bool _areClientSizeChangedEventsIgnored;
+
         #region Internal Properties
 
         internal Game Game { get; private set; }
@@ -296,8 +298,18 @@ namespace MonoGame.Framework
             _form.Show();
         }
 
+        internal void EnableClientSizeChangedEvent(bool isEnabled)
+        {
+            _areClientSizeChangedEventsIgnored = !isEnabled;
+            if (isEnabled)
+                OnClientSizeChanged(this, EventArgs.Empty);
+        }
+
         private void OnClientSizeChanged(object sender, EventArgs eventArgs)
         {
+            if (_areClientSizeChangedEventsIgnored)
+                return;
+
             // Only resize the backbuffer in windowed mode. In fullscreen mode, it gets stretched to fit the window.
             if (Game.Window == this && !Game.graphicsDeviceManager.IsFullScreen)
             {

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -298,7 +298,8 @@ namespace MonoGame.Framework
 
         private void OnClientSizeChanged(object sender, EventArgs eventArgs)
         {
-            if (Game.Window == this)
+            // Only resize the backbuffer in windowed mode. In fullscreen mode, it gets stretched to fit the window.
+            if (Game.Window == this && !Game.graphicsDeviceManager.IsFullScreen)
             {
                 var manager = Game.graphicsDeviceManager;
 

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -310,23 +310,23 @@ namespace MonoGame.Framework
             if (_areClientSizeChangedEventsIgnored)
                 return;
 
-            // Only resize the backbuffer in windowed mode. In fullscreen mode, it gets stretched to fit the window.
-            if (Game.Window == this && !Game.graphicsDeviceManager.IsFullScreen)
+            if (Game.Window == this)
             {
                 var manager = Game.graphicsDeviceManager;
-
-                // Set the default new back buffer size and viewport, but this
-                // can be overloaded by the two events below.
-
-                var newWidth = _form.ClientRectangle.Width;
-                var newHeight = _form.ClientRectangle.Height;
-
                 if (manager.GraphicsDevice == null)
                     return;
 
-                manager.GraphicsDevice.PresentationParameters.BackBufferWidth = newWidth;
-                manager.GraphicsDevice.PresentationParameters.BackBufferHeight = newHeight;
-                manager.GraphicsDevice.OnPresentationChanged();
+                // Only resize the backbuffer in windowed mode. In fullscreen mode, it gets stretched to fit the window.
+                // Also skip resizing the backbuffer when the window is minimized.
+                if (!manager.IsFullScreen && (_form.WindowState != FormWindowState.Minimized))
+                {
+                    // Set the default new back buffer size and viewport, but this
+                    // can be overloaded by the two events below.
+                    var newSize = _form.ClientSize;
+                    manager.GraphicsDevice.PresentationParameters.BackBufferWidth = newSize.Width;
+                    manager.GraphicsDevice.PresentationParameters.BackBufferHeight = newSize.Height;
+                    manager.GraphicsDevice.OnPresentationChanged();
+                }
             }
 
             // Set the new view state which will trigger the 


### PR DESCRIPTION
A couple of bugs were introduced by PR #4959 in regards to backbuffer resizing as follows:
- Fullscreen mode was forced to the native resolution. So it was no longer possible to set a different fullscreen resolution.
- If the window was minimised, the backbuffer was resized to 0x0.

The problem was that the `WinFormsGameWindow.OnClientSizeChanged` method was always resizing the backbuffer when the window size changed. This was regardless of whether or not fullscreen mode was enabled, or if the window was minimised.

This PR fixes this by simply skipping the backbuffer resize when fullscreen is enabled or if the window is minimised.

As a side effect of this, I've also cleaned up the `ClientSizeChanged` event. It was previously firing multiple times when switching to/from fullscreen mode. Now it only fires once (which is consistent with XNA behaviour).

P.S. I think this _might_ also fix issue #5104, but I'm not sure.

UPDATE: Confirmed to fix #5236
