### PR TITLE
Performance improvements to SpriteBatch with custom Effect

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -126,28 +126,40 @@ namespace Microsoft.Xna.Framework.Graphics
 			gd.RasterizerState = _rasterizerState;
 			gd.SamplerStates[0] = _samplerState;
 			
-            // Setup the default sprite effect.
-			var vp = gd.Viewport;
-
-		    Matrix projection;
-
-            // Normal 3D cameras look into the -z direction (z = 1 is in font of z = 0). The
-            // sprite batch layer depth is the opposite (z = 0 is in front of z = 1).
-            // --> We get the correct matrix with near plane 0 and far plane -1.
-            Matrix.CreateOrthographicOffCenter(0, vp.Width, vp.Height, 0, 0, -1, out projection);
-
-            // Some platforms require a half pixel offset to match DX.
-            if (NeedsHalfPixelOffset)
+            if(_effect != null)
             {
-                projection.M41 += -0.5f * projection.M11;
-                projection.M42 += -0.5f * projection.M22;
+                // Apply the custom sprite effect.
+                // Effects with multiple passes are applied
+                // by SpriteBatcher.FlushVertexArray()
+                var passes = _effect.CurrentTechnique.Passes;
+                if(passes.Count == 1)
+                    passes[0].Apply();
             }
+            else
+            {   
+                // Setup and Apply the default sprite effect.   
+			    var vp = gd.Viewport;
 
-            Matrix.Multiply(ref _matrix, ref projection, out projection);
+		        Matrix projection;
 
-            _matrixTransform.SetValue(projection);
-            _spritePass.Apply();
-		}
+                // Normal 3D cameras look into the -z direction (z = 1 is in font of z = 0). The
+                // sprite batch layer depth is the opposite (z = 0 is in front of z = 1).
+                // --> We get the correct matrix with near plane 0 and far plane -1.
+                Matrix.CreateOrthographicOffCenter(0, vp.Width, vp.Height, 0, 0, -1, out projection);
+
+                // Some platforms require a half pixel offset to match DX.
+                if (NeedsHalfPixelOffset)
+                {
+                    projection.M41 += -0.5f * projection.M11;
+                    projection.M42 += -0.5f * projection.M22;
+                }
+                
+                Matrix.Multiply(ref _matrix, ref projection, out projection);
+
+                _matrixTransform.SetValue(projection);
+                _spritePass.Apply();
+            }
+        }
 		
         void CheckValid(Texture2D texture)
         {

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -241,8 +241,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
             var vertexCount = end - start;
 
-            // If the effect is not null, then apply each pass and render the geometry
-            if (effect != null)
+            // If the effect is not null and have multiple passes, then apply each pass and render the geometry
+            if (effect != null && effect.CurrentTechnique.Passes.Count > 1)
             {
                 var passes = effect.CurrentTechnique.Passes;
                 foreach (var pass in passes)

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -242,12 +242,13 @@ namespace Microsoft.Xna.Framework.Graphics
             var vertexCount = end - start;
 
             // If the effect is not null and have multiple passes, then apply each pass and render the geometry
-            if (effect != null && effect.CurrentTechnique.Passes.Count > 1)
+            if (effect != null)
             {
                 var passes = effect.CurrentTechnique.Passes;
                 foreach (var pass in passes)
                 {
-                    pass.Apply();
+                    if (passes.Count > 1)
+                        pass.Apply();
 
                     // Whatever happens in pass.Apply, make sure the texture being drawn
                     // ends up in Textures[0].


### PR DESCRIPTION
- Skip Setup of _spritePass when we have a custom Effect.
- Single pass custom Effects are applied During Setup(), same as
_spritePass. Effects with multiple passes are applied by
SpriteBatcher.FlushVertexArray() as before. (ImmediateMode applies the
effect on every .Draw() in that case).