### PR TITLE
Fix BoundinBox.Contains(Vector3) to match XNA

### DIFF
--- a/MonoGame.Framework/BoundingBox.cs
+++ b/MonoGame.Framework/BoundingBox.cs
@@ -214,16 +214,11 @@ namespace Microsoft.Xna.Framework
                 || point.Z > this.Max.Z)
             {
                 result = ContainmentType.Disjoint;
-            }//or if point is on box because coordonate of point is lesser or equal
-            else if (point.X == this.Min.X
-                || point.X == this.Max.X
-                || point.Y == this.Min.Y
-                || point.Y == this.Max.Y
-                || point.Z == this.Min.Z
-                || point.Z == this.Max.Z)
-                result = ContainmentType.Intersects;
+            }
             else
+            {
                 result = ContainmentType.Contains;
+            }
         }
 
         private static readonly Vector3 MaxVector3 = new Vector3(float.MaxValue);

--- a/Test/Framework/Bounding.cs
+++ b/Test/Framework/Bounding.cs
@@ -12,6 +12,28 @@ namespace MonoGame.Tests.Framework
     class Bounding
     {
         [Test]
+        public void BoxContainsVector3Test()
+        {
+            var box = new BoundingBox(Vector3.Zero, Vector3.One);
+
+            Assert.AreEqual(ContainmentType.Disjoint, box.Contains(-Vector3.One));
+            Assert.AreEqual(ContainmentType.Disjoint, box.Contains(new Vector3(0.5f, 0.5f, -1f)));
+            Assert.AreEqual(ContainmentType.Contains, box.Contains(Vector3.Zero));
+            Assert.AreEqual(ContainmentType.Contains, box.Contains(new Vector3(0f, 0, 0.5f)));
+            Assert.AreEqual(ContainmentType.Contains, box.Contains(new Vector3(0f, 0.5f, 0.5f)));
+            Assert.AreEqual(ContainmentType.Contains, box.Contains(new Vector3(0.5f, 0.5f, 0.5f)));
+        }
+
+        [Test]
+        public void BoxContainsIdenticalBox()
+        {
+            var b1 = new BoundingBox(Vector3.Zero, Vector3.One);
+            var b2 = new BoundingBox(Vector3.Zero, Vector3.One);
+
+            Assert.AreEqual(ContainmentType.Contains, b1.Contains(b2));
+        }
+
+        [Test]
         public void BoundingSphereTests()
         {
             var zeroPoint = BoundingSphere.CreateFromPoints( new[] {Vector3.Zero} );

--- a/Test/Framework/Bounding.cs
+++ b/Test/Framework/Bounding.cs
@@ -21,6 +21,9 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(ContainmentType.Contains, box.Contains(Vector3.Zero));
             Assert.AreEqual(ContainmentType.Contains, box.Contains(new Vector3(0f, 0, 0.5f)));
             Assert.AreEqual(ContainmentType.Contains, box.Contains(new Vector3(0f, 0.5f, 0.5f)));
+            Assert.AreEqual(ContainmentType.Contains, box.Contains(Vector3.One));
+            Assert.AreEqual(ContainmentType.Contains, box.Contains(new Vector3(1f, 1, 0.5f)));
+            Assert.AreEqual(ContainmentType.Contains, box.Contains(new Vector3(1f, 0.5f, 0.5f)));
             Assert.AreEqual(ContainmentType.Contains, box.Contains(new Vector3(0.5f, 0.5f, 0.5f)));
         }
 


### PR DESCRIPTION
Fixes #5245. XNA returns Contains when a vector is on one of the boxes faces/edges so MG should too.