### PR TITLE
Fix performance hit when Immediate is used with a custom Effect.

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -147,6 +147,16 @@ namespace Microsoft.Xna.Framework.Graphics
 
             _matrixTransform.SetValue(projection);
             _spritePass.Apply();
+
+            // Apply the custom sprite effect.
+            if(_effect != null)
+            {                
+                // Effects with multiple passes are applied
+                // by SpriteBatcher.FlushVertexArray()
+                var passes = _effect.CurrentTechnique.Passes;
+                if(passes.Count == 1)
+                    passes[0].Apply();
+            }
 		}
 		
         void CheckValid(Texture2D texture)

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -241,17 +241,20 @@ namespace Microsoft.Xna.Framework.Graphics
 
             var vertexCount = end - start;
 
-            // If the effect is not null, then apply each pass and render the geometry
+            // If the effect is not null and have multiple passes, then apply each pass and render the geometry
             if (effect != null)
             {
                 var passes = effect.CurrentTechnique.Passes;
                 foreach (var pass in passes)
                 {
-                    pass.Apply();
+                    if (passes.Count > 1)
+                    {
+                        pass.Apply();
 
-                    // Whatever happens in pass.Apply, make sure the texture being drawn
-                    // ends up in Textures[0].
-                    _device.Textures[0] = texture;
+                        // Whatever happens in pass.Apply, make sure the texture being drawn
+                        // ends up in Textures[0].
+                        _device.Textures[0] = texture;
+                    }
 
                     _device.DrawUserIndexedPrimitives(
                         PrimitiveType.TriangleList,


### PR DESCRIPTION
SpriteBatcher.FlushVertexArray() reapplies the custom Effect on every Draw.

Frame rate drops from 80fps to 65fps in my test.
This PR apply the custom Effect the same way we do for SpriteEffect.
The only expeption is Effects with multiple passes.