### PR TITLE
Fix: IndexBufferWriter doesn't detect the correct IndexElementSize.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/IndexBufferWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/IndexBufferWriter.cs
@@ -11,7 +11,17 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
     {
         protected internal override void Write(ContentWriter output, IndexCollection value)
         {
-            var shortIndices = value.Count < ushort.MaxValue;
+            // Check if the buffer and can be saved as Int16.
+            var shortIndices = true;
+            foreach(var index in value)
+            {
+                if(index > ushort.MaxValue)
+                {
+                    shortIndices = false;
+                    break;
+                }
+            }
+
             output.Write(shortIndices);
 
             var byteCount = shortIndices


### PR DESCRIPTION
IndexElementSize depends on the number of Vertices, not the number of indices.