### PR TITLE
[Pipeline Tool] Optimize ProjectView image loading

### DIFF
--- a/Tools/Pipeline/Global.Linux.cs
+++ b/Tools/Pipeline/Global.Linux.cs
@@ -3,12 +3,10 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Eto.Drawing;
-using Eto.Forms;
 using Eto.GtkSharp.Drawing;
 using Gtk;
 
@@ -34,26 +32,34 @@ namespace MonoGame.Tools.Pipeline
     static partial class Global
     {
         private static IconTheme _theme;
-        private static Gdk.Pixbuf _iconMissing;
-        private static Gtk.Application _app;
+        private static Application _app;
 
         private static void PlatformInit()
         {
             Linux = true;
             _theme = IconTheme.Default;
 
-            try
-            {
-                _iconMissing = _theme.LoadIcon("error", 16, 0);
-            }
-            catch
-            {
-                _iconMissing = new Gdk.Pixbuf(null, "TreeView.Missing.png");
-            }
+            var iconMissing = _theme.LoadIcon("error", 16, 0);
+            var file = _theme.LoadIcon("text-x-generic", 16, 0);
+            var fileMissing = file.Copy();
+            iconMissing.Composite(fileMissing, 8, 8, 8, 8, 8, 8, 0.5, 0.5, Gdk.InterpType.Tiles, 255);
+            var folder = _theme.LoadIcon("folder", 16, 0);
+            var folderMissing = folder.Copy();
+            iconMissing.Composite(folderMissing, 8, 8, 8, 8, 8, 8, 0.5, 0.5, Gdk.InterpType.Tiles, 255);
+
+            _files["."] = ToEtoImage(file);
+            _fileMissing = ToEtoImage(fileMissing);
+            _folder = ToEtoImage(folder);
+            _folderMissing = ToEtoImage(folderMissing);
+
+            _xwtFiles["."] = ToXwtImage(file);
+            _xwtFileMissing = ToXwtImage(fileMissing);
+            _xwtFolder = ToXwtImage(folder);
+            _xwtFolderMissing = ToXwtImage(folderMissing);
 
             if (Gtk.Global.MajorVersion >= 3 && Gtk.Global.MinorVersion >= 16)
             {
-                _app = new Gtk.Application(null, GLib.ApplicationFlags.None);
+                _app = new Application(null, GLib.ApplicationFlags.None);
                 _app.Register(GLib.Cancellable.Current);
 
                 UseHeaderBar = Gtk3Wrapper.gtk_application_prefers_app_menu(_app.Handle);
@@ -62,7 +68,7 @@ namespace MonoGame.Tools.Pipeline
 
         private static void PlatformShowOpenWithDialog(string filePath)
         {
-            var adialoghandle = Gtk3Wrapper.gtk_app_chooser_dialog_new(((Gtk.Window)MainWindow.Instance.ControlObject).Handle, 
+            var adialoghandle = Gtk3Wrapper.gtk_app_chooser_dialog_new(((Window)MainWindow.Instance.ControlObject).Handle, 
                                                                        4 + (int)DialogFlags.Modal, 
                                                                        Gtk3Wrapper.g_file_new_for_path(filePath));
             var adialog = new AppChooserDialog(adialoghandle);
@@ -73,50 +79,26 @@ namespace MonoGame.Tools.Pipeline
             adialog.Destroy();
         }
 
-        private static Gdk.Pixbuf PlatformGetDirectoryIcon(bool exists)
-        {
-            var icon = _theme.LoadIcon("folder", 16, 0);
-
-            if (!exists)
-            {
-                icon = icon.Copy();
-                _iconMissing.Composite(icon, 8, 8, 8, 8, 8, 8, 0.5, 0.5, Gdk.InterpType.Tiles, 255);
-            }
-
-            return icon;
-        }
-
-        private static Gdk.Pixbuf PlatformGetFileIcon(string path, bool exists)
+        private static Gdk.Pixbuf PlatformGetFileIcon(string path)
         {
             Gdk.Pixbuf icon = null;
 
-            try
-            {
-                var info = new GLib.FileInfo(Gtk3Wrapper.g_file_query_info(Gtk3Wrapper.g_file_new_for_path(path), "standard::*", 0, new IntPtr(), new IntPtr()));
-                var sicon = info.Icon.ToString().Split(' ');
+            var info = new GLib.FileInfo(Gtk3Wrapper.g_file_query_info(Gtk3Wrapper.g_file_new_for_path(path), "standard::*", 0, new IntPtr(), new IntPtr()));
+            var sicon = info.Icon.ToString().Split(' ');
 
-                for (int i = sicon.Length - 1; i >= 1; i--)
+            for (int i = sicon.Length - 1; i >= 1; i--)
+            {
+                try
                 {
-                    try
-                    {
-                        icon = _theme.LoadIcon(sicon[i], 16, 0);
-                        if (icon != null)
-                            break;
-                    }
-                    catch { }
+                    icon = _theme.LoadIcon(sicon[i], 16, 0);
+                    if (icon != null)
+                        break;
                 }
+                catch { }
             }
-            catch { }
 
             if (icon == null)
-                icon = _theme.LoadIcon("text-x-generic", 16, 0);
-
-
-            if (!exists)
-            {
-                icon = icon.Copy();
-                _iconMissing.Composite(icon, 8, 8, 8, 8, 8, 8, 0.5, 0.5, Gdk.InterpType.Tiles, 255);
-            }
+                throw new Exception();
 
             return icon;
         }

--- a/Tools/Pipeline/Global.Mac.cs
+++ b/Tools/Pipeline/Global.Mac.cs
@@ -14,13 +14,18 @@ namespace MonoGame.Tools.Pipeline
         {
             
         }
-    
-        private static Image PlatformGetDirectoryIcon(bool exists)
+
+        private static Image PlatformGetFileIcon(string path)
         {
             throw new NotImplementedException();
         }
 
-        private static Image PlatformGetFileIcon(string path, bool exists)
+        private static Bitmap ToEtoImage(Image image)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static Xwt.Drawing.Image ToXwtImage(Image image)
         {
             throw new NotImplementedException();
         }

--- a/Tools/Pipeline/Global.Windows.cs
+++ b/Tools/Pipeline/Global.Windows.cs
@@ -26,6 +26,21 @@ namespace MonoGame.Tools.Pipeline
         {
             var reg = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
             IsWindows10 = (reg.GetValue("ProductName") as string).StartsWith("Windows 10");
+
+            var file = ExtractIcon(0).ToBitmap();
+            var fileMissing = ExtractIcon(271).ToBitmap();
+            var folder = ExtractIcon(4).ToBitmap();
+            var folderMissing = ExtractIcon(234).ToBitmap();
+
+            _files["."] = ToEtoImage(file);
+            _fileMissing = ToEtoImage(fileMissing);
+            _folder = ToEtoImage(folder);
+            _folderMissing = ToEtoImage(folderMissing);
+
+            _xwtFiles["."] = ToXwtImage(file);
+            _xwtFileMissing = ToXwtImage(fileMissing);
+            _xwtFolder = ToXwtImage(folderMissing);
+            _xwtFolderMissing = ToXwtImage(folderMissing);
         }
 
         public static System.Drawing.Icon ExtractIcon(int number)
@@ -37,37 +52,9 @@ namespace MonoGame.Tools.Pipeline
             return System.Drawing.Icon.FromHandle(large);
         }
 
-        private static System.Drawing.Bitmap PlatformGetDirectoryIcon(bool exists)
+        private static System.Drawing.Bitmap PlatformGetFileIcon(string path)
         {
-            System.Drawing.Bitmap icon;
-
-            if (exists)
-                icon = ExtractIcon(4).ToBitmap();
-            else
-                icon = ExtractIcon(234).ToBitmap();
-
-            return icon;
-        }
-
-        private static System.Drawing.Bitmap PlatformGetFileIcon(string path, bool exists)
-        {
-            System.Drawing.Bitmap icon;
-
-            if (exists)
-            {
-                try
-                {
-                    icon = System.Drawing.Icon.ExtractAssociatedIcon(path).ToBitmap();
-                }
-                catch
-                {
-                    icon = ExtractIcon(0).ToBitmap();
-                }
-            }
-            else
-                icon = ExtractIcon(271).ToBitmap();
-
-            return icon;
+            return System.Drawing.Icon.ExtractAssociatedIcon(path).ToBitmap();
         }
 
         private static Bitmap ToEtoImage(System.Drawing.Bitmap bitmap)

--- a/Tools/Pipeline/Global.cs
+++ b/Tools/Pipeline/Global.cs
@@ -3,34 +3,52 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Eto.Drawing;
-using Eto.Forms;
 
 namespace MonoGame.Tools.Pipeline
 {
     static partial class Global
     {
+        public static string NotAllowedCharacters
+        {
+            get
+            {
+                if (Unix)
+                    return Linux ? "/" : ":";
+
+                return "/?<>\\:*|\"";
+            }
+        }
+
         public static bool Linux { get; private set; }
         public static bool UseHeaderBar { get; private set; }
         public static bool Unix { get; private set; }
+
+        private static Dictionary<string, Image> _files;
+        private static Image _fileMissing, _folder, _folderMissing;
+
+        private static Dictionary<string, Xwt.Drawing.Image> _xwtFiles;
+        private static Xwt.Drawing.Image _xwtFileMissing, _xwtFolder, _xwtFolderMissing;
 
         static Global()
         {
             Unix = Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX;
 
+            _files = new Dictionary<string, Image>();
+            _files.Add(".", Bitmap.FromResource("TreeView.File.png"));
+            _fileMissing = Bitmap.FromResource("TreeView.FileMissing.png");
+            _folder = Bitmap.FromResource("TreeView.Folder.png");
+            _folderMissing = Bitmap.FromResource("TreeView.FolderMissing.png");
+
+            _xwtFiles = new Dictionary<string, Xwt.Drawing.Image>();
+            _xwtFiles.Add(".", Xwt.Drawing.Image.FromResource("TreeView.File.png"));
+            _xwtFileMissing = Xwt.Drawing.Image.FromResource("TreeView.FileMissing.png");
+            _xwtFolder = Xwt.Drawing.Image.FromResource("TreeView.Folder.png");
+            _xwtFolderMissing = Xwt.Drawing.Image.FromResource("TreeView.FolderMissing.png");
+
             PlatformInit();
-        }
-
-        public static string NotAllowedCharacters
-        {
-            get
-            {
-                if (Global.Unix)
-                    return Global.Linux ? "/" : ":";
-
-                return "/?<>\\:*|\"";
-            }
         }
 
         public static bool CheckString(string s)
@@ -58,54 +76,60 @@ namespace MonoGame.Tools.Pipeline
 
         public static Image GetEtoDirectoryIcon(bool exists)
         {
-#if WINDOWS || LINUX
-            try
-            {
-                return ToEtoImage(PlatformGetDirectoryIcon(exists));
-            }
-            catch { }
-#endif
-
-            return exists ? Bitmap.FromResource("TreeView.Folder.png") : Bitmap.FromResource("TreeView.FolderMissing.png");
+            return exists ? _folder : _folderMissing;
         }
 
         public static Image GetEtoFileIcon(string path, bool exists)
         {
-#if WINDOWS || LINUX
+            if (!exists)
+                return _fileMissing;
+            
+            var ext = Path.GetExtension(path);
+            if (_files.ContainsKey(ext))
+                return _files[ext];
+
+            Image icon;
+
             try
             {
-                return ToEtoImage(PlatformGetFileIcon(path, exists));
+                icon = ToEtoImage(PlatformGetFileIcon(path));
             }
-            catch { }
-#endif
+            catch
+            {
+                icon = _files["."];
+            }
 
-            return exists ? Bitmap.FromResource("TreeView.File.png") : Bitmap.FromResource("TreeView.FileMissing.png");
+            _files.Add(ext, icon);
+            return icon;
         }
 
         public static Xwt.Drawing.Image GetXwtDirectoryIcon(bool exists)
         {
-#if WINDOWS || LINUX
-            try
-            {
-                return ToXwtImage(PlatformGetDirectoryIcon(exists));
-            }
-            catch { }
-#endif
-
-            return exists ? Xwt.Drawing.Image.FromResource("TreeView.Folder.png") : Xwt.Drawing.Image.FromResource("TreeView.FolderMissing.png");
+            return exists ? _xwtFolder : _xwtFolderMissing;
         }
 
         public static Xwt.Drawing.Image GetXwtFileIcon(string path, bool exists)
         {
-#if WINDOWS || LINUX
+            if (!exists)
+                return _xwtFileMissing;
+
+            var ext = Path.GetExtension(path);
+            if (_xwtFiles.ContainsKey(ext))
+                return _xwtFiles[ext];
+
+            Xwt.Drawing.Image icon;
+
             try
             {
-                return ToXwtImage(PlatformGetFileIcon(path, exists));
+                icon = ToXwtImage(PlatformGetFileIcon(path));
             }
-            catch { }
-#endif
+            catch
+            {
+                icon = _xwtFiles["."];
+            }
 
-            return exists ? Xwt.Drawing.Image.FromResource("TreeView.File.png") : Xwt.Drawing.Image.FromResource("TreeView.FileMissing.png");
+            _xwtFiles.Add(ext, icon);
+            return icon;
         }
 
         public static Image GetEtoIcon(string resource)


### PR DESCRIPTION
This PR makes it so projectview icons get cached on load, so for example if it loads an image of a file with .png extension, next time it comes across a file with that extension it will use a cached version of the image instead of loading a whole new one.

This should make Pipeline Tool use a lot less memory for big projects.