### PR TITLE
Performance improvements to SpriteBatch 

### DIFF
--- a/Installers/Linux/RUN/postinstall.sh
+++ b/Installers/Linux/RUN/postinstall.sh
@@ -9,15 +9,15 @@ echodep()
 	do
 		line="$line."
 	done
+	
+	echo -ne "$line"
     
 	if eval "$2"
 	then
-		line="$line\e[32m[Found]\e[0m"
+		echo -e "\e[32m[Found]\e[0m"
 	else
-		line="$line\e[31m[Not Found]\e[0m"
+		echo -e "\e[31m[Not Found]\e[0m"
 	fi
-	
-	echo -e "$line"
 }
 
 # Check installation priviledge
@@ -29,13 +29,32 @@ fi
 DIR=$(pwd)
 IDIR="/usr/lib/mono/xbuild/MonoGame/v3.0"
 
+# Find MonoDevelop
+MDTOOL="?????"
+
+if type "monodevelop" > /dev/null 2>&1
+then
+	if eval "monodevelop --help | grep 'MonoDevelop 6' > /dev/null 2>&1"
+	then
+		MDTOOL="mdtool"
+	fi
+fi
+
+if type "monodevelop-stable" > /dev/null 2>&1
+then
+	if eval "monodevelop-stable --help | grep 'MonoDevelop 6' > /dev/null 2>&1"
+	then
+		MDTOOL="mdtool-stable"
+	fi
+fi
+
 # Show dependency list
 echo "Dependencies:"
 echodep "mono-runtime" "type 'mono' > /dev/null 2>&1"
 echodep "gtk-sharp3" "type 'gacutil' > /dev/null 2>&1 && gacutil /l gtk-sharp | grep -q 3.0.0.0"
 echo ""
 echo "Optional Dependencies:"
-echodep "MonoDevelop 6" "monodevelop --help | grep 'MonoDevelop 6' > /dev/null 2>&1"
+echodep "MonoDevelop 6" "$MDTOOL > /dev/null 2>&1"
 echodep "Rider" "type 'rider' > /dev/null 2>&1"
 echodep "referenceassemblies-pcl / mono-pcl" "test -d /usr/lib/mono/xbuild/Microsoft/Portable"
 echodep "ttf-mscorefonts-installer / mscore-fonts" "fc-list | grep -q Arial"
@@ -96,10 +115,10 @@ then
 fi
 
 # MonoDevelop addin
-if monodevelop --help | grep 'MonoDevelop 6' > /dev/null 2>&1
+if [ "$MONODEVELOP" != "?????" ]
 then
 	echo "Installing MonoDevelop Addin..."
-	sudo -H -u $SUDO_USER bash -c "mdtool setup install -y $DIR/Main/MonoDevelop.MonoGame.mpack  > /dev/null"
+	sudo -H -u $SUDO_USER bash -c "$MDTOOL setup install -y $DIR/Main/MonoDevelop.MonoGame.mpack  > /dev/null"
 fi
 
 # Monogame Pipeline terminal commands

--- a/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
@@ -278,14 +278,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
             try
             {
                 string ffmpegCodecName, ffmpegMuxerName;
-                int format;
+                //int format;
                 switch (formatType)
                 {
                     case ConversionFormat.Adpcm:
                         // ADPCM Microsoft 
                         ffmpegCodecName = "adpcm_ms";
                         ffmpegMuxerName = "wav";
-                        format = 0x0002; /* WAVE_FORMAT_ADPCM */
+                        //format = 0x0002; /* WAVE_FORMAT_ADPCM */
                         break;
                     case ConversionFormat.Pcm:
                         // XNA seems to preserve the bit size of the input
@@ -297,13 +297,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                         else
                             ffmpegCodecName = "pcm_s16le";
                         ffmpegMuxerName = "wav";
-                        format = 0x0001; /* WAVE_FORMAT_PCM */
+                        //format = 0x0001; /* WAVE_FORMAT_PCM */
                         break;
                     case ConversionFormat.WindowsMedia:
                         // Windows Media Audio 2
                         ffmpegCodecName = "wmav2";
                         ffmpegMuxerName = "asf";
-                        format = 0x0161; /* WAVE_FORMAT_WMAUDIO2 */
+                        //format = 0x0161; /* WAVE_FORMAT_WMAUDIO2 */
                         break;
                     case ConversionFormat.Xma:
                         throw new NotSupportedException(
@@ -312,20 +312,20 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                         // ADPCM IMA WAV
                         ffmpegCodecName = "adpcm_ima_wav";
                         ffmpegMuxerName = "wav";
-                        format = 0x0011; /* WAVE_FORMAT_IMA_ADPCM */
+                        //format = 0x0011; /* WAVE_FORMAT_IMA_ADPCM */
                         break;
                     case ConversionFormat.Aac:
                         // AAC (Advanced Audio Coding)
                         // Requires -strict experimental
                         ffmpegCodecName = "aac";
                         ffmpegMuxerName = "ipod";
-                        format = 0x0000; /* WAVE_FORMAT_UNKNOWN */
+                        //format = 0x0000; /* WAVE_FORMAT_UNKNOWN */
                         break;
                     case ConversionFormat.Vorbis:
                         // Vorbis
                         ffmpegCodecName = "libvorbis";
                         ffmpegMuxerName = "ogg";
-                        format = 0x0000; /* WAVE_FORMAT_UNKNOWN */
+                        //format = 0x0000; /* WAVE_FORMAT_UNKNOWN */
                         break;
                     default:
                         // Unknown format

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -247,6 +247,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             s = s.Trim();
 
             var split = s.Split (':');
+            if (split.Length < 2)
+                return String.Empty;
+
             //check font family, fontconfig might return a fallback
             if (split [1].Contains (",")) { //this file defines multiple family names
                 var families = split [1].Split (',');

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Xna.Framework.Graphics
             return adapter;
         }
 
-        protected bool PlatformIsProfileSupported(GraphicsProfile graphicsProfile)
+        private bool PlatformIsProfileSupported(GraphicsProfile graphicsProfile)
         {
             if(UseReferenceDevice)
                 return true;

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -337,6 +337,12 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
             CheckValid(texture);
 
+            if(origin != Vector2.Zero)
+            {
+                origin.X = origin.X * ((float)destinationRectangle.Width ) / (float)( (sourceRectangle.HasValue && sourceRectangle.Value.Width  != 0) ? sourceRectangle.Value.Width  : texture.Width );
+                origin.Y = origin.Y * ((float)destinationRectangle.Height) / (float)( (sourceRectangle.HasValue && sourceRectangle.Value.Height != 0) ? sourceRectangle.Value.Height : texture.Height);
+            }
+
             DrawInternal(texture,
 			      new Vector4(destinationRectangle.X,
 			                  destinationRectangle.Y,
@@ -345,8 +351,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			      sourceRectangle,
 			      color,
 			      rotation,
-			      new Vector2(origin.X * ((float)destinationRectangle.Width / (float)( (sourceRectangle.HasValue && sourceRectangle.Value.Width != 0) ? sourceRectangle.Value.Width : texture.Width)),
-                        			origin.Y * ((float)destinationRectangle.Height) / (float)( (sourceRectangle.HasValue && sourceRectangle.Value.Height != 0) ? sourceRectangle.Value.Height : texture.Height)),
+			      origin,
 			      effects,
                   layerDepth,
 			      true);

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -422,8 +422,8 @@ namespace Microsoft.Xna.Framework.Graphics
                         destinationRectangle.Z,
                         destinationRectangle.W,
                         color,
-                        _texCoordTL,
-                        _texCoordBR,
+                        ref _texCoordTL,
+                        ref _texCoordBR,
                         depth);
             }
             else
@@ -437,8 +437,8 @@ namespace Microsoft.Xna.Framework.Graphics
                         sin,
                         cos,
                         color,
-                        _texCoordTL,
-                        _texCoordBR,
+                        ref _texCoordTL,
+                        ref _texCoordBR,
                         depth);
             }
 

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -398,10 +398,8 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
-                _texCoordTL.X = 0f;
-                _texCoordTL.Y = 0f;
-                _texCoordBR.X = 1f;
-                _texCoordBR.Y = 1f;
+                _texCoordTL = Vector2.Zero;
+                _texCoordBR = Vector2.One;
             }
             
 			if ((effect & SpriteEffects.FlipVertically) != 0) {

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -428,14 +428,14 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
 		    {
-                item.Set(destinationRectangle.X,
-                        destinationRectangle.Y,
-                        -origin.X,
-                        -origin.Y,
+                var sin = (float)Math.Sin(rotation);
+                var cos = (float)Math.Cos(rotation);
+                item.Set(destinationRectangle.X - (origin.X*cos-origin.Y*sin),
+                        destinationRectangle.Y - (origin.X*sin+origin.Y*cos),
                         destinationRectangle.Z,
                         destinationRectangle.W,
-                        (float)Math.Sin(rotation),
-                        (float)Math.Cos(rotation),
+                        sin,
+                        cos,
                         color,
                         _texCoordTL,
                         _texCoordBR,

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -420,8 +420,8 @@ namespace Microsoft.Xna.Framework.Graphics
                         destinationRectangle.Z,
                         destinationRectangle.W,
                         color,
-                        ref _texCoordTL,
-                        ref _texCoordBR,
+                        _texCoordTL,
+                        _texCoordBR,
                         depth);
             }
             else
@@ -435,8 +435,8 @@ namespace Microsoft.Xna.Framework.Graphics
                         sin,
                         cos,
                         color,
-                        ref _texCoordTL,
-                        ref _texCoordBR,
+                        _texCoordTL,
+                        _texCoordBR,
                         depth);
             }
 

--- a/MonoGame.Framework/Graphics/SpriteBatchItem.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatchItem.cs
@@ -23,34 +23,34 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexBR = new VertexPositionColorTexture();            
 		}
 		
-		public void Set ( float x, float y, float dx, float dy, float w, float h, float sin, float cos, Color color, Vector2 texCoordTL, Vector2 texCoordBR, float depth )
+		public void Set ( float x, float y, float w, float h, float sin, float cos, Color color, Vector2 texCoordTL, Vector2 texCoordBR, float depth )
 		{
             // TODO, Should we be just assigning the Depth Value to Z?
             // According to http://blogs.msdn.com/b/shawnhar/archive/2011/01/12/spritebatch-billboards-in-a-3d-world.aspx
             // We do.
-			vertexTL.Position.X = x+dx*cos-dy*sin;
-            vertexTL.Position.Y = y+dx*sin+dy*cos;
+            vertexTL.Position.X = x;
+            vertexTL.Position.Y = y;
             vertexTL.Position.Z = depth;
             vertexTL.Color = color;
             vertexTL.TextureCoordinate.X = texCoordTL.X;
             vertexTL.TextureCoordinate.Y = texCoordTL.Y;
 
-			vertexTR.Position.X = x+(dx+w)*cos-dy*sin;
-            vertexTR.Position.Y = y+(dx+w)*sin+dy*cos;
+            vertexTR.Position.X = x +w*cos;
+            vertexTR.Position.Y = y +w*sin;
             vertexTR.Position.Z = depth;
             vertexTR.Color = color;
             vertexTR.TextureCoordinate.X = texCoordBR.X;
             vertexTR.TextureCoordinate.Y = texCoordTL.Y;
 
-			vertexBL.Position.X = x+dx*cos-(dy+h)*sin;
-            vertexBL.Position.Y = y+dx*sin+(dy+h)*cos;
+            vertexBL.Position.X = x -h*sin;
+            vertexBL.Position.Y = y +h*cos;
             vertexBL.Position.Z = depth;
             vertexBL.Color = color;
             vertexBL.TextureCoordinate.X = texCoordTL.X;
             vertexBL.TextureCoordinate.Y = texCoordBR.Y;
 
-			vertexBR.Position.X = x+(dx+w)*cos-(dy+h)*sin;
-            vertexBR.Position.Y = y+(dx+w)*sin+(dy+h)*cos;
+            vertexBR.Position.X = x +w*cos-h*sin;
+            vertexBR.Position.Y = y +w*sin+h*cos;
             vertexBR.Position.Z = depth;
             vertexBR.Color = color;
             vertexBR.TextureCoordinate.X = texCoordBR.X;

--- a/MonoGame.Framework/Graphics/SpriteBatchItem.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatchItem.cs
@@ -32,8 +32,7 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexTL.Position.Y = y;
             vertexTL.Position.Z = depth;
             vertexTL.Color = color;
-            vertexTL.TextureCoordinate.X = texCoordTL.X;
-            vertexTL.TextureCoordinate.Y = texCoordTL.Y;
+            vertexTL.TextureCoordinate = texCoordTL;
 
             vertexTR.Position.X = x +w*cos;
             vertexTR.Position.Y = y +w*sin;
@@ -53,8 +52,7 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexBR.Position.Y = y +w*sin+h*cos;
             vertexBR.Position.Z = depth;
             vertexBR.Color = color;
-            vertexBR.TextureCoordinate.X = texCoordBR.X;
-            vertexBR.TextureCoordinate.Y = texCoordBR.Y;
+            vertexBR.TextureCoordinate = texCoordBR;
 		}
 
         public void Set(float x, float y, float w, float h, Color color, ref Vector2 texCoordTL, ref Vector2 texCoordBR, float depth)
@@ -63,8 +61,7 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexTL.Position.Y = y;
             vertexTL.Position.Z = depth;
             vertexTL.Color = color;
-            vertexTL.TextureCoordinate.X = texCoordTL.X;
-            vertexTL.TextureCoordinate.Y = texCoordTL.Y;
+            vertexTL.TextureCoordinate = texCoordTL;
 
             vertexTR.Position.X = x + w;
             vertexTR.Position.Y = y;
@@ -84,8 +81,7 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexBR.Position.Y = y + h;
             vertexBR.Position.Z = depth;
             vertexBR.Color = color;
-            vertexBR.TextureCoordinate.X = texCoordBR.X;
-            vertexBR.TextureCoordinate.Y = texCoordBR.Y;
+            vertexBR.TextureCoordinate = texCoordBR;
         }
 
         #region Implement IComparable

--- a/MonoGame.Framework/Graphics/SpriteBatchItem.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatchItem.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexBR = new VertexPositionColorTexture();            
 		}
 		
-		public void Set ( float x, float y, float w, float h, float sin, float cos, Color color, Vector2 texCoordTL, Vector2 texCoordBR, float depth )
+		public void Set ( float x, float y, float w, float h, float sin, float cos, Color color, ref Vector2 texCoordTL, ref Vector2 texCoordBR, float depth )
 		{
             // TODO, Should we be just assigning the Depth Value to Z?
             // According to http://blogs.msdn.com/b/shawnhar/archive/2011/01/12/spritebatch-billboards-in-a-3d-world.aspx
@@ -57,7 +57,7 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexBR.TextureCoordinate.Y = texCoordBR.Y;
 		}
 
-        public void Set(float x, float y, float w, float h, Color color, Vector2 texCoordTL, Vector2 texCoordBR, float depth)
+        public void Set(float x, float y, float w, float h, Color color, ref Vector2 texCoordTL, ref Vector2 texCoordBR, float depth)
         {
             vertexTL.Position.X = x;
             vertexTL.Position.Y = y;

--- a/MonoGame.Framework/Graphics/SpriteBatchItem.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatchItem.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexBR = new VertexPositionColorTexture();            
 		}
 		
-		public void Set ( float x, float y, float w, float h, float sin, float cos, Color color, ref Vector2 texCoordTL, ref Vector2 texCoordBR, float depth )
+		public void Set ( float x, float y, float w, float h, float sin, float cos, Color color, Vector2 texCoordTL, Vector2 texCoordBR, float depth )
 		{
             // TODO, Should we be just assigning the Depth Value to Z?
             // According to http://blogs.msdn.com/b/shawnhar/archive/2011/01/12/spritebatch-billboards-in-a-3d-world.aspx
@@ -55,7 +55,7 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexBR.TextureCoordinate = texCoordBR;
 		}
 
-        public void Set(float x, float y, float w, float h, Color color, ref Vector2 texCoordTL, ref Vector2 texCoordBR, float depth)
+        public void Set(float x, float y, float w, float h, Color color, Vector2 texCoordTL, Vector2 texCoordBR, float depth)
         {
             vertexTL.Position.X = x;
             vertexTL.Position.Y = y;

--- a/MonoGame.Framework/Graphics/States/Blend.cs
+++ b/MonoGame.Framework/Graphics/States/Blend.cs
@@ -58,11 +58,11 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
 		InverseDestinationAlpha,
 	    /// <summary>
-        /// Each component of the color is multiplied by a constant in the <see cref="Microsoft.Xna.Framework.Graphics.GraphicsDevice.BlendFactor"/>.
+        /// Each component of the color is multiplied by a constant in the <see cref="P:Microsoft.Xna.Framework.Graphics.GraphicsDevice.BlendFactor"/>.
 	    /// </summary>
 		BlendFactor,
         /// <summary>
-        /// Each component of the color is multiplied by a inversed constant in the <see cref="GraphicsDevice.BlendFactor"/>.
+        /// Each component of the color is multiplied by a inversed constant in the <see cref="P:Microsoft.Xna.Framework.Graphics.GraphicsDevice.BlendFactor"/>.
         /// </summary>
 		InverseBlendFactor,
         /// <summary>

--- a/MonoGame.Framework/Graphics/States/BlendState.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// The color used as blend factor when alpha blending.
         /// </summary>
         /// <remarks>
-        /// <see cref="GraphicsDevice.BlendFactor"/> is set to this value when this <see cref="BlendState"/>
+        /// <see cref="P:Microsoft.Xna.Framework.Graphics.GraphicsDevice.BlendFactor"/> is set to this value when this <see cref="BlendState"/>
         /// is bound to a GraphicsDevice.
         /// </remarks>
 	    public Color BlendFactor

--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -24,11 +24,10 @@ namespace Microsoft.Xna.Framework.Input
             {
                 return PlatformGetHandle();
             }
-#pragma warning disable RECS0029 // Warns about property or indexer setters and event adders or removers that do not use the value parameter
             set
-#pragma warning restore RECS0029 // Warns about property or indexer setters and event adders or removers that do not use the value parameter
             {
                 // only for XNA compatibility, yet
+                IntPtr temp = value;
             }
         }
 

--- a/Tools/2MGFX/ShaderData.cs
+++ b/Tools/2MGFX/ShaderData.cs
@@ -29,7 +29,9 @@ namespace TwoMGFX
             public string name;
             public VertexElementUsage usage;
 			public int index;
+#pragma warning disable 649
             public int location;
+#pragma warning restore 649
         }
 
 		/// <summary>

--- a/Tools/Pipeline/MainWindow.cs
+++ b/Tools/Pipeline/MainWindow.cs
@@ -12,8 +12,10 @@ namespace MonoGame.Tools.Pipeline
 {
     partial class MainWindow : Form, IView
     {
+#pragma warning disable 649
         public EventHandler<EventArgs> RecentChanged;
         public EventHandler<EventArgs> TitleChanged;
+#pragma warning restore 649
         public const string TitleBase = "MonoGame Pipeline Tool";
         public static MainWindow Instance;
 


### PR DESCRIPTION
-Skip Calculations when Origin == Zero.
-Add _texelSize in Texture2D to avoid divisions in SpriteBatch.
 Used in calculating  origin & textureCord from sourceRectangle.


Current develop (Baseline)
33.83ms (100%)
Avoid extra calculations when Origin = Zero
30.38ms (89.8%)
Add _texelSize in Texture2D. Replace DIVs with MULs.
29.34ms (86.7%)

*test*
```
 var amount = 100000;
            var screenSize = 800;
            var spriteSize = 64;
            Rectangle textRect = new Rectangle(0,0,64,64);
            for (int i = 0; i < amount; i++)
            {
                var dest = new Rectangle(random.Next(screenSize), random.Next(screenSize), spriteSize, spriteSize);
                spriteBatch.Draw(_texture, dest, textRect, Color.White, random.Next(360), Vector2.Zero, SpriteEffects.None, 1);                
            }
```