### PR TITLE
Use OpenGL flag when creating an SDL Window

### DIFF
--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -105,10 +105,14 @@ namespace Microsoft.Xna.Framework
                 _winy = display.Y + display.Height / 2;
             }
 
+            var initflags =
+                Sdl.Window.State.OpenGL |
+                Sdl.Window.State.Hidden;
+
             // We need a dummy handle for GraphicDevice until our window gets created
             _handle = Sdl.Window.Create("", _winx, _winy,
                 GraphicsDeviceManager.DefaultBackBufferWidth, GraphicsDeviceManager.DefaultBackBufferHeight,
-                Sdl.Window.State.Hidden);
+                initflags);
         }
 
         internal void CreateWindow()


### PR DESCRIPTION
Allows a graphics device to be created before the main window is created by enabling a OpenGL context to be bound to the Window.   This is the primary cause of failed OpenGL unit tests under Windows.