### PR TITLE
Don't lose textures when applying effect

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/EffectPass.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectPass.cs
@@ -122,7 +122,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 var param = _effect.Parameters[sampler.parameter];
                 var texture = param.Data as Texture;
 
-                textures[sampler.textureSlot] = texture;
+                if (texture != null)
+                    textures[sampler.textureSlot] = texture;
 
                 // If there is a sampler state set it.
                 if (sampler.state != null)


### PR DESCRIPTION
This is not necessary the correct behavior and I'm unable to test it on anything else than UltimaXNA but this XNA game expects textures are preserved when applying an effect multiple times and between frames. On MonoGame I had to reset them per effect apply.

As an additional note, the game in question has `RenderTargetUsage.PreserveContents` set for the graphics device.