### PR TITLE
Validate Texture constructor arguments

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -84,9 +84,11 @@ namespace Microsoft.Xna.Framework.Graphics
         protected Texture2D(GraphicsDevice graphicsDevice, int width, int height, bool mipmap, SurfaceFormat format, SurfaceType type, bool shared, int arraySize)
 		{
             if (graphicsDevice == null)
-            {
                 throw new ArgumentNullException("graphicsDevice", FrameworkResources.ResourceCreationWhenDeviceIsNull);
-            }
+            if (width <= 0)
+                throw new ArgumentOutOfRangeException("width","Texture width must be greater than zero");
+            if (height <= 0)
+                throw new ArgumentOutOfRangeException("height","Texture height must be greater than zero");
             if (arraySize > 1 && !graphicsDevice.GraphicsCapabilities.SupportsTextureArrays)
                 throw new ArgumentException("Texture arrays are not supported on this graphics device", "arraySize");
 

--- a/MonoGame.Framework/Graphics/Texture3D.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.cs
@@ -37,9 +37,14 @@ namespace Microsoft.Xna.Framework.Graphics
 		protected Texture3D (GraphicsDevice graphicsDevice, int width, int height, int depth, bool mipMap, SurfaceFormat format, bool renderTarget)
 		{
 		    if (graphicsDevice == null)
-		    {
 		        throw new ArgumentNullException("graphicsDevice", FrameworkResources.ResourceCreationWhenDeviceIsNull);
-		    }
+            if (width <= 0)
+                throw new ArgumentOutOfRangeException("width","Texture width must be greater than zero");
+            if (height <= 0)
+                throw new ArgumentOutOfRangeException("height","Texture height must be greater than zero");
+            if (depth <= 0)
+                throw new ArgumentOutOfRangeException("depth","Texture depth must be greater than zero");
+
 		    this.GraphicsDevice = graphicsDevice;
             this._width = width;
             this._height = height;

--- a/MonoGame.Framework/Graphics/TextureCube.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.cs
@@ -31,9 +31,10 @@ namespace Microsoft.Xna.Framework.Graphics
         internal TextureCube(GraphicsDevice graphicsDevice, int size, bool mipMap, SurfaceFormat format, bool renderTarget)
         {
             if (graphicsDevice == null)
-            {
                 throw new ArgumentNullException("graphicsDevice", FrameworkResources.ResourceCreationWhenDeviceIsNull);
-            }
+            if (size <= 0)
+                throw new ArgumentOutOfRangeException("size","Cube size must be greater than zero");
+
             this.GraphicsDevice = graphicsDevice;
 			this.size = size;
             this._format = format;

--- a/Test/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Test/Framework/Graphics/RenderTarget2DTest.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using NUnit.Framework;
@@ -11,6 +12,15 @@ namespace MonoGame.Tests.Graphics
     [TestFixture]
     class RenderTarget2DTest : GraphicsDeviceTestFixtureBase
     {
+        [Test]
+        public void ZeroSizeShouldFailTest()
+        {
+            RenderTarget2D renderTarget;
+            Assert.Throws<ArgumentOutOfRangeException>(() => renderTarget = new RenderTarget2D(gd, 0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => renderTarget = new RenderTarget2D(gd, 1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => renderTarget = new RenderTarget2D(gd, 0, 0));
+        }
+
         [Test]
 #if XNA
         [Ignore]

--- a/Test/Framework/Graphics/RenderTargetCubeTest.cs
+++ b/Test/Framework/Graphics/RenderTargetCubeTest.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using NUnit.Framework;
@@ -11,6 +12,13 @@ namespace MonoGame.Tests.Graphics
     [TestFixture]
     class RenderTargetCubeTest : GraphicsDeviceTestFixtureBase
     {
+        [Test]
+        public void ZeroSizeShouldFailTest()
+        {
+            RenderTargetCube renderTarget;
+            Assert.Throws<ArgumentOutOfRangeException>(() => renderTarget = new RenderTargetCube(gd, 0, false, SurfaceFormat.Color, DepthFormat.None));
+        }
+
         [TestCase(1)]
         [TestCase(8)]
         [TestCase(31)]

--- a/Test/Framework/Graphics/Texture2DNonVisualTest.cs
+++ b/Test/Framework/Graphics/Texture2DNonVisualTest.cs
@@ -73,6 +73,15 @@ namespace MonoGame.Tests.Graphics
 #endif
         }
 
+        [Test]
+        public void ZeroSizeShouldFailTest()
+        {
+            Texture2D texture;
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture2D(gd, 0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture2D(gd, 1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture2D(gd, 0, 0));
+        }
+
         [TestCase(25, 23, 1, 1, 0, 1)]
         [TestCase(25, 23, 1, 1, 1, 1)]
         [TestCase(25, 23, 2, 1, 0, 2)]

--- a/Test/Framework/Graphics/Texture3DNonVisualTest.cs
+++ b/Test/Framework/Graphics/Texture3DNonVisualTest.cs
@@ -52,6 +52,21 @@ namespace MonoGame.Tests.Graphics
         {
             t.SetData(reference);
         }
+
+        [Test]
+        public void ZeroSizeShouldFailTest()
+        {
+            Texture3D texture;
+            var gd = _game.GraphicsDevice;
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture3D(gd, 0, 1, 1, false, SurfaceFormat.Color));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture3D(gd, 1, 0, 1, false, SurfaceFormat.Color));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture3D(gd, 1, 1, 0, false, SurfaceFormat.Color));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture3D(gd, 0, 0, 1, false, SurfaceFormat.Color));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture3D(gd, 1, 0, 0, false, SurfaceFormat.Color));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture3D(gd, 0, 1, 0, false, SurfaceFormat.Color));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture3D(gd, 0, 0, 0, false, SurfaceFormat.Color));
+        }
+
         [Test]
         public void SetData1ParameterTest()
         {

--- a/Test/Framework/Graphics/TextureCubeTest.cs
+++ b/Test/Framework/Graphics/TextureCubeTest.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using NUnit.Framework;
@@ -11,6 +12,13 @@ namespace MonoGame.Tests.Graphics
     [TestFixture]
     class TextureCubeTest : GraphicsDeviceTestFixtureBase
     {
+        [Test]
+        public void ZeroSizeShouldFailTest()
+        {
+            TextureCube texture;
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture = new TextureCube(gd, 0, false, SurfaceFormat.Color));
+        }
+
         [TestCase(1)]
         [TestCase(8)]
         [TestCase(31)]


### PR DESCRIPTION
Validate width, height, depth, size arguments for Texture2D/Texture3D/TextureCube.

Test that constructor of Texture2D/Texture3D/TextureCube/RenderTarget2D/RenderTargetCube throws ArgumentOutOfRangeException.