### PR TITLE
Custom texture compression for SpriteFonts

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             }
         }
 
-        protected override void PlatformCompressTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool generateMipmaps, bool sharpAlpha)
+        protected override void PlatformCompressTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool generateMipmaps, bool isSpriteFont)
         {
             format = GetTextureFormatForPlatform(format, context.TargetPlatform);
 
@@ -127,7 +127,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     break;
 
                 case TextureProcessorOutputFormat.DxtCompressed:
-                    GraphicsUtil.CompressDxt(context.TargetProfile, content, generateMipmaps, sharpAlpha);
+                    GraphicsUtil.CompressDxt(context.TargetProfile, content, generateMipmaps, isSpriteFont);
                     break;
 
                 case TextureProcessorOutputFormat.Etc1Compressed:
@@ -135,7 +135,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     break;
 
                 case TextureProcessorOutputFormat.PvrCompressed:
-                    GraphicsUtil.CompressPvrtc(content, generateMipmaps, sharpAlpha);
+                    GraphicsUtil.CompressPvrtc(content, generateMipmaps, isSpriteFont);
                     break;
             }
         }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     break;
 
                 case TextureProcessorOutputFormat.PvrCompressed:
-                    GraphicsUtil.CompressPvrtc(content, generateMipmaps);
+                    GraphicsUtil.CompressPvrtc(content, generateMipmaps, sharpAlpha);
                     break;
             }
         }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -123,10 +123,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             return result;
         }
 
-        public static void CompressPvrtc(TextureContent content, bool generateMipMaps, bool sharpAlpha)
+        public static void CompressPvrtc(TextureContent content, bool generateMipMaps, bool isSpriteFont)
         {
             // If sharp alpha is required (for a font texture page), use 16-bit color instead of PVR
-            if (sharpAlpha)
+            if (isSpriteFont)
             {
                 CompressColor16Bit(content, generateMipMaps);
                 return;
@@ -152,7 +152,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 Compress(typeof(PvrtcRgba4BitmapContent), content, generateMipMaps);
         }
 
-        public static void CompressDxt(GraphicsProfile profile, TextureContent content, bool generateMipMaps, bool sharpAlpha)
+        public static void CompressDxt(GraphicsProfile profile, TextureContent content, bool generateMipMaps, bool isSpriteFont)
         {
             var face = content.Faces[0][0];
 
@@ -167,7 +167,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             if (alphaRange == AlphaRange.Opaque)
                 Compress(typeof(Dxt1BitmapContent), content, generateMipMaps);
-            else if (sharpAlpha)
+            else if (isSpriteFont)
                 CompressFontDXT3(content, generateMipMaps);
             else if (alphaRange == AlphaRange.Cutout)
                 Compress(typeof(Dxt3BitmapContent), content, generateMipMaps);
@@ -275,7 +275,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         }
 
         // Compress the greyscale font texture page using a specially-formulated DXT3 mode
-        static unsafe void CompressFontDXT3(TextureContent content, bool generateMipmaps)
+        static public unsafe void CompressFontDXT3(TextureContent content, bool generateMipmaps)
         {
             if (content.Faces.Count > 1)
                 throw new PipelineException("Font textures should only have one face");

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.IO;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
 using FreeImageAPI;
@@ -122,8 +123,15 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             return result;
         }
 
-        public static void CompressPvrtc(TextureContent content, bool generateMipMaps)
+        public static void CompressPvrtc(TextureContent content, bool generateMipMaps, bool sharpAlpha)
         {
+            // If sharp alpha is required (for a font texture page), use 16-bit color instead of PVR
+            if (sharpAlpha)
+            {
+                CompressColor16Bit(content, generateMipMaps);
+                return;
+            }
+
             // Calculate number of mip levels
             var width = content.Faces[0][0].Height;
             var height = content.Faces[0][0].Width;
@@ -159,7 +167,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             if (alphaRange == AlphaRange.Opaque)
                 Compress(typeof(Dxt1BitmapContent), content, generateMipMaps);
-            else if (alphaRange == AlphaRange.Cutout || sharpAlpha)
+            else if (sharpAlpha)
+                CompressFontDXT3(content, generateMipMaps);
+            else if (alphaRange == AlphaRange.Cutout)
                 Compress(typeof(Dxt3BitmapContent), content, generateMipMaps);
             else
                 Compress(typeof(Dxt5BitmapContent), content, generateMipMaps);
@@ -262,6 +272,242 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 // Converts all existing faces and mipmaps
                 content.ConvertBitmapType(targetType);
             }
+        }
+
+        // Compress the greyscale font texture page using a specially-formulated DXT3 mode
+        static unsafe void CompressFontDXT3(TextureContent content, bool generateMipmaps)
+        {
+            if (content.Faces.Count > 1)
+                throw new PipelineException("Font textures should only have one face");
+
+            var block = new Vector4[16];
+            for (int i = 0; i < content.Faces[0].Count; ++i)
+            {
+                var face = content.Faces[0][i];
+                var xBlocks = (face.Width + 3) / 4;
+                var yBlocks = (face.Height + 3) / 4;
+                var dxt3Size = xBlocks * yBlocks * 16;
+                var buffer = new byte[dxt3Size];
+
+                var bytes = face.GetPixelData();
+                fixed (byte* b = bytes)
+                {
+                    Vector4* colors = (Vector4*)b;
+
+                    int w = 0;
+                    int h = 0;
+                    int x = 0;
+                    int y = 0;
+                    while (h < (face.Height & ~3))
+                    {
+                        w = 0;
+                        x = 0;
+
+                        var h0 = h * face.Width;
+                        var h1 = h0 + face.Width;
+                        var h2 = h1 + face.Width;
+                        var h3 = h2 + face.Width;
+
+                        while (w < (face.Width & ~3))
+                        {
+                            block[0] = colors[w + h0];
+                            block[1] = colors[w + h0 + 1];
+                            block[2] = colors[w + h0 + 2];
+                            block[3] = colors[w + h0 + 3];
+                            block[4] = colors[w + h1];
+                            block[5] = colors[w + h1 + 1];
+                            block[6] = colors[w + h1 + 2];
+                            block[7] = colors[w + h1 + 3];
+                            block[8] = colors[w + h2];
+                            block[9] = colors[w + h2 + 1];
+                            block[10] = colors[w + h2 + 2];
+                            block[11] = colors[w + h2 + 3];
+                            block[12] = colors[w + h3];
+                            block[13] = colors[w + h3 + 1];
+                            block[14] = colors[w + h3 + 2];
+                            block[15] = colors[w + h3 + 3];
+
+                            int offset = (x + y * xBlocks) * 16;
+                            CompressFontDXT3Block(block, buffer, offset);
+
+                            w += 4;
+                            ++x;
+                        }
+
+                        // Do partial block at end of row
+                        if (w < face.Width)
+                        {
+                            var cols = face.Width - w;
+                            Array.Clear(block, 0, 16);
+                            for (int r = 0; r < 4; ++r)
+                            {
+                                h0 = (h + r) * face.Width;
+                                for (int c = 0; c < cols; ++c)
+                                    block[(r * 4) + c] = colors[w + h0 + c];
+                            }
+
+                            int offset = (x + y * xBlocks) * 16;
+                            CompressFontDXT3Block(block, buffer, offset);
+                        }
+
+                        h += 4;
+                        ++y;
+                    }
+
+                    // Do last partial row
+                    if (h < face.Height)
+                    {
+                        var rows = face.Height - h;
+                        w = 0;
+                        x = 0;
+                        while (w < (face.Width & ~3))
+                        {
+                            Array.Clear(block, 0, 16);
+                            for (int r = 0; r < rows; ++r)
+                            {
+                                var h0 = (h + r) * face.Width;
+                                block[(r * 4) + 0] = colors[w + h0 + 0];
+                                block[(r * 4) + 1] = colors[w + h0 + 1];
+                                block[(r * 4) + 2] = colors[w + h0 + 2];
+                                block[(r * 4) + 3] = colors[w + h0 + 3];
+                            }
+
+                            int offset = (x + y * xBlocks) * 16;
+                            CompressFontDXT3Block(block, buffer, offset);
+
+                            w += 4;
+                            ++x;
+                        }
+
+                        // Do last partial block
+                        if (w < face.Width)
+                        {
+                            var cols = face.Width - w;
+                            Array.Clear(block, 0, 16);
+                            for (int r = 0; r < rows; ++r)
+                            {
+                                var h0 = (h + r) * face.Width;
+                                for (int c = 0; c < cols; ++c)
+                                    block[(r * 4) + c] = colors[w + h0 + c];
+                            }
+
+                            int offset = (x + y * xBlocks) * 16;
+                            CompressFontDXT3Block(block, buffer, offset);
+                        }
+                    }
+                }
+
+                var dxt3 = new Dxt3BitmapContent(face.Width, face.Height);
+                dxt3.SetPixelData(buffer);
+                content.Faces[0][i] = dxt3;
+            }
+        }
+
+        // Maps a 2-bit greyscale to the index required for DXT3
+        // 00 = color0
+        // 01 = color1
+        // 10 = 2/3 * color0 + 1/3 * color1
+        // 11 = 1/3 * color0 + 2/3 * color1
+        static byte[] dxt3Map = new byte[] { 0, 2, 3, 1 };
+
+        // Compress a single 4x4 block from colors into buffer at the given offset
+        static void CompressFontDXT3Block(Vector4[] colors, byte[] buffer, int offset)
+        {
+            // Get the alpha into a 0-15 range
+            int a0 = (int)(colors[0].W * 15.0);
+            int a1 = (int)(colors[1].W * 15.0);
+            int a2 = (int)(colors[2].W * 15.0);
+            int a3 = (int)(colors[3].W * 15.0);
+            int a4 = (int)(colors[4].W * 15.0);
+            int a5 = (int)(colors[5].W * 15.0);
+            int a6 = (int)(colors[6].W * 15.0);
+            int a7 = (int)(colors[7].W * 15.0);
+            int a8 = (int)(colors[8].W * 15.0);
+            int a9 = (int)(colors[9].W * 15.0);
+            int a10 = (int)(colors[10].W * 15.0);
+            int a11 = (int)(colors[11].W * 15.0);
+            int a12 = (int)(colors[12].W * 15.0);
+            int a13 = (int)(colors[13].W * 15.0);
+            int a14 = (int)(colors[14].W * 15.0);
+            int a15 = (int)(colors[15].W * 15.0);
+
+            // Duplicate the top two bits into the bottom two bits so we get one of four values: b0000, b0101, b1010, b1111
+            a0 = (a0 & 0xC) | (a0 >> 2);
+            a1 = (a1 & 0xC) | (a1 >> 2);
+            a2 = (a2 & 0xC) | (a2 >> 2);
+            a3 = (a3 & 0xC) | (a3 >> 2);
+            a4 = (a4 & 0xC) | (a4 >> 2);
+            a5 = (a5 & 0xC) | (a5 >> 2);
+            a6 = (a6 & 0xC) | (a6 >> 2);
+            a7 = (a7 & 0xC) | (a7 >> 2);
+            a8 = (a8 & 0xC) | (a8 >> 2);
+            a9 = (a9 & 0xC) | (a9 >> 2);
+            a10 = (a10 & 0xC) | (a10 >> 2);
+            a11 = (a11 & 0xC) | (a11 >> 2);
+            a12 = (a12 & 0xC) | (a12 >> 2);
+            a13 = (a13 & 0xC) | (a13 >> 2);
+            a14 = (a14 & 0xC) | (a14 >> 2);
+            a15 = (a15 & 0xC) | (a15 >> 2);
+
+            // 4-bit alpha
+            buffer[offset + 0] = (byte)((a1 << 4) | a0);
+            buffer[offset + 1] = (byte)((a3 << 4) | a2);
+            buffer[offset + 2] = (byte)((a5 << 4) | a4);
+            buffer[offset + 3] = (byte)((a7 << 4) | a6);
+            buffer[offset + 4] = (byte)((a9 << 4) | a8);
+            buffer[offset + 5] = (byte)((a11 << 4) | a10);
+            buffer[offset + 6] = (byte)((a13 << 4) | a12);
+            buffer[offset + 7] = (byte)((a15 << 4) | a14);
+
+            // color0 (transparent)
+            buffer[offset + 8] = 0;
+            buffer[offset + 9] = 0;
+
+            // color1 (white)
+            buffer[offset + 10] = 255;
+            buffer[offset + 11] = 255;
+
+            // Get the red (to be used for green and blue channels as well) into a 0-15 range
+            a0 = (int)(colors[0].Z * 15.0);
+            a1 = (int)(colors[1].Z * 15.0);
+            a2 = (int)(colors[2].Z * 15.0);
+            a3 = (int)(colors[3].Z * 15.0);
+            a4 = (int)(colors[4].Z * 15.0);
+            a5 = (int)(colors[5].Z * 15.0);
+            a6 = (int)(colors[6].Z * 15.0);
+            a7 = (int)(colors[7].Z * 15.0);
+            a8 = (int)(colors[8].Z * 15.0);
+            a9 = (int)(colors[9].Z * 15.0);
+            a10 = (int)(colors[10].Z * 15.0);
+            a11 = (int)(colors[11].Z * 15.0);
+            a12 = (int)(colors[12].Z * 15.0);
+            a13 = (int)(colors[13].Z * 15.0);
+            a14 = (int)(colors[14].Z * 15.0);
+            a15 = (int)(colors[15].Z * 15.0);
+
+            // Duplicate the top two bits into the bottom two bits so we get one of four values: b0000, b0101, b1010, b1111
+            a0 = (a0 & 0xC) | (a0 >> 2);
+            a1 = (a1 & 0xC) | (a1 >> 2);
+            a2 = (a2 & 0xC) | (a2 >> 2);
+            a3 = (a3 & 0xC) | (a3 >> 2);
+            a4 = (a4 & 0xC) | (a4 >> 2);
+            a5 = (a5 & 0xC) | (a5 >> 2);
+            a6 = (a6 & 0xC) | (a6 >> 2);
+            a7 = (a7 & 0xC) | (a7 >> 2);
+            a8 = (a8 & 0xC) | (a8 >> 2);
+            a9 = (a9 & 0xC) | (a9 >> 2);
+            a10 = (a10 & 0xC) | (a10 >> 2);
+            a11 = (a11 & 0xC) | (a11 >> 2);
+            a12 = (a12 & 0xC) | (a12 >> 2);
+            a13 = (a13 & 0xC) | (a13 >> 2);
+            a14 = (a14 & 0xC) | (a14 >> 2);
+            a15 = (a15 & 0xC) | (a15 >> 2);
+
+            // Color indices (00 = color0, 01 = color1, 10 = 2/3 * color0 + 1/3 * color1, 11 = 1/3 * color0 + 2/3 * color1)
+            buffer[offset + 12] = (byte)((dxt3Map[a3 >> 2] << 6) | (dxt3Map[a2 >> 2] << 4) | (dxt3Map[a1 >> 2] << 2) | dxt3Map[a0 >> 2]);
+            buffer[offset + 13] = (byte)((dxt3Map[a7 >> 2] << 6) | (dxt3Map[a6 >> 2] << 4) | (dxt3Map[a5 >> 2] << 2) | dxt3Map[a4 >> 2]);
+            buffer[offset + 14] = (byte)((dxt3Map[a11 >> 2] << 6) | (dxt3Map[a10 >> 2] << 4) | (dxt3Map[a9 >> 2] << 2) | dxt3Map[a8 >> 2]);
+            buffer[offset + 15] = (byte)((dxt3Map[a15 >> 2] << 6) | (dxt3Map[a14 >> 2] << 4) | (dxt3Map[a13 >> 2] << 2) | dxt3Map[a12 >> 2]);
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/TextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/TextureProfile.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         /// <param name="content">The content to be compressed.</param>
         /// <param name="format">The user requested format for compression.</param>
         /// <param name="generateMipmaps">If mipmap generation is required.</param>
-        /// <param name="sharpAlpha">If the texture has sharp alpha cutouts.</param>
-        public void ConvertTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool generateMipmaps, bool sharpAlpha)
+        /// <param name="isSpriteFont">If the texture has represents a sprite font, i.e. is greyscale and has sharp black/white contrast.</param>
+        public void ConvertTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool generateMipmaps, bool isSpriteFont)
         {
             // We do nothing in this case.
             if (format == TextureProcessorOutputFormat.NoChange)
@@ -75,7 +75,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             try
             {
                 // All other formats require platform specific choices.
-                PlatformCompressTexture(context, content, format, generateMipmaps, sharpAlpha);
+                PlatformCompressTexture(context, content, format, generateMipmaps, isSpriteFont);
             }
             catch (EntryPointNotFoundException ex)
             {
@@ -94,6 +94,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             }
         }
 
-        protected abstract void PlatformCompressTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool generateMipmaps, bool sharpAlpha);
+        protected abstract void PlatformCompressTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool generateMipmaps, bool isSpriteFont);
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/TextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/TextureProfile.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             try
             {
                 // All other formats require platform specific choices.
-                PlatformCompressTexture(context, content, format, generateMipmaps, false);
+                PlatformCompressTexture(context, content, format, generateMipmaps, sharpAlpha);
             }
             catch (EntryPointNotFoundException ex)
             {

--- a/MonoGame.Framework.Content.Pipeline/Utilities/Vector4Converter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/Vector4Converter.cs
@@ -24,24 +24,24 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities
         Vector4 IVector4Converter<byte>.ToVector4(byte value)
         {
             var f = (float)value / (float)byte.MaxValue;
-            return new Vector4(f, f, f, f);
+            return new Vector4(1f, 1f, 1f, f);
         }
 
         Vector4 IVector4Converter<short>.ToVector4(short value)
         {
             var f = (float)value / (float)short.MaxValue;
-            return new Vector4(f, f, f, f);
+            return new Vector4(1f, 1f, 1f, f);
         }
 
         Vector4 IVector4Converter<int>.ToVector4(int value)
         {
             var f = (float)value / (float)int.MaxValue;
-            return new Vector4(f, f, f, f);
+            return new Vector4(1f, 1f, 1f, f);
         }
 
         Vector4 IVector4Converter<float>.ToVector4(float value)
         {
-            return new Vector4(value, value, value, value);
+            return new Vector4(1f, 1f, 1f, value);
         }
 
         Vector4 IVector4Converter<Color>.ToVector4(Color value)
@@ -56,22 +56,22 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities
 
         byte IVector4Converter<byte>.FromVector4(Vector4 value)
         {
-            return (byte)(value.X * (float)byte.MaxValue);
+            return (byte)(value.W * (float)byte.MaxValue);
         }
 
         short IVector4Converter<short>.FromVector4(Vector4 value)
         {
-            return (short)(value.X * (float)short.MaxValue);
+            return (short)(value.W * (float)short.MaxValue);
         }
 
         int IVector4Converter<int>.FromVector4(Vector4 value)
         {
-            return (int)(value.X * (float)int.MaxValue);
+            return (int)(value.W * (float)int.MaxValue);
         }
 
         float IVector4Converter<float>.FromVector4(Vector4 value)
         {
-            return value.X;
+            return value.W;
         }
 
         Color IVector4Converter<Color>.FromVector4(Vector4 value)


### PR DESCRIPTION
- Implemented a custom DXT3 compressor for font texture pages to eliminate block compression artifacts.
- iOS uses 16-bit colour textures for compressed font texture pages.
- Android already used 16-bit colour textures for compressed font texture pages as a side effect of ETC1 support.
- Added PremultiplyAlpha property to FontDescriptionProcessor for consistency (FontTextureProcessor and TextureProcessor already have the same property).

![customdxt3font](https://cloud.githubusercontent.com/assets/694943/20312208/5ad52988-ab9e-11e6-9855-5d52f710afaa.png)

Fixes #2853