### PR TITLE
Use up to 8 render targets.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private IndexBuffer _indexBuffer;
         private bool _indexBufferDirty;
 
-        private readonly RenderTargetBinding[] _currentRenderTargetBindings = new RenderTargetBinding[4];
+        private readonly RenderTargetBinding[] _currentRenderTargetBindings = new RenderTargetBinding[8];
         private int _currentRenderTargetCount;
         private readonly RenderTargetBinding[] _tempRenderTargetBinding = new RenderTargetBinding[1];
 


### PR DESCRIPTION
Feature level 10.0 can have up to 8 render targets.
https://msdn.microsoft.com/en-us/library/windows/desktop/ff476876(v=vs.85).aspx

fix http://community.monogame.net/t/error-when-setrendertargets-more-than-4-rtbinding/8408
