### PR TITLE
[DesktopGL] Fix debugging from Windows

### DIFF
--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -51,6 +51,10 @@ namespace Microsoft.Xna.Framework
             if (version <= 204)
                 Debug.WriteLine ("Please use SDL 2.0.5 or higher.");
 
+            // Needed so VS can debug the project on Windows
+            if (version >= 205 && CurrentPlatform.OS == OS.Windows && Debugger.IsAttached)
+                Sdl.SetHint("SDL_WINDOWS_DISABLE_THREAD_NAMING", "1");
+
             Sdl.Init((int)(
                 Sdl.InitFlags.Video |
                 Sdl.InitFlags.Joystick |


### PR DESCRIPTION
Documentation states that the hint name is `SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING`, but looking at the source code it seems that the hint is `SDL_WINDOWS_DISABLE_THREAD_NAMING` (source code const is getting assigned a different value from it's name). 

In the end I had the time to test this.