### PR TITLE
Implement GraphicsAdapter.IsProfileSupported()

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
@@ -116,6 +116,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
         protected bool PlatformIsProfileSupported(GraphicsProfile graphicsProfile)
         {
+            if(UseReferenceDevice)
+                return true;
+
             switch(graphicsProfile)
             {
                 case GraphicsProfile.Reach:

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
@@ -5,11 +5,15 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using SharpDX.Direct3D;
+using SharpDX.DXGI;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
     partial class GraphicsAdapter
     {
+        SharpDX.DXGI.Adapter1 _adapter;
+
         private static void PlatformInitializeAdapters(out ReadOnlyCollection<GraphicsAdapter> adapters)
         {
             var factory = new SharpDX.DXGI.Factory1();
@@ -31,8 +35,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
                     monitor.Dispose();
                 }
-
-                device.Dispose();
             }
 
             factory.Dispose();
@@ -50,6 +52,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private static GraphicsAdapter CreateAdapter(SharpDX.DXGI.Adapter1 device, SharpDX.DXGI.Output monitor)
         {            
             var adapter = new GraphicsAdapter();
+            adapter._adapter = device;
 
             adapter.DeviceName = monitor.Description.DeviceName.TrimEnd(new char[] {'\0'});
             adapter.Description = device.Description1.Description.TrimEnd(new char[] {'\0'});
@@ -109,6 +112,19 @@ namespace Microsoft.Xna.Framework.Graphics
             adapter._supportedDisplayModes = new DisplayModeCollection(modes);
 
             return adapter;
+        }
+
+        protected bool PlatformIsProfileSupported(GraphicsProfile graphicsProfile)
+        {
+            switch(graphicsProfile)
+            {
+                case GraphicsProfile.Reach:
+                    return SharpDX.Direct3D11.Device.IsSupportedFeatureLevel(_adapter, FeatureLevel.Level_9_1);
+                case GraphicsProfile.HiDef:
+                    return SharpDX.Direct3D11.Device.IsSupportedFeatureLevel(_adapter, FeatureLevel.Level_10_0);
+                default:
+                    throw new InvalidOperationException();
+            }
         }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
@@ -377,6 +377,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public bool IsProfileSupported(GraphicsProfile graphicsProfile)
         {
+            if(UseReferenceDevice)
+                return true;
+
             switch(graphicsProfile)
             {
                 case GraphicsProfile.Reach:

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
@@ -375,6 +375,21 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        public bool IsProfileSupported(GraphicsProfile graphicsProfile)
+        {
+            switch(graphicsProfile)
+            {
+                case GraphicsProfile.Reach:
+                    return true;
+                case GraphicsProfile.HiDef:
+                    bool result = true;
+                    // TODO: check adapter capabilities...
+                    return result;
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
 #if WINDOWS && !OPENGL
         [System.Runtime.InteropServices.DllImport("gdi32.dll", CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true, ExactSpelling = true)]
         public static extern int GetDeviceCaps(IntPtr hDC, int nIndex);

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -134,6 +134,11 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
         */
 
+        public bool IsProfileSupported(GraphicsProfile graphicsProfile)
+        {
+            return PlatformIsProfileSupported(graphicsProfile);
+        }
+
         public void Dispose()
         {
             // We don't keep any resources, so we have

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -205,8 +205,13 @@ namespace Microsoft.Xna.Framework.Graphics
         public GraphicsDevice(GraphicsAdapter adapter, GraphicsProfile graphicsProfile, PresentationParameters presentationParameters)
         {
             Adapter = adapter;
+#if DIRECTX
             if (!adapter.IsProfileSupported(graphicsProfile))
                 throw new NoSuitableGraphicsDeviceException(String.Format("Adapter '{0}' does not support the {1} profile.", adapter.Description, graphicsProfile));
+#else
+            if (!adapter.IsProfileSupported(graphicsProfile))
+                throw new NoSuitableGraphicsDeviceException(String.Format("Adapter does not support the {1} profile.", graphicsProfile));
+#endif
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
             PresentationParameters = presentationParameters;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -205,6 +205,8 @@ namespace Microsoft.Xna.Framework.Graphics
         public GraphicsDevice(GraphicsAdapter adapter, GraphicsProfile graphicsProfile, PresentationParameters presentationParameters)
         {
             Adapter = adapter;
+            if (!adapter.IsProfileSupported(graphicsProfile))
+                throw new NoSuitableGraphicsDeviceException(String.Format("Adapter '{0}' does not support the {1} profile.", adapter.Description, graphicsProfile));
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
             PresentationParameters = presentationParameters;


### PR DESCRIPTION
On 3.6 you have to use SharpDX to query for the GPU feature level or target just HiDef and let the app crash if HiDef is not supported (3.5 had HiDef as default if supported).

With this PR you can check for supported profile and enable HiDef. 
ex:
```
        public Game1()
        {
            graphics = new GraphicsDeviceManager(this);
            Content.RootDirectory = "Content";
            graphics.PreparingDeviceSettings += Graphics_PreparingDeviceSettings;
        }

        private void Graphics_PreparingDeviceSettings(object sender, PreparingDeviceSettingsEventArgs e)
        {
            if(e.GraphicsDeviceInformation.Adapter.IsProfileSupported(GraphicsProfile.HiDef))
                e.GraphicsDeviceInformation.GraphicsProfile = GraphicsProfile.HiDef;
        }
```

