### PR TITLE
Marshal size of refactor

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1347,8 +1347,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             DynamicIndexBuffer buffer;
 
-            var indexType = typeof(T);
-            var indexSize = Marshal.SizeOf(indexType);
+            var indexSize = Utilities.ReflectionHelpers.SizeOf<T>.Get();
             var indexElementSize = indexSize == 2 ? IndexElementSize.SixteenBits : IndexElementSize.ThirtyTwoBits;
 
             var requiredIndexCount = Math.Max(indexCount, 6000);

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformSetData<T>(int level, int arraySlice, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct
         {
-            var elementSizeInByte = Marshal.SizeOf(typeof(T));
+            var elementSizeInByte = Utilities.ReflectionHelpers.SizeOf<T>.Get();
             var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
             // Use try..finally to make sure dataHandle is freed in case of an error
             try
@@ -167,7 +167,7 @@ namespace Microsoft.Xna.Framework.Graphics
                             // We need to copy each row separatly and skip trailing zeros.
                             stream.Seek(0, SeekOrigin.Begin);
 
-                            int elementSizeInByte = Marshal.SizeOf(typeof(T));
+                            int elementSizeInByte = Utilities.ReflectionHelpers.SizeOf<T>.Get();
                             for (var row = 0; row < rows; row++)
                             {
                                 int i;

--- a/MonoGame.Framework/Graphics/Texture3D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.DirectX.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Xna.Framework.Graphics
                                      int left, int top, int right, int bottom, int front, int back,
                                      T[] data, int startIndex, int elementCount, int width, int height, int depth)
         {
-            var elementSizeInByte = Marshal.SizeOf(typeof(T));
+            var elementSizeInByte = Utilities.ReflectionHelpers.SizeOf<T>.Get();
             var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
             try
             {

--- a/MonoGame.Framework/Graphics/TextureCube.DirectX.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.DirectX.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Xna.Framework.Graphics
                             // We need to copy each row separatly and skip trailing zeros.
                             stream.Seek(startIndex, SeekOrigin.Begin);
 
-                            int elementSizeInByte = Marshal.SizeOf(typeof(T));
+                            int elementSizeInByte = Utilities.ReflectionHelpers.SizeOf<T>.Get();
                             for (var row = 0; row < rows; row++)
                             {
                                 int i;

--- a/MonoGame.Framework/Graphics/TextureCube.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.cs
@@ -69,8 +69,8 @@ namespace Microsoft.Xna.Framework.Graphics
             if (data == null) 
                 throw new ArgumentNullException("data");
 
-            var elementSizeInByte = Marshal.SizeOf(typeof(T));
-			var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+            var elementSizeInByte = Utilities.ReflectionHelpers.SizeOf<T>.Get();
+            var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
             // Use try..finally to make sure dataHandle is freed in case of an error
             try
             {

--- a/MonoGame.Framework/Graphics/Vertices/DynamicVertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/DynamicVertexBuffer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void SetData<T>(T[] data, int startIndex, int elementCount, SetDataOptions options) where T : struct
         {
-            var elementSizeInBytes = Marshal.SizeOf(typeof(T));
+            var elementSizeInBytes = Utilities.ReflectionHelpers.SizeOf<T>.Get();
             base.SetDataInternal<T>(0, data, startIndex, elementCount, elementSizeInBytes, options);
         }
     }

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.DirectX.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
-                var elementSizeInBytes = Marshal.SizeOf(typeof(T));
+                var elementSizeInBytes = Utilities.ReflectionHelpers.SizeOf<T>.Get();
                 var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
                 try
                 {

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>The IndexElementSize enum value that matches the type</returns>
         static IndexElementSize SizeForType(GraphicsDevice graphicsDevice, Type type)
         {
-            switch (Marshal.SizeOf(type))
+            switch (Utilities.ReflectionHelpers.ManagedSizeOf(type))
             {
                 case 2:
                     return IndexElementSize.SixteenBits;

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void GetData<T> (int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride) where T : struct
         {
-            var elementSizeInBytes = Marshal.SizeOf(typeof(T));
+            var elementSizeInBytes = Utilities.ReflectionHelpers.SizeOf<T>.Get();
 
             if (vertexStride == 0)
                 vertexStride = elementSizeInBytes;
@@ -74,13 +74,13 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void GetData<T>(T[] data, int startIndex, int elementCount) where T : struct
         {
-            var elementSizeInByte = Marshal.SizeOf(typeof(T));
+            var elementSizeInByte = Utilities.ReflectionHelpers.SizeOf<T>.Get();
             this.GetData<T>(0, data, startIndex, elementCount, elementSizeInByte);
         }
 
         public void GetData<T>(T[] data) where T : struct
         {
-            var elementSizeInByte = Marshal.SizeOf(typeof(T));
+            var elementSizeInByte = Utilities.ReflectionHelpers.SizeOf<T>.Get();
             this.GetData<T>(0, data, 0, data.Length, elementSizeInByte);
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// must be within the <paramref name="data"/> array bounds.</param>
 		public void SetData<T>(T[] data, int startIndex, int elementCount) where T : struct
         {
-            var elementSizeInBytes = Marshal.SizeOf(typeof(T));
+            var elementSizeInBytes = Utilities.ReflectionHelpers.SizeOf<T>.Get();
             SetDataInternal<T>(0, data, startIndex, elementCount, elementSizeInBytes, SetDataOptions.None);
 		}
 		
@@ -159,7 +159,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="data">Data array.</param>
         public void SetData<T>(T[] data) where T : struct
         {
-            var elementSizeInBytes = Marshal.SizeOf(typeof(T));
+            var elementSizeInBytes = Utilities.ReflectionHelpers.SizeOf<T>.Get();
             SetDataInternal<T>(0, data, 0, data.Length, elementSizeInBytes, SetDataOptions.None);
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (data == null)
                 throw new ArgumentNullException("data");
 
-            var elementSizeInBytes = Marshal.SizeOf(typeof(T));
+            var elementSizeInBytes = Utilities.ReflectionHelpers.SizeOf<T>.Get();
             var bufferSize = VertexCount * VertexDeclaration.VertexStride;
 
             if (vertexStride == 0)

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Xna.Framework.Utilities
 
             static SizeOf()
             {
-#if LINUX || WINDOWS
+#if LINUX || WINDOWS || WEB
                 var type = typeof(T);
                 _sizeOf = Marshal.SizeOf(type);
 #else

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -6,163 +6,183 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Utilities
 {
-	internal static class ReflectionHelpers
-	{
-		public static bool IsValueType(Type targetType)
-		{
-			if (targetType == null)
-			{
-				throw new NullReferenceException("Must supply the targetType parameter");
-			}
+    internal static class ReflectionHelpers
+    {
+        public static bool IsValueType(Type targetType)
+        {
+            if (targetType == null)
+            {
+                throw new NullReferenceException("Must supply the targetType parameter");
+            }
 #if WINRT
-			return targetType.GetTypeInfo().IsValueType;
+            return targetType.GetTypeInfo().IsValueType;
 #else
 			return targetType.IsValueType;
 #endif
-		}
+        }
 
-		public static Type GetBaseType(Type targetType)
-		{
-			if (targetType == null)
-			{
-				throw new NullReferenceException("Must supply the targetType parameter");
-			}
+        public static Type GetBaseType(Type targetType)
+        {
+            if (targetType == null)
+            {
+                throw new NullReferenceException("Must supply the targetType parameter");
+            }
 #if WINRT
-			var type = targetType.GetTypeInfo().BaseType;
+            var type = targetType.GetTypeInfo().BaseType;
 #else
 			var type = targetType.BaseType;
 #endif
-			return type;
-		}
+            return type;
+        }
 
-		/// <summary>
-		/// Returns true if the given type represents a non-object type that is not abstract.
-		/// </summary>
-		public static bool IsConcreteClass(Type t)
-		{
-			if (t == null)
-			{
-				throw new NullReferenceException("Must supply the t (type) parameter");
-			}
+        /// <summary>
+        /// Returns true if the given type represents a non-object type that is not abstract.
+        /// </summary>
+        public static bool IsConcreteClass(Type t)
+        {
+            if (t == null)
+            {
+                throw new NullReferenceException("Must supply the t (type) parameter");
+            }
 
-			if (t == typeof(object))
-				return false;
+            if (t == typeof(object))
+                return false;
 #if WINRT
-			var ti = t.GetTypeInfo();
-			if (ti.IsClass && !ti.IsAbstract)
-				return true;
+            var ti = t.GetTypeInfo();
+            if (ti.IsClass && !ti.IsAbstract)
+                return true;
 #else
 			if (t.IsClass && !t.IsAbstract)
 				return true;
 #endif
-			return false;
-		}
+            return false;
+        }
 
-		public static MethodInfo GetPropertyGetMethod(PropertyInfo property)
-		{
-			if (property == null)
-			{
-				throw new NullReferenceException("Must supply the property parameter");
-			}
+        public static MethodInfo GetPropertyGetMethod(PropertyInfo property)
+        {
+            if (property == null)
+            {
+                throw new NullReferenceException("Must supply the property parameter");
+            }
 
 #if WINRT
-			return property.GetMethod;
+            return property.GetMethod;
 #else
 			return property.GetGetMethod();
 #endif
-		}
+        }
 
-		public static MethodInfo GetPropertySetMethod(PropertyInfo property)
-		{
-			if (property == null)
-			{
-				throw new NullReferenceException("Must supply the property parameter");
-			}
+        public static MethodInfo GetPropertySetMethod(PropertyInfo property)
+        {
+            if (property == null)
+            {
+                throw new NullReferenceException("Must supply the property parameter");
+            }
 
 #if WINRT
-			return property.SetMethod;
+            return property.SetMethod;
 #else
 			return property.GetSetMethod();
 #endif
-		}
+        }
 
-		public static T GetCustomAttribute<T>(MemberInfo member) where T : Attribute
-		{
-			if (member == null)
-				throw new NullReferenceException("Must supply the member parameter");
+        public static T GetCustomAttribute<T>(MemberInfo member) where T : Attribute
+        {
+            if (member == null)
+                throw new NullReferenceException("Must supply the member parameter");
 
 #if WINRT
-			return member.GetCustomAttribute(typeof(T)) as T;
+            return member.GetCustomAttribute(typeof(T)) as T;
 #else
 			return Attribute.GetCustomAttribute(member, typeof(T)) as T;
 #endif
-		}
+        }
 
-		/// <summary>
-		/// Returns true if the get method of the given property exist and are public.
-		/// Note that we allow a getter-only property to be serialized (and deserialized),
-		/// *if* CanDeserializeIntoExistingObject is true for the property type.
-		/// </summary>
-		public static bool PropertyIsPublic(PropertyInfo property)
-		{
-			if (property == null)
-			{
-				throw new NullReferenceException("Must supply the property parameter");
-			}
+        /// <summary>
+        /// Returns true if the get method of the given property exist and are public.
+        /// Note that we allow a getter-only property to be serialized (and deserialized),
+        /// *if* CanDeserializeIntoExistingObject is true for the property type.
+        /// </summary>
+        public static bool PropertyIsPublic(PropertyInfo property)
+        {
+            if (property == null)
+            {
+                throw new NullReferenceException("Must supply the property parameter");
+            }
 
-			var getMethod = GetPropertyGetMethod(property);
-			if (getMethod == null || !getMethod.IsPublic)
-				return false;
+            var getMethod = GetPropertyGetMethod(property);
+            if (getMethod == null || !getMethod.IsPublic)
+                return false;
 
-			return true;
-		}
+            return true;
+        }
 
-		/// <summary>
-		/// Returns true if the given type can be assigned the given value
-		/// </summary>
-		public static bool IsAssignableFrom(Type type, object value)
-		{
-			if (type == null)
-				throw new ArgumentNullException("type");
-			if (value == null)
-				throw new ArgumentNullException("value");
+        /// <summary>
+        /// Returns true if the given type can be assigned the given value
+        /// </summary>
+        public static bool IsAssignableFrom(Type type, object value)
+        {
+            if (type == null)
+                throw new ArgumentNullException("type");
+            if (value == null)
+                throw new ArgumentNullException("value");
 
-			return IsAssignableFromType(type, value.GetType());
-		}
+            return IsAssignableFromType(type, value.GetType());
+        }
 
-		/// <summary>
-		/// Returns true if the given type can be assigned a value with the given object type
-		/// </summary>
-		public static bool IsAssignableFromType(Type type, Type objectType)
-		{
-			if (type == null)
-				throw new ArgumentNullException("type");
-			if (objectType == null)
-				throw new ArgumentNullException("objectType");
+        /// <summary>
+        /// Returns true if the given type can be assigned a value with the given object type
+        /// </summary>
+        public static bool IsAssignableFromType(Type type, Type objectType)
+        {
+            if (type == null)
+                throw new ArgumentNullException("type");
+            if (objectType == null)
+                throw new ArgumentNullException("objectType");
 #if WINRT
-			if (type.GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
-				return true;
+            if (type.GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
+                return true;
 #else
 			if (type.IsAssignableFrom(objectType))
 				return true;
 #endif
-			return false;
-		}
+            return false;
+        }
 
-		internal static class SizeOf<T>
-		{
-			static int _sizeOf;
+        internal static class SizeOf<T>
+        {
+            static int _sizeOf;
 
-			static SizeOf()
-			{
-				var type = typeof(T);
-				_sizeOf = Marshal.SizeOf(type);
-			}
+            static SizeOf()
+            {
+#if LINUX || WINDOWS
+                var type = typeof(T);
+                _sizeOf = Marshal.SizeOf(type);
+#else
+                _sizeOf = Marshal.SizeOf<T>();
+#endif
+            }
 
-			static public int Get()
-			{
-				return _sizeOf;
-			}
-		}
-	}
+            static public int Get()
+            {
+                return _sizeOf;
+            }
+        }
+
+        static System.Collections.Generic.Dictionary<Type, int> _sizeOfCollection;
+        internal static int ManagedSizeOf(Type type)
+        {
+            int _sizeOf = 0;
+            _sizeOf = _sizeOfCollection[type];
+            if (_sizeOf < 1)
+            {
+                _sizeOf = Marshal.SizeOf(type);
+                _sizeOfCollection.Add(type, _sizeOf);
+            }
+            return _sizeOf;
+
+        }
+
+    }
+
 }

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Xna.Framework.Utilities
 
             static SizeOf()
             {
-#if LINUX || WINDOWS || WEB
+#if LINUX || WINDOWS || WEB || SILVERLIGHT
                 var type = typeof(T);
                 _sizeOf = Marshal.SizeOf(type);
 #else

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Utilities
 {
@@ -34,9 +35,9 @@ namespace Microsoft.Xna.Framework.Utilities
 			return type;
 		}
 
-        /// <summary>
-        /// Returns true if the given type represents a non-object type that is not abstract.
-        /// </summary>
+		/// <summary>
+		/// Returns true if the given type represents a non-object type that is not abstract.
+		/// </summary>
 		public static bool IsConcreteClass(Type t)
 		{
 			if (t == null)
@@ -44,8 +45,8 @@ namespace Microsoft.Xna.Framework.Utilities
 				throw new NullReferenceException("Must supply the t (type) parameter");
 			}
 
-            if (t == typeof(object))
-                return false;
+			if (t == typeof(object))
+				return false;
 #if WINRT
 			var ti = t.GetTypeInfo();
 			if (ti.IsClass && !ti.IsAbstract)
@@ -57,33 +58,33 @@ namespace Microsoft.Xna.Framework.Utilities
 			return false;
 		}
 
-        public static MethodInfo GetPropertyGetMethod(PropertyInfo property)
-        {
-            if (property == null)
-            {
-                throw new NullReferenceException("Must supply the property parameter");
-            }
+		public static MethodInfo GetPropertyGetMethod(PropertyInfo property)
+		{
+			if (property == null)
+			{
+				throw new NullReferenceException("Must supply the property parameter");
+			}
 
 #if WINRT
-            return property.GetMethod;
+			return property.GetMethod;
 #else
-            return property.GetGetMethod();
+			return property.GetGetMethod();
 #endif
-        }
+		}
 
-        public static MethodInfo GetPropertySetMethod(PropertyInfo property)
-        {
-            if (property == null)
-            {
-                throw new NullReferenceException("Must supply the property parameter");
-            }
+		public static MethodInfo GetPropertySetMethod(PropertyInfo property)
+		{
+			if (property == null)
+			{
+				throw new NullReferenceException("Must supply the property parameter");
+			}
 
 #if WINRT
-            return property.SetMethod;
+			return property.SetMethod;
 #else
-            return property.GetSetMethod();
+			return property.GetSetMethod();
 #endif
-        }
+		}
 
 		public static T GetCustomAttribute<T>(MemberInfo member) where T : Attribute
 		{
@@ -93,32 +94,32 @@ namespace Microsoft.Xna.Framework.Utilities
 #if WINRT
 			return member.GetCustomAttribute(typeof(T)) as T;
 #else
-            return Attribute.GetCustomAttribute(member, typeof(T)) as T;
+			return Attribute.GetCustomAttribute(member, typeof(T)) as T;
 #endif
 		}
 
-        /// <summary>
-        /// Returns true if the get method of the given property exist and are public.
-        /// Note that we allow a getter-only property to be serialized (and deserialized),
-        /// *if* CanDeserializeIntoExistingObject is true for the property type.
-        /// </summary>
-        public static bool PropertyIsPublic(PropertyInfo property)
-        {
-            if (property == null)
-            {
-                throw new NullReferenceException("Must supply the property parameter");
-            }
+		/// <summary>
+		/// Returns true if the get method of the given property exist and are public.
+		/// Note that we allow a getter-only property to be serialized (and deserialized),
+		/// *if* CanDeserializeIntoExistingObject is true for the property type.
+		/// </summary>
+		public static bool PropertyIsPublic(PropertyInfo property)
+		{
+			if (property == null)
+			{
+				throw new NullReferenceException("Must supply the property parameter");
+			}
 
-            var getMethod = GetPropertyGetMethod(property);
-            if (getMethod == null || !getMethod.IsPublic)
-                return false;
+			var getMethod = GetPropertyGetMethod(property);
+			if (getMethod == null || !getMethod.IsPublic)
+				return false;
 
-            return true;
-        }
+			return true;
+		}
 
-        /// <summary>
-        /// Returns true if the given type can be assigned the given value
-        /// </summary>
+		/// <summary>
+		/// Returns true if the given type can be assigned the given value
+		/// </summary>
 		public static bool IsAssignableFrom(Type type, object value)
 		{
 			if (type == null)
@@ -126,27 +127,42 @@ namespace Microsoft.Xna.Framework.Utilities
 			if (value == null)
 				throw new ArgumentNullException("value");
 
-            return IsAssignableFromType(type, value.GetType());
+			return IsAssignableFromType(type, value.GetType());
 		}
 
-        /// <summary>
-        /// Returns true if the given type can be assigned a value with the given object type
-        /// </summary>
-        public static bool IsAssignableFromType(Type type, Type objectType)
-        {
-            if (type == null)
-                throw new ArgumentNullException("type");
-            if (objectType == null)
-                throw new ArgumentNullException("objectType");
+		/// <summary>
+		/// Returns true if the given type can be assigned a value with the given object type
+		/// </summary>
+		public static bool IsAssignableFromType(Type type, Type objectType)
+		{
+			if (type == null)
+				throw new ArgumentNullException("type");
+			if (objectType == null)
+				throw new ArgumentNullException("objectType");
 #if WINRT
-            if (type.GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
-                return true;
+			if (type.GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
+				return true;
 #else
-            if (type.IsAssignableFrom(objectType))
-                return true;
+			if (type.IsAssignableFrom(objectType))
+				return true;
 #endif
-            return false;
-        }
+			return false;
+		}
 
+		internal static class SizeOf<T>
+		{
+			static int _sizeOf;
+
+			static SizeOf()
+			{
+				var type = typeof(T);
+				_sizeOf = Marshal.SizeOf(type);
+			}
+
+			static public int Get()
+			{
+				return _sizeOf;
+			}
+		}
 	}
 }

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -17,7 +16,7 @@ namespace Microsoft.Xna.Framework.Utilities
 #if WINRT
             return targetType.GetTypeInfo().IsValueType;
 #else
-			return targetType.IsValueType;
+            return targetType.IsValueType;
 #endif
         }
 
@@ -30,7 +29,7 @@ namespace Microsoft.Xna.Framework.Utilities
 #if WINRT
             var type = targetType.GetTypeInfo().BaseType;
 #else
-			var type = targetType.BaseType;
+            var type = targetType.BaseType;
 #endif
             return type;
         }
@@ -52,8 +51,8 @@ namespace Microsoft.Xna.Framework.Utilities
             if (ti.IsClass && !ti.IsAbstract)
                 return true;
 #else
-			if (t.IsClass && !t.IsAbstract)
-				return true;
+            if (t.IsClass && !t.IsAbstract)
+                return true;
 #endif
             return false;
         }
@@ -68,7 +67,7 @@ namespace Microsoft.Xna.Framework.Utilities
 #if WINRT
             return property.GetMethod;
 #else
-			return property.GetGetMethod();
+            return property.GetGetMethod();
 #endif
         }
 
@@ -82,7 +81,7 @@ namespace Microsoft.Xna.Framework.Utilities
 #if WINRT
             return property.SetMethod;
 #else
-			return property.GetSetMethod();
+            return property.GetSetMethod();
 #endif
         }
 
@@ -94,7 +93,7 @@ namespace Microsoft.Xna.Framework.Utilities
 #if WINRT
             return member.GetCustomAttribute(typeof(T)) as T;
 #else
-			return Attribute.GetCustomAttribute(member, typeof(T)) as T;
+            return Attribute.GetCustomAttribute(member, typeof(T)) as T;
 #endif
         }
 
@@ -111,6 +110,7 @@ namespace Microsoft.Xna.Framework.Utilities
             }
 
             var getMethod = GetPropertyGetMethod(property);
+
             if (getMethod == null || !getMethod.IsPublic)
                 return false;
 
@@ -143,12 +143,15 @@ namespace Microsoft.Xna.Framework.Utilities
             if (type.GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
                 return true;
 #else
-			if (type.IsAssignableFrom(objectType))
-				return true;
+            if (type.IsAssignableFrom(objectType))
+                return true;
 #endif
             return false;
         }
 
+        /// <summary>
+        /// Generics handler for Marshal.SizeOf
+        /// </summary>
         internal static class SizeOf<T>
         {
             static int _sizeOf;
@@ -169,20 +172,12 @@ namespace Microsoft.Xna.Framework.Utilities
             }
         }
 
-        static System.Collections.Generic.Dictionary<Type, int> _sizeOfCollection;
+        /// <summary>
+        /// Fallback handler for Marshal.SizeOf(type)
+        /// </summary>
         internal static int ManagedSizeOf(Type type)
         {
-            int _sizeOf = 0;
-            _sizeOf = _sizeOfCollection[type];
-            if (_sizeOf < 1)
-            {
-                _sizeOf = Marshal.SizeOf(type);
-                _sizeOfCollection.Add(type, _sizeOf);
-            }
-            return _sizeOf;
-
+            return Marshal.SizeOf(type);
         }
-
     }
-
 }


### PR DESCRIPTION
PR to address #5280

All elements supporting Generics (<T>) aligned to new ReflectionHelpers.SizeOf<T> function.
SizeOf<T> tested against platforms for support. Linux / Windows falls back to old SizeOf(Type) method

IndexBuffer however has no generics, so a fall back method in ReflectionHelpers added to enable caching of Marshal.SizeOf implemented using a dictionary.

Both IndexBuffer and VertexBuffer should really support generics fully but this would be a breaking change.