### PR TITLE
Make Game.Exit set a flag to exit at the end of the tick.

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Xna.Framework
 
         private TimeSpan _maxElapsedTime = TimeSpan.FromMilliseconds(500);
 
-
+        private bool _shouldExit;
         private bool _suppressDraw;
         
         public Game()
@@ -323,7 +323,7 @@ namespace Microsoft.Xna.Framework
 #endif
         public void Exit()
         {
-            Platform.Exit();
+            _shouldExit = true;
             _suppressDraw = true;
         }
 
@@ -501,6 +501,9 @@ namespace Microsoft.Xna.Framework
             {
                 DoDraw(_gameTime);
             }
+
+            if (_shouldExit)
+                Platform.Exit();
         }
 
         #endregion

--- a/Test/Framework/GameTest.cs
+++ b/Test/Framework/GameTest.cs
@@ -1,86 +1,15 @@
-#region License
-/*
-Microsoft Public License (Ms-PL)
-MonoGame - Copyright © 2009-2012 The MonoGame Team
-
-All rights reserved.
-
-This license governs use of the accompanying software. If you use the software,
-you accept this license. If you do not accept the license, do not use the
-software.
-
-1. Definitions
-
-The terms "reproduce," "reproduction," "derivative works," and "distribution"
-have the same meaning here as under U.S. copyright law.
-
-A "contribution" is the original software, or any additions or changes to the
-software.
-
-A "contributor" is any person that distributes its contribution under this
-license.
-
-"Licensed patents" are a contributor's patent claims that read directly on its
-contribution.
-
-2. Grant of Rights
-
-(A) Copyright Grant- Subject to the terms of this license, including the
-license conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free copyright license to reproduce its
-contribution, prepare derivative works of its contribution, and distribute its
-contribution or any derivative works that you create.
-
-(B) Patent Grant- Subject to the terms of this license, including the license
-conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free license under its licensed patents to
-make, have made, use, sell, offer for sale, import, and/or otherwise dispose of
-its contribution in the software or derivative works of the contribution in the
-software.
-
-3. Conditions and Limitations
-
-(A) No Trademark License- This license does not grant you rights to use any
-contributors' name, logo, or trademarks.
-
-(B) If you bring a patent claim against any contributor over patents that you
-claim are infringed by the software, your patent license from such contributor
-to the software ends automatically.
-
-(C) If you distribute any portion of the software, you must retain all
-copyright, patent, trademark, and attribution notices that are present in the
-software.
-
-(D) If you distribute any portion of the software in source code form, you may
-do so only under this license by including a complete copy of this license with
-your distribution. If you distribute any portion of the software in compiled or
-object code form, you may only do so under a license that complies with this
-license.
-
-(E) The software is licensed "as-is." You bear the risk of using it. The
-contributors give no express warranties, guarantees or conditions. You may have
-additional consumer rights under your local laws which this license cannot
-change. To the extent permitted under your local laws, the contributors exclude
-the implied warranties of merchantability, fitness for a particular purpose and
-non-infringement.
-*/
-#endregion License
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Threading;
 
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
-
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace MonoGame.Tests {
 	static partial class GameTest {
@@ -238,6 +167,70 @@ namespace MonoGame.Tests {
 				//Assert.That(_game, Has.Property("DrawCount").EqualTo(10));
 			}
 		}
+
+        [TestFixture]
+        public class Misc
+        {
+            [Test]
+            public void ExitHappensAtEndOfTick()
+            {
+                // Exit called in Run
+                var g = new ExitTestGame();
+
+                // TODO this is not necessary for XNA, but MG crashes when no GDM is set and Run is called
+                new GraphicsDeviceManager(g);
+                g.Run();
+                Assert.AreEqual(1, g.UpdateCount);
+                Assert.AreEqual(0, g.DrawCount); // Draw should be suppressed
+                Assert.AreEqual(1, g.ExitingCount);
+
+                g.Dispose();
+            }
+
+            private class ExitTestGame : CountCallsGame
+            {
+                protected override void Update(GameTime gameTime)
+                {
+                    Exit();
+                    base.Update(gameTime);
+                    Assert.IsNotNull(Window);
+                    Assert.AreEqual(0, ExitingCount);
+                }
+            }
+
+            private class CountCallsGame : Game
+            {
+                public int BeginRunCount { get; set; }
+                public int InitializeCount { get; set; }
+                public int LoadContentCount { get; set; }
+                public int UnloadContentCount { get; set; }
+                public int UpdateCount { get; set; }
+                public int BeginDrawCount { get; set; }
+                public int DrawCount { get; set; }
+                public int EndDrawCount { get; set; }
+                public int EndRunCount { get; set; }
+                public int DeactivatedCount { get; set; }
+                public int ActivatedCount { get; set; }
+                public int ExitingCount { get; set; }
+                public int DisposeCount { get; set; }
+
+                protected override void BeginRun() { BeginRunCount++; base.BeginRun(); }
+                protected override void Initialize() { InitializeCount++; base.Initialize(); }
+                protected override void LoadContent() { LoadContentCount++; base.LoadContent(); }
+                protected override void UnloadContent() { UnloadContentCount++; base.UnloadContent(); }
+                protected override void Update(GameTime gameTime) { UpdateCount++; base.Update(gameTime); }
+                protected override bool BeginDraw() { BeginDrawCount++; return base.BeginDraw(); }
+                protected override void Draw(GameTime gameTime) { DrawCount++; base.Draw(gameTime); }
+                protected override void EndDraw() { EndDrawCount++; base.EndDraw(); }
+                protected override void EndRun() { EndRunCount++; base.EndRun(); }
+
+                protected override void OnActivated(object sender, EventArgs args) { ActivatedCount++; base.OnActivated(sender, args); }
+                protected override void OnDeactivated(object sender, EventArgs args) { DeactivatedCount++; base.OnDeactivated(sender, args); }
+                protected override void OnExiting(object sender, EventArgs args) { ExitingCount++; base.OnExiting(sender, args); }
+                protected override void Dispose(bool disposing) { DisposeCount++; base.Dispose(disposing); }
+            }
+
+        }
 
 		public class MockGame : TestGameBase {
 			public MockGame ()


### PR DESCRIPTION
As discussed in #5127 `Game.Exit` should not immediately dispose of the game window, but should set a flag and handle actual exiting and disposal at the end of the tick.
fixes #5127

I think this doesn't work for Android since it uses a [custom run loop](https://github.com/MonoGame/MonoGame/blob/7c3d6870a38f8a5e479e64d935d692f2610e1cda/MonoGame.Framework/Android/AndroidGamePlatform.cs#L105). @dellis1972 How should this be handled? 
Are there any other platforms that have their own run loop?