### PR TITLE
Misc Pipeline Fix

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             // Get the platform specific texture profile.
             var texProfile = TextureProfile.ForPlatform(context.TargetPlatform);
 
-			try {
+            {
 				if (!File.Exists(fontName)) {
 					throw new Exception(string.Format("Could not load {0}", fontName));
 				}
@@ -132,10 +132,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 				}
 
                 output.Texture.Faces[0].Add(face);            
-			}
-			catch(Exception ex)
-			{
-			    throw;
 			}
 
             if (PremultiplyAlpha)

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -133,8 +133,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 
                 output.Texture.Faces[0].Add(face);            
 			}
-			catch(Exception ex) {
-				context.Logger.LogImportantMessage("{0}", ex.ToString());
+			catch(Exception ex)
+			{
+			    throw;
 			}
 
             if (PremultiplyAlpha)

--- a/Tools/MGCB/ConsoleLogger.cs
+++ b/Tools/MGCB/ConsoleLogger.cs
@@ -30,7 +30,12 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                     warning += "(" + contentIdentity.FragmentIdentifier + ")";
                 warning += ": ";
             }
-            warning += string.Format(message, messageArgs);
+            
+            if (messageArgs != null && messageArgs.Length != 0)
+                warning += string.Format(message, messageArgs);
+            else if (!string.IsNullOrEmpty(message))
+                warning += message;
+
             Console.WriteLine(warning);
         }
     }


### PR DESCRIPTION
Two simple pipeline fixes/improvements.

Fixed case in `FontDescriptionProcessor` where we were consuming fatal exceptions instead of letting them be reported to the user as errors.

Protect against crashes when `message` or `messageArgs` is null in `ConsoleLogger.LogWarning()`.