### PR TITLE
[WP8] fix Texture2D.FromStream()

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -198,16 +198,15 @@ namespace Microsoft.Xna.Framework.Graphics
         {
 #if WINDOWS_PHONE
             WriteableBitmap bitmap = null;
-            Threading.BlockOnUIThread(() =>
+            var waitEvent = new ManualResetEventSlim(false);
+            Deployment.Current.Dispatcher.BeginInvoke(() =>
             {
-                try
-                {
                     BitmapImage bitmapImage = new BitmapImage();
                     bitmapImage.SetSource(stream);
                     bitmap = new WriteableBitmap(bitmapImage);
-                }
-                catch { }
+                    waitEvent.Set();
             });
+            waitEvent.Wait();
 
             // Convert from ARGB to ABGR 
             ConvertToABGR(bitmap.PixelHeight, bitmap.PixelWidth, bitmap.Pixels);


### PR DESCRIPTION
The current implementation uses `Threading.BlockOnUIThread()` which has
a timeout of 750ms (`kMaxWaitForUIThread`).
This isn't enough for loading streams (either from the net or from the
slow  storage). The result is that the execution continues before the
bitmap is loaded and a Null exception is thrown from accessing `bitmap`.