### PR TITLE
Fix Adapter Description and DeviceName

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Xna.Framework.Graphics
         {            
             var adapter = new GraphicsAdapter();
 
-            adapter.DeviceName = monitor.Description.DeviceName;
-            adapter.Description = device.Description1.Description;
+            adapter.DeviceName = monitor.Description.DeviceName.TrimEnd(new char[] {'\0'});
+            adapter.Description = device.Description1.Description.TrimEnd(new char[] {'\0'});
             adapter.DeviceId = device.Description1.DeviceId;
             adapter.Revision = device.Description1.Revision;
             adapter.VendorId = device.Description1.VendorId;


### PR DESCRIPTION
The strings contain null termination. for example, Description is
`"Qualcomm Adreno 305 (WDDM
v1.2)\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"`
or
`"AMD Radeon (TM) R9 200
Series\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"`

Same for DeviceName:
`"\\\\.\\DISPLAY1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"`