### PR TITLE
[UAP] Alternative RenderLoop

### DIFF
--- a/MonoGame.Framework/Windows8/MetroGameWindow.cs
+++ b/MonoGame.Framework/Windows8/MetroGameWindow.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Xna.Framework
 
         #region Internal Properties
 
+        internal CoreWindow CoreWindow { get { return _coreWindow; } }
+
         internal Game Game { get; set; }
 
         internal bool IsExiting { get; set; }

--- a/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Xna.Framework
         internal static readonly TouchQueue TouchQueue = new TouchQueue();
 
         internal static ApplicationExecutionState PreviousExecutionState { get; set; }
+        
+        bool _enableRunLoop = false;
 
         public UAPGamePlatform(Game game)
             : base(game)
@@ -99,14 +101,22 @@ namespace Microsoft.Xna.Framework
             SystemNavigationManager.GetForCurrentView().BackRequested += BackRequested;
 
             CoreApplication.Suspending += this.CoreApplication_Suspending;
+            CoreApplication.Resuming += this.CoreApplication_Resuming;
 
             Game.PreviousExecutionState = PreviousExecutionState;
         }
 
         private void CoreApplication_Suspending(object sender, SuspendingEventArgs e)
         {
+            _enableRunLoop = false;
+
             if (this.Game.GraphicsDevice != null)
                 this.Game.GraphicsDevice.Trim();
+        }
+
+        private void CoreApplication_Resuming(object sender, Object e)
+        {
+            StartRunLoop();
         }
 
         public override GameRunBehavior DefaultRunBehavior
@@ -132,11 +142,42 @@ namespace Microsoft.Xna.Framework
 
         public override void StartRunLoop()
         {
-            CompositionTarget.Rendering += (o, a) =>
+            if (!_enableRunLoop)
             {
-				UAPGameWindow.Instance.Tick();
-                GamePad.Back = false;
-            };
+                _enableRunLoop = true;
+                UAPGameWindow.Instance.CoreWindow.Dispatcher.RunIdleAsync(OnRenderFrame);
+            }
+        }
+
+        private void OnRenderFrame(IdleDispatchedHandlerArgs e)
+        {
+            if (_enableRunLoop)
+                OnRenderFrame(e.IsDispatcherIdle);
+        }
+
+        private void OnRenderFrame()
+        {
+            if (_enableRunLoop)
+            {
+                var dispatcher = UAPGameWindow.Instance.CoreWindow.Dispatcher;
+                if (dispatcher.ShouldYield(CoreDispatcherPriority.Idle))
+                    dispatcher.RunIdleAsync(OnRenderFrame);
+                else
+                    OnRenderFrame(true);
+            }
+        }
+
+        private void OnRenderFrame(bool isQueueEmpty)
+        {
+            UAPGameWindow.Instance.Tick();
+            GamePad.Back = false;
+
+            // Request next frame
+            var dispatcher = UAPGameWindow.Instance.CoreWindow.Dispatcher;
+            if (isQueueEmpty)
+                dispatcher.RunAsync(CoreDispatcherPriority.Low, OnRenderFrame);
+            else
+                dispatcher.RunIdleAsync(OnRenderFrame);
         }
         
         public override void Exit()

--- a/MonoGame.Framework/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPGameWindow.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Xna.Framework
         private InputEvents _windowEvents;
 
         #region Internal Properties
+        
+        internal CoreWindow CoreWindow { get { return _coreWindow; } }
 
         internal Game Game { get; set; }
 


### PR DESCRIPTION
Use Idle for Tick(). Let Dispatcher process all events (input/resize/rotate) before rendering.

Fixes mouse, keyboard lag [UAP]  touch, rotation lag & freeze (WP8.1). 
#4897, #5300, #3948, #3589, #3316, #4105(?).