### PR TITLE
Avoid IndexOutOfRangeException when fc-match returns no matches

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -247,6 +247,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             s = s.Trim();
 
             var split = s.Split (':');
+            if (split.Length < 2)
+                return String.Empty;
+
             //check font family, fontconfig might return a fallback
             if (split [1].Contains (",")) { //this file defines multiple family names
                 var families = split [1].Split (',');


### PR DESCRIPTION
This change avoids the `IndexOutOfRangeException` that's currently being thrown if `fc-match` doesn't return any matches at all, e.g. if `fc-match` (`fontconfig`) isn't installed.

The exception prevents building spritefonts even when `fc-match` isn't actually needed, such as when the font file is located in the same directory as the `.spritefont` file.

The program already handles the case when `fc-match` fails to find the correct font. I simply handle this "not installed" case the same as the "no match" case.