### PR TITLE
WinDX: Frame latency fix

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -745,8 +745,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 multisampleDesc.Quality = quality;
             }
 
-            int vSyncFrameLatency = PresentationParameters.PresentationInterval.GetFrameLatency();
-
             // If the swap chain already exists... update it.
             if (_swapChain != null)
             {
@@ -755,17 +753,6 @@ namespace Microsoft.Xna.Framework.Graphics
                                         PresentationParameters.BackBufferHeight,
                                         format,
                                         SwapChainFlags.None);
-
-                // Update Vsync setting.
-                using (var dxgiDevice = _d3dDevice.QueryInterface<SharpDX.DXGI.Device1>())
-                {
-                    // If VSync is disabled, Ensure that DXGI does not queue more than one frame at a time. This 
-                    // both reduces latency and ensures that the application will only render 
-                    // after each VSync, minimizing power consumption.
-                    // Setting latency to 0 (PresentInterval.Immediate) will result in the hardware default.
-                    // (normally 3) 
-                    dxgiDevice.MaximumFrameLatency = vSyncFrameLatency;
-                }
             }
 
             // Otherwise, create a new swap chain.
@@ -804,12 +791,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 {
                     _swapChain = new SwapChain(dxgiFactory, dxgiDevice, desc);
                     dxgiFactory.MakeWindowAssociation(PresentationParameters.DeviceWindowHandle, WindowAssociationFlags.IgnoreAll);
-                    // If VSync is disabled, Ensure that DXGI does not queue more than one frame at a time. This 
-                    // both reduces latency and ensures that the application will only render 
-                    // after each VSync, minimizing power consumption.
-                    // Setting latency to 0 (PresentInterval.Immediate) will result in the hardware default.
-                    // (normally 3) 
-                    dxgiDevice.MaximumFrameLatency = vSyncFrameLatency;
+                    // To reduce latency, ensure that DXGI does not queue more than one frame at a time.
+                    // Docs: https://msdn.microsoft.com/en-us/library/windows/desktop/ff471334(v=vs.85).aspx
+                    dxgiDevice.MaximumFrameLatency = 1;
                 }
             }
 
@@ -1002,7 +986,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             try
             {
-                var syncInterval = PresentationParameters.PresentationInterval.GetFrameLatency();
+                var syncInterval = PresentationParameters.PresentationInterval.GetSyncInterval();
 
                 // The first argument instructs DXGI to block n VSyncs before presenting.
                 lock (_d3dContext)

--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -747,7 +747,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #endif // OPENGL
 
-        public static int GetFrameLatency(this PresentInterval interval)
+        public static int GetSyncInterval(this PresentInterval interval)
         {
             switch (interval)
             {

--- a/MonoGame.Framework/Graphics/SwapChainRenderTarget.cs
+++ b/MonoGame.Framework/Graphics/SwapChainRenderTarget.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 try
                 {
-                    _swapChain.Present(PresentInterval.GetFrameLatency(), PresentFlags.None);
+                    _swapChain.Present(PresentInterval.GetSyncInterval(), PresentFlags.None);
                 }
                 catch (SharpDX.SharpDXException)
                 {


### PR DESCRIPTION
I recently found an issue in MonoGame while investigating some frame latency issues in my game. The maximum frame latency was being set to 3 frames when v-sync was disabled.

The problem was that it seems to have been confused with the sync interval setting ([documentation on sync interval](https://msdn.microsoft.com/en-us/library/windows/desktop/bb174576(v=vs.85).aspx)). So when v-sync was disabled, the frame latency was set to 0 (which means to use the default value of 3) ([documentation on maximum frame latency](https://msdn.microsoft.com/en-us/library/windows/desktop/ff471334(v=vs.85).aspx)).

The PR fixes it so that the maximum frame latency is always 1. I've also tidied up some things to make the code clearer.