### PR TITLE
WinDX: Fix to ensure window is maximised when starting in fullscreen

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -49,7 +49,7 @@ namespace MonoGame.Framework
 
             _window.EnableClientSizeChangedEvent(false); // Disable ClientSizeChanged event while the window is initialised
 
-            _window.Initialize(gdm.PreferredBackBufferWidth, gdm.PreferredBackBufferHeight);
+            _window.ChangeClientSize(new Size(gdm.PreferredBackBufferWidth, gdm.PreferredBackBufferHeight));
 
             base.BeforeInitialize();
 


### PR DESCRIPTION
I came across a rare problem which seemed to only show up on older/slower computers. Sometimes when starting in borderless fullscreen (i.e. `HardwareModeSwitch = false`), the window would not get maximised.

After some investigation, I could see that it was maximised at first but was then immediately restored to it's original size after that. It turns out the problem was that `Form.Show` was being called twice - once in `WinFormsGameWindow.Initialize` (via `WinFormsGamePlatform.BeforeInitialize`), and again in `WinFormsGameWindow.RunLoop`. So to fix this, I simply changed `WinFormsGamePlatform.BeforeInitialize` to only set the form's `ClientSize`, and let `RunLoop` call `Show` afterwards.