### PR TITLE
WinDX: Fix to find closest available mode for CurrentDisplayMode

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
@@ -111,6 +111,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
             adapter._supportedDisplayModes = new DisplayModeCollection(modes);
 
+            if (adapter._currentDisplayMode == null) //(i.e. desktop mode wasn't found in the available modes)
+                adapter._currentDisplayMode = new DisplayMode(desktopWidth, desktopHeight, SurfaceFormat.Color);
+
             return adapter;
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
@@ -101,9 +101,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
                     modes.Add(mode);
 
-                    if (mode.Width == desktopWidth && mode.Height == desktopHeight && mode.Format == SurfaceFormat.Color)
+                    if (adapter._currentDisplayMode == null)
                     {
-                        if (adapter._currentDisplayMode == null)
+                        if (mode.Width == desktopWidth && mode.Height == desktopHeight && mode.Format == SurfaceFormat.Color)
                             adapter._currentDisplayMode = mode;
                     }
                 }


### PR DESCRIPTION
**UPDATE 29-Dec: As per discussion, changed this to force the current display mode to the desktop resolution even if it's not an available mode.**

I've found that `GraphicsAdapter.CurrentDisplayMode` can sometimes be null in certain circumstances because the reported desktop resolution isn't one of the available modes. This PR attempts to find the next closest mode if a mode matching the desktop resolution isn't found.

An example of this happening that I saw was crash reports showing 2715x1527 as the desktop resolution, but modes only going up to 1920x1080. After some digging I found that 2715x1527 is a resolution associated with an NVIDIA feature called Dynamic Super Resolution (DSR). I tried enabling this feature on my machine, but when I did it actually showed 2715x1527 as an available mode. So I can only assume that the machines with this problem somehow had their DSR settings messed up. So at least with this PR, `CurrentDisplayMode` falls back to the next closest resolution on these machines.