### PR TITLE
WinDX: Fixed potential crash when setting MediaPlayer.Volume

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Xna.Framework.Media
     {
         private static MediaSession _session;
         private static AudioStreamVolume _volumeController;
+        private static readonly object _volumeLock = new object();
         private static PresentationClock _clock;
 
         private static Song _nextSong;
@@ -147,12 +148,15 @@ namespace Microsoft.Xna.Framework.Media
 
         private static void SetChannelVolumes()
         {
-            if (_volumeController == null)
-                return;
+            lock (_volumeLock)
+            {
+                if (_volumeController == null)
+                    return;
 
-            float volume = _isMuted ? 0f : _volume;
-            for (int i = 0; i < _volumeController.ChannelCount; i++)
-                _volumeController.SetChannelVolume(i, volume);
+                float volume = _isMuted ? 0f : _volume;
+                for (int i = 0; i < _volumeController.ChannelCount; i++)
+                    _volumeController.SetChannelVolume(i, volume);
+            }
         }
 
         private static void PlatformSetVolume(float volume)
@@ -209,10 +213,13 @@ namespace Microsoft.Xna.Framework.Media
 
         private static void StartNewSong(Song song, TimeSpan? startPosition)
         {
-            if (_volumeController != null)
+            lock (_volumeLock)
             {
-                _volumeController.Dispose();
-                _volumeController = null;
+                if (_volumeController != null)
+                {
+                    _volumeController.Dispose();
+                    _volumeController = null;
+                }
             }
 
             _currentSong = song;
@@ -236,9 +243,12 @@ namespace Microsoft.Xna.Framework.Media
 
         private static void OnTopologyReady()
         {
-            IntPtr volumeObjectPtr;
-            MediaFactory.GetService(_session, MediaServiceKeys.StreamVolume, AudioStreamVolumeGuid, out volumeObjectPtr);
-            _volumeController = CppObject.FromPointer<AudioStreamVolume>(volumeObjectPtr);
+            lock (_volumeLock)
+            {
+                IntPtr volumeObjectPtr;
+                MediaFactory.GetService(_session, MediaServiceKeys.StreamVolume, AudioStreamVolumeGuid, out volumeObjectPtr);
+                _volumeController = CppObject.FromPointer<AudioStreamVolume>(volumeObjectPtr);
+            }
 
             SetChannelVolumes();
 


### PR DESCRIPTION
I'm fairly confident this fixes #4298

In certain circumstances, setting `MediaPlayer.Volume` could cause a crash. I actually managed to reliably reproduce this by continually setting the volume and playing a new song every few seconds.

The cause of the crash was due to the code not properly considering that different threads could be messing with the volume controller. So if `MediaPlayer.Volume` was being set at the same time that a new song started playing, an exception could occur.

The fix was to simply use a lock when dealing with the volume controller. After adding the lock, I could no longer reproduce this crash.