### PR TITLE
Fix GL VS attribute caching bug

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -947,7 +947,8 @@ namespace Microsoft.Xna.Framework.Graphics
             var vertexDeclaration = _vertexBuffers.Get(0).VertexBuffer.VertexDeclaration;
             var vertexOffset = (IntPtr)(vertexDeclaration.VertexStride * baseVertex);
 
-            vertexDeclaration.Apply(_vertexShader, vertexOffset);
+            var programHash = _vertexShader.HashKey | _pixelShader.HashKey;
+            vertexDeclaration.Apply(_vertexShader, vertexOffset, programHash);
 
             GL.DrawElements(target,
                                      indexElementCount,
@@ -972,7 +973,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Setup the vertex declaration to point at the VB data.
             vertexDeclaration.GraphicsDevice = this;
-            vertexDeclaration.Apply(_vertexShader, vbHandle.AddrOfPinnedObject());
+            var programHash = _vertexShader.HashKey | _pixelShader.HashKey;
+            vertexDeclaration.Apply(_vertexShader, vbHandle.AddrOfPinnedObject(), programHash);
 
             //Draw
             GL.DrawArrays(PrimitiveTypeGL(primitiveType),
@@ -988,7 +990,8 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             ApplyState(true);
 
-            _vertexBuffers.Get(0).VertexBuffer.VertexDeclaration.Apply(_vertexShader, IntPtr.Zero);
+            var programHash = _vertexShader.HashKey | _pixelShader.HashKey;
+            _vertexBuffers.Get(0).VertexBuffer.VertexDeclaration.Apply(_vertexShader, IntPtr.Zero, programHash);
 
 			GL.DrawArrays(PrimitiveTypeGL(primitiveType),
 			              vertexStart,
@@ -1015,7 +1018,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Setup the vertex declaration to point at the VB data.
             vertexDeclaration.GraphicsDevice = this;
-            vertexDeclaration.Apply(_vertexShader, vertexAddr);
+            var programHash = _vertexShader.HashKey | _pixelShader.HashKey;
+            vertexDeclaration.Apply(_vertexShader, vertexAddr, programHash);
 
             //Draw
             GL.DrawElements(    PrimitiveTypeGL(primitiveType),
@@ -1048,7 +1052,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Setup the vertex declaration to point at the VB data.
             vertexDeclaration.GraphicsDevice = this;
-            vertexDeclaration.Apply(_vertexShader, vertexAddr);
+            var programHash = _vertexShader.HashKey | _pixelShader.HashKey;
+            vertexDeclaration.Apply(_vertexShader, vertexAddr, programHash);
 
             //Draw
             GL.DrawElements(    PrimitiveTypeGL(primitiveType),

--- a/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
@@ -24,11 +24,10 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         Dictionary<int, VertexDeclarationAttributeInfo> shaderAttributeInfo = new Dictionary<int, VertexDeclarationAttributeInfo>();
 
-		internal void Apply(Shader shader, IntPtr offset)
+		internal void Apply(Shader shader, IntPtr offset, int programHash)
 		{
             VertexDeclarationAttributeInfo attrInfo;
-            int shaderHash = shader.GetHashCode();
-            if (!shaderAttributeInfo.TryGetValue(shaderHash, out attrInfo))
+            if (!shaderAttributeInfo.TryGetValue(programHash, out attrInfo))
             {
                 // Get the vertex attribute info and cache it
                 attrInfo = new VertexDeclarationAttributeInfo(GraphicsDevice.MaxVertexAttributes);
@@ -51,7 +50,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
                 }
 
-                shaderAttributeInfo.Add(shaderHash, attrInfo);
+                shaderAttributeInfo.Add(programHash, attrInfo);
             }
 
             // Apply the vertex attribute info


### PR DESCRIPTION
Fixes #4909. The bug is explained in that issue too, but I'll summarize here.

It comes down to that for OpenGL we cache vertex shader attributes based on a hash of the vertex shader, but when an attribute is not used in the current shader program the compiler will optimize it out and asking the location of that attribute will return -1. That value will be cached however and when another technique with the same vertex shader is later applied, the cached value of the location of that attribute will be fetched even though it might be used and does not actually have location -1. The fix I applied, as suggested by @ed022, is to hash based on the current program, i.e. a hash based on the hash of the vertex and pixel shader. I used the same hash that's used for caching shader programs.