### PR TITLE
Fixed GraphicsDevice.Present() to check for current render target.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -543,6 +543,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void Present()
         {
+            // We cannot present with a RT set on the device.
+            if (_currentRenderTargetCount != 0)
+                throw new InvalidOperationException("Cannot call Present when a render target is active.");
+
             _graphicsMetrics = new GraphicsMetrics();
             PlatformPresent();
         }

--- a/Test/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceTest.cs
@@ -599,5 +599,26 @@ namespace MonoGame.Tests.Graphics
 
             samplerState.Dispose();
         }
+
+        [Test]
+        public void PresentInvalidOperationException()
+        {
+            // This should work else it means we had
+            // some bad state to start this test!
+            gd.Present();
+
+            // You can't call present with a RT set.
+            var rt = new RenderTarget2D(gd, 100, 100);
+            gd.SetRenderTarget(rt);
+            Assert.Throws<InvalidOperationException>(() => gd.Present());
+
+            // Set the default RT and present works again.
+            gd.SetRenderTarget(null);
+            gd.Present();
+
+            // Cleanup.
+            rt.Dispose();
+        }
+
     }
 }


### PR DESCRIPTION
Fixed `GraphicsDevice.Present()` to correctly throw like XNA when RT is set.