### PR TITLE
Fix EffectPass.Apply setting textures to null when it shouldn't

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -384,6 +384,9 @@
     <Content Include="Assets\Effects\Include.fxh">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Effects\SamplerRegistersEffect.fx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Assets\Effects\TextureArrayEffect.fx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/MonoGame.Framework/Graphics/Effect/EffectPass.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectPass.cs
@@ -119,6 +119,10 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             foreach (var sampler in shader.Samplers)
             {
+                // if sampler.parameter is 255 there is no matching texture parameter
+                if (sampler.parameter == 255)
+                    continue;
+
                 var param = _effect.Parameters[sampler.parameter];
                 var texture = param.Data as Texture;
 

--- a/MonoGame.Framework/Graphics/Shader/Shader.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public SamplerState state;
 
         // TODO: This should be moved to EffectPass.
-        public int parameter;
+        public byte parameter;
     }
 
     internal struct VertexAttribute

--- a/Test/Assets/Effects/SamplerRegistersEffect.fx
+++ b/Test/Assets/Effects/SamplerRegistersEffect.fx
@@ -1,0 +1,70 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#include "include.fxh"
+
+sampler s0 : register(s0);
+sampler s1 : register(s1);
+
+struct VS_INPUT
+{
+	float4 Position : POSITION0;
+	float2 TexCoord : TEXCOORD0;
+};
+
+struct PS_INPUT
+{
+	float4 Position : SV_Position;
+	float2 TexCoord : TEXCOORD0;
+};
+
+PS_INPUT VertexShaderFunction(VS_INPUT input)
+{
+	PS_INPUT output;
+    output.Position = input.Position;
+	output.TexCoord = input.TexCoord; 
+    return output;
+}
+
+float4 PixelShader_Both(PS_INPUT input) : COLOR0
+{	
+    return tex2D(s0, input.TexCoord) * tex2D(s1, input.TexCoord);
+}
+
+float4 PixelShader_Zero(PS_INPUT input) : COLOR0
+{
+    return tex2D(s0, input.TexCoord);
+}
+
+float4 PixelShader_One(PS_INPUT input) : COLOR0
+{
+    return tex2D(s1, input.TexCoord);
+}
+
+technique Both
+{
+	pass
+	{
+		VertexShader = compile VS_PROFILE VertexShaderFunction();
+		PixelShader = compile PS_PROFILE PixelShader_Both();
+	}
+}
+
+technique Zero
+{
+	pass
+	{
+		VertexShader = compile VS_PROFILE VertexShaderFunction();
+		PixelShader = compile PS_PROFILE PixelShader_Zero();
+	}
+}
+
+technique One
+{
+	pass
+	{
+		VertexShader = compile VS_PROFILE VertexShaderFunction();
+		PixelShader = compile PS_PROFILE PixelShader_One();
+	}
+}

--- a/Test/ContentPipeline/EffectProcessorTests.cs
+++ b/Test/ContentPipeline/EffectProcessorTests.cs
@@ -3,6 +3,8 @@ using Microsoft.Xna.Framework.Content.Pipeline;
 using NUnit.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline.Processors;
 using System.IO;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 #if DIRECTX
 using System.Collections.Generic;
 using TwoMGFX;
@@ -120,6 +122,23 @@ namespace MonoGame.Tests.ContentPipeline
             Assert.NotNull(output);
 
             // TODO: Should we test the writer?
+        }
+
+        [Test]
+        public void SamplerDoesNotProduceTextureParams()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+            ((IGraphicsDeviceManager) game.Services.GetService(typeof(IGraphicsDeviceManager))).CreateDevice();
+            var gd = game.GraphicsDevice;
+
+            var effect = AssetTestUtility.CompileEffect(gd, "SamplerRegistersEffect.fx");
+            Assert.AreEqual(0, effect.Parameters.Count);
+
+            effect.Dispose();
+            gd.Dispose();
+            gdm.Dispose();
+            game.Dispose();
         }
     }
 }

--- a/Test/Framework/Graphics/EffectTest.cs
+++ b/Test/Framework/Graphics/EffectTest.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Tests.ContentPipeline;
 using NUnit.Framework;
 
 namespace MonoGame.Tests.Graphics
@@ -99,6 +100,38 @@ namespace MonoGame.Tests.Graphics
 
             texture.Dispose();
             effect.Dispose();
+        }
+
+        [Test]
+        public void EffectPassShouldNotSetNullTextures()
+        {
+            var effect = AssetTestUtility.CompileEffect(gd, "SamplerRegistersEffect.fx");
+            var t0 = new Texture2D(gd, 1, 1);
+            var t1 = new Texture2D(gd, 1, 1);
+
+            gd.Textures[0] = t0;
+            gd.Textures[1] = t1;
+            Assert.AreSame(t0, gd.Textures[0]);
+            Assert.AreSame(t1, gd.Textures[1]);
+
+            effect.CurrentTechnique = effect.Techniques["Both"];
+            effect.CurrentTechnique.Passes[0].Apply();
+            Assert.AreSame(t0, gd.Textures[0]);
+            Assert.AreSame(t1, gd.Textures[1]);
+
+            effect.CurrentTechnique = effect.Techniques["Zero"];
+            effect.CurrentTechnique.Passes[0].Apply();
+            Assert.AreSame(t0, gd.Textures[0]);
+            Assert.AreSame(t1, gd.Textures[1]);
+
+            effect.CurrentTechnique = effect.Techniques["One"];
+            effect.CurrentTechnique.Passes[0].Apply();
+            Assert.AreSame(t0, gd.Textures[0]);
+            Assert.AreSame(t1, gd.Textures[1]);
+
+            effect.Dispose();
+            t0.Dispose();
+            t1.Dispose();
         }
     }
 }

--- a/Test/Framework/Graphics/EffectTest.cs
+++ b/Test/Framework/Graphics/EffectTest.cs
@@ -14,19 +14,19 @@ namespace MonoGame.Tests.Graphics
         [Test]
         public void EffectPassShouldSetTexture()
         {
-            var texture = new Texture2D(game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
-            game.GraphicsDevice.Textures[0] = null;
+            var texture = new Texture2D(gd, 1, 1, false, SurfaceFormat.Color);
+            gd.Textures[0] = null;
 
-            var effect = new BasicEffect(game.GraphicsDevice);
+            var effect = new BasicEffect(gd);
             effect.TextureEnabled = true;
             effect.Texture = texture;
 
-            Assert.That(game.GraphicsDevice.Textures[0], Is.Null);
+            Assert.That(gd.Textures[0], Is.Null);
 
             var effectPass = effect.CurrentTechnique.Passes[0];
             effectPass.Apply();
 
-            Assert.That(game.GraphicsDevice.Textures[0], Is.SameAs(texture));
+            Assert.That(gd.Textures[0], Is.SameAs(texture));
 
             texture.Dispose();
             effect.Dispose();
@@ -35,26 +35,26 @@ namespace MonoGame.Tests.Graphics
         [Test]
         public void EffectPassShouldSetTextureOnSubsequentCalls()
         {
-            var texture = new Texture2D(game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
-            game.GraphicsDevice.Textures[0] = null;
+            var texture = new Texture2D(gd, 1, 1, false, SurfaceFormat.Color);
+            gd.Textures[0] = null;
 
-            var effect = new BasicEffect(game.GraphicsDevice);
+            var effect = new BasicEffect(gd);
             effect.TextureEnabled = true;
             effect.Texture = texture;
 
-            Assert.That(game.GraphicsDevice.Textures[0], Is.Null);
+            Assert.That(gd.Textures[0], Is.Null);
 
             var effectPass = effect.CurrentTechnique.Passes[0];
             effectPass.Apply();
 
-            Assert.That(game.GraphicsDevice.Textures[0], Is.SameAs(texture));
+            Assert.That(gd.Textures[0], Is.SameAs(texture));
 
-            game.GraphicsDevice.Textures[0] = null;
+            gd.Textures[0] = null;
 
             effectPass = effect.CurrentTechnique.Passes[0];
             effectPass.Apply();
 
-            Assert.That(game.GraphicsDevice.Textures[0], Is.SameAs(texture));
+            Assert.That(gd.Textures[0], Is.SameAs(texture));
 
             texture.Dispose();
             effect.Dispose();
@@ -63,19 +63,19 @@ namespace MonoGame.Tests.Graphics
         [Test]
         public void EffectPassShouldSetTextureEvenIfNull()
         {
-            var texture = new Texture2D(game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
-            game.GraphicsDevice.Textures[0] = texture;
+            var texture = new Texture2D(gd, 1, 1, false, SurfaceFormat.Color);
+            gd.Textures[0] = texture;
 
-            var effect = new BasicEffect(game.GraphicsDevice);
+            var effect = new BasicEffect(gd);
             effect.TextureEnabled = true;
             effect.Texture = null;
 
-            Assert.That(game.GraphicsDevice.Textures[0], Is.SameAs(texture));
+            Assert.That(gd.Textures[0], Is.SameAs(texture));
 
             var effectPass = effect.CurrentTechnique.Passes[0];
             effectPass.Apply();
 
-            Assert.That(game.GraphicsDevice.Textures[0], Is.Null);
+            Assert.That(gd.Textures[0], Is.Null);
 
             texture.Dispose();
             effect.Dispose();
@@ -84,18 +84,18 @@ namespace MonoGame.Tests.Graphics
         [Test]
         public void EffectPassShouldOverrideTextureIfNotExplicitlySet()
         {
-            var texture = new Texture2D(game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
-            game.GraphicsDevice.Textures[0] = texture;
+            var texture = new Texture2D(gd, 1, 1, false, SurfaceFormat.Color);
+            gd.Textures[0] = texture;
 
-            var effect = new BasicEffect(game.GraphicsDevice);
+            var effect = new BasicEffect(gd);
             effect.TextureEnabled = true;
 
-            Assert.That(game.GraphicsDevice.Textures[0], Is.SameAs(texture));
+            Assert.That(gd.Textures[0], Is.SameAs(texture));
 
             var effectPass = effect.CurrentTechnique.Passes[0];
             effectPass.Apply();
 
-            Assert.That(game.GraphicsDevice.Textures[0], Is.Null);
+            Assert.That(gd.Textures[0], Is.Null);
 
             texture.Dispose();
             effect.Dispose();

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -306,6 +306,9 @@
     <Content Include="Assets\Effects\Include.fxh">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Effects\SamplerRegistersEffect.fx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Assets\Effects\VertexTextureEffect.fx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Tools/2MGFX/EffectObject.cs
+++ b/Tools/2MGFX/EffectObject.cs
@@ -739,46 +739,11 @@ namespace TwoMGFX
                 for (var s = 0; s < shader._samplers.Length; s++)
                 {
                     var sampler = shader._samplers[s];
-
                     var match = parameters.FindIndex(e => e.name == sampler.parameterName);
-                    if (match == -1)
-                    {
-                        // Store the index for runtime lookup.
-                        shader._samplers[s].parameter = parameters.Count;
 
-                        var param = new d3dx_parameter();
-                        param.class_ = D3DXPARAMETER_CLASS.OBJECT;
-                        param.name = sampler.parameterName;
-                        param.semantic = string.Empty;
-
-                        switch (sampler.type)
-                        {
-                            case MojoShader.MOJOSHADER_samplerType.MOJOSHADER_SAMPLER_1D:
-                                param.type = D3DXPARAMETER_TYPE.TEXTURE1D;
-                                break;
-
-                            case MojoShader.MOJOSHADER_samplerType.MOJOSHADER_SAMPLER_2D:
-                                param.type = D3DXPARAMETER_TYPE.TEXTURE2D;
-                                break;
-
-                            case MojoShader.MOJOSHADER_samplerType.MOJOSHADER_SAMPLER_VOLUME:
-                                param.type = D3DXPARAMETER_TYPE.TEXTURE3D;
-                                break;
-
-                            case MojoShader.MOJOSHADER_samplerType.MOJOSHADER_SAMPLER_CUBE:
-                                param.type = D3DXPARAMETER_TYPE.TEXTURECUBE;
-                                break;
-                        }
-
-                        parameters.Add(param);
-                    }
-                    else
-                    {
-                        // TODO: Make sure the type and size of 
-                        // the parameter match up!
-
-                        shader._samplers[s].parameter = match;
-                    }
+                    // if there is no matching texture, set parameter to 255 so we know at runtime
+                    // TODO: In case of match, make sure the type and size of the parameter match up!
+                    shader._samplers[s].parameter = match == -1 ? 255 : match;
                 }
             }
 


### PR DESCRIPTION
This is just a failing test that shows what happens issue #5261, no fix yet. I did some cleanup first, so you should only look at the second commit for clarity.

Here's the situation where this issue occurs:
You set the register for your samplers in your effect, but don't bind a texture to it. Then you set the textures using `GraphicsDevice.Texture[i]`. Now you apply a pass of a technique of your effect. In [SetShaderSamplers](https://github.com/MonoGame/MonoGame/blob/develop/MonoGame.Framework/Graphics/Effect/EffectPass.cs#L98) the `GraphicsDevice.Texture[i]` are set to null because the texture parameters of the effect are never set and we do `textures[sampler.textureSlot] = _effect.Parameters[sampler.parameter] as Texture;`. In XNA the textures you set before applying are still there so we should somehow avoid overwriting the value in this case. I'm not exactly sure how to fix this, I think XNA handles this in a completely different way. I'm not sure how/where XNA stores these textures, but it doesn't do it in the effect parameters like MG. When debugging I noticed XNA did not have *any* parameters for the effect while MG has the 2 implicit textures (stored under the sampler names) because there are two samplers. 
That also means that in MonoGame you can do `effect.Parameters["s0"].SetValue(MyCoolTexture);` while in XNA you can only use `GraphicsDevice.Texture[0] =MyCoolTexture1` (which also works in MG).

Another kind of unrelated detail I noticed while writing tests for this is XNA throws when you try to apply a pass from an effect that is not the current effect and MG doesn't.