### PR TITLE
Fix conversion of float to Color to match XNA

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/Font/GlyphPacker.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Font/GlyphPacker.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 		static BitmapContent CopyGlyphsToOutput(List<ArrangedGlyph> glyphs, int width, int height)
 		{
             var output = new PixelBitmapContent<Color>(width, height);
+            // Fill the output with non-premultiplied black
+            output.ReplaceColor(Color.Transparent, Color.Black);
 
 			foreach (var glyph in glyphs)
 			{

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -165,10 +165,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             // Test the alpha channel to figure out if we have alpha.
             var alphaRange = CalculateAlphaRange(face);
 
-            if (alphaRange == AlphaRange.Opaque)
-                Compress(typeof(Dxt1BitmapContent), content, generateMipMaps);
-            else if (isSpriteFont)
+            if (isSpriteFont)
                 CompressFontDXT3(content, generateMipMaps);
+            else if (alphaRange == AlphaRange.Opaque)
+                Compress(typeof(Dxt1BitmapContent), content, generateMipMaps);
             else if (alphaRange == AlphaRange.Cutout)
                 Compress(typeof(Dxt3BitmapContent), content, generateMipMaps);
             else
@@ -468,22 +468,22 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             buffer[offset + 11] = 255;
 
             // Get the red (to be used for green and blue channels as well) into a 0-15 range
-            a0 = (int)(colors[0].Z * 15.0);
-            a1 = (int)(colors[1].Z * 15.0);
-            a2 = (int)(colors[2].Z * 15.0);
-            a3 = (int)(colors[3].Z * 15.0);
-            a4 = (int)(colors[4].Z * 15.0);
-            a5 = (int)(colors[5].Z * 15.0);
-            a6 = (int)(colors[6].Z * 15.0);
-            a7 = (int)(colors[7].Z * 15.0);
-            a8 = (int)(colors[8].Z * 15.0);
-            a9 = (int)(colors[9].Z * 15.0);
-            a10 = (int)(colors[10].Z * 15.0);
-            a11 = (int)(colors[11].Z * 15.0);
-            a12 = (int)(colors[12].Z * 15.0);
-            a13 = (int)(colors[13].Z * 15.0);
-            a14 = (int)(colors[14].Z * 15.0);
-            a15 = (int)(colors[15].Z * 15.0);
+            a0 = (int)(colors[0].X * 15.0);
+            a1 = (int)(colors[1].X * 15.0);
+            a2 = (int)(colors[2].X * 15.0);
+            a3 = (int)(colors[3].X * 15.0);
+            a4 = (int)(colors[4].X * 15.0);
+            a5 = (int)(colors[5].X * 15.0);
+            a6 = (int)(colors[6].X * 15.0);
+            a7 = (int)(colors[7].X * 15.0);
+            a8 = (int)(colors[8].X * 15.0);
+            a9 = (int)(colors[9].X * 15.0);
+            a10 = (int)(colors[10].X * 15.0);
+            a11 = (int)(colors[11].X * 15.0);
+            a12 = (int)(colors[12].X * 15.0);
+            a13 = (int)(colors[13].X * 15.0);
+            a14 = (int)(colors[14].X * 15.0);
+            a15 = (int)(colors[15].X * 15.0);
 
             // Duplicate the top two bits into the bottom two bits so we get one of four values: b0000, b0101, b1010, b1111
             a0 = (a0 & 0xC) | (a0 >> 2);

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -141,16 +141,33 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                 var idx = 0;
                 for (; idx < data.Length; )
                 {
-                    var r = data[idx + 0];
-                    var g = data[idx + 1];
-                    var b = data[idx + 2];
-                    var a = data[idx + 3];
-                    var col = Color.FromNonPremultiplied(r, g, b, a);
+                    var r = data[idx];
 
-                    data[idx + 0] = col.R;
-                    data[idx + 1] = col.G;
-                    data[idx + 2] = col.B;
-                    data[idx + 3] = col.A;
+                    // Special case of simply copying the R component into the A, since R is the value of white alpha we want
+                    data[idx + 0] = r;
+                    data[idx + 1] = r;
+                    data[idx + 2] = r;
+                    data[idx + 3] = r;
+
+                    idx += 4;
+                }
+
+                bmp.SetPixelData(data);
+            }
+            else
+            {
+                var bmp = output.Texture.Faces[0][0];
+                var data = bmp.GetPixelData();
+                var idx = 0;
+                for (; idx < data.Length; )
+                {
+                    var r = data[idx];
+
+                    // Special case of simply moving the R component into the A and setting RGB to solid white, since R is the value of white alpha we want
+                    data[idx + 0] = 255;
+                    data[idx + 1] = 255;
+                    data[idx + 2] = 255;
+                    data[idx + 3] = r;
 
                     idx += 4;
                 }

--- a/MonoGame.Framework.Content.Pipeline/Utilities/Vector4Converter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/Vector4Converter.cs
@@ -24,24 +24,24 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities
         Vector4 IVector4Converter<byte>.ToVector4(byte value)
         {
             var f = (float)value / (float)byte.MaxValue;
-            return new Vector4(1f, 1f, 1f, f);
+            return new Vector4(f, 0f, 0f, 1f);
         }
 
         Vector4 IVector4Converter<short>.ToVector4(short value)
         {
             var f = (float)value / (float)short.MaxValue;
-            return new Vector4(1f, 1f, 1f, f);
+            return new Vector4(f, 0f, 0f, 1f);
         }
 
         Vector4 IVector4Converter<int>.ToVector4(int value)
         {
             var f = (float)value / (float)int.MaxValue;
-            return new Vector4(1f, 1f, 1f, f);
+            return new Vector4(f, 0f, 0f, 1f);
         }
 
         Vector4 IVector4Converter<float>.ToVector4(float value)
         {
-            return new Vector4(1f, 1f, 1f, value);
+            return new Vector4(value, 0f, 0f, 1f);
         }
 
         Vector4 IVector4Converter<Color>.ToVector4(Color value)
@@ -56,22 +56,22 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities
 
         byte IVector4Converter<byte>.FromVector4(Vector4 value)
         {
-            return (byte)(value.W * (float)byte.MaxValue);
+            return (byte)(value.X * (float)byte.MaxValue);
         }
 
         short IVector4Converter<short>.FromVector4(Vector4 value)
         {
-            return (short)(value.W * (float)short.MaxValue);
+            return (short)(value.X * (float)short.MaxValue);
         }
 
         int IVector4Converter<int>.FromVector4(Vector4 value)
         {
-            return (int)(value.W * (float)int.MaxValue);
+            return (int)(value.X * (float)int.MaxValue);
         }
 
         float IVector4Converter<float>.FromVector4(Vector4 value)
         {
-            return value.W;
+            return value.X;
         }
 
         Color IVector4Converter<Color>.FromVector4(Vector4 value)

--- a/Test/ContentPipeline/BitmapContentTests.cs
+++ b/Test/ContentPipeline/BitmapContentTests.cs
@@ -51,7 +51,7 @@ namespace MonoGame.Tests.ContentPipeline
                     Assert.AreEqual(color1, b2.GetPixel(x, y));
         }
 
-        void BitmapCopyFullResize<T>(T color1)
+        void BitmapCopyFullResize<T>(T color1, IEqualityComparer<T> comparer)
             where T : struct, IEquatable<T>
         {
             var b1 = new PixelBitmapContent<T>(8, 8);
@@ -61,7 +61,7 @@ namespace MonoGame.Tests.ContentPipeline
 
             for (var y = 0; y < b2.Height; y++)
                 for (var x = 0; x < b2.Width; x++)
-                    Assert.AreEqual(color1, b2.GetPixel(x, y));
+                    Assert.That(color1, Is.EqualTo(b2.GetPixel(x, y)).Using(comparer));
         }
 
         void BitmapConvertFullNoResize<T, U>(T color1, U color2)
@@ -126,7 +126,7 @@ namespace MonoGame.Tests.ContentPipeline
                     Assert.AreEqual(x >= 4 && y >= 4 ? color1 : color2, b2.GetPixel(x, y));
         }
 
-        void BitmapCopyRegionResize<T>(T color1, T color2)
+        void BitmapCopyRegionResize<T>(T color1, T color2, IEqualityComparer<T> comparer)
             where T : struct, IEquatable<T>
         {
             var b1 = new PixelBitmapContent<T>(8, 8);
@@ -137,13 +137,15 @@ namespace MonoGame.Tests.ContentPipeline
 
             for (var y = 0; y < b2.Height; y++)
                 for (var x = 0; x < b2.Width; x++)
-                    Assert.AreEqual(x < 3 && y < 6 ? color1 : color2, b2.GetPixel(x, y));
+                    Assert.That(x < 3 && y < 6 ? color1 : color2, Is.EqualTo(b2.GetPixel(x, y)).Using(comparer));
         }
 
         [Test]
         public void BitmapCopyFullNoResize()
         {
+#if !XNA
             BitmapCopyFullNoResize<byte>(56);
+#endif
             BitmapCopyFullNoResize<float>(0.56f);
             BitmapCopyFullNoResize<Color>(Color.Red);
             BitmapCopyFullNoResize<Vector4>(new Vector4(1.0f, 0.0f, 0.0f, 1.0f));
@@ -152,17 +154,21 @@ namespace MonoGame.Tests.ContentPipeline
         [Test]
         public void BitmapCopyFullResize()
         {
-            BitmapCopyFullResize<byte>(56);
-            BitmapCopyFullResize<float>(0.56f);
-            BitmapCopyFullResize<Color>(Color.Red);
-            BitmapCopyFullResize<Vector4>(new Vector4(1.0f, 0.0f, 0.0f, 1.0f));
+#if !XNA
+            BitmapCopyFullResize<byte>(56, ByteComparer.Equal);
+#endif
+            BitmapCopyFullResize<float>(0.56f, FloatComparer.Epsilon);
+            BitmapCopyFullResize<Color>(Color.Red, ColorComparer.Equal);
+            BitmapCopyFullResize<Vector4>(new Vector4(1.0f, 0.0f, 0.0f, 1.0f), Vector4Comparer.Epsilon);
         }
 
         [Test]
         public void BitmapConvertFullNoResize()
         {
-            BitmapConvertFullNoResize<byte, Color>(byte.MaxValue, Color.White);
-            BitmapConvertFullNoResize<float, Color>(1.0f, Color.White);
+#if !XNA
+            BitmapConvertFullNoResize<byte, Color>(byte.MaxValue, Color.Red);
+#endif
+            BitmapConvertFullNoResize<float, Color>(1.0f, Color.Red);
             BitmapConvertFullNoResize<Color, Vector4>(Color.Red, new Vector4(1.0f, 0.0f, 0.0f, 1.0f));
             BitmapConvertFullNoResize<Vector4, Color>(new Vector4(1.0f, 0.0f, 0.0f, 1.0f), Color.Red);
         }
@@ -170,7 +176,9 @@ namespace MonoGame.Tests.ContentPipeline
         [Test]
         public void BitmapCompressFullNoResize()
         {
+#if !XNA
             BitmapCompressFullNoResize<byte>(56);
+#endif
             BitmapCompressFullNoResize<float>(0.56f);
             BitmapCompressFullNoResize<Color>(Color.Red);
             BitmapCompressFullNoResize<Vector4>(new Vector4(1.0f, 0.0f, 0.0f, 1.0f));
@@ -179,7 +187,9 @@ namespace MonoGame.Tests.ContentPipeline
         [Test]
         public void BitmapCompressFullResize()
         {
+#if !XNA
             BitmapCompressFullResize<byte>(56);
+#endif
             BitmapCompressFullResize<float>(0.56f);
             BitmapCompressFullResize<Color>(Color.Red);
             BitmapCompressFullResize<Vector4>(new Vector4(1.0f, 0.0f, 0.0f, 1.0f));
@@ -188,7 +198,9 @@ namespace MonoGame.Tests.ContentPipeline
         [Test]
         public void BitmapCopySameRegionNoResize()
         {
+#if !XNA
             BitmapCopySameRegionNoResize<byte>(56, 48);
+#endif
             BitmapCopySameRegionNoResize<float>(0.56f, 0.48f);
             BitmapCopySameRegionNoResize<Color>(Color.Red, Color.Blue);
             BitmapCopySameRegionNoResize<Vector4>(new Vector4(1.0f, 0.0f, 0.0f, 1.0f), new Vector4(0.0f, 0.0f, 1.0f, 1.0f));
@@ -197,7 +209,9 @@ namespace MonoGame.Tests.ContentPipeline
         [Test]
         public void BitmapCopyMoveRegionNoResize()
         {
+#if !XNA
             BitmapCopyMoveRegionNoResize<byte>(56, 48);
+#endif
             BitmapCopyMoveRegionNoResize<float>(0.56f, 0.48f);
             BitmapCopyMoveRegionNoResize<Color>(Color.Red, Color.Blue);
             BitmapCopyMoveRegionNoResize<Vector4>(new Vector4(1.0f, 0.0f, 0.0f, 1.0f), new Vector4(0.0f, 0.0f, 1.0f, 1.0f));
@@ -206,10 +220,12 @@ namespace MonoGame.Tests.ContentPipeline
         [Test]
         public void BitmapCopyRegionResize()
         {
-            BitmapCopyRegionResize<byte>(56, 48);
-            BitmapCopyRegionResize<float>(0.56f, 0.48f);
-            BitmapCopyRegionResize<Color>(Color.Red, Color.Blue);
-            BitmapCopyRegionResize<Vector4>(new Vector4(1.0f, 0.0f, 0.0f, 1.0f), new Vector4(0.0f, 0.0f, 1.0f, 1.0f));
+#if !XNA
+            BitmapCopyRegionResize<byte>(56, 48, ByteComparer.Equal);
+#endif
+            BitmapCopyRegionResize<float>(0.56f, 0.48f, FloatComparer.Epsilon);
+            BitmapCopyRegionResize<Color>(Color.Red, Color.Blue, ColorComparer.Equal);
+            BitmapCopyRegionResize<Vector4>(new Vector4(1.0f, 0.0f, 0.0f, 1.0f), new Vector4(0.0f, 0.0f, 1.0f, 1.0f), Vector4Comparer.Epsilon);
         }
     }
 }

--- a/Test/Framework/Graphics/GraphicsAdapterTest.cs
+++ b/Test/Framework/Graphics/GraphicsAdapterTest.cs
@@ -55,9 +55,14 @@ namespace MonoGame.Tests.Graphics
                 Assert.GreaterOrEqual(adapter.SupportedDisplayModes.Count(), 1);
                 Assert.AreEqual(1, adapter.SupportedDisplayModes.Count(m => Equals(m, adapter.CurrentDisplayMode)));
 
-                // Seems like XNA treats aspect ratios above 16:10 as wide screen.
+                // Seems like XNA treats aspect ratios above 16:10 as wide screen. A 1680x1050 display (exactly 16:10) was considered not to be wide screen.
+                // MonoGame considers ratios equal or greater than 16:10 to be wide screen.
                 const float minWideScreenAspect = 16.0f / 10.0f;
+#if XNA
+                var isWidescreen = adapter.CurrentDisplayMode.AspectRatio > minWideScreenAspect;
+#else
                 var isWidescreen = adapter.CurrentDisplayMode.AspectRatio >= minWideScreenAspect;
+#endif
                 Assert.AreEqual(isWidescreen, adapter.IsWideScreen); 
 
                 foreach (var mode in adapter.SupportedDisplayModes)

--- a/Test/Framework/Visual/MiscellaneousTests.cs
+++ b/Test/Framework/Visual/MiscellaneousTests.cs
@@ -82,6 +82,9 @@ namespace MonoGame.Tests.Visual {
 	class MiscellaneousTests : VisualTestFixtureBase
     {
 		[Test]
+#if XNA
+        [Ignore]
+#endif
 		public void DrawOrder_falls_back_to_order_of_addition_to_Game ()
 		{
 			Game.PreDrawWith += (sender, e) => {

--- a/Test/Runner/Utility.cs
+++ b/Test/Runner/Utility.cs
@@ -47,6 +47,44 @@ namespace MonoGame.Tests {
         }
     }
 
+    public class ByteComparer : IEqualityComparer<byte>
+    {
+        static public ByteComparer Equal = new ByteComparer();
+
+        private ByteComparer()
+        {
+        }
+
+        public bool Equals(byte x, byte y)
+        {
+            return x == y;
+        }
+
+        public int GetHashCode(byte obj)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class ColorComparer : IEqualityComparer<Color>
+    {
+        static public ColorComparer Equal = new ColorComparer();
+
+        private ColorComparer()
+        {
+        }
+
+        public bool Equals(Color x, Color y)
+        {
+            return x == y;
+        }
+
+        public int GetHashCode(Color obj)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     public class FloatComparer : IEqualityComparer<float>
     {
         static public FloatComparer Epsilon = new FloatComparer(0.000001f);


### PR DESCRIPTION
* As a consequence, font glyph packing and DXT3 font texture compression was also fixed to suit.
* Ensured that non-premultiplied SpriteFont works correctly for compressed and non-compressed font textures.
* Changed GraphicAdapter widescreen test to treat 16:10 as widescreen for MonoGame but not for XNA.

Included adapted fixes from @Jjagg #5388
* Disable `PixelBitmapContext<byte>` tests for XNA.
* `PixelBitmapContext<float>` and `PixelBitmapContent<Vector4>` tests that resize the bitmap now use an epsilon comparison.
* Add [Ignore] attribute to `MiscellaneousTests.DrawOrder_falls_back_to_order_of_addition_to_Game` for XNA.