### PR TITLE
WrapAngle optimisation & tests

### DIFF
--- a/MonoGame.Framework/MathHelper.cs
+++ b/MonoGame.Framework/MathHelper.cs
@@ -295,22 +295,17 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="angle">The angle to reduce, in radians.</param>
         /// <returns>The new angle, in radians.</returns>
-	public static float WrapAngle(float angle)
-	{
-            angle = (float)Math.IEEERemainder((double)angle, 6.2831854820251465);
-	    if (angle <= -3.14159274f)
-	    {
-		angle += 6.28318548f;
-	    }
-	    else
-	    {
-		if (angle > 3.14159274f)
-		{
-		   angle -= 6.28318548f;
-		}
-	    }
-	    return angle;
-	}
+        public static float WrapAngle(float angle)
+        {
+            if ((angle > -Pi) && (angle <= Pi))
+                return angle;
+            angle %= TwoPi;
+            if (angle <= -Pi)
+                return angle + TwoPi;
+            if (angle > Pi)
+                return angle - TwoPi;
+            return angle;
+        }
 
  	/// <summary>
         /// Determines if value is powered by two.

--- a/Test/Framework/MathHelperTest.cs
+++ b/Test/Framework/MathHelperTest.cs
@@ -83,5 +83,75 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(5, MathHelper.Max(-5, 5));
             Assert.AreEqual(5, MathHelper.Max(5, -5));
         }
+
+        [TestCase(MathHelper.PiOver4, 0.7853982f)]
+        [TestCase(MathHelper.PiOver2, 1.5707964f)]
+        [TestCase(MathHelper.Pi, 3.1415927f)]
+        [TestCase(MathHelper.TwoPi, 6.2831855f)]
+        public void PiConstantsAreExpectedValues(float actualValue, float expectedValue)
+        {
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestCase(0f, 0f)]
+        [TestCase(MathHelper.PiOver4, MathHelper.PiOver4)]
+        [TestCase(-MathHelper.PiOver4, -MathHelper.PiOver4)]
+        [TestCase(MathHelper.PiOver2, MathHelper.PiOver2)]
+        [TestCase(-MathHelper.PiOver2, -MathHelper.PiOver2)]
+        [TestCase(MathHelper.Pi, MathHelper.Pi)]
+        [TestCase(-MathHelper.Pi, MathHelper.Pi)]
+        [TestCase(MathHelper.TwoPi, 0f)]
+        [TestCase(-MathHelper.TwoPi, 0f)]
+        [TestCase(10f, -2.566371f)]
+        [TestCase(-10f, 2.566371f)]
+        // Pi boundaries
+        [TestCase(3.1415927f, 3.1415927f)]
+        [TestCase(3.141593f, -3.1415925f)]
+        [TestCase(-3.1415925f, -3.1415925f)]
+        [TestCase(-3.1415927f, 3.1415927f)]
+        // 2 * Pi boundaries
+        [TestCase(6.283185f, -4.7683716E-7f)]
+        [TestCase(6.2831855f, 0f)]
+        [TestCase(6.283186f, 4.7683716E-7f)]
+        [TestCase(-6.283185f, 4.7683716E-7f)]
+        [TestCase(-6.2831855f, 0f)]
+        [TestCase(-6.283186f, -4.7683716E-7f)]
+        // 3 * Pi boundaries
+        [TestCase(9.424778f, 3.1415925f)]
+        [TestCase(9.424779f, -3.141592f)]
+        [TestCase(-9.424778f, -3.1415925f)]
+        [TestCase(-9.424779f, 3.141592f)]
+        // 4 * Pi boundaries
+        [TestCase(12.56637f, -9.536743E-7f)]
+        [TestCase(12.566371f, 0f)]
+        [TestCase(12.566372f, 9.536743E-7f)]
+        [TestCase(-12.56637f, 9.536743E-7f)]
+        [TestCase(-12.566371f, 0f)]
+        [TestCase(-12.566372f, -9.536743E-7f)]
+        // 5 * Pi boundaries
+        [TestCase(15.707963f, 3.141592f)]
+        [TestCase(15.707964f, -3.1415925f)]
+        [TestCase(-15.707963f, -3.141592f)]
+        [TestCase(-15.707964f, 3.1415925f)]
+        // 10 * Pi boundaries
+        [TestCase(31.415926f, -1.4305115E-6f)]
+        [TestCase(31.415928f, 4.7683716E-7f)]
+        [TestCase(-31.415926f, 1.4305115E-6f)]
+        [TestCase(-31.415928f, -4.7683716E-7f)]
+        // 20 * Pi boundaries
+        [TestCase(62.831852f, -2.861023E-6f)]
+        [TestCase(62.831856f, 9.536743E-7f)]
+        [TestCase(-62.831852f, 2.861023E-6f)]
+        [TestCase(-62.831856f, -9.536743E-7f)]
+        // 20000000 * Pi boundaries
+        [TestCase(6.2831852E7f, -2.8202515f)]
+        [TestCase(6.2831856E7f, 1.1797485f)]
+        [TestCase(-6.2831852E7f, 2.8202515f)]
+        [TestCase(-6.2831856E7f, -1.1797485f)]
+        public void WrapAngleReturnsExpectedValues(float angle, float expectedValue)
+        {
+            var actualValue = MathHelper.WrapAngle(angle);
+            Assert.AreEqual(expectedValue, actualValue);
+        }
     }
 }


### PR DESCRIPTION
This is a performance optimisation for the `MathHelper.WrapAngle` method, plus a heap of tests proving that it returns the same results as XNA.

The same result can be calculated using the standard modulo operator which is much faster than the `Math.IEEERemainder` operation. While the 2 operations do give different results (e.g. `10f % MathHelper.TwoPi = 3.716815f` and `Math.IEEERemainder(10f, MathHelper.TwoPi) = -2.566371f`), these are accounted for by the additional limit checks. But don't take my word for it, the tests I've added prove that.

Here are my benchmarks of the original method versus this new one using modulo. The new method takes about 64% less time! But I also added a check to skip the calculations if the value is already within range, and in this case it takes 92% less time than the original!

Method | Mean | StdDev | StdErr | Min | Q1 | Median | Q3 | Max | P95 | Op/s | Scaled | Scaled-StdDev
--- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---
Original | 51.2411 ns | 0.1013 ns | 0.0281 ns | 51.1090 ns | 51.1818 ns | 51.2110 ns | 51.2752 ns | 51.4786 ns | 51.4391 ns | 19515601.45 | 1.00 | 0.00
New (outside range) | 18.7181 ns | 0.1280 ns | 0.0330 ns | 18.6689 ns | 18.6694 ns | 18.6699 ns | 18.6705 ns | 19.0591 ns | 19.0216 ns | 53424196.85 | 0.36 | 0.00
New (within range) | 4.1722 ns | 0.0004 ns | 0.0001 ns | 4.1715 ns | 4.1721 ns | 4.1722 ns | 4.1724 ns | 4.1729 ns | 4.1727 ns | 239682313.82 | 0.08 | 0.00