### PR TITLE
Improve Point and Rectangle HashCode

### DIFF
--- a/MonoGame.Framework/Point.cs
+++ b/MonoGame.Framework/Point.cs
@@ -187,7 +187,14 @@ namespace Microsoft.Xna.Framework
         /// <returns>Hash code of this <see cref="Point"/>.</returns>
         public override int GetHashCode()
         {
-            return X ^ Y;
+            unchecked
+            {
+                var hash = 17;
+                hash = hash * 23 + X.GetHashCode();
+                hash = hash * 23 + Y.GetHashCode();
+                return hash;
+            }
+
         }
 
         /// <summary>

--- a/MonoGame.Framework/Rectangle.cs
+++ b/MonoGame.Framework/Rectangle.cs
@@ -339,7 +339,15 @@ namespace Microsoft.Xna.Framework
         /// <returns>Hash code of this <see cref="Rectangle"/>.</returns>
         public override int GetHashCode()
         {
-            return (X ^ Y ^ Width ^ Height);
+            unchecked
+            {
+                var hash = 17;
+                hash = hash * 23 + X.GetHashCode();
+                hash = hash * 23 + Y.GetHashCode();
+                hash = hash * 23 + Width.GetHashCode();
+                hash = hash * 23 + Height.GetHashCode();
+                return hash;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
These hash codes were symmetric. That means `new Point(x, y).GetHashCode() == new Point(y, x).GetHashCode()` would evaluate to true. For Rectangle it's worse since any permutation of the 4 values will result in the same hashcode. I didn't check any other structs, but there are probably more hashcodes implemented like this. Though since these are mutable structs people shouldn't rely on the hashcode too much anyway. 

New algorithm came from http://stackoverflow.com/questions/263400/what-is-the-best-algorithm-for-an-overridden-system-object-gethashcode/263416#263416 by StackOverflow/C# god Jon Skeet.