### PR TITLE
Some minor additions to #5139

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -571,9 +571,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (DeviceReset != null)
                 DeviceReset(this, EventArgs.Empty);
-
-            if (DeviceLost != null)
-                DeviceLost(this, EventArgs.Empty);
         }
 
         public void Reset(PresentationParameters presentationParameters)

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -354,17 +354,10 @@ namespace MonoGame.Framework
             // This is critical for some NUnit runners which
             // typically will run all the tests on the same
             // process/thread.
-#if DEBUG
-            var msg = new NativeMessage();
-            do
+            NativeMessage msg;
+            while (PeekMessage(out msg, IntPtr.Zero, WM_QUIT, WM_QUIT, 1))
             {
-                if (msg.msg == WM_QUIT)
-                    break;
-
-                Thread.Sleep(100);
-            } 
-            while (PeekMessage(out msg, IntPtr.Zero, 0, 1 << 5, 1));
-#endif
+            }
         }
 
         public void CenterForm()

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -354,10 +354,15 @@ namespace MonoGame.Framework
             // This is critical for some NUnit runners which
             // typically will run all the tests on the same
             // process/thread.
-            NativeMessage msg;
-            while (PeekMessage(out msg, IntPtr.Zero, WM_QUIT, WM_QUIT, 1))
+            var msg = new NativeMessage();
+            do
             {
-            }
+                if (msg.msg == WM_QUIT)
+                    break;
+
+                Thread.Sleep(100);
+            } 
+            while (PeekMessage(out msg, IntPtr.Zero, 0, 1 << 5, 1));
         }
 
         public void CenterForm()

--- a/Test/Framework/Graphics/GraphicsDeviceManagerTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceManagerTest.cs
@@ -326,7 +326,7 @@ namespace MonoGame.Tests.Graphics
     internal class GraphicsDeviceManagerFixtureTest : GraphicsDeviceTestFixtureBase
     {
         [Test]
-        public void ResettingDeviceTriggersGdmEvents()
+        public void ResettingDeviceTriggersResetEvents()
         {
             var resetCount = 0;
             var resettingCount = 0;
@@ -344,6 +344,29 @@ namespace MonoGame.Tests.Graphics
 
             Assert.AreEqual(1, resetCount);
             Assert.AreEqual(1, resettingCount);
+        }
+        
+        [Test]
+        public void NewDeviceDoesNotTriggerReset()
+        {
+            var resetCount = 0;
+            var devLostCount = 0;
+
+            gd.DeviceReset += (sender, args) =>
+            {
+                resetCount++;
+            };
+            gd.DeviceLost += (sender, args) =>
+            {
+                devLostCount++;
+            };
+
+            // changing the profile requires creating a new device
+            gdm.GraphicsProfile = GraphicsProfile.Reach;
+            gdm.ApplyChanges();
+
+            Assert.AreEqual(0, resetCount);
+            Assert.AreEqual(0, devLostCount);
         }
 
         [Test]

--- a/Test/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceTest.cs
@@ -68,8 +68,9 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
-        public void ResetInvokedBeforeDeviceLost()
+        public void ResetDoesNotTriggerDeviceLost()
         {
+            // TODO figure out exactly when a device is lost
             var resetCount = 0;
             var devLostCount = 0;
 
@@ -88,7 +89,7 @@ namespace MonoGame.Tests.Graphics
             gd.Reset();
 
             Assert.AreEqual(1, resetCount);
-            Assert.AreEqual(1, devLostCount);
+            Assert.AreEqual(0, devLostCount);
         }
 
         // TODO Make sure dynamic graphics resources are notified when graphics device is lost


### PR DESCRIPTION
Fixes a test that failed in XNA for now. We don't handle a lost device at all at this point :/
Also made the PeekMessage filter only let through WM_QUIT messages since that's all that were interested in.

With the PeekMessage filter #5139 fixed two more issues (autoclosing here): fixes #3995 and fixes #5416 