### PR TITLE
Command-line parameter prefixes

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -30,6 +30,11 @@
       <MonoExe Condition=" '$(OS)' != 'Windows_NT' And Exists ('/usr/bin/mono') ">/usr/bin/mono</MonoExe>
       <MonoExe Condition=" '$(OS)' != 'Windows_NT' And '$(MonoExe)' == '' ">mono</MonoExe>
 
+      <LongParamPrefix Condition=" '$(OS)' != 'Windows_NT' ">--</MonoExe>
+      <LongParamPrefix Condition=" '$(OS)' == 'Windows_NT' ">/</MonoExe>
+      <ShortParamPrefix Condition=" '$(OS)' != 'Windows_NT' ">-</MonoExe>
+      <ShortParamPrefix Condition=" '$(OS)' == 'Windows_NT' ">/</MonoExe>
+
       <MonoGameContentBuilderExe Condition="'$(MonoGameContentBuilderExe)' == ''">$(MSBuildThisFileDirectory)Tools\MGCB.exe</MonoGameContentBuilderExe>
       <MonoGameContentBuilderCmd>&quot;$(MonoGameContentBuilderExe)&quot;</MonoGameContentBuilderCmd>
       <MonoGameContentBuilderCmd Condition=" '$(OS)' != 'Windows_NT' ">$(MonoExe) $(MonoGameContentBuilderCmd)</MonoGameContentBuilderCmd>
@@ -38,7 +43,7 @@
       <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">Assets\</PlatformResourcePrefix>
       <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' == ''"></PlatformResourcePrefix>
 
-      <Header>/platform:$(MonoGamePlatform) /outputDir:&quot;$(ParentOutputDir)&quot; /intermediateDir:&quot;$(ParentIntermediateDir)&quot; /quiet</Header>
+      <Header>$(LongParamPrefix)platform:$(MonoGamePlatform) $(LongParamPrefix)outputDir:&quot;$(ParentOutputDir)&quot; $(LongParamPrefix)intermediateDir:&quot;$(ParentIntermediateDir)&quot; $(LongParamPrefix)quiet</Header>
     </PropertyGroup>
 
     <!-- Get all Mono Game Content References and store them in a list -->
@@ -87,7 +92,7 @@
   </PropertyGroup>
 
   <Target Name="RunContentBuilder">
-    <Exec Condition=" '%(ContentReferences.FullPath)' != '' " Command="$(MonoGameContentBuilderCmd) /@:&quot;%(ContentReferences.FullPath)&quot; $(Header)"
+    <Exec Condition=" '%(ContentReferences.FullPath)' != '' " Command="$(MonoGameContentBuilderCmd) $(ShortParamPrefix)@:&quot;%(ContentReferences.FullPath)&quot; $(Header)"
           WorkingDirectory="%(ContentReferences.RootDir)%(ContentReferences.Directory)" />
 
     <CreateItem Include="$(ParentOutputDir)\**\*.*">

--- a/Tools/2MGFX/CommandLineParser.cs
+++ b/Tools/2MGFX/CommandLineParser.cs
@@ -21,6 +21,8 @@ namespace TwoMGFX
     //
     public class CommandLineParser
     {
+        private string _paramPrefix = "/";
+
         object _optionsObject;
 
         Queue<FieldInfo> _requiredOptions = new Queue<FieldInfo>();
@@ -33,6 +35,11 @@ namespace TwoMGFX
         // Constructor.
         public CommandLineParser(object optionsObject)
         {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                _paramPrefix = "/";
+            else
+                _paramPrefix = "--";
+
             this._optionsObject = optionsObject;
 
             // Reflect to find what commandline options are available.
@@ -54,9 +61,9 @@ namespace TwoMGFX
                     _optionalOptions.Add(fieldName.ToLowerInvariant(), field);
 
                     if (field.FieldType == typeof(bool))
-                        _optionalUsageHelp.Add(string.Format("/{0} {1}", fieldName, description));
+                        _optionalUsageHelp.Add(string.Format("{2}{0} {1}", fieldName, description, _paramPrefix));
                     else
-                        _optionalUsageHelp.Add(string.Format("/{0}:value {1}", fieldName, description));
+                        _optionalUsageHelp.Add(string.Format("{2}{0}:value {1}", fieldName, description, _paramPrefix));
                 }
             }
         }
@@ -86,7 +93,7 @@ namespace TwoMGFX
 
         bool ParseArgument(string arg)
         {
-            if (arg.StartsWith("/"))
+            if (arg.StartsWith(_paramPrefix))
             {
                 // After the first escaped argument we can no
                 // longer read non-escaped arguments.

--- a/Tools/MGCB/CommandLineParser.cs
+++ b/Tools/MGCB/CommandLineParser.cs
@@ -92,8 +92,22 @@ namespace MGCB
         public delegate void ErrorCallback(string msg, object[] args);
         public event ErrorCallback OnError;
 
+        private string _longParamPrefix = "/";
+        private string _shortParamPrefix = "/";
+
         public MGBuildParser(object optionsObject)
         {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                _longParamPrefix = "/";
+                _shortParamPrefix = "/";
+            }
+            else
+            {
+                _longParamPrefix = "--";
+                _shortParamPrefix = "-";
+            }
+
             _optionsObject = optionsObject;
             _requiredOptions = new Queue<MemberInfo>();
             _optionalOptions = new Dictionary<string, MemberInfo>();
@@ -281,7 +295,7 @@ namespace MGCB
                     continue;
                 }
 
-                if (arg.StartsWith("/@:") || arg.StartsWith("-@:"))
+                if (arg.StartsWith(_shortParamPrefix + "@:"))
                 {
                     var file = arg.Substring(3);
                     var commands = File.ReadAllLines(file);
@@ -314,7 +328,7 @@ namespace MGCB
 
         private bool ParseArgument(string arg)
         {
-            if (arg.StartsWith("/") || arg.StartsWith("-"))
+            if (arg.StartsWith(_longParamPrefix))
             {
                 // After the first escaped argument we can no
                 // longer read non-escaped arguments.

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -43,6 +43,9 @@ namespace MonoGame.Tools.Pipeline
             Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
         };
 
+        private string _longParamPrefix = "/";
+        private string _shortParamPrefix = "/";
+
         public IEnumerable<ContentItemTemplate> Templates
         {
             get { return _templateItems; }
@@ -100,6 +103,17 @@ namespace MonoGame.Tools.Pipeline
 
         private PipelineController(IView view)
         {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                _longParamPrefix = "/";
+                _shortParamPrefix = "/";
+            }
+            else
+            {
+                _longParamPrefix = "--";
+                _shortParamPrefix = "-";
+            }
+
             Instance = this;
             PipelineSettings.Default.Load();
 
@@ -381,9 +395,9 @@ namespace MonoGame.Tools.Pipeline
 
         public void Build(bool rebuild)
         {
-            var commands = string.Format("/@:\"{0}\" {1}", _project.OriginalPath, rebuild ? "/rebuild" : string.Empty);
+            var commands = string.Format("{2}@:\"{0}\" {1}", _project.OriginalPath, rebuild ? _longParamPrefix + "rebuild" : string.Empty, _shortParamPrefix);
             if (LaunchDebugger)
-                commands += " /launchdebugger";
+                commands += " " + _longParamPrefix + "launchdebugger";
             BuildCommand(commands);
         }
 
@@ -436,9 +450,9 @@ namespace MonoGame.Tools.Pipeline
             }
 
             // Run the build the command.
-            var commands = string.Format("/@:\"{0}\" /rebuild /incremental", tempPath);
+            var commands = string.Format("{1}@:\"{0}\" {2}rebuild {2}incremental", tempPath, _shortParamPrefix, _longParamPrefix);
             if (LaunchDebugger)
-                commands += " /launchdebugger";
+                commands += " " + _longParamPrefix + "launchdebugger";
 
             BuildCommand(commands);
 
@@ -471,9 +485,9 @@ namespace MonoGame.Tools.Pipeline
 
             View.OutputClear();
 
-            var commands = string.Format("/clean /intermediateDir:\"{0}\" /outputDir:\"{1}\"", _project.IntermediateDir, _project.OutputDir);
+            var commands = string.Format("{2}clean {2}intermediateDir:\"{0}\" {2}outputDir:\"{1}\"", _project.IntermediateDir, _project.OutputDir, _longParamPrefix);
             if (LaunchDebugger)
-                commands += " /launchdebugger";
+                commands += " " + _longParamPrefix + "launchdebugger";
 
             _buildTask = Task.Factory.StartNew(() => DoBuild(commands));
             _buildTask.ContinueWith((e) => View.Invoke(UpdateMenu));


### PR DESCRIPTION
Command-line parameters on Windows use /
Command-line parameters on Linux and Mac use - for short parameters and -- for long parameters.

Started this because - and -- is what non-Windows users expect, and 2MGFX fails to parse parameters on non-Windows platforms with absolute paths (starting with /) as the input or output parameters.