### PR TITLE
Tests always create reference device

### DIFF
--- a/Test/Framework/TestGameBase.cs
+++ b/Test/Framework/TestGameBase.cs
@@ -76,6 +76,7 @@ using System.Text;
 using System.Threading;
 
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 
 using MonoGame.Tests.Components;
 
@@ -93,7 +94,11 @@ namespace MonoGame.Tests {
 #if XNA
             Content.RootDirectory = AppDomain.CurrentDomain.BaseDirectory;
 #endif
-			Services.AddService<IFrameInfoSource> (this);
+            // We do all the tests using the reference device to
+            // avoid driver glitches and get consistant rendering.
+            GraphicsAdapter.UseReferenceDevice = true;
+
+            Services.AddService<IFrameInfoSource>(this);
 			SuppressExtraUpdatesAndDraws = true;
 		}
 

--- a/Test/Framework/Visual/VisualTestGame.cs
+++ b/Test/Framework/Visual/VisualTestGame.cs
@@ -82,10 +82,6 @@ namespace MonoGame.Tests.Visual {
 				GraphicsProfile = GraphicsProfile.HiDef,
 			};
 
-			// We do all the tests using the reference device to
-			// avoid driver glitches and get consistant rendering.
-			GraphicsAdapter.UseReferenceDevice = true;
-
 			Services.AddService<IFrameCaptureSource> (this);
 		}
 


### PR DESCRIPTION
Any tests that create a graphics device always create a reference device, rather than just the visual tests.