### PR TITLE
[OpenGL] Fix SetData on compressed textures

### DIFF
--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -983,7 +983,7 @@ namespace OpenGL
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
         public delegate void CompressedTexSubImage2DDelegate (TextureTarget target, int level,
-            int x, int y, int width, int height, PixelFormat format, int size, IntPtr data);
+            int x, int y, int width, int height, PixelInternalFormat format, int size, IntPtr data);
         public static CompressedTexSubImage2DDelegate CompressedTexSubImage2D;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     if (glFormat == (PixelFormat)GLPixelFormat.CompressedTextureFormats)
                     {
                         GL.CompressedTexSubImage2D(TextureTarget.Texture2D, level, rect.X, rect.Y,
-                            rect.Width, rect.Height, glFormat, elementCount - startBytes, dataPtr);
+                            rect.Width, rect.Height, glInternalFormat, elementCount - startBytes, dataPtr);
                         GraphicsExtensions.CheckGLError();
                     }
                     else

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -36,6 +36,7 @@ using PixelFormat = MonoMac.OpenGL.PixelFormat;
 using OpenTK.Graphics.OpenGL;
 using GLPixelFormat = OpenTK.Graphics.OpenGL.All;
 using PixelFormat = OpenTK.Graphics.OpenGL.PixelFormat;
+using PixelInternalFormat = OpenTK.Graphics.OpenGL.PixelFormat;
 #endif
 #endif
 
@@ -49,6 +50,7 @@ using PixelFormat = OpenGL.PixelFormat;
 using OpenTK.Graphics.ES20;
 using GLPixelFormat = OpenTK.Graphics.ES20.All;
 using PixelFormat = OpenTK.Graphics.ES20.PixelFormat;
+using PixelInternalFormat = OpenTK.Graphics.ES20.PixelFormat;
 #endif
 
 #if ANDROID
@@ -67,7 +69,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformConstruct(int width, int height, bool mipmap, SurfaceFormat format, SurfaceType type, bool shared)
         {
             this.glTarget = TextureTarget.Texture2D;
-            
+
             Threading.BlockOnUIThread(() =>
             {
                 // Store the current bound texture.
@@ -145,8 +147,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     GraphicsExtensions.CheckGLError();
                     if (glFormat == (PixelFormat)GLPixelFormat.CompressedTextureFormats)
                     {
-                        GL.CompressedTexSubImage2D(TextureTarget.Texture2D, level, rect.X, rect.Y,
-                            rect.Width, rect.Height, glInternalFormat, elementCount - startBytes, dataPtr);
+                        GL.CompressedTexSubImage2D(TextureTarget.Texture2D, level, rect.X, rect.Y, rect.Width, rect.Height,
+                            (PixelInternalFormat) glInternalFormat, elementCount - startBytes, dataPtr);
                         GraphicsExtensions.CheckGLError();
                     }
                     else
@@ -295,7 +297,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 BitmapData bitmapData = image.LockBits(new System.Drawing.Rectangle(0, 0, image.Width, image.Height),
                     ImageLockMode.ReadOnly, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-                if (bitmapData.Stride != image.Width * 4) 
+                if (bitmapData.Stride != image.Width * 4)
                     throw new NotImplementedException();
                 Marshal.Copy(bitmapData.Scan0, data, 0, data.Length);
                 image.UnlockBits(bitmapData);
@@ -500,16 +502,16 @@ namespace Microsoft.Xna.Framework.Graphics
 			{
 				throw new ArgumentNullException("format", "'format' cannot be null (Nothing in Visual Basic)");
 			}
-			
+
 			byte[] data = null;
 			GCHandle? handle = null;
 			Bitmap bitmap = null;
-			try 
+			try
 			{
 				data = new byte[width * height * 4];
 				handle = GCHandle.Alloc(data, GCHandleType.Pinned);
 				GetData(data);
-				
+
 				// internal structure is BGR while bitmap expects RGB
 				for(int i = 0; i < data.Length; i += 4)
 				{
@@ -517,12 +519,12 @@ namespace Microsoft.Xna.Framework.Graphics
 					data[i + 0] = data[i + 2];
 					data[i + 2] = temp;
 				}
-				
+
 				bitmap = new Bitmap(width, height, width * 4, System.Drawing.Imaging.PixelFormat.Format32bppArgb, handle.Value.AddrOfPinnedObject());
-				
+
 				bitmap.Save(stream, format);
-			} 
-			finally 
+			}
+			finally
 			{
 				if (bitmap != null)
 				{
@@ -558,7 +560,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 #endif
 
-        // This method allows games that use Texture2D.FromStream 
+        // This method allows games that use Texture2D.FromStream
         // to reload their textures after the GL context is lost.
         private void PlatformReload(Stream textureStream)
         {

--- a/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     var target = GetGLCubeFace(face);
                     if (glFormat == (PixelFormat) GLPixelFormat.CompressedTextureFormats)
                     {
-                        GL.CompressedTexSubImage2D(target, level, rect.X, rect.Y, rect.Width, rect.Height, (PixelFormat)glInternalFormat, elementCount * startBytes, dataPtr);
+                        GL.CompressedTexSubImage2D(target, level, rect.X, rect.Y, rect.Width, rect.Height, glInternalFormat, elementCount * startBytes, dataPtr);
                         GraphicsExtensions.CheckGLError();
                     }
                     else
@@ -177,9 +177,9 @@ namespace Microsoft.Xna.Framework.Graphics
             });
         }
 
-		private TextureTarget GetGLCubeFace(CubeMapFace face) 
+		private TextureTarget GetGLCubeFace(CubeMapFace face)
         {
-			switch (face) 
+			switch (face)
             {
 			case CubeMapFace.PositiveX: return TextureTarget.TextureCubeMapPositiveX;
 			case CubeMapFace.NegativeX: return TextureTarget.TextureCubeMapNegativeX;

--- a/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
@@ -12,6 +12,7 @@ using Bool = MonoMac.OpenGL.Boolean;
 #if (MONOMAC && !PLATFORM_MACOS_LEGACY)
 using OpenTK.Graphics.OpenGL;
 using GLPixelFormat = OpenTK.Graphics.OpenGL.All;
+using PixelInternalFormat = OpenTK.Graphics.OpenGL.PixelFormat;
 using Bool = OpenTK.Graphics.OpenGL.Boolean;
 #endif
 #if DESKTOPGL
@@ -23,6 +24,7 @@ using PixelFormat = OpenGL.PixelFormat;
 using OpenTK.Graphics.ES20;
 using GLPixelFormat = OpenTK.Graphics.ES20.All;
 using PixelFormat = OpenTK.Graphics.ES20.PixelFormat;
+using PixelInternalFormat = OpenTK.Graphics.ES20.PixelFormat;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -160,7 +162,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     var target = GetGLCubeFace(face);
                     if (glFormat == (PixelFormat) GLPixelFormat.CompressedTextureFormats)
                     {
-                        GL.CompressedTexSubImage2D(target, level, rect.X, rect.Y, rect.Width, rect.Height, glInternalFormat, elementCount * startBytes, dataPtr);
+                        GL.CompressedTexSubImage2D(target, level, rect.X, rect.Y, rect.Width, rect.Height,
+                            (PixelInternalFormat) glInternalFormat, elementCount * startBytes, dataPtr);
                         GraphicsExtensions.CheckGLError();
                     }
                     else


### PR DESCRIPTION
We had wrong bindings for CompressedTexSubImage2D and because of the changes in #5121 all SetData calls used that binding and crashed because of it.