### PR TITLE
Fix two bugs in OpenAL implementation

### DIFF
--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -114,6 +114,10 @@ namespace Microsoft.Xna.Framework.Audio
         /// </summary>
 		private OpenALSoundController()
         {
+            // On Windows, set the DLL search path for correct native binaries
+            if (PlatformParameters.DetectWindowsArchitecture)
+                NativeHelper.InitDllDirectory();
+            
             if (!OpenSoundController())
             {
                 return;

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -114,9 +114,10 @@ namespace Microsoft.Xna.Framework.Audio
         /// </summary>
 		private OpenALSoundController()
         {
+#if WINDOWS
             // On Windows, set the DLL search path for correct native binaries
-            if (PlatformParameters.DetectWindowsArchitecture)
-                NativeHelper.InitDllDirectory();
+            NativeHelper.InitDllDirectory();
+#endif
             
             if (!OpenSoundController())
             {

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -108,7 +108,8 @@ namespace Microsoft.Xna.Framework.Audio
                 if (inst.IsDisposed || inst.State == SoundState.Stopped || (inst._effect == null && !inst._isDynamic))
                 {
 #if OPENAL
-                    inst.Stop(true); // force stopping it to free its AL source
+                    if (!inst.IsDisposed)
+                        inst.Stop(true); // force stopping it to free its AL source
 #endif
                     Add(inst);
                     continue;

--- a/MonoGame.Framework/Utilities/CurrentPlatform.cs
+++ b/MonoGame.Framework/Utilities/CurrentPlatform.cs
@@ -100,10 +100,12 @@ namespace MonoGame.Utilities
     {
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool SetDllDirectory(string lpPathName);
-
+        
+        private static bool _dllDirectorySet = false;
+        
         public static void InitDllDirectory()
         {
-            if (CurrentPlatform.OS == OS.Windows)
+            if (CurrentPlatform.OS == OS.Windows && !_dllDirectorySet)
             {
                 string executingDirectory = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
                 if (Environment.Is64BitProcess)
@@ -114,6 +116,8 @@ namespace MonoGame.Utilities
                 {
                     NativeHelper.SetDllDirectory(System.IO.Path.Combine(executingDirectory, "x86"));
                 }
+                
+                _dllDirectorySet = true;
             }
         }
     }


### PR DESCRIPTION
* An oversight by me caused `Stop()` to be executed on an already disposed sound effect, which is a throwing operation with `DynamicSoundEffectInstance` (XNA compatibility).
* The native DLL search path was set in `SDLGamePlatform` constructor, but the audio tests are run first. Therefore `soft_oal.dll` was not found, which caused test failures and an epic finalizer crash, rendering the test project unrunnable as is. I added the path check to `OpenALSoundController` so that there is no load order dependency anymore.