### PR TITLE
fix: SoundEffect.Play() was not setting volume, pitch, or pan

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -262,13 +262,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// </remarks>
         public bool Play()
         {
-            var inst = GetPooledInstance(false);
-            if (inst == null)
-                return false;
-
-            inst.Play();
-
-            return true;
+            return Play(1f, 0f, 0f);
         }
 
         /// <summary>Gets an internal SoundEffectInstance and plays it with the specified volume, pitch, and panning.</summary>


### PR DESCRIPTION
SoundEffect.Play() was not setting volume, pitch, or pan. This meant that if it grabbed an instance from the pool, it would use whatever volume / pitch / pan that instance previously had.