### PR TITLE
Simplified parameter prefix

### DIFF
--- a/Tools/2MGFX/CommandLineParser.cs
+++ b/Tools/2MGFX/CommandLineParser.cs
@@ -34,6 +34,7 @@ namespace TwoMGFX
         public CommandLineParser(object optionsObject)
         {
             this._optionsObject = optionsObject;
+            var prefix = Environment.OSVersion.Platform == PlatformID.Win32NT ? "/" : "-";
 
             // Reflect to find what commandline options are available.
             foreach (var field in optionsObject.GetType().GetFields())
@@ -54,9 +55,9 @@ namespace TwoMGFX
                     _optionalOptions.Add(fieldName.ToLowerInvariant(), field);
 
                     if (field.FieldType == typeof(bool))
-                        _optionalUsageHelp.Add(string.Format("/{0} {1}", fieldName, description));
+                        _optionalUsageHelp.Add(string.Format("{2}{0} {1}", fieldName, description, prefix));
                     else
-                        _optionalUsageHelp.Add(string.Format("/{0}:value {1}", fieldName, description));
+                        _optionalUsageHelp.Add(string.Format("{2}{0}:value {1}", fieldName, description, prefix));
                 }
             }
         }
@@ -86,7 +87,7 @@ namespace TwoMGFX
 
         bool ParseArgument(string arg)
         {
-            if (arg.StartsWith("/"))
+            if (arg.StartsWith("/") || arg.StartsWith("-"))
             {
                 // After the first escaped argument we can no
                 // longer read non-escaped arguments.

--- a/Tools/2MGFX/Options.cs
+++ b/Tools/2MGFX/Options.cs
@@ -6,10 +6,10 @@ namespace TwoMGFX
 {
     public class Options
     {
-        [CommandLineParser.Required]
+        [CommandLineParser.Name("SourceFile", "\t - Path of the shader source file")]
         public string SourceFile;
 
-        [CommandLineParser.Required]
+        [CommandLineParser.Name("OutputFile", "\t - Path of the output file")]
         public string OutputFile = string.Empty;
 
         [CommandLineParser.ProfileName]

--- a/Tools/2MGFX/Program.cs
+++ b/Tools/2MGFX/Program.cs
@@ -24,6 +24,13 @@ namespace TwoMGFX
             if (!parser.ParseCommandLine(args))
                 return 1;
 
+            // Validate that we have a source file
+            if (string.IsNullOrEmpty(options.SourceFile))
+            {
+                Console.Error.WriteLine("A source file must be specified");
+                return 1;
+            }
+
             // Validate the input file exits.
             if (!File.Exists(options.SourceFile))
             {


### PR DESCRIPTION
Replaces #5421.

* Added "-" as an optional parameter prefix in addition to "/" in 2MGFX.
* Source file and output file parameters in 2MGFX now use "/SourceFile:" and "/OutputFile:" parameter names to avoid trying to differentiate between parameters and absolute paths on Linux and Mac.