### PR TITLE
XAudio: Fixed output channel levels to match XNA

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -122,6 +122,9 @@
     <Compile Include="Framework\Audio\SoundEffectTest.cs" />
     <Compile Include="Framework\Audio\XactTest.cs" />
     <Compile Include="Framework\Audio\DynamicSoundEffectInstanceTest.cs" />
+    <Compile Include="Framework\Audio\SoundEffectInstanceXAudioTest.cs">
+        <Platforms>Windows</Platforms>
+    </Compile>
 
     <Compile Include="Framework\Components\DrawFrameNumberComponent.cs" />
     <Compile Include="Framework\Components\FlexibleGameComponent.cs" />

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -282,9 +282,12 @@ namespace Microsoft.Xna.Framework.Audio
             }
 
             if (voice == null && Device != null)
+            {
                 voice = new SourceVoice(Device, _format, VoiceFlags.UseFilter, XAudio2.MaximumFrequencyRatio);
+                inst._voice = voice;
+                inst.UpdateOutputMatrix(); // Ensure the output matrix is set for this new voice
+            }
 
-            inst._voice = voice;
             inst._format = _format;
         }
 

--- a/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         private SharpDX.XAudio2.Fx.Reverb _reverb;
 
-        private static readonly float[] _panMatrix = new float[8];
+        private static readonly float[] _panMatrix = new float[16];
 
         private float _reverbMix;
 
@@ -254,85 +254,52 @@ namespace Microsoft.Xna.Framework.Audio
 
             // Set the pan on the correct channels based on the reverb mix.
             if (!(_reverbMix > 0.0f))
-                _voice.SetOutputMatrix(srcChannelCount, dstChannelCount, CalculatePanMatrix(_pan, 1.0f));
+                _voice.SetOutputMatrix(srcChannelCount, dstChannelCount, CalculatePanMatrix(_pan, 1.0f, srcChannelCount));
             else
             {
-                _voice.SetOutputMatrix(SoundEffect.ReverbVoice, srcChannelCount, dstChannelCount, CalculatePanMatrix(_pan, _reverbMix));
-                _voice.SetOutputMatrix(SoundEffect.MasterVoice, srcChannelCount, dstChannelCount, CalculatePanMatrix(_pan, 1.0f - Math.Min(_reverbMix, 1.0f)));
+                _voice.SetOutputMatrix(SoundEffect.ReverbVoice, srcChannelCount, dstChannelCount, CalculatePanMatrix(_pan, _reverbMix, srcChannelCount));
+                _voice.SetOutputMatrix(SoundEffect.MasterVoice, srcChannelCount, dstChannelCount, CalculatePanMatrix(_pan, 1.0f - Math.Min(_reverbMix, 1.0f), srcChannelCount));
             }
         }
 
-        private static float[] CalculatePanMatrix(float pan, float scale)
+        private static float[] CalculatePanMatrix(float pan, float scale, int inputChannels)
         {
-            // From X3DAudio documentation:
-            /*
-                For submix and mastering voices, and for source voices without a channel mask or a channel mask of 0, 
-                   XAudio2 assumes default speaker positions according to the following table. 
-
-                Channels
-
-                Implicit Channel Positions
-
-                1 Always maps to FrontLeft and FrontRight at full scale in both speakers (special case for mono sounds) 
-                2 FrontLeft, FrontRight (basic stereo configuration) 
-                3 FrontLeft, FrontRight, LowFrequency (2.1 configuration) 
-                4 FrontLeft, FrontRight, BackLeft, BackRight (quadraphonic) 
-                5 FrontLeft, FrontRight, FrontCenter, SideLeft, SideRight (5.0 configuration) 
-                6 FrontLeft, FrontRight, FrontCenter, LowFrequency, SideLeft, SideRight (5.1 configuration) (see the following remarks) 
-                7 FrontLeft, FrontRight, FrontCenter, LowFrequency, SideLeft, SideRight, BackCenter (6.1 configuration) 
-                8 FrontLeft, FrontRight, FrontCenter, LowFrequency, BackLeft, BackRight, SideLeft, SideRight (7.1 configuration) 
-                9 or more No implicit positions (one-to-one mapping)                      
-             */
+            // XNA only ever outputs to the front left/right speakers (channels 0 and 1)
+            // Assumes there are at least 2 speaker channels to output to
 
             // Clear all the channels.
             var panMatrix = _panMatrix;
             Array.Clear(panMatrix, 0, panMatrix.Length);
 
-            // Notes:
-            //
-            // Since XNA does not appear to expose any 'master' voice channel mask / speaker configuration,
-            // I assume the mappings listed above should be used.
-            //
-            // Assuming it is correct to pan all channels which have a left/right component.
-
-            var lVal = (1.0f - pan) * scale;
-            var rVal = (1.0f + pan) * scale;
-
-            switch (SoundEffect.Speakers)
+            if (inputChannels == 1) // Mono source
             {
-                case Speakers.Stereo:
-                case Speakers.TwoPointOne:
-                case Speakers.Surround:
-                    panMatrix[0] = lVal;
-                    panMatrix[1] = rVal;
-                    break;
-
-                case Speakers.Quad:
-                    panMatrix[0] = panMatrix[2] = lVal;
-                    panMatrix[1] = panMatrix[3] = rVal;
-                    break;
-
-                case Speakers.FourPointOne:
-                    panMatrix[0] = panMatrix[3] = lVal;
-                    panMatrix[1] = panMatrix[4] = rVal;
-                    break;
-
-                case Speakers.FivePointOne:
-                case Speakers.SevenPointOne:
-                case Speakers.FivePointOneSurround:
-                    panMatrix[0] = panMatrix[4] = lVal;
-                    panMatrix[1] = panMatrix[5] = rVal;
-                    break;
-
-                case Speakers.SevenPointOneSurround:
-                    panMatrix[0] = panMatrix[4] = panMatrix[6] = lVal;
-                    panMatrix[1] = panMatrix[5] = panMatrix[7] = rVal;
-                    break;
-
-                case Speakers.Mono:
-                default:
-                    // don't do any panning here   
-                    break;
+                // Left/Right output levels:
+                //   Pan -1.0: L = 1.0, R = 0.0
+                //   Pan  0.0: L = 1.0, R = 1.0
+                //   Pan +1.0: L = 0.0, R = 1.0
+                panMatrix[0] = (pan > 0f) ? ((1f - pan) * scale) : scale; // Front-left output
+                panMatrix[1] = (pan < 0f) ? ((1f + pan) * scale) : scale; // Front-right output
+            }
+            else if (inputChannels == 2) // Stereo source
+            {
+                // Left/Right input (Li/Ri) mix for Left/Right outputs (Lo/Ro):
+                //   Pan -1.0: Lo = 0.5Li + 0.5Ri, Ro = 0.0Li + 0.0Ri
+                //   Pan  0.0: Lo = 1.0Li + 0.0Ri, Ro = 0.0Li + 1.0Ri
+                //   Pan +1.0: Lo = 0.0Li + 0.0Ri, Ro = 0.5Li + 0.5Ri
+                if (pan <= 0f)
+                {
+                    panMatrix[0] = (1f + pan * 0.5f) * scale; // Front-left output, Left input
+                    panMatrix[1] = (-pan * 0.5f) * scale; // Front-left output, Right input
+                    panMatrix[2] = 0f; // Front-right output, Left input
+                    panMatrix[3] = (1f + pan) * scale; // Front-right output, Right input
+                }
+                else
+                {
+                    panMatrix[0] = (1f - pan) * scale; // Front-left output, Left input
+                    panMatrix[1] = 0f; // Front-left output, Right input
+                    panMatrix[2] = (pan * 0.5f) * scale; // Front-right output, Left input
+                    panMatrix[3] = (1f - pan * 0.5f) * scale; // Front-right output, Right input
+                }
             }
 
             return panMatrix;

--- a/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Xna.Framework.Audio
             UpdateOutputMatrix();
         }
 
-        private void UpdateOutputMatrix()
+        internal void UpdateOutputMatrix()
         {
             var srcChannelCount = _voice.VoiceDetails.InputChannelCount;
             var dstChannelCount = SoundEffect.MasterVoice.VoiceDetails.InputChannelCount;

--- a/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Xna.Framework.Audio
             }
         }
 
-        private static float[] CalculateOutputMatrix(float pan, float scale, int inputChannels)
+        internal static float[] CalculateOutputMatrix(float pan, float scale, int inputChannels)
         {
             // XNA only ever outputs to the front left/right speakers (channels 0 and 1)
             // Assumes there are at least 2 speaker channels to output to

--- a/Test/Framework/Audio/SoundEffectInstanceXAudioTest.cs
+++ b/Test/Framework/Audio/SoundEffectInstanceXAudioTest.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Xna.Framework.Audio;
+using NUnit.Framework;
+
+namespace MonoGame.Tests.Audio
+{
+    // Tests specific to SoundEffectInstance.XAudio (Windows DirectX)
+    public class SoundEffectInstanceXAudioTest
+    {
+        // Mono source
+        [TestCase( 0f, 1f, 1, 1f, 1f)]
+        [TestCase(-1f, 1f, 1, 1f, 0f)]
+        [TestCase( 1f, 1f, 1, 0f, 1f)]
+        [TestCase(-0.75f, 1f, 1, 1f, 0.25f)]
+        [TestCase( 0.75f, 1f, 1, 0.25f, 1f)]
+        [TestCase( 0f, 0.75f, 1, 0.75f, 0.75f)]
+        // Mono source, scaled
+        [TestCase(0f, 0.75f, 1, 0.75f, 0.75f)]
+        [TestCase(-1f, 0.75f, 1, 0.75f, 0f)]
+        [TestCase( 1f, 0.75f, 1, 0f, 0.75f)]
+        // Stereo source
+        [TestCase(0f, 1f, 2, 1f, 0f, 0f, 1f)]
+        [TestCase(-1f, 1f, 2, 0.5f, 0.5f, 0f, 0f)]
+        [TestCase(1f, 1f, 2, 0f, 0f, 0.5f, 0.5f)]
+        [TestCase(-0.5f, 1f, 2, 0.75f, 0.25f, 0f, 0.5f)]
+        [TestCase(0.5f, 1f, 2, 0.5f, 0f, 0.25f, 0.75f)]
+        [TestCase(-0.75f, 1f, 2, 0.625f, 0.375f, 0f, 0.25f)]
+        [TestCase(0.75f, 1f, 2, 0.25f, 0f, 0.375f, 0.625f)]
+        // Stereo source, scaled
+        [TestCase(0f, 0.75f, 2, 0.75f, 0f, 0f, 0.75f)]
+        [TestCase(-1f, 0.75f, 2, 0.375f, 0.375f, 0f, 0f)]
+        [TestCase(1f, 0.75f, 2, 0f, 0f, 0.375f, 0.375f)]
+        public void CalculateOutputMatrixReturnsExpectedResults(
+            float pan, float scale, int inputChannels,
+            params float[] expectedValues)
+        {
+            var outputMatrix = SoundEffectInstance.CalculateOutputMatrix(pan, scale, inputChannels);
+
+            for (int i = 0; i < expectedValues.Length; i++)
+                Assert.AreEqual(expectedValues[i], outputMatrix[i], "Channel#" + i);
+
+            // the remaining values should be 0
+            for (int i = expectedValues.Length; i < outputMatrix.Length; i++)
+                Assert.AreEqual(0f, outputMatrix[i], "Channel#" + i);
+        }
+    }
+}


### PR DESCRIPTION
There are currently a few issues relating to sound effect output channel levels in MonoGame. e.g.

- Stereo samples sometimes only playing on the left speaker
- Levels being too loud when panning is applied
- Levels being too loud when more than 2 output speakers are configured (e.g. 5.1/7.1 Surround)

This PR fixes these issues, and makes the output channel levels in line with XNA (see issue #5054 for further details).

I've also added some XAudio specific unit tests which confirm that the output matrix calculations are returning expected results.

Fixes #5054