### PR TITLE
Monogame did not respect Android screen orientation lock by user, fixed.

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/Android/Activity1.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/Android/Activity1.cs
@@ -18,6 +18,7 @@ namespace ${Namespace}
 	           Theme = "@style/Theme.Splash",
                AlwaysRetainTaskState=true,
 	           LaunchMode=LaunchMode.SingleInstance,
+			   ScreenOrientation = ScreenOrientation.FullUser,
 	           ConfigurationChanges = ConfigChanges.Orientation | 
 	                                  ConfigChanges.KeyboardHidden | 
 	                                  ConfigChanges.Keyboard |

--- a/MonoGame.Framework/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Android/AndroidGameWindow.cs
@@ -292,8 +292,6 @@ namespace Microsoft.Xna.Framework
                         TouchPanelState.ReleaseAllTouches();
                     }
 
-                    Game.Activity.RequestedOrientation = requestedOrientation;
-
                     OnOrientationChanged();
                 }
             }

--- a/MonoGame.Framework/Android/OrientationListener.cs
+++ b/MonoGame.Framework/Android/OrientationListener.cs
@@ -4,6 +4,7 @@ using Android.Content;
 using Android.Content.Res;
 using Android.Hardware;
 using Android.Views;
+using Android.Provider;
 
 namespace Microsoft.Xna.Framework
 {
@@ -26,6 +27,17 @@ namespace Microsoft.Xna.Framework
             // Avoid changing orientation whilst the screen is locked
             if (ScreenReceiver.ScreenLocked)
                 return;
+
+            // Check if screen orientation is locked by user: if it's locked, do not change orientation.
+            try
+            {
+                if (Settings.System.GetInt(Application.Context.ContentResolver, "accelerometer_rotation") == 0)
+                    return;
+            }
+            catch (Settings.SettingNotFoundException)
+            {
+                // Do nothing (or log warning?). In case android API or Xamarin do not support this Android system property.
+            }
 
             var disporientation = AndroidCompatibility.GetAbsoluteOrientation(orientation);
 

--- a/MonoGame.Framework/Android/OrientationListener.cs
+++ b/MonoGame.Framework/Android/OrientationListener.cs
@@ -4,7 +4,6 @@ using Android.Content;
 using Android.Content.Res;
 using Android.Hardware;
 using Android.Views;
-using Android.Provider;
 
 namespace Microsoft.Xna.Framework
 {
@@ -27,17 +26,6 @@ namespace Microsoft.Xna.Framework
             // Avoid changing orientation whilst the screen is locked
             if (ScreenReceiver.ScreenLocked)
                 return;
-
-            // Check if screen orientation is locked by user: if it's locked, do not change orientation.
-            try
-            {
-                if (Settings.System.GetInt(Application.Context.ContentResolver, "accelerometer_rotation") == 0)
-                    return;
-            }
-            catch (Settings.SettingNotFoundException)
-            {
-                // Do nothing (or log warning?). In case android API or Xamarin do not support this Android system property.
-            }
 
             var disporientation = AndroidCompatibility.GetAbsoluteOrientation(orientation);
 

--- a/ProjectTemplates/VisualStudio2010/Android/Activity1.cs
+++ b/ProjectTemplates/VisualStudio2010/Android/Activity1.cs
@@ -11,7 +11,7 @@ namespace $safeprojectname$
         , Theme = "@style/Theme.Splash"
         , AlwaysRetainTaskState=true
         , LaunchMode=Android.Content.PM.LaunchMode.SingleInstance
-        , ScreenOrientation = ScreenOrientation.SensorLandscape
+        , ScreenOrientation = ScreenOrientation.FullUser
         , ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden | ConfigChanges.ScreenSize)]
     public class Activity1 : Microsoft.Xna.Framework.AndroidGameActivity
     {


### PR DESCRIPTION
Added check if user locked screen orientation. If he did lock it, then screen orientation is not changed anymore.