### PR TITLE
Fix bugs in MeshHelper

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/MeshBuilder.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/MeshBuilder.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             _currentGeometryContent.Indices.Add(pos);
         }
 
-        public int CreateVertexChannel<T>(string usage) where T : struct
+        public int CreateVertexChannel<T>(string usage)
         {
             if (_finishedMesh)
                 throw new InvalidOperationException("This MeshBuilder can no longer be used because FinishMesh has been called.");

--- a/Test/ContentPipeline/MeshHelperTest.cs
+++ b/Test/ContentPipeline/MeshHelperTest.cs
@@ -18,6 +18,15 @@ namespace MonoGame.Tests.ContentPipeline
             VertexColorEnabled = true,
         };
 
+        private readonly BasicMaterialContent material2 = new BasicMaterialContent
+        {
+            Name = "Material2",
+            Alpha = 0.5f,
+            DiffuseColor = Color.Blue.ToVector3(),
+            VertexColorEnabled = true,
+        };
+
+
         [Test]
         public void TestMergePositions()
         {
@@ -41,6 +50,56 @@ namespace MonoGame.Tests.ContentPipeline
             Assert.AreEqual(3, geom.Vertices.Positions.Count);
             Assert.AreEqual(3, geom.Vertices.PositionIndices.Count);
             Assert.AreEqual(0, geom.Vertices.PositionIndices[0]);
+            Assert.AreEqual(1, geom.Vertices.PositionIndices[1]);
+            Assert.AreEqual(0, geom.Vertices.PositionIndices[2]);
+        }
+
+        [Test]
+        public void TestMergePositionsMultipleGeometries()
+        {
+             var mb = MeshBuilder.StartMesh("Test");
+
+            mb.CreatePosition(new Vector3(0f, 0f, 0f));
+            mb.CreatePosition(new Vector3(1f, 1f, 1f));
+            mb.CreatePosition(new Vector3(2f, 2f, 2f));
+            mb.CreatePosition(new Vector3(0f, 0f, 0f));
+            mb.CreatePosition(new Vector3(1f, 1f, 1f));
+            mb.CreatePosition(new Vector3(2f, 2f, 2f));
+
+            mb.SetMaterial(material1);
+
+            mb.AddTriangleVertex(2);
+            mb.AddTriangleVertex(1);
+            mb.AddTriangleVertex(0);
+            mb.AddTriangleVertex(5);
+            mb.AddTriangleVertex(4);
+            mb.AddTriangleVertex(3);
+
+            mb.SetMaterial(material2);
+            mb.AddTriangleVertex(5);
+            mb.AddTriangleVertex(4);
+            mb.AddTriangleVertex(3);
+
+            var mesh = mb.FinishMesh();
+            Assert.AreEqual(6, mesh.Positions.Count);
+
+            MeshHelper.MergeDuplicatePositions(mesh, 1f);
+            Assert.AreEqual(3, mesh.Positions.Count);
+
+            var geom = mesh.Geometry[0];
+            Assert.AreEqual(6, geom.Vertices.Positions.Count);
+            Assert.AreEqual(6, geom.Vertices.PositionIndices.Count);
+            Assert.AreEqual(2, geom.Vertices.PositionIndices[0]);
+            Assert.AreEqual(1, geom.Vertices.PositionIndices[1]);
+            Assert.AreEqual(0, geom.Vertices.PositionIndices[2]);
+            Assert.AreEqual(2, geom.Vertices.PositionIndices[0]);
+            Assert.AreEqual(1, geom.Vertices.PositionIndices[1]);
+            Assert.AreEqual(0, geom.Vertices.PositionIndices[2]);
+
+            geom = mesh.Geometry[1];
+            Assert.AreEqual(3, geom.Vertices.Positions.Count);
+            Assert.AreEqual(3, geom.Vertices.PositionIndices.Count);
+            Assert.AreEqual(2, geom.Vertices.PositionIndices[0]);
             Assert.AreEqual(1, geom.Vertices.PositionIndices[1]);
             Assert.AreEqual(0, geom.Vertices.PositionIndices[2]);
         }


### PR DESCRIPTION
I made some mistakes when implementing this stuff in #5408. There was also a bug in CalculateNormals.
And I removed a level of indirection that was not needed in IndexUpdateList which makes it way easier to understand.

I hope it's all working with this, this is hard to write tests for. Well, more arduous than hard because there are so many options and it's a lot of work to create a mesh manually. Would be nice if we could test with a model that we know has some duplicate stuff in it and compare results against XNA.