### PR TITLE
Prevent crash when multisampling is not supported in DirectX

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -710,9 +710,13 @@ namespace Microsoft.Xna.Framework.Graphics
             if (PresentationParameters.MultiSampleCount > 1)
             {
                 var quality = GetMultiSamplingQuality(format, PresentationParameters.MultiSampleCount);
-                
-                multisampleDesc.Count = PresentationParameters.MultiSampleCount;
-                multisampleDesc.Quality = quality;
+
+                // Zero is returned if the adapter does not support multisampling
+                if (quality > 0)
+                {
+                    multisampleDesc.Count = PresentationParameters.MultiSampleCount;
+                    multisampleDesc.Quality = quality;
+                }
             }
 
             // If the swap chain already exists... update it.


### PR DESCRIPTION
If the GPU/driver does not support multisampling for a back buffer format, the quality returned is 0, which became -1.  Passing this value to create the D3D11Device causes it to fail with a SharpDX exception.

Don't know how to add a unit test for this since it appears to be hardware/driver dependent.