### PR TITLE
Reverted PR #2481, double pitch.

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -8,8 +8,6 @@ using System.IO;
 #if MONOMAC && PLATFORM_MACOS_LEGACY
 using MonoMac.AudioToolbox;
 using MonoMac.AudioUnit;
-using MonoMac.AVFoundation;
-using MonoMac.Foundation;
 using MonoMac.OpenAL;
 #elif OPENAL
 #if GLES || MONOMAC
@@ -20,8 +18,6 @@ using OpenAL;
 #if IOS || MONOMAC
 using AudioToolbox;
 using AudioUnit;
-using AVFoundation;
-using Foundation;
 #endif
 #endif
 
@@ -81,27 +77,9 @@ namespace Microsoft.Xna.Framework.Audio
                 int channelsPerFrame = asbd.ChannelsPerFrame;
                 int bitsPerChannel = asbd.BitsPerChannel;
 
-                // There is a random chance that properties asbd.ChannelsPerFrame and asbd.BitsPerChannel are invalid because of a bug in Xamarin.iOS
-                // See: https://bugzilla.xamarin.com/show_bug.cgi?id=11074 (Failed to get buffer attributes error when playing sounds)
-                if (channelsPerFrame <= 0 || bitsPerChannel <= 0)
-                {
-                    NSError err;
-                    using (NSData nsData = NSData.FromArray(audiodata))
-                    using (AVAudioPlayer player = AVAudioPlayer.FromData(nsData, out err))
-                    {
-                        channelsPerFrame = (int)player.NumberOfChannels;
-                        bitsPerChannel = player.SoundSetting.LinearPcmBitDepth.GetValueOrDefault(16);
-
-						Rate = (float)player.SoundSetting.SampleRate;
-                        duration = TimeSpan.FromSeconds(player.Duration);
-                    }
-                }
-                else
-                {
-                    Rate = (float)asbd.SampleRate;
-                    double durationSec = (Size / ((bitsPerChannel / 8) * channelsPerFrame)) / asbd.SampleRate;
-                    duration = TimeSpan.FromSeconds(durationSec);
-                }
+                Rate = (float)asbd.SampleRate;
+                double durationSec = (Size / ((bitsPerChannel / 8) * channelsPerFrame)) / asbd.SampleRate;
+                duration = TimeSpan.FromSeconds(durationSec);
 
                 if (channelsPerFrame == 1)
                     Format = (bitsPerChannel == 8) ? ALFormat.Mono8 : ALFormat.Mono16;


### PR DESCRIPTION
PR #2481 was a workaround for Xamarin.iOS bug, [Failed to get buffer attributes error when playing sounds](https://bugzilla.xamarin.com/show_bug.cgi?id=11074).
The bug was marked as resolved at 2017-01-30 19:54 UTC.
I tested this on iPad and could not reproduce the bug anymore.
I believe that PR #2481 can be reverted now.