### PR TITLE
Bump Pipeline tool on MacOS to use v4.6.1.

### DIFF
--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -28,6 +28,9 @@
       <Platform Name="MacOS">TRACE;MONOMAC;GTK2</Platform>
       <Platform Name="Linux">TRACE;LINUX;GTK3</Platform>
     </CustomDefinitions>
+    <FrameworkVersions>
+      <Platform Name="MacOS"><Version>v4.6.1</Version></Platform>
+    </FrameworkVersions>
   </Properties>
 
   <Files>

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -31,6 +31,7 @@
     <FrameworkVersions>
       <Platform Name="MacOS"><Version>v4.6.1</Version></Platform>
     </FrameworkVersions>
+    <IncludeMonoRuntimeOnMac>True</IncludeMonoRuntimeOnMac>
   </Properties>
 
   <Files>

--- a/Installers/MacOS/Scripts/Pipeline/postinstall
+++ b/Installers/MacOS/Scripts/Pipeline/postinstall
@@ -37,6 +37,9 @@ if [ -d '/Applications/Xamarin Studio.app' ]
 then
   /Applications/Xamarin\ Studio.app/Contents/MacOS/mdtool setup uninstall MonoDevelop.MonoGame -y
 fi
+if [ -! d '/Library/Frameworks/Mono.framework/Versions/4.6.2' ]
+	ln -s /Library/Frameworks/Mono.framework/Versions/Current /Library/Frameworks/Mono.framework/Versions/4.6.2
+fi
 sudo rm /usr/local/bin/mgcb
 sudo rm /usr/local/bin/monogame-uninstall
 " >> /usr/local/bin/monogame-uninstall

--- a/Installers/MacOS/Scripts/Pipeline/postinstall
+++ b/Installers/MacOS/Scripts/Pipeline/postinstall
@@ -37,7 +37,7 @@ if [ -d '/Applications/Xamarin Studio.app' ]
 then
   /Applications/Xamarin\ Studio.app/Contents/MacOS/mdtool setup uninstall MonoDevelop.MonoGame -y
 fi
-if [ -! d '/Library/Frameworks/Mono.framework/Versions/4.6.2' ]
+if [ ! -d '/Library/Frameworks/Mono.framework/Versions/4.6.2' ]
 	ln -s /Library/Frameworks/Mono.framework/Versions/Current /Library/Frameworks/Mono.framework/Versions/4.6.2
 fi
 sudo rm /usr/local/bin/mgcb

--- a/Installers/default.build
+++ b/Installers/default.build
@@ -54,7 +54,8 @@
       <copy todir="../Tools/Pipeline/bin/MacOS/AnyCPU/Release/Pipeline.app/Contents/MonoBundle">
          <fileset basedir="../Tools/Pipeline/bin/MacOS/AnyCPU/Release">
              <include name="ff*"/>
-         </fileset>
+             <include name="*.dylib"/> 
+        </fileset>
       </copy>
       <!-- Correct the id of the dylibs -->
       <foreach item="File" property="dylibname">

--- a/Installers/default.build
+++ b/Installers/default.build
@@ -56,6 +56,18 @@
              <include name="ff*"/>
          </fileset>
       </copy>
+      <!-- Correct the id of the dylibs -->
+      <foreach item="File" property="dylibname">
+          <in>
+             <items basedir="../Tools/Pipeline/bin/MacOS/AnyCPU/Release/Pipeline.app/Contents/MonoBundle/">
+             <include name="*.dylib" />
+             </items>
+          </in>
+          <do>
+             <echo message="${path::get-file-name(dylibname)}" />
+             <exec program="install_name_tool" workingdir="../Tools/Pipeline/bin/MacOS/AnyCPU/Release/Pipeline.app/Contents/MonoBundle" commandline=' -id "${path::get-file-name(dylibname)}" ${path::get-file-name(dylibname)}' />
+          </do>
+      </foreach>
       <exec program="pkgbuild" workingdir="../Tools/Pipeline/bin/MacOS/AnyCPU/Release" commandline=" --component ./Pipeline.app --identifier com.monogame.pipeline --version ${buildNumber} --scripts ${project::get-base-directory()}/MacOS/Scripts/Pipeline --install-location /Applications ${project::get-base-directory()}/Pipeline.MacOS.pkg" />
       <exec program="pkgbuild" workingdir="." commandline=" --root ./root --identifier com.monogame.xsaddin --version ${buildNumber} --scripts ${project::get-base-directory()}/MacOS/Scripts/Addin ${project::get-base-directory()}/MonoGame.XamarinStudio.Addin.pkg" />
       <!-- Build Framework .pkg -->

--- a/Installers/default.build
+++ b/Installers/default.build
@@ -65,7 +65,7 @@
           </in>
           <do>
              <echo message="${path::get-file-name(dylibname)}" />
-             <exec program="install_name_tool" workingdir="../Tools/Pipeline/bin/MacOS/AnyCPU/Release/Pipeline.app/Contents/MonoBundle" commandline=' -id "${path::get-file-name(dylibname)}" ${path::get-file-name(dylibname)}' />
+             <exec program="install_name_tool" workingdir="../Tools/Pipeline/bin/MacOS/AnyCPU/Release/Pipeline.app/Contents/MonoBundle" commandline=' -id "@executable_path/../MonoBundle/${path::get-file-name(dylibname)}" ${path::get-file-name(dylibname)}' />
           </do>
       </foreach>
       <exec program="pkgbuild" workingdir="../Tools/Pipeline/bin/MacOS/AnyCPU/Release" commandline=" --component ./Pipeline.app --identifier com.monogame.pipeline --version ${buildNumber} --scripts ${project::get-base-directory()}/MacOS/Scripts/Pipeline --install-location /Applications ${project::get-base-directory()}/Pipeline.MacOS.pkg" />


### PR DESCRIPTION
This Pr fixes a few issues. Firstly we bump Mac Pipeline tool to target v4.6.1 of mono. This is so that we don't get any build errors about System.Runtime. 
Secondly we include some missing files for the MGCB which we package with the Tool. namely the native libraries such as libnvtt.dylib. 
Finally we create a symlink from the Current mono to 4.6.2. Currently the build bot is on stable (4.6.2) and there is a hard dependency somewhere (i've not found it yet) on that mono. So the easiest solution for now is the use a symlink. 
Once we upgrade the build bot to 4.8.0 (when it goes stable) we will need to revisit this.