### PR TITLE
SpriteBatch optimisation: Only calculate projection matrix when viewport changes

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Xna.Framework.Graphics
         readonly EffectPass _spritePass;
 
 		Matrix? _matrix;
+	    private Viewport _lastViewport;
+	    private Matrix _projection;
 		Rectangle _tempRect = new Rectangle (0,0,0,0);
 		Vector2 _texCoordTL = new Vector2 (0,0);
 		Vector2 _texCoordBR = new Vector2 (0,0);
@@ -126,30 +128,36 @@ namespace Microsoft.Xna.Framework.Graphics
 			gd.RasterizerState = _rasterizerState;
 			gd.SamplerStates[0] = _samplerState;
 			
-            // Setup the default sprite effect.
 			var vp = gd.Viewport;
-
-		    Matrix projection;
-
-            // Normal 3D cameras look into the -z direction (z = 1 is in font of z = 0). The
-            // sprite batch layer depth is the opposite (z = 0 is in front of z = 1).
-            // --> We get the correct matrix with near plane 0 and far plane -1.
-            Matrix.CreateOrthographicOffCenter(0, vp.Width, vp.Height, 0, 0, -1, out projection);
-
-            // Some platforms require a half pixel offset to match DX.
-            if (NeedsHalfPixelOffset)
+            if ((vp.Width != _lastViewport.Width) || (vp.Height != _lastViewport.Height))
             {
-                projection.M41 += -0.5f * projection.M11;
-                projection.M42 += -0.5f * projection.M22;
+                // Normal 3D cameras look into the -z direction (z = 1 is in font of z = 0). The
+                // sprite batch layer depth is the opposite (z = 0 is in front of z = 1).
+                // --> We get the correct matrix with near plane 0 and far plane -1.
+                Matrix.CreateOrthographicOffCenter(0, vp.Width, vp.Height, 0, 0, -1, out _projection);
+
+                // Some platforms require a half pixel offset to match DX.
+                if (NeedsHalfPixelOffset)
+                {
+                    _projection.M41 += -0.5f * _projection.M11;
+                    _projection.M42 += -0.5f * _projection.M22;
+                }
+
+                _lastViewport = vp;
             }
 
             if (_matrix.HasValue)
             {
                 var transformMatrix = _matrix.GetValueOrDefault();
-                Matrix.Multiply(ref transformMatrix, ref projection, out projection);
+                Matrix projection;
+                Matrix.Multiply(ref transformMatrix, ref _projection, out projection);
+                _matrixTransform.SetValue(projection);
+            }
+            else
+            {
+                _matrixTransform.SetValue(_projection);
             }
 
-            _matrixTransform.SetValue(projection);
             _spritePass.Apply();
 		}
 		

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -147,16 +147,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
             if (_matrix.HasValue)
-            {
-                var transformMatrix = _matrix.GetValueOrDefault();
-                Matrix projection;
-                Matrix.Multiply(ref transformMatrix, ref _projection, out projection);
-                _matrixTransform.SetValue(projection);
-            }
+                _matrixTransform.SetValue(_matrix.GetValueOrDefault() * _projection);
             else
-            {
                 _matrixTransform.SetValue(_projection);
-            }
 
             _spritePass.Apply();
 		}


### PR DESCRIPTION
I was inspired by PR #5456 by @nkast and came up with another related optimisation :)

This PR only re-calculates the projection matrix when the viewport changes. Given that the viewport will normally rarely change, this results in a not bad performance boost (takes about 16% less time). It's not quite as good a boost as PR #5456, but decent nonetheless :)

Benchmarks (using BenchmarkDotNet):
```c#
spriteBatch.Begin();
spriteBatch.End();
```
Benchmark | Median time | Scale<br>(Original baseline) | Scale<br>(PR #5456 baseline)
:--- | ---:|:---:|:---:
Original code (before PR #5456) | 383.2844 ns | 1.00 | 1.28
After PR #5456 | 299.4846 ns | 0.78 | 1.00
This PR | 253.0242 ns | 0.66 | **0.84**