### PR TITLE
Add support for /define:foo=bar

### DIFF
--- a/Tools/MGCB/CommandLineParser.cs
+++ b/Tools/MGCB/CommandLineParser.cs
@@ -281,6 +281,18 @@ namespace MGCB
                     continue;
                 }
 
+                if (arg.StartsWith("/define:") || arg.StartsWith("-define:"))
+                {
+                    var words = arg.Substring(8).Split('=');
+                    var name = words[0];
+                    var value = words[1];
+
+                    _properties[name] = value;
+
+                    continue;
+
+                }
+
                 if (arg.StartsWith("/@:") || arg.StartsWith("-@:"))
                 {
                     var file = arg.Substring(3);


### PR DESCRIPTION
The documentation has an example of this and oddly the code
was in implemented. So I figured we should probably support it :)