### PR TITLE
Fix initialization of SwapChain in UWP projects

### DIFF
--- a/MonoGame.Framework/GraphicsDeviceManager.WinRT.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.WinRT.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Xna.Framework
         public SwapChainPanel SwapChainPanel { get; set; }
 #endif
 
-        partial void PlatformInitialize(PresentationParameters presentationParameters)
+        partial void PlatformPreparePresentationParameters(PresentationParameters presentationParameters)
         {
 #if WINDOWS_UAP
 

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -273,6 +273,8 @@ namespace Microsoft.Xna.Framework
 
         partial void PlatformApplyChanges();
 
+        partial void PlatformPreparePresentationParameters(PresentationParameters presentationParameters);
+
         private void PreparePresentationParameters(PresentationParameters presentationParameters)
         {
             presentationParameters.BackBufferFormat = _preferredBackBufferFormat;
@@ -297,6 +299,8 @@ namespace Microsoft.Xna.Framework
             {
                 presentationParameters.MultiSampleCount = 0;
             }
+
+            PlatformPreparePresentationParameters(presentationParameters);
         }
 
         private void PrepareGraphicsDeviceInformation(GraphicsDeviceInformation gdi)


### PR DESCRIPTION
The swapchain from the XAML was being discarded by being set too early in PlatformInitialize. Added PlatformPreparePresentationParameters to allow the swapchain to be set and retained during device creation.

Fixes #5462