### PR TITLE
Fixed UWP resize

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
@@ -77,6 +77,9 @@ namespace Microsoft.Xna.Framework.Graphics
         {
         }
 
+        string _description = string.Empty;
+        public string Description { get { return _description; } private set { _description = value; } }
+
         public DisplayMode CurrentDisplayMode
         {
             get

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -555,6 +555,14 @@ namespace Microsoft.Xna.Framework.Graphics
             _d2dContext.TextAntialiasMode = SharpDX.Direct2D1.TextAntialiasMode.Grayscale;
         }
 
+        internal void OnPresentationChanged()
+        {
+            CreateSizeDependentResources();
+            ApplyRenderTargets(null);
+        }
+
+#endif
+
         partial void PlatformValidatePresentationParameters(PresentationParameters presentationParameters)
         {
 #if WINDOWS_UAP
@@ -568,14 +576,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("PresentationParameters.DeviceWindowHandle must not be null.");
 #endif
         }
-
-        internal void OnPresentationChanged()
-        {
-            CreateSizeDependentResources();
-            ApplyRenderTargets(null);
-        }
-
-#endif
 
 #if WINDOWS_STOREAPP || WINDOWS_UAP || WINDOWS_PHONE
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -555,6 +555,20 @@ namespace Microsoft.Xna.Framework.Graphics
             _d2dContext.TextAntialiasMode = SharpDX.Direct2D1.TextAntialiasMode.Grayscale;
         }
 
+        partial void PlatformValidatePresentationParameters(PresentationParameters presentationParameters)
+        {
+#if WINDOWS_UAP
+            if (presentationParameters.SwapChainPanel == null)
+                throw new ArgumentException("PresentationParameters.SwapChainPanel must not be null.");
+#elif WINDOWS_STOREAPP
+            if (presentationParameters.DeviceWindowHandle == IntPtr.Zero && presentationParameters.SwapChainBackgroundPanel == null)
+                throw new ArgumentException("PresentationParameters.DeviceWindowHandle or PresentationParameters.SwapChainBackgroundPanel must be not null.");
+#else
+            if (presentationParameters.DeviceWindowHandle == IntPtr.Zero)
+                throw new ArgumentException("PresentationParameters.DeviceWindowHandle must not be null.");
+#endif
+        }
+
         internal void OnPresentationChanged()
         {
             CreateSizeDependentResources();

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -1085,5 +1085,10 @@ namespace Microsoft.Xna.Framework.Graphics
             presentationParameters.MultiSampleCount = 4;
             quality = 0;
         }
+
+        internal void OnPresentationChanged()
+        {
+            ApplyRenderTargets(null);
+        }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -555,8 +555,12 @@ namespace Microsoft.Xna.Framework.Graphics
         }
         */
 
+        partial void PlatformValidatePresentationParameters(PresentationParameters presentationParameters);
+
         public void Reset()
         {
+            PlatformValidatePresentationParameters(PresentationParameters);
+
             if (DeviceResetting != null)
                 DeviceResetting(this, EventArgs.Empty);
 
@@ -567,14 +571,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 DeviceReset(this, EventArgs.Empty);
         }
 
-        partial void PlatformValidatePresentationParameters(PresentationParameters presentationParameters);
-
         public void Reset(PresentationParameters presentationParameters)
         {
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
-
-            PlatformValidatePresentationParameters(presentationParameters);
 
             PresentationParameters = presentationParameters;
             Reset();

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -201,13 +201,8 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (adapter == null)
                 throw new ArgumentNullException("adapter");
-#if DIRECTX
             if (!adapter.IsProfileSupported(graphicsProfile))
                 throw new NoSuitableGraphicsDeviceException(String.Format("Adapter '{0}' does not support the {1} profile.", adapter.Description, graphicsProfile));
-#else
-            if (!adapter.IsProfileSupported(graphicsProfile))
-                throw new NoSuitableGraphicsDeviceException(String.Format("Adapter does not support the {1} profile.", graphicsProfile));
-#endif
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
             Adapter = adapter;
@@ -560,7 +555,6 @@ namespace Microsoft.Xna.Framework.Graphics
         }
         */
 
-#if WINDOWS && DIRECTX
         public void Reset()
         {
             if (DeviceResetting != null)
@@ -573,35 +567,18 @@ namespace Microsoft.Xna.Framework.Graphics
                 DeviceReset(this, EventArgs.Empty);
         }
 
+        partial void PlatformValidatePresentationParameters(PresentationParameters presentationParameters);
+
         public void Reset(PresentationParameters presentationParameters)
         {
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
-            if (presentationParameters.DeviceWindowHandle == IntPtr.Zero)
-                throw new ArgumentException("PresentationParameters.DeviceWindowHandle must not be null.");
+
+            PlatformValidatePresentationParameters(presentationParameters);
 
             PresentationParameters = presentationParameters;
             Reset();
         }
-#else
-        // TODO: implement these
-        public void Reset()
-        {
-            
-        }
-
-        public void Reset(PresentationParameters presentationParameters)
-        {
-
-        }
-#endif
-
-        /*
-        public void Reset(PresentationParameters presentationParameters, GraphicsAdapter graphicsAdapter)
-        {
-            throw new NotImplementedException();
-        }
-        */
 
         /// <summary>
         /// Trigger the DeviceResetting event

--- a/MonoGame.Framework/WindowsUniversal/XamlGame.cs
+++ b/MonoGame.Framework/WindowsUniversal/XamlGame.cs
@@ -23,7 +23,7 @@ namespace MonoGame.Framework
         /// </summary>
         /// <param name="launchParameters">The command line arguments from launch.</param>
         /// <param name="window">The core window object.</param>
-        /// <param name="swapChainBackgroundPanel">The XAML SwapChainBackgroundPanel to which we render the scene and recieve input events.</param>
+        /// <param name="swapChainPanel">The XAML SwapChainPanel to which we render the scene and receive input events.</param>
         /// <returns></returns>
         static public T Create(string launchParameters, CoreWindow window, SwapChainPanel swapChainPanel)
         {


### PR DESCRIPTION
* GraphicsDevice.Resize was implemented for Windows DirectX only, not UWP or Store Apps.
* Added GraphicsDevice.PlatformValidatePresentationParameters().
* Now one common implementation of GraphicsDevice.Resize. On OpenGL it does nothing but reset render targets.
* Added an empty implementation for GraphicsAdapter.Description in GraphicsAdapter.Legacy.cs.
* GraphicsDevice.cs now has no conditionals for platform-specific code.
* Fixed a XMLDoc warning in XamlGame.cs.

Fixes #5462