### PR TITLE
ModelTest added to definition file and XNA tests project.

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -175,6 +175,7 @@
     <Compile Include="Framework\Graphics\SpriteBatchTest.cs" />
     <Compile Include="Framework\Graphics\SpriteFontTest.cs" />
     <Compile Include="Framework\Graphics\ViewportTest.cs" />
+    <Compile Include="Framework\Graphics\ModelTest.cs" />
     <Compile Include="Framework\Graphics\OcclusionQueryTest.cs" />
     <Compile Include="Framework\Visual\VisualTestFixtureBase.cs" />
     <Compile Include="Framework\Visual\VisualTestGame.cs" />

--- a/Test/Framework/Graphics/ModelTest.cs
+++ b/Test/Framework/Graphics/ModelTest.cs
@@ -11,6 +11,10 @@ using System.Linq;
 
 namespace MonoGame.Tests.Graphics
 {
+
+#if !XNA // Disabled because XNA doesn't support manual Model creation
+
+
     [TestFixture]
     internal sealed class ModelTest : GraphicsDeviceTestFixtureBase
     {
@@ -71,4 +75,5 @@ namespace MonoGame.Tests.Graphics
             Assert.Throws<ArgumentOutOfRangeException>(() => model.CopyBoneTransformsTo(new Matrix[0]));
         }
     }
+#endif
 }

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Framework\Graphics\GraphicsDeviceTest.cs" />
     <Compile Include="Framework\Graphics\GraphicsDeviceTestFixtureBase.cs" />
     <Compile Include="Framework\Graphics\MiscellaneousTests.cs" />
+    <Compile Include="Framework\Graphics\ModelTest.cs" />
     <Compile Include="Framework\Graphics\OcclusionQueryTest.cs" />
     <Compile Include="Framework\Graphics\RasterizerStateTest.cs" />
     <Compile Include="Framework\Graphics\RenderTarget2DTest.cs" />
@@ -844,6 +845,9 @@
     <None Include="Assets\Textures\SampleCube64DXT1Mips.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -846,9 +846,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Is good to have new tests in main MG project, but is expected to have them in definition file and XNA project file.

Related to #4699 