### PR TITLE
[DesktopGL] General Fixes

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -539,6 +539,9 @@
     <Compile Include="GraphicsDeviceManager.cs">
 		<Platforms>Windows,WindowsGL,Linux,Windows8,WindowsPhone81,WindowsUniversal,Web</Platforms>
     </Compile>
+    <Compile Include="GraphicsDeviceManager.SDL.cs">
+      <Platforms>WindowsGL,Linux</Platforms>
+    </Compile>
     <Compile Include="GraphicsDeviceManager.WinRT.cs">
 		<Platforms>Windows8,WindowsPhone81,WindowsUniversal</Platforms>
     </Compile>

--- a/MonoGame.Framework/GraphicsDeviceManager.SDL.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.SDL.cs
@@ -1,0 +1,49 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Microsoft.Xna.Framework
+{
+    public partial class GraphicsDeviceManager
+    {
+        partial void PlatformInitialize(PresentationParameters presentationParameters)
+        {
+            var surfaceFormat = _game.graphicsDeviceManager.PreferredBackBufferFormat.GetColorFormat();
+            var depthStencilFormat = _game.graphicsDeviceManager.PreferredDepthStencilFormat;
+
+            // TODO Need to get this data from the Presentation Parameters
+            Sdl.GL.SetAttribute(Sdl.GL.Attribute.RedSize, surfaceFormat.R);
+            Sdl.GL.SetAttribute(Sdl.GL.Attribute.GreenSize, surfaceFormat.G);
+            Sdl.GL.SetAttribute(Sdl.GL.Attribute.BlueSize, surfaceFormat.B);
+            Sdl.GL.SetAttribute(Sdl.GL.Attribute.AlphaSize, surfaceFormat.A);
+
+            switch (depthStencilFormat)
+            {
+                case DepthFormat.None:
+                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.DepthSize, 0);
+                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.StencilSize, 0);
+                    break;
+                case DepthFormat.Depth16:
+                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.DepthSize, 16);
+                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.StencilSize, 0);
+                    break;
+                case DepthFormat.Depth24:
+                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.DepthSize, 24);
+                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.StencilSize, 0);
+                    break;
+                case DepthFormat.Depth24Stencil8:
+                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.DepthSize, 24);
+                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.StencilSize, 8);
+                    break;
+            }
+
+            Sdl.GL.SetAttribute(Sdl.GL.Attribute.DoubleBuffer, 1);
+            Sdl.GL.SetAttribute(Sdl.GL.Attribute.ContextMajorVersion, 2);
+            Sdl.GL.SetAttribute(Sdl.GL.Attribute.ContextMinorVersion, 1);
+
+            ((SdlGameWindow)SdlGameWindow.Instance).CreateWindow();
+        }
+    }
+}

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -163,6 +163,8 @@ namespace Microsoft.Xna.Framework
                         IsActive = true;
                     else if (ev.Window.EventID == Sdl.Window.EventId.FocusLost)
                         IsActive = false;
+                    else if (ev.Window.EventID == Sdl.Window.EventId.Moved)
+                        _view.Moved();
                 }
             }
         }

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -79,7 +79,6 @@ namespace Microsoft.Xna.Framework
 
         public override void BeforeInitialize ()
         {
-            _view.InitGraphics();
             SdlRunLoop();
 
             base.BeforeInitialize ();

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -47,7 +47,11 @@ namespace Microsoft.Xna.Framework
 
                 return new Point(x, y);
             }
-            set { Sdl.Window.SetPosition(Handle, value.X, value.Y); }
+            set
+            {
+                Sdl.Window.SetPosition(Handle, value.X, value.Y);
+                _wasMoved = true;
+            }
         }
 
         public override DisplayOrientation CurrentOrientation
@@ -84,6 +88,7 @@ namespace Microsoft.Xna.Framework
         private bool _resizable, _borderless, _willBeFullScreen, _mouseVisible, _hardwareSwitch;
         private string _screenDeviceName;
         private int _winx, _winy, _width, _height;
+        private bool _wasMoved, _supressMoved;
 
         public SdlGameWindow(Game game)
         {
@@ -263,11 +268,24 @@ namespace Microsoft.Xna.Framework
             // after the window gets resized, window position information
             // becomes wrong (for me it always returned 10 8). Solution is
             // to not try and set the window position because it will be wrong.
-            if (Sdl.Patch > 4 || !AllowUserResizing)
+            if ((Sdl.Patch > 4 || !AllowUserResizing) && !_wasMoved)
                 Sdl.Window.SetPosition(Handle, centerX, centerY);
 
             IsFullScreen = _willBeFullScreen;
             OnClientSizeChanged();
+
+            _supressMoved = true;
+        }
+
+        internal void Moved()
+        {
+            if (_supressMoved)
+            {
+                _supressMoved = false;
+                return;
+            }
+
+            _wasMoved = true;
         }
 
         public void ClientResize(int width, int height)


### PR DESCRIPTION
Stuff done:
 - Window will no longer get centered after it was moved, this mimics XNA behavior (DesktopGL version of #5467)
 - GL attributes are set before window is created (A proper CreateWindow function when compared to #5445, also I made sure to make it so it can be reused for RecreateWindow with minimal changes later on)