### PR TITLE
Added support for PngWriter to export textures with single surface fo…

### DIFF
--- a/MonoGame.Framework/Utilities/Png/PngWriter.cs
+++ b/MonoGame.Framework/Utilities/Png/PngWriter.cs
@@ -214,10 +214,12 @@ namespace MonoGame.Utilities.Png
                 case SurfaceFormat.Single:
                     var floatData = new float[colorDataLength];
                     texture2D.GetData<float>(floatData);
-                    
-                    for (int i = 0; i < colorDataLength; i++) {
+
+                    for (int i = 0; i < colorDataLength; i++)
+                    {
+                        float brightness = floatData[i];
                         // Export as a greyscale image.
-                        colorData[i] = new Color(floatData[i], floatData[i], floatData[i]);
+                        colorData[i] = new Color(brightness, brightness, brightness);
                     }
                     break;
 

--- a/MonoGame.Framework/Utilities/Png/PngWriter.cs
+++ b/MonoGame.Framework/Utilities/Png/PngWriter.cs
@@ -211,6 +211,16 @@ namespace MonoGame.Utilities.Png
 
             switch (texture2D.Format)
             {
+                case SurfaceFormat.Single:
+                    var floatData = new float[colorDataLength];
+                    texture2D.GetData<float>(floatData);
+                    
+                    for (int i = 0; i < colorDataLength; i++) {
+                        // Export as a greyscale image.
+                        colorData[i] = new Color(floatData[i], floatData[i], floatData[i]);
+                    }
+                    break;
+
                 case SurfaceFormat.Color:
                     texture2D.GetData<Color>(colorData);
                     break;


### PR DESCRIPTION
…rmat using greyscale.

Adds the basic ability to export single channel textures into png format. Extremely useful for generating height maps to be reused later on.