### PR TITLE
Fixed XML deserialization of Curve type

### DIFF
--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -376,7 +376,7 @@
     <Compile Include="Serialization\Intermediate\ContentTypeSerializer.cs" />
     <Compile Include="Serialization\Intermediate\ContentTypeSerializerAttribute.cs" />
     <Compile Include="Serialization\Intermediate\ContentTypeSerializerT.cs" />
-	<Compile Include="Serialization\Intermediate\CurveKeyCollectionSerializer.cs" />
+    <Compile Include="Serialization\Intermediate\CurveKeyCollectionSerializer.cs" />
     <Compile Include="Serialization\Intermediate\DictionarySerializer.cs" />    
     <Compile Include="Serialization\Intermediate\DoubleSerializer.cs" />    
     <Compile Include="Serialization\Intermediate\ElementSerializerT.cs" />    

--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -376,6 +376,7 @@
     <Compile Include="Serialization\Intermediate\ContentTypeSerializer.cs" />
     <Compile Include="Serialization\Intermediate\ContentTypeSerializerAttribute.cs" />
     <Compile Include="Serialization\Intermediate\ContentTypeSerializerT.cs" />
+	<Compile Include="Serialization\Intermediate\CurveKeyCollectionSerializer.cs" />
     <Compile Include="Serialization\Intermediate\DictionarySerializer.cs" />    
     <Compile Include="Serialization\Intermediate\DoubleSerializer.cs" />    
     <Compile Include="Serialization\Intermediate\ElementSerializerT.cs" />    
@@ -394,6 +395,7 @@
     <Compile Include="Serialization\Intermediate\NamespaceAliasHelper.cs" />
     <Compile Include="Serialization\Intermediate\NonGenericIListSerializer.cs" />
     <Compile Include="Serialization\Intermediate\NullableSerializer.cs" />
+	<Compile Include="Serialization\Intermediate\PackedElementsHelper.cs" />
     <Compile Include="Serialization\Intermediate\PlaneSerializer.cs" />
     <Compile Include="Serialization\Intermediate\PointSerializer.cs" />
     <Compile Include="Serialization\Intermediate\QuaternionSerializer.cs" />

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -920,6 +920,9 @@
     <Content Include="Assets\Xml\27_Colors.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+	<Content Include="Assets\Xml\28_XnaCurve.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
 
     <Content Include="Assets\Fonts\Default.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/CurveKeyCollectionSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/CurveKeyCollectionSerializer.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
+{
+    [ContentTypeSerializer]
+    class CurveKeyCollectionSerializer : ContentTypeSerializer<CurveKeyCollection>
+    {
+        public CurveKeyCollectionSerializer() :
+            base("Keys")
+        { }
+
+        public override bool CanDeserializeIntoExistingObject => true;
+
+        protected internal override CurveKeyCollection Deserialize(
+            IntermediateReader input,
+            ContentSerializerAttribute format,
+            CurveKeyCollection existingInstance)
+        {
+            var result = existingInstance ?? new CurveKeyCollection();
+
+            if (input.Xml.HasValue)
+            {
+                var elements = PackedElementsHelper.ReadElements(input);
+                if (elements.Length > 0)
+                {
+                    // Each CurveKey consists of 5 elements
+                    if (elements.Length % 5 != 0)
+                        throw new InvalidContentException(
+                            "Elements count in CurveKeyCollection is inncorect!");
+                    try
+                    {
+                        // Parse all CurveKeys
+                        for (int i = 0; i < elements.Length; i += 5)
+                        {
+                            // Order: Position, Value, TangentIn, TangentOut and Continuity
+                            var curveKey = new CurveKey
+                                (XmlConvert.ToSingle(elements[i]),
+                                 XmlConvert.ToSingle(elements[i + 1]),
+                                 XmlConvert.ToSingle(elements[i + 2]),
+                                 XmlConvert.ToSingle(elements[i + 3]),
+                                 (CurveContinuity)Enum.Parse(
+                                     typeof(CurveContinuity),
+                                     elements[i + 4],
+                                     true));
+                            result.Add(curveKey);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        throw new InvalidContentException
+                            ("Error parsing CurveKey", e);
+                    }
+                }
+            }
+            return result;
+        }
+
+
+        protected internal override void Serialize(
+            IntermediateWriter output,
+            CurveKeyCollection value,
+            ContentSerializerAttribute format)
+        {
+            var elements = new List<string>();
+            foreach (var curveKey in value)
+            {
+                // Order: Position, Value, TangentIn, TangentOut and Continuity
+                elements.Add(XmlConvert.ToString(curveKey.Position));
+                elements.Add(XmlConvert.ToString(curveKey.Value));
+                elements.Add(XmlConvert.ToString(curveKey.TangentIn));
+                elements.Add(XmlConvert.ToString(curveKey.TangentOut));
+                elements.Add(curveKey.Continuity.ToString());
+            }
+            var str = PackedElementsHelper.JoinElements(elements);
+            output.Xml.WriteString(str);
+        }
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/CurveKeyCollectionSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/CurveKeyCollectionSerializer.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
             base("Keys")
         { }
 
-        public override bool CanDeserializeIntoExistingObject => true;
+        public override bool CanDeserializeIntoExistingObject
+        { get { return true; } }
 
         protected internal override CurveKeyCollection Deserialize(
             IntermediateReader input,

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PackedElementsHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PackedElementsHelper.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
         }
 
         public static string JoinElements(IEnumerable<string> elements)
-            => string.Join(_writeSeperator, elements);
+        {
+            return string.Join(_writeSeperator, elements);
+        }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PackedElementsHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PackedElementsHelper.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
+{
+    internal static class PackedElementsHelper
+    {
+        private static readonly char[] _seperators = { ' ', '\t', '\n' };
+
+        private const string _writeSeperator = " ";
+
+        internal static string[] ReadElements(IntermediateReader input)
+        {
+            if (input.Xml.IsEmptyElement)
+                return new string[0];
+
+            string str = string.Empty;
+            while (input.Xml.NodeType != XmlNodeType.EndElement)
+            {
+                if (input.Xml.NodeType == XmlNodeType.Comment)
+                    input.Xml.Read();
+                else
+                    str += input.Xml.ReadString();
+            }
+
+            // Special case for char ' '
+            if (str.Length > 0 && str.Trim() == string.Empty)
+                return new string[] { str };
+
+            var elements = str.Split(_seperators, StringSplitOptions.RemoveEmptyEntries);
+            if (elements.Length == 1 && string.IsNullOrEmpty(elements[0]))
+                return new string[0];
+
+            return elements;
+        }
+
+        public static string JoinElements(IEnumerable<string> elements)
+            => string.Join(_writeSeperator, elements);
+    }
+}

--- a/MonoGame.Framework/Curve.cs
+++ b/MonoGame.Framework/Curve.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Xna.Framework
     {
         #region Private Fields
 
-        private CurveKeyCollection _keys;
-        private CurveLoopType _postLoop;
         private CurveLoopType _preLoop;
+        private CurveLoopType _postLoop;
+        private CurveKeyCollection _keys;
 
         #endregion
 
@@ -35,12 +35,13 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// The collection of curve keys.
+        /// Defines how to handle weighting values that are less than the first control point in the curve.
         /// </summary>
         [DataMember]
-        public CurveKeyCollection Keys
+        public CurveLoopType PreLoop
         {
-            get { return this._keys; }
+            get { return this._preLoop; }
+            set { this._preLoop = value; }
         }
 
         /// <summary>
@@ -54,13 +55,12 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Defines how to handle weighting values that are less than the first control point in the curve.
+        /// The collection of curve keys.
         /// </summary>
         [DataMember]
-        public CurveLoopType PreLoop
+        public CurveKeyCollection Keys
         {
-            get { return this._preLoop; }
-            set { this._preLoop = value; }
+            get { return this._keys; }
         }
 
         #endregion

--- a/Test/Assets/Xml/28_XnaCurve.xml
+++ b/Test/Assets/Xml/28_XnaCurve.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<XnaContent xmlns:Framework="Microsoft.Xna.Framework">
+  <Asset Type="Framework:Curve">
+    <PreLoop>Constant</PreLoop>
+    <PostLoop>Constant</PostLoop>
+    <Keys>0 1 0 0 Smooth 0.5 0.5 0 0 Smooth</Keys>
+  </Asset>
+</XnaContent>

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -593,5 +593,29 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(colors.Blue, Color.Blue);
             });
         }
+
+        [Test]
+        public void XnaCurve()
+        {
+            // Curve in 28_XnaCurve.xml is formated the same way as by XNA's serializer
+            DeserializeCompileAndLoad<Curve>("28_XnaCurve.xml", curve =>
+            {
+                Assert.AreEqual(CurveLoopType.Constant, curve.PreLoop);
+                Assert.AreEqual(CurveLoopType.Constant, curve.PostLoop);
+                Assert.AreEqual(2, curve.Keys.Count);
+                var key1 = curve.Keys[0];
+                Assert.AreEqual(0, key1.Position);
+                Assert.AreEqual(1, key1.Value);
+                Assert.AreEqual(0, key1.TangentIn);
+                Assert.AreEqual(0, key1.TangentOut);
+                Assert.AreEqual(CurveContinuity.Smooth, key1.Continuity);
+                var key2 = curve.Keys[1];
+                Assert.AreEqual(0.5f, key2.Position);
+                Assert.AreEqual(0.5f, key2.Value);
+                Assert.AreEqual(0, key2.TangentIn);
+                Assert.AreEqual(0, key2.TangentOut);
+                Assert.AreEqual(CurveContinuity.Smooth, key2.Continuity);
+            });
+        }
     }
 }

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -494,5 +494,20 @@ namespace MonoGame.Tests.ContentPipeline
                 Blue = Color.Blue
             });
         }
+
+        [Test]
+        public void XnaCurve()
+        {
+            SerializeAndAssert("28_XnaCurve.xml", new Curve
+            {
+                PreLoop = CurveLoopType.Constant,
+                PostLoop = CurveLoopType.Constant,
+                Keys =
+                {
+                    new CurveKey(0,1,0,0,CurveContinuity.Smooth),
+                    new CurveKey(0.5f,0.5f,0,0,CurveContinuity.Smooth)
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
Fixes issue #5492.

- Changed order of properties inside Curve class so that order in serialization/deserialization matches XNA's
- Added CurveKeyCollectionSerializer that serializes/deserializes CurveKey collection packed like XNA
- Added unit tests