### PR TITLE
Fix typo in the exclude.addins which cause warnings when installing the Addin in XS

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/exclude.addins
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/exclude.addins
@@ -2,22 +2,22 @@
 	<Exclude>Assimp64.dll</Exclude>
 	<Exclude>nvtt.dll</Exclude>
 	<Exclude>freetype6.dll</Exclude>
-	<Exclude>pvrtc.dll</Exlcude>
-	<Exclude>templates/libs/x86/SDL2.dll</Exlcude>
-	<Exclude>templates/libs/x64/SDL2.dll</Exlcude>
+	<Exclude>pvrtc.dll</Exclude>
+	<Exclude>templates/libs/x86/SDL2.dll</Exclude>
+	<Exclude>templates/libs/x64/SDL2.dll</Exclude>
 	<Exclude>templates/libs/x86/soft_oal.dll</Exclude>
 	<Exclude>templates/libs/x64/soft_oal.dll</Exclude>
 	<!--
-	<Exclude>libnvtt.dylib</Exlcude>
-	<Exclude>libnvimage.dylib</Exlcude>
-	<Exclude>libnvmath.dylib</Exlcude>
-	<Exclude>libnvcore.dylib</Exlcude>
-	<Exclude>libpvrtc.dylib</Exlcude>
-	<Exclude>libfreetype.6.dylib</Exlcude>
-	<Exclude>libpng15.15.dylib</Exlcude>
-	<Exclude>libassimp.dylib</Exlcude>
-	<Exclude>libfreeimage.dylib</Exlcude>
-	<Exclude>libfreeimageplus.dylib</Exlcude>
+	<Exclude>libnvtt.dylib</Exclude>
+	<Exclude>libnvimage.dylib</Exclude>
+	<Exclude>libnvmath.dylib</Exclude>
+	<Exclude>libnvcore.dylib</Exclude>
+	<Exclude>libpvrtc.dylib</Exclude>
+	<Exclude>libfreetype.6.dylib</Exclude>
+	<Exclude>libpng15.15.dylib</Exclude>
+	<Exclude>libassimp.dylib</Exclude>
+	<Exclude>libfreeimage.dylib</Exclude>
+	<Exclude>libfreeimageplus.dylib</Exclude>
 	-->
 </Addins>
 


### PR DESCRIPTION
@KonajuGames @tomspilman I found this one today, more on the way.