### PR TITLE
Fix #5498 Pipeline Tool template loading on MacOS

### DIFF
--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -305,39 +305,39 @@
     </EmbeddedResource>
 
     <!-- Copy the template resources to the output -->
-	<None Include="Templates\Effect.png">
+	<Content Include="Templates\Effect.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-	<None Include="Templates\Effect.fx">
+    </Content>
+	<Content Include="Templates\Effect.fx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-	<None Include="Templates\Effect.template">
+    </Content>
+	<Content Include="Templates\Effect.template">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-	<None Include="Templates\SpriteEffect.fx">
+    </Content>
+	<Content Include="Templates\SpriteEffect.fx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-	<None Include="Templates\SpriteEffect.template">
+    </Content>
+	<Content Include="Templates\SpriteEffect.template">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Templates\Xml.png">
+    </Content>
+    <Content Include="Templates\Xml.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Templates\XmlContent.xml">
+    </Content>
+    <Content Include="Templates\XmlContent.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Templates\XmlContent.template">
+    </Content>
+    <Content Include="Templates\XmlContent.template">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Templates\Font.png">
+    </Content>
+    <Content Include="Templates\Font.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Templates\SpriteFont.spritefont">
+    </Content>
+    <Content Include="Templates\SpriteFont.spritefont">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Templates\SpriteFont.template">
+    </Content>
+    <Content Include="Templates\SpriteFont.template">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </Content>
 
     <BundleResource Include="Resources\App.icns">
       <Platforms>MacOS</Platforms>

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -113,7 +113,12 @@ namespace MonoGame.Tools.Pipeline
             _watcher = new FileWatcher(this, view);
 
             _templateItems = new List<ContentItemTemplate>();
-            LoadTemplates(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Templates"));
+            var root = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (Directory.Exists(Path.Combine (root, "..", "Resources", "Templates")))
+            {
+                root = Path.Combine(root, "..", "Resources");
+            }
+            LoadTemplates(Path.Combine(root, "Templates"));
             UpdateMenu();
 
             view.UpdateRecentList(PipelineSettings.Default.ProjectHistory);


### PR DESCRIPTION
This had two problems

1) The templates were not being included in the Mac App because
the Action for the items was not Content but None.

2) The templates ended up in the Resources directory on Mac which
is where they are supposed to be. So we need to update the app
to look in that location too.

@KonajuGames @tomspilman bug number two fixed :)