### PR TITLE
Nuget portable target update

### DIFF
--- a/NuGetPackages/MonoGame.Framework.Content.Pipeline.Portable.nuspec
+++ b/NuGetPackages/MonoGame.Framework.Content.Pipeline.Portable.nuspec
@@ -23,7 +23,7 @@
         </dependencies>
 	</metadata>
     <files>
-        <file src="..\..\MonoGame.Framework.Content.Pipeline\bin\Portable\AnyCPU\MonoGame.Framework.Content.Pipeline.dll" target="lib\net40\MonoGame.Framework.Content.Pipeline.dll" />
-        <file src="..\..\MonoGame.Framework.Content.Pipeline\bin\Windows\AnyCPU\Release\MonoGame.Framework.Content.Pipeline.xml" target="lib\net40\MonoGame.Framework.Content.Pipeline.xml" />
+        <file src="..\..\MonoGame.Framework.Content.Pipeline\bin\Portable\AnyCPU\MonoGame.Framework.Content.Pipeline.dll" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.Content.Pipeline.dll" />
+        <file src="..\..\MonoGame.Framework.Content.Pipeline\bin\Windows\AnyCPU\Release\MonoGame.Framework.Content.Pipeline.xml" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.Content.Pipeline.xml" />
     </files>
 </package>

--- a/NuGetPackages/MonoGame.Framework.Portable.nuspec
+++ b/NuGetPackages/MonoGame.Framework.Portable.nuspec
@@ -20,8 +20,9 @@
         </references>	
 	</metadata>
     <files>
-        <file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\net40\MonoGame.Framework.dll" />
-        <file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\net40\MonoGame.Framework.xml" />
-        <file src="..\..\NuGetPackages\readme\MonoGame.Framework\readme.txt" target="readme.txt" />
+        <file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.dll" />
+        <file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.xml" />
+        <file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\netstandard1.0\MonoGame.Framework.dll" />
+        <file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\netstandard1.0\MonoGame.Framework.xml" />        <file src="..\..\NuGetPackages\readme\MonoGame.Framework\readme.txt" target="readme.txt" />
     </files>
 </package>

--- a/NuGetPackages/MonoGame.Framework.Portable.nuspec
+++ b/NuGetPackages/MonoGame.Framework.Portable.nuspec
@@ -22,7 +22,6 @@
     <files>
         <file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.dll" />
         <file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.xml" />
-        <file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\netstandard1.0\MonoGame.Framework.dll" />
-        <file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\netstandard1.0\MonoGame.Framework.xml" />        <file src="..\..\NuGetPackages\readme\MonoGame.Framework\readme.txt" target="readme.txt" />
+        <file src="..\..\NuGetPackages\readme\MonoGame.Framework\readme.txt" target="readme.txt" />
     </files>
 </package>

--- a/NuGetPackages/readme/MonoGame.Framework/readme.txt
+++ b/NuGetPackages/readme/MonoGame.Framework/readme.txt
@@ -12,12 +12,11 @@ Each NuGet now targets an individual platform to make for easier management and 
 The currently available packages are:
 	* Windows GL (OpenGL)
 	* Windows DX (DirectX)
-	* Windows 8 & 8.1
-	* Windows Phone 8
+	* Windows 8.1
 	* Windows Phone 8.1 
-	* Windows Universal projects
+	* Windows Universal / UWP projects
 	* iOS (Xamarin.iOS only)
-	* MacOS (net4 / net45 / MonoMac and Xamarin.Mac)
+	* MacOS (net45 / MonoMac and Xamarin.Mac)
 	* Android
 	* Linux
 


### PR DESCRIPTION
Updated the targets for the two portable NuGet definitions.
Old files were only targeting .Net4 and not Portable Net targets.