### PR TITLE
Use POSITION0 as the default Vertex Shader input in Effect.fx template

### DIFF
--- a/Tools/Pipeline/Templates/Effect.fx
+++ b/Tools/Pipeline/Templates/Effect.fx
@@ -11,7 +11,7 @@ matrix WorldViewProjection;
 
 struct VertexShaderInput
 {
-	float4 Position : SV_POSITION;
+	float4 Position : POSITION0;
 	float4 Color : COLOR0;
 };
 


### PR DESCRIPTION
Related to PR #4195

https://github.com/DigitalRune/MonoGame/blob/0a032e2d9f2d42739e9b99ed9599534e5cb45003/MonoGame.Framework/Graphics/Vertices/InputLayoutCache.cs#L101-L119
> - XNA/MonoGame only has VertexElementUsage.Position, so there is no way to distinguish between "POSITION" and "SV_Position".
> - "SV_Position" cannot be used with any index other than 0, i.e. the DirectX FX compiler does not accept "SV_Position1", "SV_Position2", ...

