### PR TITLE
Added ability to determine the underlying game platform type during the run-time.

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -271,6 +271,7 @@
     <Compile Include="GamePlatform.Mobile.cs">
       <Platforms>Android,iOS,Web,tvOS</Platforms>
     </Compile>
+    <Compile Include="GamePlatformType.cs" />
     <Compile Include="GameRunBehavior.cs" />
     <Compile Include="GameServiceContainer.cs" />
     <Compile Include="GameTime.cs" />

--- a/MonoGame.Framework/Android/AndroidGamePlatform.cs
+++ b/MonoGame.Framework/Android/AndroidGamePlatform.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Xna.Framework
 {
     class AndroidGamePlatform : GamePlatform
     {
+        public override GamePlatformType GamePlatformType
+        {
+            get { return GamePlatformType.Android; }
+        }
+
         public AndroidGamePlatform(Game game)
             : base(game)
         {

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -58,6 +58,11 @@ namespace Microsoft.Xna.Framework
 
         partial void PlatformConstruct();       
 
+        public GamePlatformType GamePlatformType
+        {
+            get { return Platform.GamePlatformType; }
+        }
+        
         public Game()
         {
             _instance = this;

--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -7,7 +7,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Microsoft.Xna.Framework.Input.Touch;
 
-
 namespace Microsoft.Xna.Framework
 {
     abstract partial class GamePlatform : IDisposable
@@ -99,6 +98,8 @@ namespace Microsoft.Xna.Framework
                 _window = value;
             }
         }
+
+        public abstract GamePlatformType GamePlatformType { get; }
 
         #endregion
 

--- a/MonoGame.Framework/GamePlatformType.cs
+++ b/MonoGame.Framework/GamePlatformType.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+namespace Microsoft.Xna.Framework
+{
+    public partial struct GamePlatformType : IEquatable<GamePlatformType>
+    {
+        // The public platforms that MonoGame supports
+        public static readonly GamePlatformType Android = new GamePlatformType("Android");
+        public static readonly GamePlatformType iOS = new GamePlatformType("iOS");
+        public static readonly GamePlatformType DesktopGL = new GamePlatformType("DesktopGL");
+        public static readonly GamePlatformType Windows = new GamePlatformType("Windows");
+        public static readonly GamePlatformType WindowsUniversal = new GamePlatformType("WindowsUniversal");
+        public static readonly GamePlatformType Web = new GamePlatformType("Web");
+
+        private readonly int _id;
+        private readonly string _name;
+
+        public string Name
+        {
+            get { return _name; }
+        }
+
+        public GamePlatformType(string name)
+        {
+            _name = name;
+            _id = name.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is GamePlatformType && this == (GamePlatformType) obj;
+        }
+
+        public override int GetHashCode()
+        {
+            // The _id field is already the hashcode of the platform name
+            return _id;
+        }
+
+        public static bool operator ==(GamePlatformType a, GamePlatformType b)
+        {
+            return a._id == b._id;
+        }
+
+        public static bool operator !=(GamePlatformType a, GamePlatformType b)
+        {
+            return a._id != b._id;
+        }
+
+        public bool Equals(GamePlatformType other)
+        {
+            return _id == other._id;
+        }
+    }
+}

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Xna.Framework
         private int _isExiting;
         private SdlGameWindow _view;
 
+        public override GamePlatformType GamePlatformType
+        {
+            get { return GamePlatformType.DesktopGL; }
+        }
+
         public SdlGamePlatform(Game game)
             : base(game)
         {

--- a/MonoGame.Framework/Web/WebGamePlatform.cs
+++ b/MonoGame.Framework/Web/WebGamePlatform.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Xna.Framework
     {
         private WebGameWindow _view;
 
+        public override GamePlatformType GamePlatformType
+        {
+            get { return GamePlatformType.Web; }
+        }
+
         public WebGamePlatform(Game game)
             : base(game)
         {

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -18,6 +18,11 @@ namespace MonoGame.Framework
 
         private WinFormsGameWindow _window;
 
+        public override GamePlatformType GamePlatformType
+        {
+            get { return GamePlatformType.Windows; }
+        }
+
         public WinFormsGamePlatform(Game game)
             : base(game)
         {

--- a/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
@@ -31,6 +31,11 @@ namespace Microsoft.Xna.Framework
 
         internal static ApplicationExecutionState PreviousExecutionState { get; set; }
 
+        public override GamePlatformType GamePlatformType
+        {
+            get { return GamePlatformType.WindowsUniversal; }
+        }
+
         public UAPGamePlatform(Game game)
             : base(game)
         {

--- a/MonoGame.Framework/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/iOS/iOSGamePlatform.cs
@@ -91,6 +91,11 @@ namespace Microsoft.Xna.Framework
         private List<NSObject> _applicationObservers;
         private CADisplayLink _displayLink;
 
+        public override GamePlatformType GamePlatformType
+        {
+            get { return GamePlatformType.iOS; }
+        }
+
         public iOSGamePlatform(Game game) :
             base(game)
         {


### PR DESCRIPTION
It may be useful in some cases.
I.e. if you are creating Effect by providing it's bytecode and therefore would need to know whether the underlying platform is DX or GL.