### PR TITLE
Fix texture ValidateParams exception with DXT1/3/5 decompression on Linux

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -86,21 +86,32 @@ namespace Microsoft.Xna.Framework.Content
 					    case SurfaceFormat.Dxt1:
                         case SurfaceFormat.Dxt1SRgb:
                         case SurfaceFormat.Dxt1a:
-                            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsDxt1 && convertedFormat == SurfaceFormat.Color)
-						        levelData = DxtUtil.DecompressDxt1(levelData, levelWidth, levelHeight);
-						    break;
+				            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsDxt1 && convertedFormat == SurfaceFormat.Color)
+				            {
+				                levelData = DxtUtil.DecompressDxt1(levelData, levelWidth, levelHeight);
+				                levelDataSizeInBytes = levelData.Length;
+				            }
+				            break;
 					    case SurfaceFormat.Dxt3:
 					    case SurfaceFormat.Dxt3SRgb:
                             if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
-                            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc && convertedFormat == SurfaceFormat.Color)
-						        levelData = DxtUtil.DecompressDxt3(levelData, levelWidth, levelHeight);
-						    break;
+				                if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc &&
+				                    convertedFormat == SurfaceFormat.Color)
+				                {
+				                    levelData = DxtUtil.DecompressDxt3(levelData, levelWidth, levelHeight);
+                                    levelDataSizeInBytes = levelData.Length;
+                                }
+				            break;
 					    case SurfaceFormat.Dxt5:
 					    case SurfaceFormat.Dxt5SRgb:
                             if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
-                            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc && convertedFormat == SurfaceFormat.Color)
-    						    levelData = DxtUtil.DecompressDxt5(levelData, levelWidth, levelHeight);
-						    break;
+				                if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc &&
+				                    convertedFormat == SurfaceFormat.Color)
+				                {
+				                    levelData = DxtUtil.DecompressDxt5(levelData, levelWidth, levelHeight);
+                                    levelDataSizeInBytes = levelData.Length;
+                                }
+				            break;
                         case SurfaceFormat.Bgra5551:
                             {
 #if OPENGL


### PR DESCRIPTION
When running on Linux without DXT decompression support (such as the Mesa OpenGL software renderer), the code path for decompressing DXT textures on load is hit.  This code currently has a bug where `levelDataSizeInBytes` is passed through to the `SetData` method, but `levelDataSizeInBytes` is not updated after DXT decompression, so the validation which occurs inside Texture2D to check that the element count is correct fails.

@KonajuGames has informed me this code path is likely going away soon, so I'll also be future proofing Protogame to turn off DXT compression for textures in the content pipeline when targeting Linux (since it's not supported everywhere).