### PR TITLE
#5511 - Enable VertexBuffer/IndexBuffer.GetData() on iOS

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #if IOS
             var ptr = GL.Ext.MapBufferRange(All.ElementArrayBuffer, (IntPtr)0, (IntPtr)(elementCount * elementSizeInByte), (int)All.MapReadBitExt);
-#elif
+#else
             var ptr = GL.MapBuffer(BufferTarget.ElementArrayBuffer, BufferAccess.ReadOnly);
 #endif
             // Pointer to the start of data to read in the index buffer

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Xna.Framework.Graphics
             // Pointer to the start of data in the vertex buffer
 #if IOS
             var ptr = GL.Ext.MapBufferRange(All.ArrayBuffer, (IntPtr)0, (IntPtr)(elementCount * vertexStride), (int)All.MapReadBitExt);
-#elif
+#else
             var ptr = GL.MapBuffer(BufferTarget.ArrayBuffer, BufferAccess.ReadOnly);
 #endif
 


### PR DESCRIPTION
Enable VertexBuffer/IndexBuffer.GetData() on iOS