### PR TITLE
Mark 'shortcut' Draw() overload for future removal.

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -197,6 +197,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="layerDepth">An optional depth of the layer of this sprite. 0 by default.</param>
         /// <exception cref="InvalidOperationException">Throwns if both <paramref name="position"/> and <paramref name="destinationRectangle"/> been used.</exception>
         /// <remarks>This overload uses optional parameters. This overload requires only one of <paramref name="position"/> and <paramref name="destinationRectangle"/> been used.</remarks>
+        [Obsolete("In future versions this method can be removed.")]
         public void Draw (Texture2D texture,
                 Vector2? position = null,
                 Rectangle? destinationRectangle = null,


### PR DESCRIPTION
This method can be confusing (#5311) and it's bad on performance.

Similar discussion in #5403.