### PR TITLE
Support SwapChainPanel on W8.1 / WP8.1 and update templates to use SwapChainPanel

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1396,6 +1396,9 @@
     <Compile Include="Windows8\GameFrameworkViewSource.cs">
       <Platforms>Windows8</Platforms>
     </Compile>
+    <Compile Include="Windows8\GenericSwapChainPanel.cs">
+      <Platforms>Windows8,WindowsPhone81,WindowsUniversal</Platforms>
+    </Compile>    
     <Compile Include="Windows8\InputEvents.cs">
       <Platforms>Windows8,WindowsPhone81,WindowsUniversal</Platforms>
     </Compile>

--- a/MonoGame.Framework/GameTimer.cs
+++ b/MonoGame.Framework/GameTimer.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Xna.Framework
 
             // Do we need to initialize the window event handlers?
             if (_windowEvents == null && Window.Current != null)
-                _windowEvents = new InputEvents(Window.Current.CoreWindow, SharedGraphicsDeviceManager.Current.SwapChainBackgroundPanel, MetroGamePlatform.TouchQueue);
+                _windowEvents = new InputEvents(Window.Current.CoreWindow, SharedGraphicsDeviceManager.Current.SwapChainPanel.Panel, MetroGamePlatform.TouchQueue);
             if (_windowEvents != null)
                 _windowEvents.UpdateState();
 

--- a/MonoGame.Framework/Graphics/PresentationParameters.cs
+++ b/MonoGame.Framework/Graphics/PresentationParameters.cs
@@ -103,14 +103,8 @@ namespace Microsoft.Xna.Framework.Graphics
             set { deviceWindowHandle = value; }
         }
 
-#if WINDOWS_STOREAPP
-        [CLSCompliant(false)]
-        public SwapChainBackgroundPanel SwapChainBackgroundPanel { get; set; }
-#endif
-
-#if WINDOWS_UAP
-        [CLSCompliant(false)]
-        public SwapChainPanel SwapChainPanel { get; set; }
+#if WINDOWS_STOREAPP || WINDOWS_UAP
+        public GenericSwapChainPanel SwapChainPanel { get; set; }
 #endif
 
         /// <summary>

--- a/MonoGame.Framework/GraphicsDeviceManager.WinRT.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.WinRT.cs
@@ -12,14 +12,8 @@ namespace Microsoft.Xna.Framework
 {
     partial class GraphicsDeviceManager
     {
-#if WINDOWS_STOREAPP
-        [CLSCompliant(false)]
-        public SwapChainBackgroundPanel SwapChainBackgroundPanel { get; set; }
-#endif
-
-#if WINDOWS_UAP
-        [CLSCompliant(false)] 
-        public SwapChainPanel SwapChainPanel { get; set; }
+#if WINDOWS_STOREAPP || WINDOWS_UAP
+        public GenericSwapChainPanel SwapChainPanel { get; set; }
 #endif
 
         partial void PlatformPreparePresentationParameters(PresentationParameters presentationParameters)
@@ -33,15 +27,15 @@ namespace Microsoft.Xna.Framework
 
             // The graphics device can use a XAML panel or a window
             // to created the default swapchain target.
-            if (SwapChainBackgroundPanel != null)
+            if (SwapChainPanel != null)
             {
                 presentationParameters.DeviceWindowHandle = IntPtr.Zero;
-                presentationParameters.SwapChainBackgroundPanel = this.SwapChainBackgroundPanel;
+                presentationParameters.SwapChainPanel = this.SwapChainPanel;
             }
             else
             {
                 presentationParameters.DeviceWindowHandle = _game.Window.Handle;
-                presentationParameters.SwapChainBackgroundPanel = null;
+                presentationParameters.SwapChainPanel = null;
             }
 #endif
         }

--- a/MonoGame.Framework/SharedGraphicsDeviceManager.cs
+++ b/MonoGame.Framework/SharedGraphicsDeviceManager.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Xna.Framework
 		public SwapChainPanel SwapChainPanel { get; set; }
 #else
 		[CLSCompliant(false)]
-        public SwapChainBackgroundPanel SwapChainBackgroundPanel { get; set; }
+        public GenericSwapChainPanel SwapChainPanel { get; set; }
 #endif
 
         public event EventHandler<EventArgs> DeviceCreated;
@@ -90,7 +90,7 @@ namespace Microsoft.Xna.Framework
 #if WINDOWS_UAP
 			presentationParameters.SwapChainPanel = this.SwapChainPanel;
 #else
-			presentationParameters.SwapChainBackgroundPanel = this.SwapChainBackgroundPanel;
+			presentationParameters.SwapChainPanel = this.SwapChainPanel;
 #endif
 
             if (createDevice)

--- a/MonoGame.Framework/Windows/GamerServices/Guide.cs
+++ b/MonoGame.Framework/Windows/GamerServices/Guide.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Xna.Framework.GamerServices
         {
 #if WINDOWS_STOREAPP
 			// If SwapChainBackgroundPanel is null then we are running the non-XAML template
-			if (Game.Instance.graphicsDeviceManager.SwapChainBackgroundPanel == null)
+			if (Game.Instance.graphicsDeviceManager.SwapChainPanel == null)
 			{
 				throw new NotImplementedException("This method works only when using the XAML template.");
 			}

--- a/MonoGame.Framework/Windows8/GenericSwapChainPanel.cs
+++ b/MonoGame.Framework/Windows8/GenericSwapChainPanel.cs
@@ -1,0 +1,97 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using SharpDX;
+using SharpDX.DXGI;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Microsoft.Xna.Framework
+{
+    public class GenericSwapChainPanel
+    {
+        internal readonly Grid Panel;
+        
+        internal GenericSwapChainPanel(SwapChainPanel swapChainPanel)
+        {
+            Panel = swapChainPanel;
+        }
+
+        internal GenericSwapChainPanel(SwapChainBackgroundPanel swapChainBackgroundPanel)
+        {
+            Panel = swapChainBackgroundPanel;
+        }
+        
+        internal void SetSwapChain(SwapChain1 _swapChain)
+        {
+            if (Panel is SwapChainBackgroundPanel)
+            {
+                using (var nativePanel = ComObject.As<SharpDX.DXGI.ISwapChainBackgroundPanelNative>(Panel))
+                    nativePanel.SwapChain = _swapChain;
+            }
+            else
+            {                
+                using (var nativePanel = ComObject.As<SharpDX.DXGI.ISwapChainPanelNative>(Panel))
+                    nativePanel.SwapChain = _swapChain;
+            }
+        }
+
+        internal CoreIndependentInputSource CreateCoreIndependentInputSource(CoreInputDeviceTypes inputDevices)
+        {   
+            if (Panel is SwapChainBackgroundPanel)
+                return ((SwapChainBackgroundPanel)Panel).CreateCoreIndependentInputSource(inputDevices);
+            else
+                return ((SwapChainPanel)Panel).CreateCoreIndependentInputSource(inputDevices);
+        }
+        
+        public float CompositionScaleX
+        {
+            get
+            {
+                if (Panel is SwapChainBackgroundPanel)
+                    return 1f;
+                else
+                    return ((SwapChainPanel)Panel).CompositionScaleX;
+            }
+        }
+                
+        public float CompositionScaleY
+        {
+            get
+            {
+                if (Panel is SwapChainBackgroundPanel)
+                    return 1f;
+                else
+                    return ((SwapChainPanel)Panel).CompositionScaleY;
+            }
+        }
+
+        public double ActualWidth
+        {
+            get
+            {
+                if (Panel is SwapChainBackgroundPanel)
+                    return ((SwapChainBackgroundPanel)Panel).ActualWidth;
+                else
+                    return ((SwapChainPanel)Panel).ActualWidth;
+            }
+        }
+        
+        public double ActualHeight
+        {
+            get
+            {
+                if (Panel is SwapChainBackgroundPanel)
+                    return ((SwapChainBackgroundPanel)Panel).ActualHeight;
+                else
+                    return ((SwapChainPanel)Panel).ActualHeight;
+            }
+        }
+        
+        [CLSCompliant(false)]
+        public CoreDispatcher Dispatcher { get { return Panel.Dispatcher; } }
+    }
+}

--- a/MonoGame.Framework/Windows8/XamlGame.cs
+++ b/MonoGame.Framework/Windows8/XamlGame.cs
@@ -31,18 +31,23 @@ namespace MonoGame.Framework
         /// <returns></returns>
         static public T Create(string launchParameters, CoreWindow window, SwapChainBackgroundPanel swapChainBackgroundPanel)
         {
+            return Create(launchParameters, window, new GenericSwapChainPanel(swapChainBackgroundPanel));
+        }
+        
+        static private T Create(string launchParameters, CoreWindow window, GenericSwapChainPanel swapChainPanel)
+        {
             if (launchParameters == null)
                 throw new NullReferenceException("The launch parameters cannot be null!");
             if (window == null)
                 throw new NullReferenceException("The window cannot be null!");
-            if (swapChainBackgroundPanel == null)
+            if (swapChainPanel == null)
                 throw new NullReferenceException("The swap chain panel cannot be null!");
 
             // Save any launch parameters to be parsed by the platform.
             MetroGamePlatform.LaunchParameters = launchParameters;
 
             // Setup the window class.
-            MetroGameWindow.Instance.Initialize(window, swapChainBackgroundPanel, MetroGamePlatform.TouchQueue);
+            MetroGameWindow.Instance.Initialize(window, swapChainPanel.Panel, MetroGamePlatform.TouchQueue);
 
             // Construct the game.
             var game = new T();
@@ -50,7 +55,7 @@ namespace MonoGame.Framework
             // Set the swap chain panel on the graphics mananger.
             if (game.graphicsDeviceManager == null)
                 throw new NullReferenceException("You must create the GraphicsDeviceManager in the Game constructor!");
-            game.graphicsDeviceManager.SwapChainBackgroundPanel = swapChainBackgroundPanel;
+            game.graphicsDeviceManager.SwapChainPanel = swapChainPanel;
 
             // Start running the game.
             game.Run(GameRunBehavior.Asynchronous);

--- a/MonoGame.Framework/Windows8/XamlGame.cs
+++ b/MonoGame.Framework/Windows8/XamlGame.cs
@@ -29,9 +29,22 @@ namespace MonoGame.Framework
         /// <param name="window">The core window object.</param>
         /// <param name="swapChainBackgroundPanel">The XAML SwapChainBackgroundPanel to which we render the scene and recieve input events.</param>
         /// <returns></returns>
+        [Obsolete("Use Create(string launchParameters, CoreWindow window, SwapChainPanel swapChainPanel) instead. In future versions this method can be removed.")]
         static public T Create(string launchParameters, CoreWindow window, SwapChainBackgroundPanel swapChainBackgroundPanel)
         {
             return Create(launchParameters, window, new GenericSwapChainPanel(swapChainBackgroundPanel));
+        }
+
+        /// <summary>
+        /// Creates your Game class initializing it to work within a XAML application window.
+        /// </summary>
+        /// <param name="launchParameters">The command line arguments from launch.</param>
+        /// <param name="window">The core window object.</param>
+        /// <param name="swapChainPanel">The XAML SwapChainPanel to which we render the scene and receive input events.</param>
+        /// <returns></returns>
+        static public T Create(string launchParameters, CoreWindow window, SwapChainPanel swapChainPanel)
+        {
+            return Create(launchParameters, window, new GenericSwapChainPanel(swapChainPanel));
         }
         
         static private T Create(string launchParameters, CoreWindow window, GenericSwapChainPanel swapChainPanel)

--- a/MonoGame.Framework/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPGameWindow.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Xna.Framework
         private CoreWindow _coreWindow;
         private DisplayInformation _dinfo;
         private ApplicationView _appView;
-        private SwapChainPanel _swapChainPanel;
         private Rectangle _viewBounds;
 
         private object _eventLocker = new object();
@@ -123,9 +122,8 @@ namespace Microsoft.Xna.Framework
 
             _orientation = ToOrientation(_dinfo.CurrentOrientation);
             _dinfo.OrientationChanged += DisplayProperties_OrientationChanged;
-            _swapChainPanel = inputElement as SwapChainPanel;
 
-            _swapChainPanel.SizeChanged += SwapChain_SizeChanged;
+            ((FrameworkElement)inputElement).SizeChanged += SwapChain_SizeChanged;
 
             _coreWindow.Closed += Window_Closed;
             _coreWindow.Activated += Window_FocusChanged;

--- a/MonoGame.Framework/WindowsUniversal/XamlGame.cs
+++ b/MonoGame.Framework/WindowsUniversal/XamlGame.cs
@@ -27,6 +27,11 @@ namespace MonoGame.Framework
         /// <returns></returns>
         static public T Create(string launchParameters, CoreWindow window, SwapChainPanel swapChainPanel)
         {
+            return Create(launchParameters, window, new GenericSwapChainPanel(swapChainPanel));
+        }
+        
+        static private T Create(string launchParameters, CoreWindow window, GenericSwapChainPanel swapChainPanel)
+        { 
             if (launchParameters == null)
                 throw new NullReferenceException("The launch parameters cannot be null!");
             if (window == null)
@@ -38,7 +43,7 @@ namespace MonoGame.Framework
             UAPGamePlatform.LaunchParameters = launchParameters;
 
 			// Setup the window class.
-			UAPGameWindow.Instance.Initialize(window, swapChainPanel, UAPGamePlatform.TouchQueue);
+			UAPGameWindow.Instance.Initialize(window, swapChainPanel.Panel, UAPGamePlatform.TouchQueue);
 
             // Construct the game.
             var game = new T();

--- a/ProjectTemplates/VisualStudio2012/WindowsStoreXaml/GamePage.xaml
+++ b/ProjectTemplates/VisualStudio2012/WindowsStoreXaml/GamePage.xaml
@@ -1,4 +1,4 @@
-﻿<SwapChainBackgroundPanel
+﻿<Page
     x:Class="$safeprojectname$.GamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,7 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
-    </Grid>
+    <SwapChainPanel x:Name="swapChainPanel" />
     
-</SwapChainBackgroundPanel>
+</Page>

--- a/ProjectTemplates/VisualStudio2012/WindowsStoreXaml/GamePage.xaml.cs
+++ b/ProjectTemplates/VisualStudio2012/WindowsStoreXaml/GamePage.xaml.cs
@@ -9,7 +9,7 @@ namespace $safeprojectname$
     /// <summary>
     /// The root page used to display the game.
     /// </summary>
-    public sealed partial class GamePage : SwapChainBackgroundPanel
+    public sealed partial class GamePage : Page
     {
         readonly Game1 _game;
 
@@ -18,7 +18,7 @@ namespace $safeprojectname$
             this.InitializeComponent();
 
             // Create the game.
-            _game = XamlGame<Game1>.Create(args, Window.Current.CoreWindow, this);
+            _game = XamlGame<Game1>.Create(args, Window.Current.CoreWindow, swapChainPanel);
         }
     }
 }

--- a/ProjectTemplates/VisualStudio2012/WindowsStoreXaml/MonoGameWindowsStoreXaml.vstemplate
+++ b/ProjectTemplates/VisualStudio2012/WindowsStoreXaml/MonoGameWindowsStoreXaml.vstemplate
@@ -16,7 +16,7 @@
     <EnableLocationBrowseButton>true</EnableLocationBrowseButton>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <TargetPlatformName>Windows</TargetPlatformName>
-    <RequiredPlatformVersion>8</RequiredPlatformVersion>
+    <RequiredPlatformVersion>8.1</RequiredPlatformVersion>
     <CreateInPlace>true</CreateInPlace>
   </TemplateData>
   <TemplateContent>

--- a/ProjectTemplates/VisualStudio2013/WindowsPhone8.1/GamePage.xaml
+++ b/ProjectTemplates/VisualStudio2013/WindowsPhone8.1/GamePage.xaml
@@ -1,4 +1,4 @@
-﻿<SwapChainBackgroundPanel
+﻿<Page
     x:Class="$safeprojectname$.GamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,7 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
+    <SwapChainPanel x:Name="swapChainPanel" />
 
-    </Grid>
-</SwapChainBackgroundPanel>
+</Page>

--- a/ProjectTemplates/VisualStudio2013/WindowsPhone8.1/GamePage.xaml.cs
+++ b/ProjectTemplates/VisualStudio2013/WindowsPhone8.1/GamePage.xaml.cs
@@ -20,7 +20,7 @@ namespace $safeprojectname$
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    public sealed partial class GamePage : SwapChainBackgroundPanel
+    public sealed partial class GamePage : Page
     {
         readonly Game1 _game;
 
@@ -28,7 +28,7 @@ namespace $safeprojectname$
         {
             this.InitializeComponent();
 
-            _game = XamlGame<Game1>.Create(launchArguments, Window.Current.CoreWindow, this);
+            _game = XamlGame<Game1>.Create(launchArguments, Window.Current.CoreWindow, swapChainPanel);
         }
     }
 }

--- a/ProjectTemplates/VisualStudio2013/WindowsStoreXaml/GamePage.xaml
+++ b/ProjectTemplates/VisualStudio2013/WindowsStoreXaml/GamePage.xaml
@@ -1,4 +1,4 @@
-﻿<SwapChainBackgroundPanel
+﻿<Page
     x:Class="$safeprojectname$.GamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,7 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
-    </Grid>
+    <SwapChainPanel x:Name="swapChainPanel" />
     
-</SwapChainBackgroundPanel>
+</Page>

--- a/ProjectTemplates/VisualStudio2013/WindowsStoreXaml/GamePage.xaml.cs
+++ b/ProjectTemplates/VisualStudio2013/WindowsStoreXaml/GamePage.xaml.cs
@@ -9,7 +9,7 @@ namespace $safeprojectname$
     /// <summary>
     /// The root page used to display the game.
     /// </summary>
-    public sealed partial class GamePage : SwapChainBackgroundPanel
+    public sealed partial class GamePage : Page
     {
         readonly Game1 _game;
 
@@ -18,7 +18,7 @@ namespace $safeprojectname$
             this.InitializeComponent();
 
             // Create the game.
-            _game = XamlGame<Game1>.Create(args, Window.Current.CoreWindow, this);
+            _game = XamlGame<Game1>.Create(args, Window.Current.CoreWindow, swapChainPanel);
         }
     }
 }

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/Shared/GamePage.xaml
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/Shared/GamePage.xaml
@@ -1,4 +1,4 @@
-﻿<SwapChainBackgroundPanel
+﻿<Page
     x:Class="$ext_safeprojectname$.GamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,7 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid >
+    <SwapChainPanel x:Name="swapChainPanel" />
 
-    </Grid>
-</SwapChainBackgroundPanel>
+</Page>

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/Shared/GamePage.xaml.cs
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/Shared/GamePage.xaml.cs
@@ -20,7 +20,7 @@ namespace $ext_safeprojectname$
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    public sealed partial class GamePage : SwapChainBackgroundPanel
+    public sealed partial class GamePage : Page
     {
         readonly Game1 _game;
 
@@ -30,7 +30,7 @@ namespace $ext_safeprojectname$
 
             // Create the game.
 
-            _game = XamlGame<Game1>.Create(launchArguments, Window.Current.CoreWindow, this);
+            _game = XamlGame<Game1>.Create(launchArguments, Window.Current.CoreWindow, swapChainPanel);
         }
     }
 }

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/Windows/Windows.Application.Windows.csproj
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/Windows/Windows.Application.Windows.csproj
@@ -20,6 +20,7 @@
     <PackageCertificateKeyFile>$ext_safeprojectname$.Windows_TemporaryKey.pfx</PackageCertificateKeyFile>
     $endif$
     <MonoGamePlatform>WindowsStoreApp</MonoGamePlatform>
+    <TargetPlatformVersion>8.1</TargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/ProjectTemplates/VisualStudio2015/WindowsStoreXaml/GamePage.xaml
+++ b/ProjectTemplates/VisualStudio2015/WindowsStoreXaml/GamePage.xaml
@@ -1,4 +1,4 @@
-﻿<SwapChainBackgroundPanel
+﻿<Page
     x:Class="$safeprojectname$.GamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,7 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
-    </Grid>
+    <SwapChainPanel x:Name="swapChainPanel" />
     
-</SwapChainBackgroundPanel>
+</Page>

--- a/ProjectTemplates/VisualStudio2015/WindowsStoreXaml/GamePage.xaml.cs
+++ b/ProjectTemplates/VisualStudio2015/WindowsStoreXaml/GamePage.xaml.cs
@@ -9,7 +9,7 @@ namespace $safeprojectname$
     /// <summary>
     /// The root page used to display the game.
     /// </summary>
-    public sealed partial class GamePage : SwapChainBackgroundPanel
+    public sealed partial class GamePage : Page
     {
         readonly Game1 _game;
 

--- a/ProjectTemplates/VisualStudio2015/WindowsUniversal/Shared/GamePage.xaml
+++ b/ProjectTemplates/VisualStudio2015/WindowsUniversal/Shared/GamePage.xaml
@@ -1,4 +1,4 @@
-﻿<SwapChainBackgroundPanel
+﻿<Page
     x:Class="$ext_safeprojectname$.GamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,7 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid >
+    <SwapChainPanel x:Name="swapChainPanel" />
 
-    </Grid>
-</SwapChainBackgroundPanel>
+</Page>

--- a/ProjectTemplates/VisualStudio2015/WindowsUniversal/Shared/GamePage.xaml.cs
+++ b/ProjectTemplates/VisualStudio2015/WindowsUniversal/Shared/GamePage.xaml.cs
@@ -20,7 +20,7 @@ namespace $ext_safeprojectname$
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    public sealed partial class GamePage : SwapChainBackgroundPanel
+    public sealed partial class GamePage : Page
     {
         readonly Game1 _game;
 
@@ -30,7 +30,7 @@ namespace $ext_safeprojectname$
 
             // Create the game.
 
-            _game = XamlGame<Game1>.Create(launchArguments, Window.Current.CoreWindow, this);
+            _game = XamlGame<Game1>.Create(launchArguments, Window.Current.CoreWindow, swapChainPanel);
         }
     }
 }


### PR DESCRIPTION
I found SwapChainBackgroundPanel behaving very unpredictable as I was testing #5520. That makes sense since it comes from W8.0, It wasn't supposed to run in window mode (W10).
(I found a workaround for #5520 out of nowhere , but that was after I had this PR ready! 8-) )

- `SwapChainBackgroundPanel` & `SwapChainPanel` are wrapped into `GenericSwapChainPanel`.
- `SwapChainBackgroundPanel` is still supported on W8.1 to allow easier upgrade from 3.5, the constructor is marked as [Obsolete].
- W8.1 templates are updated to use `SwapChainPanel`.