### PR TITLE
Improvements to window handling and full screen switches for desktop

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1184,9 +1184,7 @@
 
 
     <!-- Utility Classes -->
-    <Compile Include="Utilities\AssemblyHelper.cs">
-      <Platforms>Angle,Linux,MacOS,Windows,WindowsGL,Web</Platforms>
-    </Compile>
+    <Compile Include="Utilities\AssemblyHelper.cs"/>
     <Compile Include="Utilities\CurrentPlatform.cs">
       <Platforms>WindowsGL,Linux</Platforms>
     </Compile>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1185,7 +1185,7 @@
 
     <!-- Utility Classes -->
     <Compile Include="Utilities\AssemblyHelper.cs">
-      <Platforms>Angle,Linux,MacOS,Windows,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,Windows,WindowsGL,Web</Platforms>
     </Compile>
     <Compile Include="Utilities\CurrentPlatform.cs">
       <Platforms>WindowsGL,Linux</Platforms>

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -532,7 +532,9 @@ namespace Microsoft.Xna.Framework
         protected virtual void Initialize()
         {
             // TODO: This should be removed once all platforms use the new GraphicsDeviceManager
+#if !DESKTOPGL
             applyChanges(graphicsDeviceManager);
+#endif
 
             // According to the information given on MSDN (see link below), all
             // GameComponents in Components at the time Initialize() is called
@@ -630,6 +632,7 @@ namespace Microsoft.Xna.Framework
         //        break entirely the possibility that additional platforms could
         //        be added by third parties without changing MonoGame itself.
 
+#if !DESKTOPGL
         internal void applyChanges(GraphicsDeviceManager manager)
         {
 			Platform.BeginScreenDeviceChange(GraphicsDevice.PresentationParameters.IsFullScreen);
@@ -648,6 +651,7 @@ namespace Microsoft.Xna.Framework
             GraphicsDevice.Viewport = viewport;
 			Platform.EndScreenDeviceChange(string.Empty, viewport.Width, viewport.Height);
         }
+#endif
 
         internal void DoUpdate(GameTime gameTime)
         {

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Xna.Framework
         protected virtual void Initialize()
         {
             // TODO: This should be removed once all platforms use the new GraphicsDeviceManager
-#if !DESKTOPGL
+#if !DESKTOPGL && !(WINDOWS && DIRECTX)
             applyChanges(graphicsDeviceManager);
 #endif
 
@@ -632,7 +632,7 @@ namespace Microsoft.Xna.Framework
         //        break entirely the possibility that additional platforms could
         //        be added by third parties without changing MonoGame itself.
 
-#if !DESKTOPGL
+#if !DESKTOPGL && !(WINDOWS && DIRECTX)
         internal void applyChanges(GraphicsDeviceManager manager)
         {
 			Platform.BeginScreenDeviceChange(GraphicsDevice.PresentationParameters.IsFullScreen);

--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -186,18 +186,6 @@ namespace Microsoft.Xna.Framework
         public abstract bool BeforeDraw(GameTime gameTime);
 
         /// <summary>
-        /// When implemented in a derived class, causes the game to enter
-        /// full-screen mode.
-        /// </summary>
-        public abstract void EnterFullScreen();
-
-        /// <summary>
-        /// When implemented in a derived class, causes the game to exit
-        /// full-screen mode.
-        /// </summary>
-        public abstract void ExitFullScreen();
-
-        /// <summary>
         /// Gives derived classes an opportunity to modify
         /// Game.TargetElapsedTime before it is set.
         /// </summary>

--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Xna.Framework {
 
 		public abstract string ScreenDeviceName { get; }
 
-		private string _title = MonoGame.Utilities.AssemblyHelper.GetDefaultWindowTitle();
+	    private string _title;
 
         /// <summary>
         /// Gets or sets the title of the game window.
@@ -79,6 +79,7 @@ namespace Microsoft.Xna.Framework {
 
         protected GameWindow()
         {
+            _title = MonoGame.Utilities.AssemblyHelper.GetDefaultWindowTitle();
             TouchPanelState = new TouchPanelState(this);
         }
 

--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Xna.Framework {
 
 		public abstract string ScreenDeviceName { get; }
 
-		private string _title;
+		private string _title = MonoGame.Utilities.AssemblyHelper.GetDefaultWindowTitle();
+
         /// <summary>
         /// Gets or sets the title of the game window.
         /// </summary>

--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -159,14 +159,5 @@ namespace Microsoft.Xna.Framework {
 		protected internal abstract void SetSupportedOrientations (DisplayOrientation orientations);
 		protected abstract void SetTitle (string title);
 
-#if DIRECTX && WINDOWS
-        public static GameWindow Create(Game game, int width, int height)
-        {
-            var window = new MonoGame.Framework.WinFormsGameWindow((MonoGame.Framework.WinFormsGamePlatform)game.Platform);
-            window.Initialize(width, height);
-
-            return window;
-        }
-#endif
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
@@ -67,7 +67,7 @@ namespace OpenGL
             Sdl.GL.SwapWindow(_winHandle);
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (_disposed)
                 return;
@@ -82,6 +82,31 @@ namespace OpenGL
                 _winHandle = IntPtr.Zero;
             else
                 _winHandle = info.Handle;
+        }
+
+        public static GraphicsContext CreateDummy()
+        {
+            return Dummy.Create();
+        }
+
+        private class Dummy : GraphicsContext
+        {
+            private Dummy(IntPtr windowHandle) : base(new WindowInfo(windowHandle))
+            {
+            }
+
+            public static GraphicsContext Create()
+            {
+                var handle = Sdl.Window.Create(string.Empty, 0, 0, 1, 1,
+                    Sdl.Window.State.OpenGL | Sdl.Window.State.Hidden);
+                return new Dummy(handle);
+            }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+                Sdl.Window.Destroy(_winHandle);
+            }
         }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -811,8 +811,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     BindFlags = SharpDX.Direct3D11.BindFlags.DepthStencil,
                 }))
 
-                    // Create a DepthStencil view on this surface to use on bind.
-                    _depthStencilView = new SharpDX.Direct3D11.DepthStencilView(_d3dDevice, depthBuffer);
+                // Create a DepthStencil view on this surface to use on bind.
+                _depthStencilView = new SharpDX.Direct3D11.DepthStencilView(_d3dDevice, depthBuffer);
             }
 
             // Set the current viewport.

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -1076,6 +1076,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             // TODO update GL context for new presentation parameters
             //      we need to recreate the window if depth/back buffer format/ms count changed
+            Viewport = new Viewport(0, 0, PresentationParameters.BackBufferWidth, PresentationParameters.BackBufferHeight);
             ApplyRenderTargets(null);
         }
     }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -104,9 +104,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 Context = GL.CreateContext(windowInfo);
             }
 
-            Context.MakeCurrent(windowInfo);
-            Context.SwapInterval = PresentationParameters.PresentationInterval.GetSwapInterval();
-
             /*if (Threading.BackgroundContext == null)
             {
                 Threading.BackgroundContext = GL.CreateContext(windowInfo);
@@ -115,6 +112,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }*/
 
             Context.MakeCurrent(windowInfo);
+            Context.SwapInterval = PresentationParameters.PresentationInterval.GetSwapInterval();
 
             /*GraphicsMode mode = GraphicsMode.Default;
             var wnd = OpenTK.Platform.Utilities.CreateSdl2WindowInfo(Game.Instance.Window.Handle);
@@ -1076,6 +1074,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void OnPresentationChanged()
         {
+            // TODO update GL context for new presentation parameters
+            //      we need to recreate the window if depth/back buffer format/ms count changed
             ApplyRenderTargets(null);
         }
     }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -208,6 +208,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new NoSuitableGraphicsDeviceException(String.Format("Adapter '{0}' does not support the {1} profile.", adapter.Description, graphicsProfile));
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
+
+            ValidatePresentationParameters(presentationParameters);
+
             Adapter = adapter;
             PresentationParameters = presentationParameters;
             _graphicsProfile = graphicsProfile;
@@ -560,9 +563,28 @@ namespace Microsoft.Xna.Framework.Graphics
 
         partial void PlatformValidatePresentationParameters(PresentationParameters presentationParameters);
 
+        private void ValidatePresentationParameters(PresentationParameters presentationParameters)
+        {
+            if (presentationParameters.IsFullScreen)
+            {
+                if (!presentationParameters.HardwareModeSwitch)
+                {
+                    // force the back buffer size to the display resolution if we're going to soft full screen
+                    presentationParameters.BackBufferWidth = DisplayMode.Width;
+                    presentationParameters.BackBufferHeight = DisplayMode.Height;
+                }
+                else
+                {
+                    // TODO figure out the display mode resolution when switching to full screen
+                }
+            }
+
+            PlatformValidatePresentationParameters(presentationParameters);
+        }
+
         public void Reset()
         {
-            PlatformValidatePresentationParameters(PresentationParameters);
+            ValidatePresentationParameters(PresentationParameters);
 
             if (DeviceResetting != null)
                 DeviceResetting(this, EventArgs.Empty);
@@ -572,6 +594,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (PresentationChanged != null)
                 PresentationChanged(this, EventArgs.Empty);
+
             if (DeviceReset != null)
                 DeviceReset(this, EventArgs.Empty);
         }

--- a/MonoGame.Framework/Graphics/PresentationParameters.cs
+++ b/MonoGame.Framework/Graphics/PresentationParameters.cs
@@ -2,7 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-	using System;
+using System;
 
 #if WINDOWS_STOREAPP || WINDOWS_UAP
 using Windows.UI.Xaml.Controls;
@@ -21,7 +21,7 @@ using Microsoft.Xna.Framework.Input.Touch;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-    public class PresentationParameters : IDisposable
+    public class PresentationParameters
     {
         #region Constants
 
@@ -41,48 +41,62 @@ namespace Microsoft.Xna.Framework.Graphics
 #if !WINRT || WINDOWS_UAP
         private bool isFullScreen;
 #endif
+        private bool hardwareModeSwitch = true;
 
         #endregion Private Fields
 
         #region Constructors
 
+        /// <summary>
+        /// Create a <see cref="PresentationParameters"/> instance with default values for all properties.
+        /// </summary>
         public PresentationParameters()
         {
             Clear();
-        }
-
-        ~PresentationParameters()
-        {
-            Dispose(false);
         }
 
         #endregion Constructors
 
         #region Properties
 
+        /// <summary>
+        /// Get or set the format of the back buffer.
+        /// </summary>
         public SurfaceFormat BackBufferFormat
         {
             get { return backBufferFormat; }
             set { backBufferFormat = value; }
         }
 
+        /// <summary>
+        /// Get or set the height of the back buffer.
+        /// </summary>
         public int BackBufferHeight
         {
             get { return backBufferHeight; }
             set { backBufferHeight = value; }
         }
 
+        /// <summary>
+        /// Get or set the width of the back buffer.
+        /// </summary>
         public int BackBufferWidth
         {
             get { return backBufferWidth; }
             set { backBufferWidth = value; }
         }
 
+        /// <summary>
+        /// Get the bounds of the back buffer.
+        /// </summary>
         public Rectangle Bounds 
         {
             get { return new Rectangle(0, 0, backBufferWidth, backBufferHeight); }
         }
 
+        /// <summary>
+        /// Get or set the handle of the window that will present the back buffer.
+        /// </summary>
         public IntPtr DeviceWindowHandle
         {
             get { return deviceWindowHandle; }
@@ -99,12 +113,18 @@ namespace Microsoft.Xna.Framework.Graphics
         public SwapChainPanel SwapChainPanel { get; set; }
 #endif
 
+        /// <summary>
+        /// Get or set the depth stencil format for the back buffer.
+        /// </summary>
 		public DepthFormat DepthStencilFormat
         {
             get { return depthStencilFormat; }
             set { depthStencilFormat = value; }
         }
 
+        /// <summary>
+        /// Get or set a value indicating if we are in full screen mode.
+        /// </summary>
         public bool IsFullScreen
         {
 			get
@@ -129,20 +149,46 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
         }
 		
+        /// <summary>
+        /// If <code>true</code> the <see cref="GraphicsDevice"/> will do a mode switch
+        /// when going to full screen mode. If <code>false</code> it will instead do a
+        /// soft full screen by maximizing the window and making it borderless.
+        /// </summary>
+        public bool HardwareModeSwitch
+        {
+            get { return hardwareModeSwitch; }
+            set { hardwareModeSwitch = value; }
+        }
+
+        /// <summary>
+        /// Get or set the multisample count for the back buffer.
+        /// </summary>
         public int MultiSampleCount
         {
             get { return multiSampleCount; }
             set { multiSampleCount = value; }
         }
 		
+        /// <summary>
+        /// Get or set the presentation interval.
+        /// </summary>
         public PresentInterval PresentationInterval { get; set; }
 
+        /// <summary>
+        /// Get or set the display orientation.
+        /// </summary>
 		public DisplayOrientation DisplayOrientation 
 		{ 
 			get; 
 			set; 
 		}
 		
+        /// <summary>
+        /// Get or set the RenderTargetUsage for the back buffer.
+        /// Determines if the back buffer is cleared when it is set as the
+        /// render target by the <see cref="GraphicsDevice"/>.
+        /// <see cref="GraphicsDevice"/> target.
+        /// </summary>
 		public RenderTargetUsage RenderTargetUsage { get; set; }
 
         #endregion Properties
@@ -150,15 +196,19 @@ namespace Microsoft.Xna.Framework.Graphics
 
         #region Methods
 
+        /// <summary>
+        /// Reset all properties to their default values.
+        /// </summary>
         public void Clear()
         {
             backBufferFormat = SurfaceFormat.Color;
 #if IOS
+            // TODO this should definitely not be done here
 			// Mainscreen.Bounds does not account for the device's orientation. it ALWAYS assumes portrait
 			var width = (int)(UIScreen.MainScreen.Bounds.Width * UIScreen.MainScreen.Scale);
 			var height = (int)(UIScreen.MainScreen.Bounds.Height * UIScreen.MainScreen.Scale);
 			
-			// Flip the dimentions if we need to.
+			// Flip the dimensions if we need to.
 			if (TouchPanel.DisplayOrientation == DisplayOrientation.LandscapeLeft ||
 			    TouchPanel.DisplayOrientation == DisplayOrientation.LandscapeRight)
 			{
@@ -184,6 +234,10 @@ namespace Microsoft.Xna.Framework.Graphics
             DisplayOrientation = Microsoft.Xna.Framework.DisplayOrientation.Default;
         }
 
+        /// <summary>
+        /// Create a copy of this <see cref="PresentationParameters"/> instance.
+        /// </summary>
+        /// <returns></returns>
         public PresentationParameters Clone()
         {
             PresentationParameters clone = new PresentationParameters();
@@ -191,35 +245,18 @@ namespace Microsoft.Xna.Framework.Graphics
             clone.backBufferHeight = this.backBufferHeight;
             clone.backBufferWidth = this.backBufferWidth;
             clone.deviceWindowHandle = this.deviceWindowHandle;
-            clone.disposed = this.disposed;
-            clone.IsFullScreen = this.IsFullScreen;
             clone.depthStencilFormat = this.depthStencilFormat;
+            clone.IsFullScreen = this.IsFullScreen;
+            clone.HardwareModeSwitch = this.HardwareModeSwitch;
             clone.multiSampleCount = this.multiSampleCount;
             clone.PresentationInterval = this.PresentationInterval;
             clone.DisplayOrientation = this.DisplayOrientation;
+            clone.RenderTargetUsage = this.RenderTargetUsage;
             return clone;
-        }
-
-        public void Dispose()
-        {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposed)
-            {
-                disposed = true;
-                if (disposing)
-                {
-                    // Dispose managed resources
-                }
-                // Dispose unmanaged resources
-            }
         }
 
         #endregion Methods
 
     }
 }
+

--- a/MonoGame.Framework/GraphicsDeviceManager.SDL.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.SDL.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using Microsoft.Xna.Framework.Graphics;
+using OpenGL;
 
 namespace Microsoft.Xna.Framework
 {
@@ -12,6 +13,7 @@ namespace Microsoft.Xna.Framework
         {
             var surfaceFormat = _game.graphicsDeviceManager.PreferredBackBufferFormat.GetColorFormat();
             var depthStencilFormat = _game.graphicsDeviceManager.PreferredDepthStencilFormat;
+            var msCount = ClampMultisampleCount(presentationParameters);
 
             // TODO Need to get this data from the Presentation Parameters
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.RedSize, surfaceFormat.R);
@@ -39,11 +41,55 @@ namespace Microsoft.Xna.Framework
                     break;
             }
 
+            if (msCount > 0)
+            {
+                Sdl.GL.SetAttribute(Sdl.GL.Attribute.MultiSampleBuffers, 1);
+                Sdl.GL.SetAttribute(Sdl.GL.Attribute.MultiSampleSamples, msCount);
+            }
+
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.DoubleBuffer, 1);
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.ContextMajorVersion, 2);
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.ContextMinorVersion, 1);
 
-            ((SdlGameWindow)SdlGameWindow.Instance).CreateWindow();
+            ((SdlGameWindow)SdlGameWindow.Instance).CreateWindow(presentationParameters);
+        }
+
+        private int ClampMultisampleCount(PresentationParameters pp)
+        {
+            if (pp.MultiSampleCount < 2)
+            {
+                pp.MultiSampleCount = 0;
+                return 0;
+            }
+
+            var msCount = pp.MultiSampleCount;
+
+            // Round down MultiSampleCount to the nearest power of two
+            // hack from http://stackoverflow.com/a/2681094
+            // Note: this will return an incorrect, but large value
+            // for very large numbers. That doesn't matter because
+            // the number will get clamped below anyway in this case.
+            msCount = msCount | (msCount >> 1);
+            msCount = msCount | (msCount >> 2);
+            msCount = msCount | (msCount >> 4);
+            msCount -= msCount >> 1;
+
+            // we need a window to create a context to check for MS support, so create a dummy window
+            using (GraphicsContext.CreateDummy())
+            {
+                int maxMsCount;
+                GL.GetInteger(GetPName.MaxSamples, out maxMsCount);
+
+                // on my machine the maxMsCount is reported to be 16, but creating a window
+                // fails when ms count is set to 16. Can someone else please check to see
+                // if they have the same issue and if the following line is acceptable
+                maxMsCount >>= 1;
+                if (maxMsCount < msCount)
+                    msCount = maxMsCount;
+            }
+
+            pp.MultiSampleCount = msCount;
+            return msCount;
         }
     }
 }

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Xna.Framework
         private GraphicsDevice _graphicsDevice;
         private bool _initialized = false;
 
-        private int _preferredBackBufferHeight;
-        private int _preferredBackBufferWidth;
+        private int _preferredBackBufferWidth = DefaultBackBufferWidth;
+        private int _preferredBackBufferHeight = DefaultBackBufferHeight;
         private SurfaceFormat _preferredBackBufferFormat;
         private DepthFormat _preferredDepthStencilFormat;
         private bool _preferMultiSampling;
@@ -63,6 +63,9 @@ namespace Microsoft.Xna.Framework
             _preferredDepthStencilFormat = DepthFormat.Depth24;
             _synchronizedWithVerticalRetrace = true;
 
+            // TODO We should get rid of this, the window size should be intialized to the back buffer size
+            //      not the other way around. At least for desktop platforms.
+#if !DESKTOPGL
             // Assume the window client size as the default back 
             // buffer resolution in the landscape orientation.
             var clientBounds = _game.Window.ClientBounds;
@@ -76,6 +79,7 @@ namespace Microsoft.Xna.Framework
                 _preferredBackBufferWidth = clientBounds.Height;
                 _preferredBackBufferHeight = clientBounds.Width;
             }
+#endif
 
             // Default to windowed mode... this is ignored on platforms that don't support it.
             _wantFullScreen = false;
@@ -106,10 +110,11 @@ namespace Microsoft.Xna.Framework
 
             try
             {
-                if (!_initialized)
-                    Initialize();
-
                 var gdi = DoPreparingDeviceSettings();
+
+                if (!_initialized)
+                    Initialize(gdi.PresentationParameters);
+
                 CreateDevice(gdi);
             }
             catch (NoSuitableGraphicsDeviceException)
@@ -286,6 +291,7 @@ namespace Microsoft.Xna.Framework
             presentationParameters.BackBufferHeight = _preferredBackBufferHeight;
             presentationParameters.DepthStencilFormat = _preferredDepthStencilFormat;
             presentationParameters.IsFullScreen = _wantFullScreen;
+            presentationParameters.HardwareModeSwitch = _hardwareModeSwitch;
             presentationParameters.PresentationInterval = _synchronizedWithVerticalRetrace ? PresentInterval.One : PresentInterval.Immediate;
             presentationParameters.DisplayOrientation = _game.Window.CurrentOrientation;
             presentationParameters.DeviceWindowHandle = _game.Window.Handle;
@@ -362,15 +368,12 @@ namespace Microsoft.Xna.Framework
 
         partial void PlatformInitialize(PresentationParameters presentationParameters);
 
-        private void Initialize()
+        private void Initialize(PresentationParameters pp)
         {
             _game.Window.SetSupportedOrientations(_supportedOrientations);
 
-            var presentationParameters = new PresentationParameters();
-            PreparePresentationParameters(presentationParameters);
-
             // Allow for any per-platform changes to the presentation.
-            PlatformInitialize(presentationParameters);
+            PlatformInitialize(pp);
 
             _initialized = true;
         }

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Xna.Framework
 
         private int _isExiting;
         private SdlGameWindow _view;
+        internal bool SupressWindowEvents;
 
         public SdlGamePlatform(Game game)
             : base(game)
@@ -66,7 +67,7 @@ namespace Microsoft.Xna.Framework
             Sdl.DisableScreenSaver();
 
             GamePad.InitDatabase();
-            Window = _view = new SdlGameWindow(_game);
+            Window = _view = new SdlGameWindow(_game, this);
 
             try
             {
@@ -167,15 +168,23 @@ namespace Microsoft.Xna.Framework
                 else if (ev.Type == Sdl.EventType.WindowEvent)
                 {
                     if (ev.Window.EventID == Sdl.Window.EventId.SizeChanged)
-                        _view.ClientResize(ev.Window.Data1, ev.Window.Data2);
+                    {
+                        if (!SupressWindowEvents)
+                            _view.ClientResize(ev.Window.Data1, ev.Window.Data2);
+                    }
                     else if (ev.Window.EventID == Sdl.Window.EventId.FocusGained)
                         IsActive = true;
                     else if (ev.Window.EventID == Sdl.Window.EventId.FocusLost)
                         IsActive = false;
                     else if (ev.Window.EventID == Sdl.Window.EventId.Moved)
-                        _view.Moved();
+                    {
+                        if (!SupressWindowEvents)
+                            _view.Moved();
+                    }
                 }
             }
+
+            SupressWindowEvents = false;
         }
 
         public override void StartRunLoop()
@@ -196,14 +205,6 @@ namespace Microsoft.Xna.Framework
         public override bool BeforeDraw(GameTime gameTime)
         {
             return true;
-        }
-
-        public override void EnterFullScreen()
-        {
-        }
-
-        public override void ExitFullScreen()
-        {
         }
 
         public override void BeginScreenDeviceChange(bool willBeFullScreen)

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Xna.Framework
                 }
                 else if (ev.Type == Sdl.EventType.WindowEvent)
                 {
-                    if (ev.Window.EventID == Sdl.Window.EventId.Resized || ev.Window.EventID == Sdl.Window.EventId.SizeChanged)
+                    if (ev.Window.EventID == Sdl.Window.EventId.SizeChanged)
                         _view.ClientResize(ev.Window.Data1, ev.Window.Data2);
                     else if (ev.Window.EventID == Sdl.Window.EventId.FocusGained)
                         IsActive = true;

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Xna.Framework
         {
             get
             {
-                if (!HasNativeWindow)
+                if (Handle == IntPtr.Zero)
                     return _position;
 
                 int x = 0, y = 0;
@@ -67,11 +67,6 @@ namespace Microsoft.Xna.Framework
         public override IntPtr Handle
         {
             get { return _handle; }
-        }
-
-        private bool HasNativeWindow
-        {
-            get { return Handle != IntPtr.Zero; }
         }
 
         public override string ScreenDeviceName
@@ -110,13 +105,11 @@ namespace Microsoft.Xna.Framework
             _game = game;
             Instance = this;
 
-            var display = GetMouseDisplay();
+            Sdl.Rectangle bounds;
+            var display = GetMouseDisplay(out bounds);
             if (display != -1)
             {
                 _screenDeviceName = Sdl.Display.GetDisplayName(display);
-
-                Sdl.Rectangle bounds;
-                Sdl.Display.GetBounds(display, out bounds);
 
                 var x = bounds.X + (bounds.Width - GraphicsDeviceManager.DefaultBackBufferWidth) / 2;
                 var y = bounds.Y + (bounds.Height - GraphicsDeviceManager.DefaultBackBufferHeight) / 2;
@@ -147,7 +140,7 @@ namespace Microsoft.Xna.Framework
 
         internal void CreateWindow(PresentationParameters pp)
         {
-            if (HasNativeWindow)
+            if (Handle != IntPtr.Zero)
                 Sdl.Window.Destroy(Handle);
 
             _width = pp.BackBufferWidth;
@@ -188,7 +181,7 @@ namespace Microsoft.Xna.Framework
             Dispose(false);
         }
 
-        private static int GetMouseDisplay()
+        private static int GetMouseDisplay(out Sdl.Rectangle bounds)
         {
             int x, y;
             Sdl.Mouse.GetGlobalState(out x, out y);
@@ -201,9 +194,13 @@ namespace Microsoft.Xna.Framework
 
                 if (x >= rect.X && x < rect.X + rect.Width &&
                     y >= rect.Y && y < rect.Y + rect.Height)
+                {
+                    bounds = rect;
                     return i;
+                }
             }
 
+            bounds = default(Sdl.Rectangle);
             return -1;
         }
 

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Reflection;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
+using OpenGL;
 
 namespace Microsoft.Xna.Framework
 {
@@ -40,6 +41,9 @@ namespace Microsoft.Xna.Framework
         {
             get
             {
+                if (!HasNativeWindow)
+                    return _position;
+
                 int x = 0, y = 0;
 
                 if (!IsFullScreen)
@@ -49,6 +53,7 @@ namespace Microsoft.Xna.Framework
             }
             set
             {
+                _position = value;
                 Sdl.Window.SetPosition(Handle, value.X, value.Y);
                 _wasMoved = true;
             }
@@ -62,6 +67,11 @@ namespace Microsoft.Xna.Framework
         public override IntPtr Handle
         {
             get { return _handle; }
+        }
+
+        private bool HasNativeWindow
+        {
+            get { return Handle != IntPtr.Zero; }
         }
 
         public override string ScreenDeviceName
@@ -80,33 +90,37 @@ namespace Microsoft.Xna.Framework
         }
 
         public static GameWindow Instance;
-        public bool IsFullScreen;
+        public bool IsFullScreen { get; private set; }
 
-        internal readonly Game _game;
+        private readonly Game _game;
         private IntPtr _handle, _icon;
         private bool _disposed;
-        private bool _resizable, _borderless, _willBeFullScreen, _mouseVisible, _hardwareSwitch;
+        private bool _resizable, _borderless, _mouseVisible, _hardwareSwitch;
         private string _screenDeviceName;
-        private int _winx, _winy, _width, _height;
+        private Point _position;
+        private int _width, _height;
         private bool _wasMoved, _supressMoved;
+
+        private ColorFormat _surfaceFormat;
+        private DepthFormat _depthStencilFormat;
+        private int _multisampleCount;
 
         public SdlGameWindow(Game game)
         {
             _game = game;
-            _screenDeviceName = "";
-
             Instance = this;
 
-            _winx = Sdl.Window.PosUndefined;
-            _winy = Sdl.Window.PosUndefined;
-            _width = GraphicsDeviceManager.DefaultBackBufferWidth;
-            _height = GraphicsDeviceManager.DefaultBackBufferHeight;
-
-            if (Sdl.Patch >= 4)
+            var display = GetMouseDisplay();
+            if (display != -1)
             {
-                var display = GetMouseDisplay();
-                _winx = display.X + display.Width / 2;
-                _winy = display.Y + display.Height / 2;
+                _screenDeviceName = Sdl.Display.GetDisplayName(display);
+
+                Sdl.Rectangle bounds;
+                Sdl.Display.GetBounds(display, out bounds);
+
+                var x = bounds.X + (bounds.Width - GraphicsDeviceManager.DefaultBackBufferWidth) / 2;
+                var y = bounds.Y + (bounds.Height - GraphicsDeviceManager.DefaultBackBufferHeight) / 2;
+                _position = new Point(x, y);
             }
             
             Sdl.SetHint("SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS", "0");
@@ -129,25 +143,33 @@ namespace Microsoft.Xna.Framework
                         catch { }
                     }
             }
-
-            _handle = Sdl.Window.Create("", _winx, _winy,
-                GraphicsDeviceManager.DefaultBackBufferWidth, GraphicsDeviceManager.DefaultBackBufferHeight,
-                Sdl.Window.State.Hidden);
         }
 
-        internal void CreateWindow()
+        internal void CreateWindow(PresentationParameters pp)
         {
+            if (HasNativeWindow)
+                Sdl.Window.Destroy(Handle);
+
+            _width = pp.BackBufferWidth;
+            _height = pp.BackBufferHeight;
+
+            _surfaceFormat = pp.BackBufferFormat.GetColorFormat();
+            _depthStencilFormat = pp.DepthStencilFormat;
+            _multisampleCount = pp.MultiSampleCount;
+
             var initflags =
                 Sdl.Window.State.OpenGL |
-                Sdl.Window.State.Hidden |
                 Sdl.Window.State.InputFocus |
                 Sdl.Window.State.MouseFocus;
 
-            if (_handle != IntPtr.Zero)
-                Sdl.Window.Destroy(_handle);
+            if (pp.IsFullScreen)
+                initflags |= pp.HardwareModeSwitch ? Sdl.Window.State.Fullscreen : Sdl.Window.State.FullscreenDesktop;
 
-            _handle = Sdl.Window.Create(MonoGame.Utilities.AssemblyHelper.GetDefaultWindowTitle(),
-                _winx - _width / 2, _winy - _height / 2,
+            IsFullScreen = pp.IsFullScreen;
+            _hardwareSwitch = pp.HardwareModeSwitch;
+
+            _handle = Sdl.Window.Create(Title,
+                _position.X, _position.Y,
                 _width, _height, initflags);
 
             if (_icon != IntPtr.Zero)
@@ -157,6 +179,8 @@ namespace Microsoft.Xna.Framework
             Sdl.Window.SetResizable(_handle, _resizable);
 
             SetCursorVisible(_mouseVisible);
+
+            _supressMoved = true;
         }
 
         ~SdlGameWindow()
@@ -164,26 +188,23 @@ namespace Microsoft.Xna.Framework
             Dispose(false);
         }
 
-        private static Sdl.Rectangle GetMouseDisplay()
+        private static int GetMouseDisplay()
         {
-            var rect = new Sdl.Rectangle();
-
             int x, y;
             Sdl.Mouse.GetGlobalState(out x, out y);
 
             var displayCount = Sdl.Display.GetNumVideoDisplays();
             for (var i = 0; i < displayCount; i++)
             {
+                Sdl.Rectangle rect;
                 Sdl.Display.GetBounds(i, out rect);
 
                 if (x >= rect.X && x < rect.X + rect.Width &&
                     y >= rect.Y && y < rect.Y + rect.Height)
-                {
-                    return rect;
-                }
+                    return i;
             }
 
-            return rect;
+            return -1;
         }
 
         public void SetCursorVisible(bool visible)
@@ -194,27 +215,41 @@ namespace Microsoft.Xna.Framework
 
         public override void BeginScreenDeviceChange(bool willBeFullScreen)
         {
-            _willBeFullScreen = willBeFullScreen;
         }
 
         public override void EndScreenDeviceChange(string screenDeviceName, int clientWidth, int clientHeight)
         {
+            var pp = _game.GraphicsDevice.PresentationParameters;
+
+            // TODO recreate the window if depth format, back buffer format or multisample count changed
+
             _screenDeviceName = screenDeviceName;
 
-            var prevBounds = ClientBounds;
             var displayIndex = Sdl.Window.GetDisplayIndex(Handle);
 
             Sdl.Rectangle displayRect;
             Sdl.Display.GetBounds(displayIndex, out displayRect);
 
-            if (_willBeFullScreen != IsFullScreen || _hardwareSwitch != _game.graphicsDeviceManager.HardwareModeSwitch)
+            if ((!IsFullScreen && pp.IsFullScreen) ||
+                (IsFullScreen && pp.IsFullScreen && _hardwareSwitch != pp.HardwareModeSwitch))
             {
-                var fullscreenFlag = _game.graphicsDeviceManager.HardwareModeSwitch ? Sdl.Window.State.Fullscreen : Sdl.Window.State.FullscreenDesktop;
-                Sdl.Window.SetFullscreen(Handle, (_willBeFullScreen) ? fullscreenFlag : 0);
-                _hardwareSwitch = _game.graphicsDeviceManager.HardwareModeSwitch;
+                IsFullScreen = true;
+                var fullscreenFlag = pp.HardwareModeSwitch ? Sdl.Window.State.Fullscreen : Sdl.Window.State.FullscreenDesktop;
+                Sdl.Window.SetFullscreen(Handle, fullscreenFlag);
+                _hardwareSwitch = pp.HardwareModeSwitch;
+
+                OnClientSizeChanged();
+            }
+            else if (IsFullScreen && !pp.IsFullScreen)
+            {
+                IsFullScreen = false;
+                Sdl.Window.SetFullscreen(Handle, 0);
+                Sdl.Window.SetPosition(Handle, _position.X, _position.Y);
+
+                OnClientSizeChanged();
             }
 
-            if (!_willBeFullScreen || _game.graphicsDeviceManager.HardwareModeSwitch)
+            if (!IsFullScreen || _hardwareSwitch)
             {
                 Sdl.Window.SetSize(Handle, clientWidth, clientHeight);
                 _width = clientWidth;
@@ -226,32 +261,32 @@ namespace Microsoft.Xna.Framework
                 _height = displayRect.Height;
             }
 
-            var centerX = Math.Max(prevBounds.X + ((prevBounds.Width - clientWidth) / 2), 0);
-            var centerY = Math.Max(prevBounds.Y + ((prevBounds.Height - clientHeight) / 2), 0);
+            if (!_wasMoved && !IsFullScreen)
+                CenterWindow();
 
-            if (IsFullScreen && !_willBeFullScreen)
-            {
-                // We need to get the display information again in case
-                // the resolution of it was changed.
-                Sdl.Display.GetBounds (displayIndex, out displayRect);
-
-                // This centering only occurs when exiting fullscreen
-                // so it should center the window on the current display.
-                centerX = displayRect.X + displayRect.Width / 2 - clientWidth / 2;
-                centerY = displayRect.Y + displayRect.Height / 2 - clientHeight / 2;
+            _supressMoved = true;
             }
 
+        private void CenterWindow()
+        {
             // If this window is resizable, there is a bug in SDL 2.0.4 where
             // after the window gets resized, window position information
             // becomes wrong (for me it always returned 10 8). Solution is
             // to not try and set the window position because it will be wrong.
-            if ((Sdl.Patch > 4 || !AllowUserResizing) && !_wasMoved)
-                Sdl.Window.SetPosition(Handle, centerX, centerY);
+            if (Sdl.Patch < 4 && AllowUserResizing)
+                return;
 
-            IsFullScreen = _willBeFullScreen;
-            OnClientSizeChanged();
+            int x, y;
+            Sdl.Window.GetPosition(Handle, out x, out y);
 
-            _supressMoved = true;
+            var di = Sdl.Window.GetDisplayIndex(Handle);
+            Sdl.Rectangle displayBounds;
+            Sdl.Display.GetBounds(di, out displayBounds);
+
+            x = displayBounds.X + (displayBounds.Width - _width) / 2;
+            y = displayBounds.Y + (displayBounds.Height - _height) / 2;
+
+            Sdl.Window.SetPosition(Handle, x, y);
         }
 
         internal void Moved()
@@ -261,6 +296,10 @@ namespace Microsoft.Xna.Framework
                 _supressMoved = false;
                 return;
             }
+
+            int x, y;
+            Sdl.Window.GetPosition(Handle, out x, out y);
+            _position = new Point(x, y);
 
             _wasMoved = true;
         }
@@ -273,6 +312,14 @@ namespace Microsoft.Xna.Framework
                 _game.GraphicsDevice.PresentationParameters.BackBufferHeight == height) {
                 return;
             }
+
+            // TODO This should not even be working... We should change preferredBackBufferWidth/Height on the
+            // GraphicsDeviceManager, but that currently causes issues because this event is raised when
+            // switching to full screen with width and height the size of the display. So it messes up
+            // the back buffer size if we set it with those values...
+
+            // The issues with the current implementation are very noticeable when
+            // both letting the user resize and resizing the backbuffer through code.
             _game.GraphicsDevice.PresentationParameters.BackBufferWidth = width;
             _game.GraphicsDevice.PresentationParameters.BackBufferHeight = height;
             _game.GraphicsDevice.Viewport = new Viewport(0, 0, width, height);

--- a/MonoGame.Framework/Windows/WinFormsGameForm.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameForm.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Windows.Forms;
 using Microsoft.Xna.Framework.Input.Touch;
+using MonoGame.Framework;
 
 
 namespace Microsoft.Xna.Framework.Windows
@@ -31,7 +32,7 @@ namespace Microsoft.Xna.Framework.Windows
     [System.ComponentModel.DesignerCategory("Code")]
     internal class WinFormsGameForm : Form
     {
-        GameWindow _window;
+        private readonly WinFormsGameWindow _window;
         public const int WM_POINTERUP = 0x0247;
         public const int WM_POINTERDOWN = 0x0246;
         public const int WM_POINTERUPDATE = 0x0245;
@@ -42,7 +43,7 @@ namespace Microsoft.Xna.Framework.Windows
 
         public bool AllowAltF4 = true;
 
-        public WinFormsGameForm(GameWindow window)
+        public WinFormsGameForm(WinFormsGameWindow window)
         {
             _window = window;
         }
@@ -81,16 +82,15 @@ namespace Microsoft.Xna.Framework.Windows
                 case WM_KEYDOWN:
                     switch (m.WParam.ToInt32())
                     {
+                        case 0x5C: // Right Windows Key
                         case 0x5B:  // Left Windows Key
 
-                            if (this.WindowState == FormWindowState.Maximized)
+                            if (_window.IsFullScreen)
                             {
                                 this.WindowState = FormWindowState.Minimized;
                             }
  		 
                             break;
-                        case 0x5C: // Right Windows Key
-                            goto case 0x5B;
                     }
                     break;
 #endif

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -16,7 +16,6 @@ namespace MonoGame.Framework
         //internal static string LaunchParameters;
 
         private WinFormsGameWindow _window;
-        private System.Drawing.Point _locationBeforeFullscreen;
 
         public WinFormsGamePlatform(Game game)
             : base(game)
@@ -51,15 +50,12 @@ namespace MonoGame.Framework
             var gdm = Game.graphicsDeviceManager;
             if (gdm == null)
             {
-                _window.Initialize(GraphicsDeviceManager.DefaultBackBufferWidth, GraphicsDeviceManager.DefaultBackBufferHeight);
+                _window.Initialize();
             }
             else
             {
                 var pp = Game.GraphicsDevice.PresentationParameters;
-                _window.Initialize(pp.BackBufferWidth, pp.BackBufferHeight);
-
-                if (gdm.IsFullScreen)
-                    EnterFullScreen();
+                _window.Initialize(pp);
             }
         }
 
@@ -91,49 +87,11 @@ namespace MonoGame.Framework
             return true;
         }
 
-        public override void EnterFullScreen()
-        {
-            // store the location of the window so we can restore it later
-            _locationBeforeFullscreen = _window.Form.Location;
-            if (Game.graphicsDeviceManager.HardwareModeSwitch)
-                Game.GraphicsDevice.SetHardwareFullscreen();
-            else
-                _window.IsBorderless = true;
-
-            _window.Form.WindowState = FormWindowState.Maximized;
-
-            InFullScreenMode = true;
-        }
-
-        public override void ExitFullScreen()
-        {
-            if (Game.graphicsDeviceManager.HardwareModeSwitch)
-                Game.GraphicsDevice.SetHardwareFullscreen();
-            else
-                _window.IsBorderless = false;
-
-            _window.Form.WindowState = FormWindowState.Normal;
-            _window.Form.Location = _locationBeforeFullscreen;
-
-            InFullScreenMode = false;
-        }
-
         internal override void OnPresentationChanged()
         {
             var pp = Game.GraphicsDevice.PresentationParameters;
-            _window.ChangeClientSize(new Size(pp.BackBufferWidth, pp.BackBufferHeight));
-
-            if (Game.GraphicsDevice.PresentationParameters.IsFullScreen && !InFullScreenMode)
-            {
-                EnterFullScreen();
-                _window.OnClientSizeChanged();
-            }
-            else if (!Game.GraphicsDevice.PresentationParameters.IsFullScreen && InFullScreenMode)
-            {
-                ExitFullScreen();
-                _window.OnClientSizeChanged();
-            }
-        }
+            _window.OnPresentationChanged(pp);
+       }
 
         public override void EndScreenDeviceChange(string screenDeviceName, int clientWidth, int clientHeight)
         {


### PR DESCRIPTION
This makes some improvements to how the GameWindow works:

- Multisampling is supported by the window on initilization. I create a dummy window to create a temporary GraphicsContext to query for multisampling support. I got some weird behaviour though, so would be nice if someone can test that.
- The window position can be set before the native window is instantiated.
- The window title can be set before the native window is instantiated.
- Initializing in full screen mode no longer depends on the internal `applyChanges` method in game. I #iffed out DESKTOPGL for that method so we know it no longer needs it. One step closer to getting rid of it completely.
- Stop listening for SDL Resized event. If it is raised, the SizeChanged event is raised too, so listening to that is sufficient.
- The ClientSizeChanged event is only raised when a user resizes the window (also while resizing, not just when resizing ends but there's no way to distinguish the two with the SDL API), not when it is resized through a back buffer size change.
- The window position is restored after exiting full screen. This is not very stable because SDL raises a bunch of events when entering/exiting full screen and we can't distinguish them from when a user moves the window. Optionally we can check if window position in the event is (0, 0) relative to the current display and assume its a full screen transition and ignore it when it is.
- Window centering now also happens after resizing the backbuffer in stead of just when exiting full screen. This is also not very stable because of the previous issue. Sometimes we detect a window move when
it's because of a full screen switch and afterwards the window will no longer be centered.

I also added some todo's/comments for more intricate stuff like recreating the window when certain presentation parameters change.