### PR TITLE
Make MonoGame content builder work from one source on all the platforms

### DIFF
--- a/Build/Projects/2MGFX.definition
+++ b/Build/Projects/2MGFX.definition
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Name="2MGFX" Path="Tools/2MGFX" Type="Console" Platforms="Windows">
+<Project Name="2MGFX" Path="Tools/2MGFX" Type="Console" Platforms="Windows,Linux">
 
   <!-- Common assembly references -->
   <References>
@@ -22,6 +22,7 @@
 
     <CustomDefinitions>
       <Platform Name="Windows">TRACE;WINDOWS</Platform>
+      <Platform Name="Linux">TRACE;LINUX</Platform>
     </CustomDefinitions>
 
   </Properties>
@@ -162,6 +163,9 @@
     </Compile>    
     <Compile Include="..\..\MonoGame.Framework\Utilities\Hash.cs">
       <Link>MonoGame.Framework\Utilities\Hash.cs</Link>
+    </Compile>
+    <Compile Include="..\..\MonoGame.Framework\Utilities\CurrentPlatform.cs">
+      <Link>MonoGame.Framework\Utilities\CurrentPlatform.cs</Link>
     </Compile>
     
     <!-- We also use a few types from the content pipeline. -->

--- a/Build/Projects/2MGFXReferences.definition
+++ b/Build/Projects/2MGFXReferences.definition
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ExternalProject Name="2MGFXReferences">
-
-  <Platform Type="Windows">
-    <Binary
-      Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.dll" />
-    <Binary
-      Name="SharpDX.D3DCompiler"
-      Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.D3DCompiler.dll" />
-    <Binary
-      Name="CppNet"
-      Path="ThirdParty/Dependencies/CppNet/CppNet.dll" />
-    <NativeBinary Path="ThirdParty\Dependencies\MojoShader\Windows\libmojoshader_64.dll" />
-  </Platform>
-
+  <Binary
+    Name="SharpDX"
+    Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.dll" />
+  <Binary
+    Name="SharpDX.D3DCompiler"
+    Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.D3DCompiler.dll" />
+  <Binary
+    Name="CppNet"
+    Path="ThirdParty/Dependencies/CppNet/CppNet.dll" />
+  <NativeBinary Path="ThirdParty\Dependencies\MojoShader\Windows\libmojoshader_64.dll" />
 </ExternalProject>

--- a/Build/Projects/Framework.Content.Pipeline.References.definition
+++ b/Build/Projects/Framework.Content.Pipeline.References.definition
@@ -1,108 +1,66 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ExternalProject Name="Framework.Content.Pipeline.References">
+  <Binary
+    Name="AssimpNet"
+    Path="ThirdParty\Dependencies\assimp\AssimpNet.dll" />
+  <Binary
+    Name="Nvidia.TextureTools"
+    Path="ThirdParty\Dependencies\NVTT\Windows\Nvidia.TextureTools.dll" />
+  <Binary
+    Name="SharpFont"
+    Path="ThirdParty\Dependencies\SharpFont\x32\SharpFont.dll" />
+  <Binary
+    Name="PVRTexLibNET"
+    Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" />
+  <Binary
+    Name="ATI.TextureConverter"
+    Path="ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll" />
+  <Binary
+    Name="SharpDX"
+    Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.dll" />
+  <Binary
+    Name="SharpDX.D3DCompiler"
+    Path="ThirdParty\Dependencies\SharpDX\Windows\SharpDX.D3DCompiler.dll" />
+  <Binary
+    Name="CppNet"
+    Path="ThirdParty\Dependencies\CppNet\CppNet.dll" />
+    
+  <!-- Windows Native Libs -->
+  <NativeBinary Path="ThirdParty\Dependencies\NVTT\Windows\x64\nvtt.dll" />
+  <NativeBinary Path="ThirdParty\Dependencies\assimp\Assimp64.dll" />
+  <NativeBinary Path="ThirdParty\Dependencies\MojoShader\Windows\libmojoshader_64.dll" />
+  <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\freetype6.dll" />
+  <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\Windows\FreeImage.dll" />
+  <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Windows\x64\ffmpeg.exe" />
+  <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Windows\x64\ffprobe.exe" />
+  <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\Windows\x64\PVRTexLibWrapper.dll" />
+    
+  <!-- Linux Native Libs -->
+  <NativeBinary Path="ThirdParty\Dependencies\assimp\libassimp.so" />
+  <NativeBinary Path="ThirdParty\Dependencies\NVTT\Linux\libnvcore.so" />
+  <NativeBinary Path="ThirdParty\Dependencies\NVTT\Linux\libnvimage.so" />
+  <NativeBinary Path="ThirdParty\Dependencies\NVTT\Linux\libnvmath.so" />
+  <NativeBinary Path="ThirdParty\Dependencies\NVTT\Linux\libnvtt.so" />
+  <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\Linux\x64\libfreeimage-3.17.0.so" />
+  <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\Linux\x86\libPVRTexLibWrapper.so" />
+  <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\Linux\x64\libPVRTexLibWrapper.so" />
 
-  <Platform Type="Linux">
-    <Binary
-      Name="AssimpNet"
-      Path="ThirdParty\Dependencies\assimp\AssimpNet.dll" />
-    <Binary
-      Name="Nvidia.TextureTools"
-      Path="ThirdParty\Dependencies\NVTT\Windows\Nvidia.TextureTools.dll" />
-    <Binary
-      Name="SharpFont"
-      Path="ThirdParty\Dependencies\SharpFont\x32\SharpFont.dll" />
-    <Binary
-      Name="PVRTexLibNET"
-      Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" />
-    <Binary
-      Name="ATI.TextureConverter"
-      Path="ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll" />
-    <NativeBinary Path="ThirdParty\Dependencies\assimp\libassimp.so" />
-    <NativeBinary Path="ThirdParty\Dependencies\NVTT\Linux\libnvcore.so" />
-    <NativeBinary Path="ThirdParty\Dependencies\NVTT\Linux\libnvimage.so" />
-    <NativeBinary Path="ThirdParty\Dependencies\NVTT\Linux\libnvmath.so" />
-    <NativeBinary Path="ThirdParty\Dependencies\NVTT\Linux\libnvtt.so" />
-    <NativeBinary Path="ThirdParty\Dependencies\NVTT\Windows\Nvidia.TextureTools.dll.config" />
-    <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll.config" />
-    <NativeBinary Path="ThirdParty\Dependencies\assimp\AssimpNet.dll.config" />
-    <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\Linux\x64\libfreeimage-3.17.0.so" />
-    <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Linux\x64\ffmpeg" />
-    <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Linux\x64\ffprobe" />
-    <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\Linux\x86\libPVRTexLibWrapper.so" />
-    <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\Linux\x64\libPVRTexLibWrapper.so" />
-    <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll.config" />
-    <NativeBinary Path="ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll.config" />
-  </Platform>
-
-
-  <Platform Type="MacOS">
-    <Binary
-      Name="AssimpNet"
-      Path="ThirdParty\Dependencies\assimp\AssimpNet.dll" />
-    <Binary
-      Name="Nvidia.TextureTools"
-      Path="ThirdParty\Dependencies\NVTT\Windows\Nvidia.TextureTools.dll" />
-    <Binary
-      Name="SharpFont"
-      Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll" />
-    <Binary
-      Name="PVRTexLibNET"
-      Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" />
-    <Binary
-      Name="ATI.TextureConverter"
-      Path="ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll" />
-    <NativeBinary Path="ThirdParty\Dependencies\NVTT\MacOS\libnvcore.dylib" />
-    <NativeBinary Path="ThirdParty\Dependencies\NVTT\MacOS\libnvimage.dylib" />
-    <NativeBinary Path="ThirdParty\Dependencies\NVTT\MacOS\libnvmath.dylib" />
-    <NativeBinary Path="ThirdParty\Dependencies\NVTT\MacOS\libnvtt.dylib" />
-    <NativeBinary Path="ThirdParty\Dependencies\NVTT\Windows\Nvidia.TextureTools.dll.config" />
-    <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\libfreetype.6.dylib" />
-    <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\libpng15.15.dylib" />
-    <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll.config" />
-    <NativeBinary Path="ThirdParty\Dependencies\assimp\AssimpNet.dll.config" />
-    <NativeBinary Path="ThirdParty\Dependencies\assimp\libassimp.dylib" />
-    <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\MacOS\ffmpeg" />
-    <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\MacOS\ffprobe" />
-    <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\MacOS\libfreeimage.dylib" />
-    <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\OSX\x86\libPVRTexLibWrapper.dylib" />
-    <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll.config" />
-    <NativeBinary Path="ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll.config" />
-  </Platform>
-
-
-  <Platform Type="Windows">
-    <Binary
-      Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.dll" />
-    <Binary
-      Name="SharpDX.D3DCompiler"
-      Path="ThirdParty\Dependencies\SharpDX\Windows\SharpDX.D3DCompiler.dll" />
-    <Binary
-      Name="CppNet"
-      Path="ThirdParty\Dependencies\CppNet\CppNet.dll" />
-    <Binary
-      Name="AssimpNet"
-      Path="ThirdParty\Dependencies\assimp\AssimpNet.dll" />
-    <Binary
-      Name="Nvidia.TextureTools"
-      Path="ThirdParty\Dependencies\NVTT\Windows\Nvidia.TextureTools.dll" />
-    <Binary
-      Name="SharpFont"
-      Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll" />
-    <Binary
-      Name="PVRTexLibNET"
-      Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" />
-    <Binary
-      Name="ATI.TextureConverter"
-      Path="ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll" />
-    <NativeBinary Path="ThirdParty\Dependencies\NVTT\Windows\x64\nvtt.dll" />
-    <NativeBinary Path="ThirdParty\Dependencies\assimp\Assimp64.dll" />
-    <NativeBinary Path="ThirdParty\Dependencies\MojoShader\Windows\libmojoshader_64.dll" />
-    <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\freetype6.dll" />
-    <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\Windows\FreeImage.dll" />
-    <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Windows\x64\ffmpeg.exe" />
-    <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Windows\x64\ffprobe.exe" />
-    <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\Windows\x64\PVRTexLibWrapper.dll" />
-  </Platform>
-	
+  <!-- Mac Native Libs -->
+  <NativeBinary Path="ThirdParty\Dependencies\NVTT\MacOS\libnvcore.dylib" />
+  <NativeBinary Path="ThirdParty\Dependencies\NVTT\MacOS\libnvimage.dylib" />
+  <NativeBinary Path="ThirdParty\Dependencies\NVTT\MacOS\libnvmath.dylib" />
+  <NativeBinary Path="ThirdParty\Dependencies\NVTT\MacOS\libnvtt.dylib" />
+  <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\libfreetype.6.dylib" />
+  <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\libpng15.15.dylib" />
+  <NativeBinary Path="ThirdParty\Dependencies\assimp\libassimp.dylib" />
+  <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\MacOS\libfreeimage.dylib" />
+  <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\OSX\x86\libPVRTexLibWrapper.dylib" />
+  
+  <!-- Mono Config Files -->
+  <NativeBinary Path="ThirdParty\Dependencies\assimp\AssimpNet.dll.config" />
+  <NativeBinary Path="ThirdParty\Dependencies\NVTT\Windows\Nvidia.TextureTools.dll.config" />
+  <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll.config" />
+  <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll.config" />
+  <NativeBinary Path="ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll.config" />
+  
 </ExternalProject>

--- a/Build/Projects/Framework.Content.Pipeline.References.definition
+++ b/Build/Projects/Framework.Content.Pipeline.References.definition
@@ -12,9 +12,6 @@
       Name="SharpFont"
       Path="ThirdParty\Dependencies\SharpFont\x32\SharpFont.dll" />
     <Binary
-      Name="FreeImageNET"
-      Path="ThirdParty\Dependencies\FreeImage.NET\FreeImageNET.dll" />
-    <Binary
       Name="PVRTexLibNET"
       Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" />
     <Binary
@@ -28,7 +25,6 @@
     <NativeBinary Path="ThirdParty\Dependencies\NVTT\Windows\Nvidia.TextureTools.dll.config" />
     <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll.config" />
     <NativeBinary Path="ThirdParty\Dependencies\assimp\AssimpNet.dll.config" />
-    <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\FreeImageNET.dll.config" />
     <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\Linux\x64\libfreeimage-3.17.0.so" />
     <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Linux\x64\ffmpeg" />
     <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Linux\x64\ffprobe" />
@@ -50,9 +46,6 @@
       Name="SharpFont"
       Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll" />
     <Binary
-      Name="FreeImageNET"
-      Path="ThirdParty\Dependencies\FreeImage.NET\FreeImageNET.dll" />
-    <Binary
       Name="PVRTexLibNET"
       Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" />
     <Binary
@@ -70,7 +63,6 @@
     <NativeBinary Path="ThirdParty\Dependencies\assimp\libassimp.dylib" />
     <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\MacOS\ffmpeg" />
     <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\MacOS\ffprobe" />
-    <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\FreeImageNET.dll.config" />
     <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\MacOS\libfreeimage.dylib" />
     <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\OSX\x86\libPVRTexLibWrapper.dylib" />
     <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll.config" />
@@ -97,9 +89,6 @@
     <Binary
       Name="SharpFont"
       Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll" />
-    <Binary
-      Name="FreeImageNET"
-      Path="ThirdParty\Dependencies\FreeImage.NET\Windows\FreeImageNET.dll" />
     <Binary
       Name="PVRTexLibNET"
       Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" />

--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -49,6 +49,10 @@
   <Files>
 
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <None Include="MonoGame.Framework.Content.Pipeline.dll.config">
+      <Platforms>Linux,MacOS</Platforms>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     
 
     <!-- Microsoft.Xna.Framework.Content.Pipeline.Audio -->
@@ -455,6 +459,7 @@
 
 	<!-- Utility Classes -->
     <Compile Include="Utilities\Vector4Converter.cs" />
+    <Compile Include="Utilities\FreeImageAPI.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.Unsafe.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.Unsafe32.Dirty.cs" />

--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -49,8 +49,23 @@
   <Files>
 
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <None Include="..\ThirdParty\Dependencies\ffmpeg\Linux\x64\ffmpeg">
+      <Link>ffmpeg.x64</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\ffmpeg\Linux\x64\ffprobe">
+      <Link>ffprobe.x64</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\ffmpeg\MacOS\ffmpeg">
+      <Link>ffmpeg.osx</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\ffmpeg\MacOS\ffprobe">
+      <Link>ffprobe.osx</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="MonoGame.Framework.Content.Pipeline.dll.config">
-      <Platforms>Linux,MacOS</Platforms>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     
@@ -177,132 +192,100 @@
     <Compile Include="Processors\VideoProcessor.cs" />
 
     <!-- TwoMGFX-->
-    <Compile Include="..\Tools\2MGFX\CommandLineParser.cs">	
-      <Platforms>Windows</Platforms>
+    <Compile Include="..\Tools\2MGFX\CommandLineParser.cs">
       <Link>Processors\MGFX\CommandLineParser.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ConstantBufferData.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ConstantBufferData.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ConstantBufferData.mojo.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ConstantBufferData.mojo.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ConstantBufferData.sharpdx.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ConstantBufferData.sharpdx.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ConstantBufferData.writer.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ConstantBufferData.writer.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\EffectObject.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\EffectObject.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\EffectObject.hlsl.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\EffectObject.hlsl.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\EffectObject.pssl.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\EffectObject.pssl.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\EffectObject.writer.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\EffectObject.writer.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\IEffectCompilerOutput.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\IEffectCompilerOutput.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\MarshalHelper.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\MarshalHelper.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ShaderCompilerException.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ShaderCompilerException.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ShaderData.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ShaderData.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ShaderData.mojo.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ShaderData.mojo.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ShaderData.pssl.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ShaderData.pssl.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ShaderData.sharpdx.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ShaderData.sharpdx.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ShaderData.writer.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ShaderData.writer.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\MojoShader.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\MojoShader.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\Options.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\Options.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\Parser.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\Parser.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ParseTree.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ParseTree.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ParseTreeTools.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ParseTreeTools.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\PassInfo.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\PassInfo.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\Preprocessor.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\Preprocessor.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\SamplerStateInfo.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\SamplerStateInfo.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\Scanner.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\Scanner.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ShaderInfo.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ShaderInfo.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ShaderProfile.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ShaderProfile.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ShaderProfile.OpenGL.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ShaderProfile.OpenGL.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\ShaderProfile.DirectX.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\ShaderProfile.DirectX.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\TechniqueInfo.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\TechniqueInfo.cs</Link>
     </Compile>
     <Compile Include="..\Tools\2MGFX\TextureFilterType.cs">
-      <Platforms>Windows</Platforms>
       <Link>Processors\MGFX\TextureFilterType.cs</Link>
     </Compile>
 

--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -460,6 +460,7 @@
 	<!-- Utility Classes -->
     <Compile Include="Utilities\Vector4Converter.cs" />
     <Compile Include="Utilities\FreeImageAPI.cs" />
+    <Compile Include="Utilities\FreeImageAPIC.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.Unsafe.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.Unsafe32.Dirty.cs" />

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1194,7 +1194,7 @@
       <Platforms>Angle,Linux,MacOS,Windows,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Utilities\CurrentPlatform.cs">
-      <Platforms>WindowsGL,Linux</Platforms>
+      <Platforms>Windows,MacOS,WindowsGL,Linux</Platforms>
     </Compile>
     <Compile Include="Utilities\Hash.cs" />
     <Compile Include="Utilities\FileHelpers.cs" />

--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
+using MonoGame.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline
 {
@@ -133,11 +134,17 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                 if (File.Exists(fullName))
                     return fullName;
 
-#if WINDOWS
-                var fullExeName = string.Concat(fullName, ".exe");
+                var fullExeName = fullName;
+
+                if (CurrentPlatform.OS == OS.Windows)
+                    fullExeName += ".exe";
+                else if (CurrentPlatform.OS == OS.Linux)
+                    fullExeName += ".x64";
+                else if (CurrentPlatform.OS == OS.MacOSX)
+                    fullExeName += ".osx";
+
                 if (File.Exists(fullExeName))
                     return fullExeName;
-#endif
             }
 
             return null;

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             // Convert to FreeImage bitmap
             var bytes = src.GetPixelData();
-            var fi = FreeImage.ConvertFromRawBits(bytes, src.Width, src.Height, SurfaceFormat.Vector4.GetSize() * src.Width, 128, 0, 0, 0, true);
+            var fi = FreeImage.ConvertFromRawBits(bytes, FREE_IMAGE_TYPE.FIT_RGBAF, src.Width, src.Height, SurfaceFormat.Vector4.GetSize() * src.Width, 128, 0, 0, 0, true);
 
             // Resize
             var newfi = FreeImage.Rescale(fi, newWidth, newHeight, FREE_IMAGE_FILTER.FILTER_BICUBIC);

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -26,18 +26,18 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             // Convert to FreeImage bitmap
             var bytes = src.GetPixelData();
-            var fi = FreeImage.ConvertFromRawBits(bytes, FREE_IMAGE_TYPE.FIT_RGBAF, src.Width, src.Height, SurfaceFormat.Vector4.GetSize() * src.Width, 128, 0, 0, 0, true);
+            var fi = FreeImage.ConvertFromRawBits(bytes, src.Width, src.Height, SurfaceFormat.Vector4.GetSize() * src.Width, 128, 0, 0, 0, true);
 
             // Resize
             var newfi = FreeImage.Rescale(fi, newWidth, newHeight, FREE_IMAGE_FILTER.FILTER_BICUBIC);
-            FreeImage.UnloadEx(ref fi);
+            FreeImage.Unload(fi);
 
             // Convert back to PixelBitmapContent<Vector4>
             src = new PixelBitmapContent<Vector4>(newWidth, newHeight);
             bytes = new byte[SurfaceFormat.Vector4.GetSize() * newWidth * newHeight];
             FreeImage.ConvertToRawBits(bytes, newfi, SurfaceFormat.Vector4.GetSize() * newWidth, 128, 0, 0, 0, true);
             src.SetPixelData(bytes);
-            FreeImage.UnloadEx(ref newfi);
+            FreeImage.Unload(newfi);
             // Convert back to source type if required
             if (format != SurfaceFormat.Vector4)
             {

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.dll.config
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.dll.config
@@ -1,0 +1,4 @@
+﻿<configuration>
+  <dllmap os="osx" dll="FreeImage" target="libfreeimage.dylib"/>
+  <dllmap os="linux" dll="FreeImage" target="libfreeimage-3.17.0.so"/>
+</configuration>

--- a/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using Assimp;
 using Assimp.Unmanaged;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+using MonoGame.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline
 {
@@ -224,17 +225,19 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         public override NodeContent Import(string filename, ContentImporterContext context)
         {
             _context = context;
-#if LINUX
-			var targetDir = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
 
-			try
-			{
-				AssimpLibrary.Instance.LoadLibrary(
-					Path.Combine(targetDir, "libassimp.so"), 
-					Path.Combine(targetDir, "libassimp.so"));
-			}
-			catch { }
-#endif
+            if (CurrentPlatform.OS == OS.Linux)
+            {
+                var targetDir = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
+
+                try
+                {
+                    AssimpLibrary.Instance.LoadLibrary(
+                        Path.Combine(targetDir, "libassimp.so"),
+                        Path.Combine(targetDir, "libassimp.so"));
+                }
+                catch { }
+            }
 
             _identity = new ContentIdentity(filename, string.IsNullOrEmpty(ImporterName) ? GetType().Name : ImporterName);
 

--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
@@ -7,9 +7,8 @@ using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
-#if WINDOWS
+using MonoGame.Utilities;
 using TwoMGFX;
-#endif
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 {
@@ -50,7 +49,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         /// <remarks>If you get an error during processing, compilation stops immediately. The effect processor displays an error message. Once you fix the current error, it is possible you may get more errors on subsequent compilation attempts.</remarks>
         public override CompiledEffectContent Process(EffectContent input, ContentProcessorContext context)
         {
-#if WINDOWS
+            if (CurrentPlatform.OS != OS.Windows)
+                throw new NotImplementedException();
+            
             var options = new Options();
             options.SourceFile = input.Identity.SourceFilename;
 
@@ -123,12 +124,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             }
 
             return result;
-#else
-            throw new NotImplementedException();
-#endif
         }
 
-#if WINDOWS
         private class ContentPipelineEffectCompilerOutput : IEffectCompilerOutput
         {
             private readonly ContentProcessorContext _context;
@@ -153,7 +150,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                 return new ContentIdentity(file, null, line + "," + column);
             }
         }
-#endif
 
         private static void ProcessErrorsAndWarnings(bool buildFailed, string shaderErrorsAndWarnings, EffectContent input, ContentProcessorContext context)
         {

--- a/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPI.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPI.cs
@@ -92,7 +92,7 @@ namespace FreeImageAPI
         FICC_PHASE
     }
 
-    public class FreeImage
+    partial class FreeImage
     {
         private const string NativeLibName = "FreeImage";
 
@@ -171,5 +171,14 @@ namespace FreeImageAPI
 
         [DllImport(NativeLibName, EntryPoint = "FreeImage_GetBlueMask")]
         public static extern uint GetBlueMask(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_AllocateT")]
+        public static extern IntPtr AllocateT(FREE_IMAGE_TYPE type, int width, int height, int bpp, uint red_mask, uint green_mask, uint blue_mask);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetScanLine")]
+        public static extern IntPtr GetScanLine(IntPtr dib, int scanline);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetLine")]
+        public static extern uint GetLine(IntPtr dib);
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPI.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPI.cs
@@ -1,0 +1,175 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Runtime.InteropServices;
+using MonoGame.Utilities;
+
+namespace FreeImageAPI
+{
+    public enum FREE_IMAGE_TYPE
+    {
+        FIT_UNKNOWN,
+        FIT_BITMAP,
+        FIT_UINT16,
+        FIT_INT16,
+        FIT_UINT32,
+        FIT_INT32,
+        FIT_FLOAT,
+        FIT_DOUBLE,
+        FIT_COMPLEX,
+        FIT_RGB16,
+        FIT_RGBA16,
+        FIT_RGBF,
+        FIT_RGBAF
+    }
+
+    public enum FREE_IMAGE_FILTER
+    {
+        FILTER_BOX,
+        FILTER_BICUBIC,
+        FILTER_BILINEAR,
+        FILTER_BSPLINE,
+        FILTER_CATMULLROM,
+        FILTER_LANCZOS3
+    }
+
+    public enum FREE_IMAGE_FORMAT
+    {
+        FIF_UNKNOWN = -1,
+        FIF_BMP,
+        FIF_ICO,
+        FIF_JPEG,
+        FIF_JNG,
+        FIF_KOALA,
+        FIF_LBM,
+        FIF_IFF,
+        FIF_MNG,
+        FIF_PBM,
+        FIF_PBMRAW,
+        FIF_PCD,
+        FIF_PCX,
+        FIF_PGM,
+        FIF_PGMRAW,
+        FIF_PNG,
+        FIF_PPM,
+        FIF_PPMRAW,
+        FIF_RAS,
+        FIF_TARGA,
+        FIF_TIFF,
+        FIF_WBMP,
+        FIF_PSD,
+        FIF_CUT,
+        FIF_XBM,
+        FIF_XPM,
+        FIF_DDS,
+        FIF_GIF,
+        FIF_HDR,
+        FIF_FAXG3,
+        FIF_SGI,
+        FIF_EXR,
+        FIF_J2K,
+        FIF_JP2,
+        FIF_PFM,
+        FIF_PICT,
+        FIF_RAW,
+        FIF_WEBP,
+        FIF_JXR
+    }
+
+    public enum FREE_IMAGE_COLOR_CHANNEL
+    {
+        FICC_RGB,
+        FICC_RED,
+        FICC_GREEN,
+        FICC_BLUE,
+        FICC_ALPHA,
+        FICC_BLACK,
+        FICC_REAL,
+        FICC_IMAG,
+        FICC_MAG,
+        FICC_PHASE
+    }
+
+    public class FreeImage
+    {
+        private const string NativeLibName = "FreeImage";
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_ConvertFromRawBits")]
+        public static extern IntPtr ConvertFromRawBits(byte[] bits, int width, int height, int pitch, uint bpp, uint red_mask, uint green_mask, uint blue_mask, bool topdown);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_Rescale")]
+        public static extern IntPtr Rescale(IntPtr dib, int dst_width, int dst_height, FREE_IMAGE_FILTER filter);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_Unload")]
+        public static extern void Unload(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_ConvertToRawBits")]
+        public static extern void ConvertToRawBits(byte[] bits, IntPtr dib, int pitch, uint bpp, uint red_mask, uint green_mask, uint blue_mask, bool topdown);
+
+        [DllImport(NativeLibName, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_GetFileTypeU")]
+        public static extern FREE_IMAGE_FORMAT GetFileTypeU(string filename, int size);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetFileType")]
+        public static extern FREE_IMAGE_FORMAT GetFileTypeS(string filename, int size);
+
+        public static FREE_IMAGE_FORMAT GetFileType(string filename, int size)
+        {
+            if (CurrentPlatform.OS == OS.Windows)
+                return GetFileTypeU(filename, size);
+            else
+                return GetFileTypeS(filename, size);
+        }
+
+        [DllImport(NativeLibName, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_LoadU")]
+        public static extern IntPtr LoadU(FREE_IMAGE_FORMAT fif, string filename, int flags);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_Load")]
+        public static extern IntPtr LoadS(FREE_IMAGE_FORMAT fif, string filename, int flags);
+
+        public static IntPtr Load(FREE_IMAGE_FORMAT fif, string filename, int flags)
+        {
+            if (CurrentPlatform.OS == OS.Windows)
+                return LoadU(fif, filename, flags);
+            else
+                return LoadS(fif, filename, flags);
+        }
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetHeight")]
+        public static extern uint GetHeight(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetWidth")]
+        public static extern uint GetWidth(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetImageType")]
+        public static extern FREE_IMAGE_TYPE GetImageType(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetChannel")]
+        public static extern IntPtr GetChannel(IntPtr dib, FREE_IMAGE_COLOR_CHANNEL channel);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_SetChannel")]
+        public static extern bool SetChannel(IntPtr dib, IntPtr dib8, FREE_IMAGE_COLOR_CHANNEL channel);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_ConvertToType")]
+        public static extern IntPtr ConvertToType(IntPtr src, FREE_IMAGE_TYPE dst_type, bool scale_linear);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_ConvertTo32Bits")]
+        public static extern IntPtr ConvertTo32Bits(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetBPP")]
+        public static extern uint GetBPP(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetPitch")]
+        public static extern uint GetPitch(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetRedMask")]
+        public static extern uint GetRedMask(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetGreenMask")]
+        public static extern uint GetGreenMask(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetBlueMask")]
+        public static extern uint GetBlueMask(IntPtr dib);
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPIC.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPIC.cs
@@ -1,0 +1,132 @@
+﻿// The following code is part of FreeImage.NET
+// https://freeimagenet.codeplex.com/SourceControl/latest#FreeImage.NET/FreeImage.NET/3.17.0.4/FreeImageWrapper.cs
+//
+// COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES
+// THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE
+// OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED
+// CODE IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT
+// THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY
+// SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL
+// PART OF THIS LICENSE. NO USE OF ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER
+// THIS DISCLAIMER.
+
+using System;
+
+namespace FreeImageAPI
+{
+    partial class FreeImage
+    {
+        public static unsafe void CopyMemory(byte* dest, byte* src, int len)
+        {
+            if (len >= 0x10)
+            {
+                do
+                {
+                    *((int*)dest) = *((int*)src);
+                    *((int*)(dest + 4)) = *((int*)(src + 4));
+                    *((int*)(dest + 8)) = *((int*)(src + 8));
+                    *((int*)(dest + 12)) = *((int*)(src + 12));
+                    dest += 0x10;
+                    src += 0x10;
+                }
+                while ((len -= 0x10) >= 0x10);
+            }
+            if (len > 0)
+            {
+                if ((len & 8) != 0)
+                {
+                    *((int*)dest) = *((int*)src);
+                    *((int*)(dest + 4)) = *((int*)(src + 4));
+                    dest += 8;
+                    src += 8;
+                }
+                if ((len & 4) != 0)
+                {
+                    *((int*)dest) = *((int*)src);
+                    dest += 4;
+                    src += 4;
+                }
+                if ((len & 2) != 0)
+                {
+                    *((short*)dest) = *((short*)src);
+                    dest += 2;
+                    src += 2;
+                }
+                if ((len & 1) != 0)
+                {
+                    *dest = *src;
+                }
+            }
+        }
+
+        public static unsafe IntPtr ConvertFromRawBits(
+            byte[] bits,
+            FREE_IMAGE_TYPE type,
+            int width,
+            int height,
+            int pitch,
+            uint bpp,
+            uint red_mask,
+            uint green_mask,
+            uint blue_mask,
+            bool topdown)
+        {
+            fixed (byte* ptr = bits)
+            {
+                return ConvertFromRawBits(
+                    (IntPtr)ptr,
+                    type,
+                    width,
+                    height,
+                    pitch,
+                    bpp,
+                    red_mask,
+                    green_mask,
+                    blue_mask,
+                    topdown);
+            }
+        }
+
+        public static unsafe IntPtr ConvertFromRawBits(
+            IntPtr bits,
+            FREE_IMAGE_TYPE type,
+            int width,
+            int height,
+            int pitch,
+            uint bpp,
+            uint red_mask,
+            uint green_mask,
+            uint blue_mask,
+            bool topdown)
+        {
+            byte* addr = (byte*)bits;
+            if ((addr == null) || (width <= 0) || (height <= 0))
+            {
+                return IntPtr.Zero;
+            }
+
+            IntPtr dib = AllocateT(type, width, height, (int)bpp, red_mask, green_mask, blue_mask);
+            if (dib != IntPtr.Zero)
+            {
+                if (topdown)
+                {
+                    for (int i = height - 1; i >= 0; --i)
+                    {
+                        CopyMemory((byte*)GetScanLine(dib, i), addr, (int)GetLine(dib));
+                        addr += pitch;
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < height; ++i)
+                    {
+                        CopyMemory((byte*)GetScanLine(dib, i), addr, (int)GetLine(dib));
+                        addr += pitch;
+                    }
+                }
+            }
+            return dib;
+        }
+    }
+}


### PR DESCRIPTION
**WIP Changes**

Stuff done:
 - Removed a bunch of #if in MG.Framework.Content.Pipeline
 - Make it so Windows, Linux and Mac content builder stuff are using the exact same files

Why do this?
 - All part of the master plan: #5262

CC. @DDReaper