### PR TITLE
First shot at including the Native libs in the Nuget Packages.

### DIFF
--- a/NuGetPackages/MonoGame.Framework.DesktopGL.nuspec
+++ b/NuGetPackages/MonoGame.Framework.DesktopGL.nuspec
@@ -18,9 +18,20 @@
         <language>en-US</language>
     </metadata>
     <files>
-        <file src="WindowsGL\AnyCPU\Release\MonoGame.Framework.dll" target="lib\net40\MonoGame.Framework.dll" />
-        <file src="WindowsGL\AnyCPU\Release\MonoGame.Framework.xml" target="lib\net40\MonoGame.Framework.xml" />
-        <file src="WindowsGL\AnyCPU\Release\MonoGame.Framework.dll.config" target="content\net40\MonoGame.Framework.dll.config" />
+        <file src="WindowsGL\AnyCPU\Release\MonoGame.Framework.dll" target="lib\net45\MonoGame.Framework.dll" />
+        <file src="WindowsGL\AnyCPU\Release\MonoGame.Framework.xml" target="lib\net45\MonoGame.Framework.xml" />
+        <file src="WindowsGL\AnyCPU\Release\MonoGame.Framework.dll.config" target="content\net45\MonoGame.Framework.dll.config" />
         <file src="..\..\NuGetPackages\readme\MonoGame.Framework\readme.txt" target="readme.txt" />
+        <file src="..\..\NuGetPackages\build\MonoGame.Framework.Native.targets" target="build\MonoGame.Framework.DesktopGL.targets" />
+        <file src="..\..\ThirdParty\Dependencies\openal-soft\Linux\x64\*" target="build\x64" />
+        <file src="..\..\ThirdParty\Dependencies\openal-soft\Linux\x86\*" target="build\x86" />
+        <file src="..\..\ThirdParty\Dependencies\openal-soft\Windows\x64\*" target="build\x64" />
+        <file src="..\..\ThirdParty\Dependencies\openal-soft\Windows\x86\*" target="build\x86" />
+        <file src="..\..\ThirdParty\Dependencies\openal-soft\MacOS\Universal\*" target="build" />
+        <file src="..\..\ThirdParty\Dependencies\SDL\Linux\x64\*" target="build\x64" />
+        <file src="..\..\ThirdParty\Dependencies\SDL\Linux\x86\*" target="build\x86" />
+        <file src="..\..\ThirdParty\Dependencies\SDL\Windows\x64\*" target="build\x64" />
+        <file src="..\..\ThirdParty\Dependencies\SDL\Windows\x86\*" target="build\x86" />
+        <file src="..\..\ThirdParty\Dependencies\SDL\MacOS\Universal\*" target="build" />
     </files>
 </package>

--- a/NuGetPackages/build/MonoGame.Framework.Native.targets
+++ b/NuGetPackages/build/MonoGame.Framework.Native.targets
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<ItemGroup>
+  <MonoGameNativeLibs Include="$(MSBuildThisFileDirectory)**" Exclude="$(MSBuildThisFileDirectory)$(MSBuildThisFileName)$(MSBuildThisFileExtension)" />
+</ItemGroup>
+<Target Name="_CopyMonoGameDependencies" AfterTargets="DeployOutputFiles">
+	<Copy SourceFiles="@(MonoGameNativeLibs)" DestinationFiles="@(MonoGameNativeLibs->'$(OutputPath)%(MonoGameNativeLibs.RecursiveDir)%(Filename)%(Extension)')" />
+</Target>
+</Project>


### PR DESCRIPTION
This adds the native libraries (SDL, openal-soft) to the DesktopGL Nuget. It also makes sure that we copy these files to the output directory.

Oh and MG is .net 45 now right? so the nuggets should reflect that.