### PR TITLE
OpenAL error handling clean up

### DIFF
--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -32,15 +32,8 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public OALSoundBuffer ()
 		{
-            try
-            {
-                AL.GenBuffers(1, out openALDataBuffer);
-                ALHelper.CheckError("Failed to generate OpenAL data buffer.");
-            }
-            catch (DllNotFoundException e)
-            {
-                throw new NoAudioHardwareException("OpenAL drivers could not be found.", e);
-            }
+            AL.GenBuffers(1, out openALDataBuffer);
+            ALHelper.CheckError("Failed to generate OpenAL data buffer.");
 		}
 
         ~OALSoundBuffer()

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -98,11 +98,6 @@ namespace Microsoft.Xna.Framework.Audio
             if (!HasSourceId || SoundState != SoundState.Playing)
                 return;
 
-            if (!controller.CheckInitState())
-            {
-                return;
-            }
-
             if (pauseCount == 0)
             {
                 AL.SourcePause(SourceId);
@@ -164,10 +159,6 @@ namespace Microsoft.Xna.Framework.Audio
 
             if (SoundState == SoundState.Paused)
             {
-                if (!controller.CheckInitState())
-                {
-                    return;
-                }
                 --pauseCount;
                 if (pauseCount == 0)
                 {
@@ -182,10 +173,6 @@ namespace Microsoft.Xna.Framework.Audio
         {
             if (HasSourceId)
             {
-                if (!controller.CheckInitState())
-                {
-                    return;
-                }
                 AL.SourceStop(SourceId);
                 ALHelper.CheckError("Failed to stop source.");
 


### PR DESCRIPTION
This PR cleans up the error handling in the OpenAL device/context initialization by making it critical and throwing ```NoAudioHardwareException``` exceptions at any kind of error and adding the AL error code to its message.

It was previously not critical and was continuing execution with no AL device, which resulted in several difficult to debug situations (because the original AL error was lost, and raising non trivial error messages or unrelated exceptions). This now allows to get more info from remote crash reporters.

It also removes some initialization checks because initialization will now halt on all errors.

This is a first step to get better stack traces in an attempt to resolve #5381.

@dellis1972 @cra0zy @KonajuGames 