### PR TITLE
Custom FreeImage wrapper

### DIFF
--- a/Build/Projects/Framework.Content.Pipeline.References.definition
+++ b/Build/Projects/Framework.Content.Pipeline.References.definition
@@ -12,9 +12,6 @@
       Name="SharpFont"
       Path="ThirdParty\Dependencies\SharpFont\x32\SharpFont.dll" />
     <Binary
-      Name="FreeImageNET"
-      Path="ThirdParty\Dependencies\FreeImage.NET\FreeImageNET.dll" />
-    <Binary
       Name="PVRTexLibNET"
       Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" />
     <Binary
@@ -28,7 +25,6 @@
     <NativeBinary Path="ThirdParty\Dependencies\NVTT\Nvidia.TextureTools.dll.config" />
     <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll.config" />
     <NativeBinary Path="ThirdParty\Dependencies\assimp\AssimpNet.dll.config" />
-    <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\FreeImageNET.dll.config" />
     <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\Linux\x64\libfreeimage-3.17.0.so" />
     <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Linux\x64\ffmpeg" />
     <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Linux\x64\ffprobe" />
@@ -50,9 +46,6 @@
       Name="SharpFont"
       Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll" />
     <Binary
-      Name="FreeImageNET"
-      Path="ThirdParty\Dependencies\FreeImage.NET\FreeImageNET.dll" />
-    <Binary
       Name="PVRTexLibNET"
       Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" />
     <Binary
@@ -70,7 +63,6 @@
     <NativeBinary Path="ThirdParty\Dependencies\assimp\libassimp.dylib" />
     <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\MacOS\ffmpeg" />
     <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\MacOS\ffprobe" />
-    <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\FreeImageNET.dll.config" />
     <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\MacOS\libfreeimage.dylib" />
     <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\OSX\x86\libPVRTexLibWrapper.dylib" />
     <NativeBinary Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll.config" />
@@ -97,9 +89,6 @@
     <Binary
       Name="SharpFont"
       Path="ThirdParty\Dependencies\SharpFont\Windows\x64\SharpFont.dll" />
-    <Binary
-      Name="FreeImageNET"
-      Path="ThirdParty\Dependencies\FreeImage.NET\Windows\FreeImageNET.dll" />
     <Binary
       Name="PVRTexLibNET"
       Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" />

--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -50,6 +50,10 @@
   <Files>
 
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <None Include="MonoGame.Framework.Content.Pipeline.dll.config">
+      <Platforms>Linux,MacOS</Platforms>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     
 
     <!-- Microsoft.Xna.Framework.Content.Pipeline.Audio -->
@@ -465,6 +469,7 @@
 
 	<!-- Utility Classes -->
     <Compile Include="Utilities\Vector4Converter.cs" />
+    <Compile Include="Utilities\FreeImageAPI.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.Unsafe.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.Unsafe32.Dirty.cs" />

--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -470,6 +470,7 @@
 	<!-- Utility Classes -->
     <Compile Include="Utilities\Vector4Converter.cs" />
     <Compile Include="Utilities\FreeImageAPI.cs" />
+    <Compile Include="Utilities\FreeImageAPIC.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.Unsafe.cs" />
     <Compile Include="Utilities\LZ4\LZ4Codec.Unsafe32.Dirty.cs" />

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             // Convert to FreeImage bitmap
             var bytes = src.GetPixelData();
-            var fi = FreeImage.ConvertFromRawBits(bytes, src.Width, src.Height, SurfaceFormat.Vector4.GetSize() * src.Width, 128, 0, 0, 0, true);
+            var fi = FreeImage.ConvertFromRawBits(bytes, FREE_IMAGE_TYPE.FIT_RGBAF, src.Width, src.Height, SurfaceFormat.Vector4.GetSize() * src.Width, 128, 0, 0, 0, true);
 
             // Resize
             var newfi = FreeImage.Rescale(fi, newWidth, newHeight, FREE_IMAGE_FILTER.FILTER_BICUBIC);

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -26,18 +26,18 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             // Convert to FreeImage bitmap
             var bytes = src.GetPixelData();
-            var fi = FreeImage.ConvertFromRawBits(bytes, FREE_IMAGE_TYPE.FIT_RGBAF, src.Width, src.Height, SurfaceFormat.Vector4.GetSize() * src.Width, 128, 0, 0, 0, true);
+            var fi = FreeImage.ConvertFromRawBits(bytes, src.Width, src.Height, SurfaceFormat.Vector4.GetSize() * src.Width, 128, 0, 0, 0, true);
 
             // Resize
             var newfi = FreeImage.Rescale(fi, newWidth, newHeight, FREE_IMAGE_FILTER.FILTER_BICUBIC);
-            FreeImage.UnloadEx(ref fi);
+            FreeImage.Unload(fi);
 
             // Convert back to PixelBitmapContent<Vector4>
             src = new PixelBitmapContent<Vector4>(newWidth, newHeight);
             bytes = new byte[SurfaceFormat.Vector4.GetSize() * newWidth * newHeight];
             FreeImage.ConvertToRawBits(bytes, newfi, SurfaceFormat.Vector4.GetSize() * newWidth, 128, 0, 0, 0, true);
             src.SetPixelData(bytes);
-            FreeImage.UnloadEx(ref newfi);
+            FreeImage.Unload(newfi);
             // Convert back to source type if required
             if (format != SurfaceFormat.Vector4)
             {

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.dll.config
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.dll.config
@@ -1,0 +1,4 @@
+﻿<configuration>
+  <dllmap os="osx" dll="FreeImage" target="libfreeimage.dylib"/>
+  <dllmap os="linux" dll="FreeImage" target="libfreeimage-3.17.0.so"/>
+</configuration>

--- a/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
@@ -2,10 +2,11 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+using System.IO;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
 using FreeImageAPI;
-using System.IO;
 using MonoGame.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline
@@ -78,13 +79,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 
             var output = new Texture2DContent { Identity = new ContentIdentity(filename) };
 
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            var fBitmap = FreeImage.LoadEx(filename, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
+            var format = FreeImage.GetFileType(filename, 0);
+            var fBitmap = FreeImage.Load(format, filename, 0);
             //if freeimage can not recognize the image type
             if(format == FREE_IMAGE_FORMAT.FIF_UNKNOWN)
                 throw new ContentLoadException("TextureImporter failed to load '" + filename + "'");
             //if freeimage can recognize the file headers but can't read its contents
-            else if(fBitmap.IsNull)
+            else if(fBitmap == IntPtr.Zero)
                 throw new InvalidContentException("TextureImporter couldn't understand the contents of '" + filename + "'", output.Identity);
             BitmapContent face = null;
             var height = (int) FreeImage.GetHeight(fBitmap);
@@ -122,7 +123,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                     face = new PixelBitmapContent<Vector4>(width, height);
                     break;
             }
-            FreeImage.UnloadEx(ref fBitmap);
+            FreeImage.Unload(fBitmap);
 
             face.SetPixelData(bytes);
             output.Faces[0].Add(face);
@@ -134,10 +135,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// <param name="fBitmap">Image to process</param>
         /// <param name="imageType">Type of the image for the procedure</param>
         /// <returns></returns>
-        private static FIBITMAP ConvertAndSwapChannels(FIBITMAP fBitmap, FREE_IMAGE_TYPE imageType)
+        private static IntPtr ConvertAndSwapChannels(IntPtr fBitmap, FREE_IMAGE_TYPE imageType)
         {
-            FIBITMAP bgra;
-            switch (imageType)
+            IntPtr bgra;
+            switch(imageType)
             {
                 // Return BGRA images as is
 
@@ -149,13 +150,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 
                 case FREE_IMAGE_TYPE.FIT_RGBF:
                     bgra = FreeImage.ConvertToType(fBitmap, FREE_IMAGE_TYPE.FIT_RGBAF, true);
-                    FreeImage.UnloadEx(ref fBitmap);
+                    FreeImage.Unload(fBitmap);
                     fBitmap = bgra;
                     break;
 
                 case FREE_IMAGE_TYPE.FIT_RGB16:
                     bgra = FreeImage.ConvertToType(fBitmap, FREE_IMAGE_TYPE.FIT_RGBA16, true);
-                    FreeImage.UnloadEx(ref fBitmap);
+                    FreeImage.Unload(fBitmap);
                     fBitmap = bgra;
                     break;
 
@@ -167,7 +168,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                     // Bitmap and other formats are converted to 32-bit by default
                     bgra = FreeImage.ConvertTo32Bits(fBitmap);
                     SwitchRedAndBlueChannels(bgra);
-                    FreeImage.UnloadEx(ref fBitmap);
+                    FreeImage.Unload(fBitmap);
                     fBitmap = bgra;
                     break;
             }
@@ -178,14 +179,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// Switches the red and blue channels
         /// </summary>
         /// <param name="fBitmap">image</param>
-        private static void SwitchRedAndBlueChannels(FIBITMAP fBitmap)
+        private static void SwitchRedAndBlueChannels(IntPtr fBitmap)
         {
             var r = FreeImage.GetChannel(fBitmap, FREE_IMAGE_COLOR_CHANNEL.FICC_RED);
             var b = FreeImage.GetChannel(fBitmap, FREE_IMAGE_COLOR_CHANNEL.FICC_BLUE);
             FreeImage.SetChannel(fBitmap, b, FREE_IMAGE_COLOR_CHANNEL.FICC_RED);
             FreeImage.SetChannel(fBitmap, r, FREE_IMAGE_COLOR_CHANNEL.FICC_BLUE);
-            FreeImage.UnloadEx(ref r);
-            FreeImage.UnloadEx(ref b);
+            FreeImage.Unload(r);
+            FreeImage.Unload(b);
         }
 
         // Loads BMP using StbSharp. This allows us to load BMP files containing BITMAPV4HEADER and BITMAPV5HEADER

--- a/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPI.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPI.cs
@@ -92,7 +92,7 @@ namespace FreeImageAPI
         FICC_PHASE
     }
 
-    public class FreeImage
+    partial class FreeImage
     {
         private const string NativeLibName = "FreeImage";
 
@@ -171,5 +171,14 @@ namespace FreeImageAPI
 
         [DllImport(NativeLibName, EntryPoint = "FreeImage_GetBlueMask")]
         public static extern uint GetBlueMask(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_AllocateT")]
+        public static extern IntPtr AllocateT(FREE_IMAGE_TYPE type, int width, int height, int bpp, uint red_mask, uint green_mask, uint blue_mask);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetScanLine")]
+        public static extern IntPtr GetScanLine(IntPtr dib, int scanline);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetLine")]
+        public static extern uint GetLine(IntPtr dib);
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPI.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPI.cs
@@ -1,0 +1,175 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Runtime.InteropServices;
+using MonoGame.Utilities;
+
+namespace FreeImageAPI
+{
+    public enum FREE_IMAGE_TYPE
+    {
+        FIT_UNKNOWN,
+        FIT_BITMAP,
+        FIT_UINT16,
+        FIT_INT16,
+        FIT_UINT32,
+        FIT_INT32,
+        FIT_FLOAT,
+        FIT_DOUBLE,
+        FIT_COMPLEX,
+        FIT_RGB16,
+        FIT_RGBA16,
+        FIT_RGBF,
+        FIT_RGBAF
+    }
+
+    public enum FREE_IMAGE_FILTER
+    {
+        FILTER_BOX,
+        FILTER_BICUBIC,
+        FILTER_BILINEAR,
+        FILTER_BSPLINE,
+        FILTER_CATMULLROM,
+        FILTER_LANCZOS3
+    }
+
+    public enum FREE_IMAGE_FORMAT
+    {
+        FIF_UNKNOWN = -1,
+        FIF_BMP,
+        FIF_ICO,
+        FIF_JPEG,
+        FIF_JNG,
+        FIF_KOALA,
+        FIF_LBM,
+        FIF_IFF,
+        FIF_MNG,
+        FIF_PBM,
+        FIF_PBMRAW,
+        FIF_PCD,
+        FIF_PCX,
+        FIF_PGM,
+        FIF_PGMRAW,
+        FIF_PNG,
+        FIF_PPM,
+        FIF_PPMRAW,
+        FIF_RAS,
+        FIF_TARGA,
+        FIF_TIFF,
+        FIF_WBMP,
+        FIF_PSD,
+        FIF_CUT,
+        FIF_XBM,
+        FIF_XPM,
+        FIF_DDS,
+        FIF_GIF,
+        FIF_HDR,
+        FIF_FAXG3,
+        FIF_SGI,
+        FIF_EXR,
+        FIF_J2K,
+        FIF_JP2,
+        FIF_PFM,
+        FIF_PICT,
+        FIF_RAW,
+        FIF_WEBP,
+        FIF_JXR
+    }
+
+    public enum FREE_IMAGE_COLOR_CHANNEL
+    {
+        FICC_RGB,
+        FICC_RED,
+        FICC_GREEN,
+        FICC_BLUE,
+        FICC_ALPHA,
+        FICC_BLACK,
+        FICC_REAL,
+        FICC_IMAG,
+        FICC_MAG,
+        FICC_PHASE
+    }
+
+    public class FreeImage
+    {
+        private const string NativeLibName = "FreeImage";
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_ConvertFromRawBits")]
+        public static extern IntPtr ConvertFromRawBits(byte[] bits, int width, int height, int pitch, uint bpp, uint red_mask, uint green_mask, uint blue_mask, bool topdown);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_Rescale")]
+        public static extern IntPtr Rescale(IntPtr dib, int dst_width, int dst_height, FREE_IMAGE_FILTER filter);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_Unload")]
+        public static extern void Unload(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_ConvertToRawBits")]
+        public static extern void ConvertToRawBits(byte[] bits, IntPtr dib, int pitch, uint bpp, uint red_mask, uint green_mask, uint blue_mask, bool topdown);
+
+        [DllImport(NativeLibName, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_GetFileTypeU")]
+        public static extern FREE_IMAGE_FORMAT GetFileTypeU(string filename, int size);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetFileType")]
+        public static extern FREE_IMAGE_FORMAT GetFileTypeS(string filename, int size);
+
+        public static FREE_IMAGE_FORMAT GetFileType(string filename, int size)
+        {
+            if (CurrentPlatform.OS == OS.Windows)
+                return GetFileTypeU(filename, size);
+            else
+                return GetFileTypeS(filename, size);
+        }
+
+        [DllImport(NativeLibName, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_LoadU")]
+        public static extern IntPtr LoadU(FREE_IMAGE_FORMAT fif, string filename, int flags);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_Load")]
+        public static extern IntPtr LoadS(FREE_IMAGE_FORMAT fif, string filename, int flags);
+
+        public static IntPtr Load(FREE_IMAGE_FORMAT fif, string filename, int flags)
+        {
+            if (CurrentPlatform.OS == OS.Windows)
+                return LoadU(fif, filename, flags);
+            else
+                return LoadS(fif, filename, flags);
+        }
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetHeight")]
+        public static extern uint GetHeight(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetWidth")]
+        public static extern uint GetWidth(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetImageType")]
+        public static extern FREE_IMAGE_TYPE GetImageType(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetChannel")]
+        public static extern IntPtr GetChannel(IntPtr dib, FREE_IMAGE_COLOR_CHANNEL channel);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_SetChannel")]
+        public static extern bool SetChannel(IntPtr dib, IntPtr dib8, FREE_IMAGE_COLOR_CHANNEL channel);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_ConvertToType")]
+        public static extern IntPtr ConvertToType(IntPtr src, FREE_IMAGE_TYPE dst_type, bool scale_linear);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_ConvertTo32Bits")]
+        public static extern IntPtr ConvertTo32Bits(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetBPP")]
+        public static extern uint GetBPP(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetPitch")]
+        public static extern uint GetPitch(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetRedMask")]
+        public static extern uint GetRedMask(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetGreenMask")]
+        public static extern uint GetGreenMask(IntPtr dib);
+
+        [DllImport(NativeLibName, EntryPoint = "FreeImage_GetBlueMask")]
+        public static extern uint GetBlueMask(IntPtr dib);
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPIC.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPIC.cs
@@ -1,0 +1,132 @@
+﻿// The following code is part of FreeImage.NET
+// https://freeimagenet.codeplex.com/SourceControl/latest#FreeImage.NET/FreeImage.NET/3.17.0.4/FreeImageWrapper.cs
+//
+// COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES
+// THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE
+// OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED
+// CODE IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT
+// THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY
+// SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL
+// PART OF THIS LICENSE. NO USE OF ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER
+// THIS DISCLAIMER.
+
+using System;
+
+namespace FreeImageAPI
+{
+    partial class FreeImage
+    {
+        public static unsafe void CopyMemory(byte* dest, byte* src, int len)
+        {
+            if (len >= 0x10)
+            {
+                do
+                {
+                    *((int*)dest) = *((int*)src);
+                    *((int*)(dest + 4)) = *((int*)(src + 4));
+                    *((int*)(dest + 8)) = *((int*)(src + 8));
+                    *((int*)(dest + 12)) = *((int*)(src + 12));
+                    dest += 0x10;
+                    src += 0x10;
+                }
+                while ((len -= 0x10) >= 0x10);
+            }
+            if (len > 0)
+            {
+                if ((len & 8) != 0)
+                {
+                    *((int*)dest) = *((int*)src);
+                    *((int*)(dest + 4)) = *((int*)(src + 4));
+                    dest += 8;
+                    src += 8;
+                }
+                if ((len & 4) != 0)
+                {
+                    *((int*)dest) = *((int*)src);
+                    dest += 4;
+                    src += 4;
+                }
+                if ((len & 2) != 0)
+                {
+                    *((short*)dest) = *((short*)src);
+                    dest += 2;
+                    src += 2;
+                }
+                if ((len & 1) != 0)
+                {
+                    *dest = *src;
+                }
+            }
+        }
+
+        public static unsafe IntPtr ConvertFromRawBits(
+            byte[] bits,
+            FREE_IMAGE_TYPE type,
+            int width,
+            int height,
+            int pitch,
+            uint bpp,
+            uint red_mask,
+            uint green_mask,
+            uint blue_mask,
+            bool topdown)
+        {
+            fixed (byte* ptr = bits)
+            {
+                return ConvertFromRawBits(
+                    (IntPtr)ptr,
+                    type,
+                    width,
+                    height,
+                    pitch,
+                    bpp,
+                    red_mask,
+                    green_mask,
+                    blue_mask,
+                    topdown);
+            }
+        }
+
+        public static unsafe IntPtr ConvertFromRawBits(
+            IntPtr bits,
+            FREE_IMAGE_TYPE type,
+            int width,
+            int height,
+            int pitch,
+            uint bpp,
+            uint red_mask,
+            uint green_mask,
+            uint blue_mask,
+            bool topdown)
+        {
+            byte* addr = (byte*)bits;
+            if ((addr == null) || (width <= 0) || (height <= 0))
+            {
+                return IntPtr.Zero;
+            }
+
+            IntPtr dib = AllocateT(type, width, height, (int)bpp, red_mask, green_mask, blue_mask);
+            if (dib != IntPtr.Zero)
+            {
+                if (topdown)
+                {
+                    for (int i = height - 1; i >= 0; --i)
+                    {
+                        CopyMemory((byte*)GetScanLine(dib, i), addr, (int)GetLine(dib));
+                        addr += pitch;
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < height; ++i)
+                    {
+                        CopyMemory((byte*)GetScanLine(dib, i), addr, (int)GetLine(dib));
+                        addr += pitch;
+                    }
+                }
+            }
+            return dib;
+        }
+    }
+}


### PR DESCRIPTION
Notes:
 - I tried to keep method / enum names the same as FreeImage.Net names
 - FreeImage documentation I used to write the wrappers: http://graphics.stanford.edu/courses/cs148-10-summer/docs/FreeImage3131.pdf

Why do this? Needed one set of FreeImage assemblies for #5528 and making a custom FreeImage.Net.dll seemed worse than doing this.