### PR TITLE
[NuGet] Replace slashes

### DIFF
--- a/NuGetPackages/MonoGame.Framework.DesktopGL.nuspec
+++ b/NuGetPackages/MonoGame.Framework.DesktopGL.nuspec
@@ -18,26 +18,26 @@
     <language>en-US</language>
   </metadata>
   <files>
-    <file src="../../NuGetPackages/readme/MonoGame.Framework/readme.txt" target="readme.txt" />
+    <file src="..\..\NuGetPackages\readme\MonoGame.Framework\readme.txt" target="readme.txt" />
     
     <!-- C# Assemblies -->
-    <file src="WindowsGL/AnyCPU/Release/MonoGame.Framework.dll" target="lib/net45/MonoGame.Framework.dll" />
-    <file src="WindowsGL/AnyCPU/Release/MonoGame.Framework.xml" target="lib/net45/MonoGame.Framework.xml" />
+    <file src="WindowsGL\AnyCPU\Release\MonoGame.Framework.dll" target="lib\net45\MonoGame.Framework.dll" />
+    <file src="WindowsGL\AnyCPU\Release\MonoGame.Framework.xml" target="lib\net45\MonoGame.Framework.xml" />
     
     <!-- Native Libs -->
-    <file src="WindowsGL/AnyCPU/Release/MonoGame.Framework.dll.config" target="build/native/MonoGame.Framework.dll.config" />
-    <file src="WindowsGL/AnyCPU/Release/libopenal.1.dylib" target="build/native/libopenal.1.dylib" />
-    <file src="WindowsGL/AnyCPU/Release/libSDL2-2.0.0.dylib" target="build/native/libSDL2-2.0.0.dylib" />
-    <file src="WindowsGL/AnyCPU/Release/x64/libopenal.so.1" target="build/native/x64/libopenal.so.1" />
-    <file src="WindowsGL/AnyCPU/Release/x64/libSDL2-2.0.so.0" target="build/native/x64/libSDL2-2.0.so.0" />
-    <file src="WindowsGL/AnyCPU/Release/x64/SDL2.dll" target="build/native/x64/SDL2.dll" />
-    <file src="WindowsGL/AnyCPU/Release/x64/soft_oal.dll" target="build/native/x64/soft_oal.dll" />
-    <file src="WindowsGL/AnyCPU/Release/x86/libopenal.so.1" target="build/native/x86/libopenal.so.1" />
-    <file src="WindowsGL/AnyCPU/Release/x86/libSDL2-2.0.so.0" target="build/native/x86/libSDL2-2.0.so.0" />
-    <file src="WindowsGL/AnyCPU/Release/x86/SDL2.dll" target="build/native/x86/SDL2.dll" />
-    <file src="WindowsGL/AnyCPU/Release/x86/soft_oal.dll" target="build/native/x86/soft_oal.dll" />
+    <file src="WindowsGL\AnyCPU\Release\MonoGame.Framework.dll.config" target="build\native\MonoGame.Framework.dll.config" />
+    <file src="WindowsGL\AnyCPU\Release\libopenal.1.dylib" target="build\native\libopenal.1.dylib" />
+    <file src="WindowsGL\AnyCPU\Release\libSDL2-2.0.0.dylib" target="build\native\libSDL2-2.0.0.dylib" />
+    <file src="WindowsGL\AnyCPU\Release\x64\libopenal.so.1" target="build\native\x64\libopenal.so.1" />
+    <file src="WindowsGL\AnyCPU\Release\x64\libSDL2-2.0.so.0" target="build\native\x64\libSDL2-2.0.so.0" />
+    <file src="WindowsGL\AnyCPU\Release\x64\SDL2.dll" target="build\native\x64\SDL2.dll" />
+    <file src="WindowsGL\AnyCPU\Release\x64\soft_oal.dll" target="build\native\x64\soft_oal.dll" />
+    <file src="WindowsGL\AnyCPU\Release\x86\libopenal.so.1" target="build\native\x86\libopenal.so.1" />
+    <file src="WindowsGL\AnyCPU\Release\x86\libSDL2-2.0.so.0" target="build\native\x86\libSDL2-2.0.so.0" />
+    <file src="WindowsGL\AnyCPU\Release\x86\SDL2.dll" target="build\native\x86\SDL2.dll" />
+    <file src="WindowsGL\AnyCPU\Release\x86\soft_oal.dll" target="build\native\x86\soft_oal.dll" />
     
     <!-- Targets file for copying -->
-    <file src="../../NuGetPackages/build/DesktopGL/DesktopGL.targets" target="build/MonoGame.Framework.DesktopGL.targets" />
+    <file src="..\..\NuGetPackages\build\DesktopGL\DesktopGL.targets" target="build\MonoGame.Framework.DesktopGL.targets" />
   </files>
 </package>


### PR DESCRIPTION
So I included `"/"` slashes so the NuGet package could be built from both Windows and Linux, and I've already tested this before and this time it worked on most files... but unfortunately it seems like the files that start with `"../"` didn't get included on the build bot, not sure why.

`"Package NuGet"` build bot does not offer artifacts so I can't really tell if this fixed it.