### PR TITLE
Add missing GL blend functions

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -365,10 +365,14 @@ namespace Microsoft.Xna.Framework.Graphics
 		public static BlendingFactorSrc GetBlendFactorSrc (this Blend blend)
 		{
 			switch (blend) {
+            case Blend.BlendFactor:
+                return BlendingFactorSrc.ConstantColor;
 			case Blend.DestinationAlpha:
 				return BlendingFactorSrc.DstAlpha;
 			case Blend.DestinationColor:
 				return BlendingFactorSrc.DstColor;
+            case Blend.InverseBlendFactor:
+                return BlendingFactorSrc.OneMinusConstantColor;
 			case Blend.InverseDestinationAlpha:
 				return BlendingFactorSrc.OneMinusDstAlpha;
 			case Blend.InverseDestinationColor:
@@ -404,15 +408,19 @@ namespace Microsoft.Xna.Framework.Graphics
 		public static BlendingFactorDest GetBlendFactorDest (this Blend blend)
 		{
 			switch (blend) {
+            case Blend.BlendFactor:
+                return BlendingFactorDest.ConstantColor;
 			case Blend.DestinationAlpha:
 				return BlendingFactorDest.DstAlpha;
-//			case Blend.DestinationColor:
-//				return BlendingFactorDest.DstColor;
-			case Blend.InverseDestinationAlpha:
+            case Blend.DestinationColor:
+                return BlendingFactorDest.DstColor;
+            case Blend.InverseBlendFactor:
+                return BlendingFactorDest.OneMinusConstantColor;
+            case Blend.InverseDestinationAlpha:
 				return BlendingFactorDest.OneMinusDstAlpha;
-//			case Blend.InverseDestinationColor:
-//				return BlendingFactorDest.OneMinusDstColor;
-			case Blend.InverseSourceAlpha:
+            case Blend.InverseDestinationColor:
+                return BlendingFactorDest.OneMinusDstColor;
+            case Blend.InverseSourceAlpha:
 				return BlendingFactorDest.OneMinusSrcAlpha;
 			case Blend.InverseSourceColor:
 				return BlendingFactorDest.OneMinusSrcColor;
@@ -420,10 +428,10 @@ namespace Microsoft.Xna.Framework.Graphics
 				return BlendingFactorDest.One;
 			case Blend.SourceAlpha:
 				return BlendingFactorDest.SrcAlpha;
-//			case Blend.SourceAlphaSaturation:
-//				return BlendingFactorDest.SrcAlphaSaturate;
-			case Blend.SourceColor:
-				return BlendingFactorDest.SrcColor;
+            case Blend.SourceAlphaSaturation:
+                return BlendingFactorDest.SrcAlphaSaturate;
+            case Blend.SourceColor:
+			    return BlendingFactorDest.SrcColor;
 			case Blend.Zero:
 				return BlendingFactorDest.Zero;
 			default:

--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -399,9 +399,9 @@ namespace Microsoft.Xna.Framework.Graphics
         #endif
 			case Blend.Zero:
 				return BlendingFactorSrc.Zero;
-			default:
-				return BlendingFactorSrc.One;
-			}
+            default:
+                throw new ArgumentOutOfRangeException("blend", "The specified blend function is not implemented.");
+            }
 
 		}
 
@@ -413,13 +413,21 @@ namespace Microsoft.Xna.Framework.Graphics
 			case Blend.DestinationAlpha:
 				return BlendingFactorDest.DstAlpha;
             case Blend.DestinationColor:
+#if MONOMAC
+                return (BlendingFactorDest)All.DstColor;
+#else
                 return BlendingFactorDest.DstColor;
+#endif
             case Blend.InverseBlendFactor:
                 return BlendingFactorDest.OneMinusConstantColor;
             case Blend.InverseDestinationAlpha:
 				return BlendingFactorDest.OneMinusDstAlpha;
             case Blend.InverseDestinationColor:
+#if MONOMAC
+                return (BlendingFactorDest)All.OneMinusDstColor;
+#else
                 return BlendingFactorDest.OneMinusDstColor;
+#endif
             case Blend.InverseSourceAlpha:
 				return BlendingFactorDest.OneMinusSrcAlpha;
 			case Blend.InverseSourceColor:
@@ -429,13 +437,17 @@ namespace Microsoft.Xna.Framework.Graphics
 			case Blend.SourceAlpha:
 				return BlendingFactorDest.SrcAlpha;
             case Blend.SourceAlphaSaturation:
+#if MONOMAC
+                return (BlendingFactorDest)All.SrcAlphaSaturate;
+#else
                 return BlendingFactorDest.SrcAlphaSaturate;
+#endif
             case Blend.SourceColor:
 			    return BlendingFactorDest.SrcColor;
 			case Blend.Zero:
 				return BlendingFactorDest.Zero;
 			default:
-				return BlendingFactorDest.One;
+				throw new ArgumentOutOfRangeException("blend", "The specified blend function is not implemented.");
 			}
 
 		}
@@ -759,7 +771,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #endif // OPENGL
 
-        public static int GetSyncInterval(this PresentInterval interval)
+                    public static int GetSyncInterval(this PresentInterval interval)
         {
             switch (interval)
             {


### PR DESCRIPTION
This fixes the `BlendState` visual test failure on OpenGL. There is still some noise in the diff, but not enough to fail the test, and it seems not to be related to the blend states.

Tested on Windows only.