### PR TITLE
Make README bullets consistent

### DIFF
--- a/Documentation/what_is_monogame.md
+++ b/Documentation/what_is_monogame.md
@@ -1,14 +1,18 @@
 MonoGame is an Open Source implementation of the Microsoft XNA 4 Framework. Our goal is to allow XNA developers on Xbox 360, Windows & Windows Phone to port their games to any platform where games are found including:
 
- * Windows 7/8/10
- * Mac OS X
- * Linux
- * iPhone/iPad/iTV
- * Android
- * Windows Phone 8.1
- * Windows 10 Mobile
- * Raspberry PI
- * Xbox One
- * PlayStation 4
- * PlayStation Vita
- * Nintendo Switch
+ * Desktop PCs
+   * Windows Store Apps (8.1 and 10)
+   * Windows Win32 (OpenGL & DirectX)
+   * Linux (OpenGL)
+   * Mac OS X (OpenGL)
+ * Mobile/Tablet Devices
+   * Android (OpenGL)
+   * iPhone/iPad (OpenGL)
+   * Windows Phone (8.1 and 10)
+ * Consoles (for registered developers)
+   * PlayStation 4
+   * PlayStation Vita
+   * Xbox One (both UWP and XDK)
+   * Nintendo Switch
+ * Other
+   * tvOS

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ One framework for creating powerful cross-platform games.  The spiritual success
 
 [![Join the chat at https://gitter.im/MonoGame/MonoGame](https://badges.gitter.im/MonoGame/MonoGame.svg)](https://gitter.im/MonoGame/MonoGame?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
- - [Build Status](#build-status)
- - [Supported Platforms](#supported-platforms)
- - [Support and Contributions](#support-and-contributions)
- - [Source Code](#source-code)
- - [Helpful Links](#helpful-links)
- - [License](#license)
+ * [Build Status](#build-status)
+ * [Supported Platforms](#supported-platforms)
+ * [Support and Contributions](#support-and-contributions)
+ * [Source Code](#source-code)
+ * [Helpful Links](#helpful-links)
+ * [License](#license)
  
 
 ## Build Status
@@ -31,19 +31,19 @@ Our [build server](http://teamcity.monogame.net/?guest=1) builds, tests, and pac
 
 We support a growing list of platforms across the desktop, mobile, and console space.  If there is a platform we don't support, please [make a request](https://github.com/MonoGame/MonoGame/issues) or [come help us](CONTRIBUTING.md) add it.
 
-- Desktop PCs
- * Windows Store Apps (8, 8.1 and 10)
- * Windows (OpenGL & DirectX)
- * Linux (OpenGL)
- * Mac OS X (OpenGL)
-- Mobile Devices
- * Android (OpenGL)
- * iOS (OpenGL)
- * Windows Phone (8, 8.1 and 10)
-- Consoles (for registered developers)
- * PlayStation 4
- * PlayStation Vita
- * Xbox One (both UWP and XDK)
+ * Desktop PCs
+   * Windows Store Apps (8, 8.1 and 10)
+   * Windows (OpenGL & DirectX)
+   * Linux (OpenGL)
+   * Mac OS X (OpenGL)
+ * Mobile Devices
+   * Android (OpenGL)
+   * iOS (OpenGL)
+   * Windows Phone (8, 8.1 and 10)
+ * Consoles (for registered developers)
+   * PlayStation 4
+   * PlayStation Vita
+   * Xbox One (both UWP and XDK)
 
 
 ## Support and Contributions

--- a/README.md
+++ b/README.md
@@ -32,18 +32,21 @@ Our [build server](http://teamcity.monogame.net/?guest=1) builds, tests, and pac
 We support a growing list of platforms across the desktop, mobile, and console space.  If there is a platform we don't support, please [make a request](https://github.com/MonoGame/MonoGame/issues) or [come help us](CONTRIBUTING.md) add it.
 
  * Desktop PCs
-   * Windows Store Apps (8, 8.1 and 10)
-   * Windows (OpenGL & DirectX)
+   * Windows Store Apps (8.1 and 10)
+   * Windows Win32 (OpenGL & DirectX)
    * Linux (OpenGL)
    * Mac OS X (OpenGL)
- * Mobile Devices
+ * Mobile/Tablet Devices
    * Android (OpenGL)
-   * iOS (OpenGL)
-   * Windows Phone (8, 8.1 and 10)
+   * iPhone/iPad (OpenGL)
+   * Windows Phone (8.1 and 10)
  * Consoles (for registered developers)
    * PlayStation 4
    * PlayStation Vita
    * Xbox One (both UWP and XDK)
+   * Nintendo Switch
+ * Other
+   * tvOS (OpenGL)
 
 
 ## Support and Contributions


### PR DESCRIPTION
Mostly did this to fix supported platforms list, which really didn't like the use of both type of bullets:

![bullets](https://cloud.githubusercontent.com/assets/6773302/24119413/48e18602-0db1-11e7-8684-476674ae7328.png)
