### PR TITLE
Fix up some weird Effects crashes.

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
@@ -430,15 +430,23 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void SetValue (int value)
 		{
-            if (ParameterClass != EffectParameterClass.Scalar || ParameterType != EffectParameterType.Int32)
+            if ((ParameterClass != EffectParameterClass.Scalar && ParameterClass != EffectParameterClass.Vector) || 
+                (ParameterType != EffectParameterType.Int32 && ParameterType != EffectParameterType.Single))
                 throw new InvalidCastException();
 
-#if OPENGL
-            // MojoShader encodes integers into a float.
-            ((float[])Data)[0] = value;
-#else
-            ((int[])Data)[0] = value;
-#endif
+            switch (ParameterType)
+            {
+                case EffectParameterType.Int32:
+                    var iData = (int[])Data;
+                    for (int i = 0; i < iData.Length; i++)
+                        iData[i] = value;
+                    break;
+                case EffectParameterType.Single:
+                    var fData = (float[])Data;
+                    for (int i = 0; i < fData.Length; i++)
+                        fData[i] = value;
+                    break;
+            }
             StateKey = unchecked(NextStateKey++);
 		}
 
@@ -799,7 +807,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public void SetValue (Single[] value)
 		{
 			for (var i=0; i<value.Length; i++)
-				Elements[i].SetValue (value[i]);
+				((float[])Data)[i] = value[i];
 
             StateKey = unchecked(NextStateKey++);
 		}

--- a/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
@@ -806,8 +806,13 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void SetValue (Single[] value)
 		{
-			for (var i=0; i<value.Length; i++)
-				((float[])Data)[i] = value[i];
+            for (var i = 0; i < value.Length; i++)
+            {
+                if (Data != null)
+                    ((float[])Data)[i] = value[i];
+                else
+                    Elements[i].SetValue (value[i]);
+            }
 
             StateKey = unchecked(NextStateKey++);
 		}

--- a/MonoGame.Framework/Graphics/Effect/EffectParameterCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectParameterCollection.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // TODO: Add a name to parameter lookup table.
 				foreach (var parameter in _parameters) 
                 {
-					if (parameter.Name == name) 
+					if (parameter.Name == name || parameter.Name == name+"Sampler") 
 						return parameter;
 				}
 


### PR DESCRIPTION
One of the samples I am porting hit this issue where the
EffectParameter.SetValue (int) for Single/Int parameters
as well as for Scalar and Vector parameters.

There was also a problem with access the Element[i] array in
EffectParameter.SetValue(Single[]). In this case it was crashing
event though the Data object was correct. This commit
removes the use of Element in favour of Data which other Setters
use.