### PR TITLE
Don't throw an error if a channel exists already, just return it.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannelCollection.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannelCollection.cs
@@ -264,10 +264,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 throw new ArgumentOutOfRangeException("index");
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentNullException("name");
-            // Don't insert a channel with the same name
-            if (IndexOf(name) >= 0)
-                throw new ArgumentException("Vertex channel with name " + name + " already exists");
-            var channel = new VertexChannel<ElementType>(name);
+            var existingIndex = IndexOf (name);
+            var exists = existingIndex >= 0;
+            var channel = exists ? (VertexChannel<ElementType>)channels[existingIndex] : new VertexChannel<ElementType>(name);
+            if (exists) {
+                channel.Items.Clear ();
+                channels.Remove (channel);
+            }
             if (channelData != null)
             {
                 // Insert the values from the enumerable into the channel


### PR DESCRIPTION
While porting a game I came across a problem where the XNA pipeline
would quite happily process a model. In the MG pipeline the following
error was thrown.

	System.ArgumentException: Vertex channel with name Tangent0 already exists

I figure rather than throwing an error we should just return the
existing channel.