### PR TITLE
Remove reference to SharpDX from project templates

### DIFF
--- a/ProjectTemplates/VisualStudio2012/WindowsStore/Application.csproj
+++ b/ProjectTemplates/VisualStudio2012/WindowsStore/Application.csproj
@@ -109,27 +109,6 @@
     <Reference Include="MonoGame.Framework">
        <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\MonoGame.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.XInput">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.XInput.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct2D1">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.Direct2D1.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct3D11">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.Direct3D11.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.DXGI">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.DXGI.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.MediaFoundation">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.MediaFoundation.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.XAudio2">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.XAudio2.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/ProjectTemplates/VisualStudio2013/WindowsStore/Application.csproj
+++ b/ProjectTemplates/VisualStudio2013/WindowsStore/Application.csproj
@@ -110,27 +110,6 @@
     <Reference Include="MonoGame.Framework">
        <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\MonoGame.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.XInput">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.XInput.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct2D1">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.Direct2D1.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct3D11">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.Direct3D11.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.DXGI">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.DXGI.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.MediaFoundation">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.MediaFoundation.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.XAudio2">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.XAudio2.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/ProjectTemplates/VisualStudio2015/WindowsStore/Application.csproj
+++ b/ProjectTemplates/VisualStudio2015/WindowsStore/Application.csproj
@@ -110,27 +110,6 @@
     <Reference Include="MonoGame.Framework">
        <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\MonoGame.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.XInput">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.XInput.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct2D1">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.Direct2D1.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct3D11">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.Direct3D11.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.DXGI">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.DXGI.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.MediaFoundation">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.MediaFoundation.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.XAudio2">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.XAudio2.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/ProjectTemplates/VisualStudio2015/WindowsStoreXaml/Application.csproj
+++ b/ProjectTemplates/VisualStudio2015/WindowsStoreXaml/Application.csproj
@@ -110,27 +110,6 @@
     <Reference Include="MonoGame.Framework">
        <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\MonoGame.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.XInput">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.XInput.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct2D1">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.Direct2D1.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct3D11">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.Direct3D11.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.DXGI">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.DXGI.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.MediaFoundation">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.MediaFoundation.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.XAudio2">
-       <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows8\SharpDX.XAudio2.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App.xaml.cs">


### PR DESCRIPTION
A MonoGame project don't need to reference SharpDX directly.