### PR TITLE
Texture2D mipmap generation and population fixes

### DIFF
--- a/Build/Projects/FrameworkReferences.Net.definition
+++ b/Build/Projects/FrameworkReferences.Net.definition
@@ -34,6 +34,7 @@
     <Reference Include="System.Core" />
     <Reference Include="mscorlib" />
     <Reference Include="Lidgren.Network" />
+    <Reference Include="OpenTK-1.0" />
   </Platform>
 
   <Platform Type="Windows">

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             }
         }
 
-        protected override void PlatformCompressTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool generateMipmaps, bool isSpriteFont)
+        protected override void PlatformCompressTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool isSpriteFont)
         {
             format = GetTextureFormatForPlatform(format, context.TargetPlatform);
 
@@ -118,23 +118,23 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             switch (format)
             {
                 case TextureProcessorOutputFormat.AtcCompressed:
-                    GraphicsUtil.CompressAti(content, generateMipmaps);
+                    GraphicsUtil.CompressAti(content);
                     break;
 
                 case TextureProcessorOutputFormat.Color16Bit:
-                    GraphicsUtil.CompressColor16Bit(content, generateMipmaps);
+                    GraphicsUtil.CompressColor16Bit(content);
                     break;
 
                 case TextureProcessorOutputFormat.DxtCompressed:
-                    GraphicsUtil.CompressDxt(context.TargetProfile, content, generateMipmaps, isSpriteFont);
+                    GraphicsUtil.CompressDxt(context.TargetProfile, content, isSpriteFont);
                     break;
 
                 case TextureProcessorOutputFormat.Etc1Compressed:
-                    GraphicsUtil.CompressEtc1(content, generateMipmaps);
+                    GraphicsUtil.CompressEtc1(content);
                     break;
 
                 case TextureProcessorOutputFormat.PvrCompressed:
-                    GraphicsUtil.CompressPvrtc(content, generateMipmaps, isSpriteFont);
+                    GraphicsUtil.CompressPvrtc(content, isSpriteFont);
                     break;
             }
         }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/TextureContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/TextureContent.cs
@@ -93,10 +93,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 var faceType = faceBitmap.GetType();
                 int width = faceBitmap.Width;
                 int height = faceBitmap.Height;
-                while (width > 1 && height > 1)
+                while (width > 1 || height > 1)
                 {
-                    width /= 2;
-                    height /= 2;
+                    if (width > 1)
+                        width /= 2;
+                    if (height > 1)
+                        height /= 2;
 
                     var mip = (BitmapContent)Activator.CreateInstance(faceType, new object[] { width, height });
                     BitmapContent.Copy(faceBitmap, mip);

--- a/MonoGame.Framework.Content.Pipeline/Graphics/TextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/TextureProfile.cs
@@ -48,9 +48,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         /// <param name="context">The processor context.</param>
         /// <param name="content">The content to be compressed.</param>
         /// <param name="format">The user requested format for compression.</param>
-        /// <param name="generateMipmaps">If mipmap generation is required.</param>
         /// <param name="isSpriteFont">If the texture has represents a sprite font, i.e. is greyscale and has sharp black/white contrast.</param>
-        public void ConvertTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool generateMipmaps, bool isSpriteFont)
+        public void ConvertTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool isSpriteFont)
         {
             // We do nothing in this case.
             if (format == TextureProcessorOutputFormat.NoChange)
@@ -60,22 +59,20 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             if (format == TextureProcessorOutputFormat.Color)
             {
                 content.ConvertBitmapType(typeof(PixelBitmapContent<Color>));
-                if (generateMipmaps)
-                    content.GenerateMipmaps(false);
                 return;
             }
 
             // Handle this common compression format.
             if (format == TextureProcessorOutputFormat.Color16Bit)
             {
-                GraphicsUtil.CompressColor16Bit(content, generateMipmaps);
+                GraphicsUtil.CompressColor16Bit(content);
                 return;
             }
 
             try
             {
                 // All other formats require platform specific choices.
-                PlatformCompressTexture(context, content, format, generateMipmaps, isSpriteFont);
+                PlatformCompressTexture(context, content, format, isSpriteFont);
             }
             catch (EntryPointNotFoundException ex)
             {
@@ -94,6 +91,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             }
         }
 
-        protected abstract void PlatformCompressTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool generateMipmaps, bool isSpriteFont);
+        protected abstract void PlatformCompressTexture(ContentProcessorContext context, TextureContent content, TextureProcessorOutputFormat format, bool isSpriteFont);
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             }
 
             // Perform the final texture conversion.
-            texProfile.ConvertTexture(context, output.Texture, TextureFormat, false, true);    
+            texProfile.ConvertTexture(context, output.Texture, TextureFormat, true);    
 
             return output;
         }

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontTextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontTextureProcessor.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             }
 
             // Perform the final texture conversion.
-            texProfile.ConvertTexture(context, output.Texture, TextureFormat, false, true);
+            texProfile.ConvertTexture(context, output.Texture, TextureFormat, true);
 
 			return output;
 		}

--- a/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                     return input;
             }
 
-            if (ColorKeyEnabled || ResizeToPowerOfTwo || MakeSquare || PremultiplyAlpha)
+            if (ColorKeyEnabled || ResizeToPowerOfTwo || MakeSquare || PremultiplyAlpha || GenerateMipmaps)
             {
                 // Convert to floating point format for modifications. Keep the original format for conversion back later on if required.
                 var originalType = input.Faces[0][0].GetType();
@@ -59,6 +59,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                     context.Logger.LogImportantMessage("Could not convert input texture for processing. " + ex.ToString());
                     throw ex; 
                 }
+
+                if (GenerateMipmaps)
+                    input.GenerateMipmaps(true);
 
                 for (int f = 0; f < input.Faces.Count; ++f)
                 {
@@ -113,7 +116,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 
             // Get the texture profile for the platform and let it convert the texture.
             var texProfile = TextureProfile.ForPlatform(context.TargetPlatform);
-            texProfile.ConvertTexture(context, input, TextureFormat, GenerateMipmaps, false);	
+            texProfile.ConvertTexture(context, input, TextureFormat, false);	
 
             return input;
         }

--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -411,6 +411,7 @@ namespace OpenGL
 
     public enum TextureParameterName {
         TextureMaxAnisotropyExt = 0x84FE,
+        TextureBaseLevel = 0x813C,
         TextureMaxLevel = 0x813D,
         TextureMinFilter = 0x2801,
         TextureMagFilter = 0x2800,

--- a/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
@@ -127,12 +127,16 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (!IsDisposed && _shaderHandle != -1)
             {
+                // Take a copy of the handle for use in the anonymous function and clear the class handle.
+                // This prevents any other disposal of the resource between now and the time the anonymous
+                // function is executed.
+                int handle = _shaderHandle;
                 Threading.BlockOnUIThread(() =>
                 {
-                    GL.DeleteShader(_shaderHandle);
+                    GL.DeleteShader(handle);
                     GraphicsExtensions.CheckGLError();
-                    _shaderHandle = -1;
                 });
+                _shaderHandle = -1;
             }
 
             base.Dispose(disposing);

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -13,7 +13,6 @@ using OpenTK.Graphics.OpenGL;
 #endif
 #elif DESKTOPGL
 using OpenGL;
-using ExtTextureFilterAnisotropic = OpenGL.TextureParameterName;
 #elif GLES
 using OpenTK.Graphics.ES20;
 #endif
@@ -23,14 +22,6 @@ namespace Microsoft.Xna.Framework.Graphics
   public partial class SamplerState
   {
       private readonly float[] _openGLBorderColor = new float[4];
-
-#if GLES
-        private const TextureParameterName TextureParameterNameTextureMaxAnisotropy = (TextureParameterName)All.TextureMaxAnisotropyExt;
-        private const TextureParameterName TextureParameterNameTextureMaxLevel = (TextureParameterName)0x813D;
-#else
-        private const TextureParameterName TextureParameterNameTextureMaxAnisotropy = (TextureParameterName)ExtTextureFilterAnisotropic.TextureMaxAnisotropyExt;
-        private const TextureParameterName TextureParameterNameTextureMaxLevel = TextureParameterName.TextureMaxLevel;
-#endif
 
         internal void Activate(GraphicsDevice device, TextureTarget target, bool useMipmaps = false)
         {
@@ -47,7 +38,7 @@ namespace Microsoft.Xna.Framework.Graphics
       case TextureFilter.Point:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
         GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.NearestMipmapNearest : TextureMinFilter.Nearest));
@@ -58,7 +49,7 @@ namespace Microsoft.Xna.Framework.Graphics
       case TextureFilter.Linear:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
         GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.LinearMipmapLinear : TextureMinFilter.Linear));
@@ -69,7 +60,7 @@ namespace Microsoft.Xna.Framework.Graphics
       case TextureFilter.Anisotropic:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, MathHelper.Clamp(this.MaxAnisotropy, 1.0f, GraphicsDevice.GraphicsCapabilities.MaxTextureAnisotropy));
+                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, MathHelper.Clamp(this.MaxAnisotropy, 1.0f, GraphicsDevice.GraphicsCapabilities.MaxTextureAnisotropy));
                     GraphicsExtensions.CheckGLError();
                 }
         GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.LinearMipmapLinear : TextureMinFilter.Linear));
@@ -80,7 +71,7 @@ namespace Microsoft.Xna.Framework.Graphics
       case TextureFilter.PointMipLinear:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
         GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.NearestMipmapLinear : TextureMinFilter.Nearest));
@@ -91,7 +82,7 @@ namespace Microsoft.Xna.Framework.Graphics
             case TextureFilter.LinearMipPoint:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
                 GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.LinearMipmapNearest : TextureMinFilter.Linear));
@@ -102,7 +93,7 @@ namespace Microsoft.Xna.Framework.Graphics
             case TextureFilter.MinLinearMagPointMipLinear:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
                 GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.LinearMipmapLinear : TextureMinFilter.Linear));
@@ -113,7 +104,7 @@ namespace Microsoft.Xna.Framework.Graphics
             case TextureFilter.MinLinearMagPointMipPoint:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
                 GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.LinearMipmapNearest: TextureMinFilter.Linear));
@@ -124,7 +115,7 @@ namespace Microsoft.Xna.Framework.Graphics
             case TextureFilter.MinPointMagLinearMipLinear:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
                 GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.NearestMipmapLinear: TextureMinFilter.Nearest));
@@ -135,7 +126,7 @@ namespace Microsoft.Xna.Framework.Graphics
             case TextureFilter.MinPointMagLinearMipPoint:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
                 GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.NearestMipmapNearest: TextureMinFilter.Nearest));
@@ -184,12 +175,13 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 if (this.MaxMipLevel > 0)
                 {
-                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterNameTextureMaxLevel, this.MaxMipLevel);
+                    GL.TexParameter(TextureTarget.Texture2D, Texture.TextureParameterNameTextureMaxLevel, this.MaxMipLevel);
                 }
                 else
                 {
-                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterNameTextureMaxLevel, 1000);
+                    GL.TexParameter(TextureTarget.Texture2D, Texture.TextureParameterNameTextureMaxLevel, 1000);
                 }
+                GraphicsExtensions.CheckGLError();
             }
         }
 

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -21,7 +21,15 @@ namespace Microsoft.Xna.Framework.Graphics
 {
   public partial class SamplerState
   {
-      private readonly float[] _openGLBorderColor = new float[4];
+#if !DESKTOPGL
+        internal const TextureParameterName TextureParameterNameTextureMaxAnisotropy = (TextureParameterName)All.TextureMaxAnisotropyExt;
+        internal const TextureParameterName TextureParameterNameTextureMaxLevel = (TextureParameterName)0x813D;
+#else
+        internal const TextureParameterName TextureParameterNameTextureMaxAnisotropy = TextureParameterName.TextureMaxAnisotropyExt;
+        internal const TextureParameterName TextureParameterNameTextureMaxLevel = TextureParameterName.TextureMaxLevel;
+#endif
+
+        private readonly float[] _openGLBorderColor = new float[4];
 
         internal void Activate(GraphicsDevice device, TextureTarget target, bool useMipmaps = false)
         {
@@ -38,7 +46,7 @@ namespace Microsoft.Xna.Framework.Graphics
       case TextureFilter.Point:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
         GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.NearestMipmapNearest : TextureMinFilter.Nearest));
@@ -49,7 +57,7 @@ namespace Microsoft.Xna.Framework.Graphics
       case TextureFilter.Linear:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
         GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.LinearMipmapLinear : TextureMinFilter.Linear));
@@ -60,7 +68,7 @@ namespace Microsoft.Xna.Framework.Graphics
       case TextureFilter.Anisotropic:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, MathHelper.Clamp(this.MaxAnisotropy, 1.0f, GraphicsDevice.GraphicsCapabilities.MaxTextureAnisotropy));
+                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, MathHelper.Clamp(this.MaxAnisotropy, 1.0f, GraphicsDevice.GraphicsCapabilities.MaxTextureAnisotropy));
                     GraphicsExtensions.CheckGLError();
                 }
         GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.LinearMipmapLinear : TextureMinFilter.Linear));
@@ -71,7 +79,7 @@ namespace Microsoft.Xna.Framework.Graphics
       case TextureFilter.PointMipLinear:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
         GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.NearestMipmapLinear : TextureMinFilter.Nearest));
@@ -82,7 +90,7 @@ namespace Microsoft.Xna.Framework.Graphics
             case TextureFilter.LinearMipPoint:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
                 GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.LinearMipmapNearest : TextureMinFilter.Linear));
@@ -93,7 +101,7 @@ namespace Microsoft.Xna.Framework.Graphics
             case TextureFilter.MinLinearMagPointMipLinear:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
                 GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.LinearMipmapLinear : TextureMinFilter.Linear));
@@ -104,7 +112,7 @@ namespace Microsoft.Xna.Framework.Graphics
             case TextureFilter.MinLinearMagPointMipPoint:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
                 GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.LinearMipmapNearest: TextureMinFilter.Linear));
@@ -115,7 +123,7 @@ namespace Microsoft.Xna.Framework.Graphics
             case TextureFilter.MinPointMagLinearMipLinear:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
                 GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.NearestMipmapLinear: TextureMinFilter.Nearest));
@@ -126,7 +134,7 @@ namespace Microsoft.Xna.Framework.Graphics
             case TextureFilter.MinPointMagLinearMipPoint:
 				if (GraphicsDevice.GraphicsCapabilities.SupportsTextureFilterAnisotropic)
                 {
-                    GL.TexParameter(target, Texture.TextureParameterNameTextureMaxAnisotropy, 1.0f);
+                    GL.TexParameter(target, TextureParameterNameTextureMaxAnisotropy, 1.0f);
                     GraphicsExtensions.CheckGLError();
                 }
                 GL.TexParameter(target, TextureParameterName.TextureMinFilter, (int)(useMipmaps ? TextureMinFilter.NearestMipmapNearest: TextureMinFilter.Nearest));
@@ -175,11 +183,11 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 if (this.MaxMipLevel > 0)
                 {
-                    GL.TexParameter(TextureTarget.Texture2D, Texture.TextureParameterNameTextureMaxLevel, this.MaxMipLevel);
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterNameTextureMaxLevel, this.MaxMipLevel);
                 }
                 else
                 {
-                    GL.TexParameter(TextureTarget.Texture2D, Texture.TextureParameterNameTextureMaxLevel, 1000);
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterNameTextureMaxLevel, 1000);
                 }
                 GraphicsExtensions.CheckGLError();
             }

--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -27,6 +27,14 @@ namespace Microsoft.Xna.Framework.Graphics
         internal PixelType glType;
         internal SamplerState glLastSamplerState;
 
+#if GLES
+        internal const TextureParameterName TextureParameterNameTextureMaxAnisotropy = (TextureParameterName)All.TextureMaxAnisotropyExt;
+        internal const TextureParameterName TextureParameterNameTextureMaxLevel = (TextureParameterName)0x813D;
+#else
+        internal const TextureParameterName TextureParameterNameTextureMaxAnisotropy = TextureParameterName.TextureMaxAnisotropyExt;
+        internal const TextureParameterName TextureParameterNameTextureMaxLevel = TextureParameterName.TextureMaxLevel;
+#endif
+
         private void PlatformGraphicsDeviceResetting()
         {
             DeleteGLTexture();

--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -27,14 +27,6 @@ namespace Microsoft.Xna.Framework.Graphics
         internal PixelType glType;
         internal SamplerState glLastSamplerState;
 
-#if !DESKTOPGL
-        internal const TextureParameterName TextureParameterNameTextureMaxAnisotropy = (TextureParameterName)All.TextureMaxAnisotropyExt;
-        internal const TextureParameterName TextureParameterNameTextureMaxLevel = (TextureParameterName)0x813D;
-#else
-        internal const TextureParameterName TextureParameterNameTextureMaxAnisotropy = TextureParameterName.TextureMaxAnisotropyExt;
-        internal const TextureParameterName TextureParameterNameTextureMaxLevel = TextureParameterName.TextureMaxLevel;
-#endif
-
         private void PlatformGraphicsDeviceResetting()
         {
             DeleteGLTexture();

--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Xna.Framework.Graphics
         internal PixelType glType;
         internal SamplerState glLastSamplerState;
 
-#if GLES
+#if !DESKTOPGL
         internal const TextureParameterName TextureParameterNameTextureMaxAnisotropy = (TextureParameterName)All.TextureMaxAnisotropyExt;
         internal const TextureParameterName TextureParameterNameTextureMaxLevel = (TextureParameterName)0x813D;
 #else

--- a/MonoGame.Framework/Graphics/Texture.cs
+++ b/MonoGame.Framework/Graphics/Texture.cs
@@ -51,6 +51,42 @@ namespace Microsoft.Xna.Framework.Graphics
             return levels;
         }
 
+        internal static void GetSizeForLevel(int width, int height, int level, out int w, out int h)
+        {
+            w = width;
+            h = height;
+            while (level > 0)
+            {
+                --level;
+                w /= 2;
+                h /= 2;
+            }
+            if (w == 0)
+                w = 1;
+            if (h == 0)
+                h = 1;
+        }
+
+        internal static void GetSizeForLevel(int width, int height, int depth, int level, out int w, out int h, out int d)
+        {
+            w = width;
+            h = height;
+            d = depth;
+            while (level > 0)
+            {
+                --level;
+                w /= 2;
+                h /= 2;
+                d /= 2;
+            }
+            if (w == 0)
+                w = 1;
+            if (h == 0)
+                h = 1;
+            if (d == 0)
+                d = 1;
+        }
+
         internal int GetPitch(int width)
         {
             Debug.Assert(width > 0, "The width is negative!");

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -614,11 +614,11 @@ namespace Microsoft.Xna.Framework.Graphics
                 {
                     if (_levelCount > 0)
                     {
-                        GL.TexParameter(TextureTarget.Texture2D, TextureParameterNameTextureMaxLevel, _levelCount - 1);
+                        GL.TexParameter(TextureTarget.Texture2D, SamplerState.TextureParameterNameTextureMaxLevel, _levelCount - 1);
                     }
                     else
                     {
-                        GL.TexParameter(TextureTarget.Texture2D, TextureParameterNameTextureMaxLevel, 1000);
+                        GL.TexParameter(TextureTarget.Texture2D, SamplerState.TextureParameterNameTextureMaxLevel, 1000);
                     }
                     GraphicsExtensions.CheckGLError();
                 }

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -71,7 +71,31 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             this.glTarget = TextureTarget.Texture2D;
             format.GetGLFormat(GraphicsDevice, out glInternalFormat, out glFormat, out glType);
-            // GL texture is generated on first access in PlatformSetData
+            GenerateGLTextureIfRequired();
+            int w = width;
+            int h = height;
+            int level = 0;
+            while (true)
+            {
+                if (glFormat == (PixelFormat)GLPixelFormat.CompressedTextureFormats)
+                {
+                    int blockSize = format.GetSize();
+                    int wBlocks = (w + 3) / 4;
+                    int hBlocks = (h + 3) / 4;
+                    GL.CompressedTexImage2D(TextureTarget.Texture2D, level, glInternalFormat, w, h, 0, wBlocks * hBlocks * blockSize, IntPtr.Zero);
+                }
+                else
+                    GL.TexImage2D(TextureTarget.Texture2D, level, glInternalFormat, w, h, 0, glFormat, glType, IntPtr.Zero);
+                GraphicsExtensions.CheckGLError();
+
+                if ((w == 1 && h == 1) || !mipmap)
+                    break;
+                if (w > 1)
+                    w = w / 2;
+                if (h > 1)
+                    h = h / 2;
+                ++level;
+            }
         }
 
         private void PlatformSetData<T>(int level, T[] data, int startIndex, int elementCount) where T : struct

--- a/MonoGame.Framework/Graphics/Texture2D.Web.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.Web.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new NotImplementedException();
         }
 
+        private void PlatformSetData<T>(int level, T[] data, int startIndex, int elementCount) where T : struct
+        {
+            throw new NotImplementedException();
+        }
+
         private void PlatformSetData<T>(int level, int arraySlice, Rectangle rect, T[] data, int startIndex, int elementCount) where T : struct
         {
             throw new NotImplementedException();

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -159,7 +159,10 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="elementCount"></param>
         public void SetData<T>(int level, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct 
         {
-            this.SetData(level, 0, rect, data, startIndex, elementCount);
+            if (rect == null)
+                PlatformSetData(level, data, startIndex, elementCount);
+            else
+                this.SetData(level, 0, rect, data, startIndex, elementCount);
         }
         /// <summary>
         /// Changes the texture's pixels
@@ -170,7 +173,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="elementCount"></param>
 		public void SetData<T>(T[] data, int startIndex, int elementCount) where T : struct
         {
-            this.SetData(0, null, data, startIndex, elementCount);
+            PlatformSetData(0, data, startIndex, elementCount);
         }
 		/// <summary>
         /// Changes the texture's pixels
@@ -181,7 +184,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 		    if (data == null)
 		        throw new ArgumentNullException("data");
-			this.SetData(0, null, data, 0, data.Length);
+            PlatformSetData(0, data, 0, data.Length);
         }
         /// <summary>
         /// Retrieves the contents of the texture

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -159,10 +159,9 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="elementCount"></param>
         public void SetData<T>(int level, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct 
         {
-            if (rect == null)
-                PlatformSetData(level, data, startIndex, elementCount);
-            else
-                this.SetData(level, 0, rect, data, startIndex, elementCount);
+            Rectangle checkedRect;
+            ValidateParams(level, 0, rect, data, startIndex, elementCount, out checkedRect);
+            PlatformSetData(level, 0, checkedRect, data, startIndex, elementCount);
         }
         /// <summary>
         /// Changes the texture's pixels
@@ -173,6 +172,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="elementCount"></param>
 		public void SetData<T>(T[] data, int startIndex, int elementCount) where T : struct
         {
+            Rectangle checkedRect;
+            ValidateParams(0, 0, null, data, startIndex, elementCount, out checkedRect);
             PlatformSetData(0, data, startIndex, elementCount);
         }
 		/// <summary>
@@ -182,8 +183,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="data"></param>
 		public void SetData<T>(T[] data) where T : struct
 		{
-		    if (data == null)
-		        throw new ArgumentNullException("data");
+            Rectangle checkedRect;
+            ValidateParams(0, 0, null, data, 0, data.Length, out checkedRect);
             PlatformSetData(0, data, 0, data.Length);
         }
         /// <summary>

--- a/Test/ContentPipeline/TextureProcessorTests.cs
+++ b/Test/ContentPipeline/TextureProcessorTests.cs
@@ -82,7 +82,10 @@ namespace MonoGame.Tests.ContentPipeline
                 TextureFormat = TextureProcessorOutputFormat.Color
             };
 
-            var face = new PixelBitmapContent<Color>(8, 8);
+            var width = 8;
+            var height = 8;
+
+            var face = new PixelBitmapContent<Color>(width, height);
             Fill(face, Color.Red);
             var input = new Texture2DContent();
             input.Faces[0] = face;
@@ -95,9 +98,6 @@ namespace MonoGame.Tests.ContentPipeline
 
             var outChain = output.Faces[0];
             Assert.AreEqual(4, outChain.Count);
-
-            var width = 8;
-            var height = 8;
 
             foreach (var outFace in outChain)
             {
@@ -128,7 +128,10 @@ namespace MonoGame.Tests.ContentPipeline
                 TextureFormat = TextureProcessorOutputFormat.Color
             };
 
-            var face = new PixelBitmapContent<Color>(16, 8);
+            var width = 16;
+            var height = 8;
+
+            var face = new PixelBitmapContent<Color>(width, height);
             Fill(face, Color.Red);
             var input = new Texture2DContent();
             input.Faces[0] = face;
@@ -140,9 +143,6 @@ namespace MonoGame.Tests.ContentPipeline
 
             var outChain = output.Faces[0];
             Assert.AreEqual(5, outChain.Count);
-
-            var width = 16;
-            var height = 8;
 
             foreach (var outFace in outChain)
             {
@@ -175,7 +175,10 @@ namespace MonoGame.Tests.ContentPipeline
                 TextureFormat = TextureProcessorOutputFormat.Color
             };
 
-            var face = new PixelBitmapContent<Color>(23, 5);
+            var width = 23;
+            var height = 5;
+
+            var face = new PixelBitmapContent<Color>(width, height);
             Fill(face, Color.Red);
             var input = new Texture2DContent();
             input.Faces[0] = face;
@@ -187,9 +190,6 @@ namespace MonoGame.Tests.ContentPipeline
 
             var outChain = output.Faces[0];
             Assert.AreEqual(5, outChain.Count);
-
-            var width = 23;
-            var height = 5;
 
             foreach (var outFace in outChain)
             {

--- a/Test/ContentPipeline/TextureProcessorTests.cs
+++ b/Test/ContentPipeline/TextureProcessorTests.cs
@@ -69,7 +69,7 @@ namespace MonoGame.Tests.ContentPipeline
         }
 
         [Test]
-        public void Mipmap()
+        public void MipmapSquarePowerOfTwo()
         {
             var context = new TestProcessorContext(TargetPlatform.Windows, "dummy.xnb");
 
@@ -111,6 +111,100 @@ namespace MonoGame.Tests.ContentPipeline
 
                 width = width >> 1;
                 height = height >> 1;
+            }
+        }
+
+        [Test]
+        public void MipmapNonSquarePowerOfTwo()
+        {
+            var context = new TestProcessorContext(TargetPlatform.Windows, "dummy.xnb");
+
+            var processor = new TextureProcessor
+            {
+                ColorKeyEnabled = false,
+                GenerateMipmaps = true,
+                PremultiplyAlpha = false,
+                ResizeToPowerOfTwo = false,
+                TextureFormat = TextureProcessorOutputFormat.Color
+            };
+
+            var face = new PixelBitmapContent<Color>(16, 8);
+            Fill(face, Color.Red);
+            var input = new Texture2DContent();
+            input.Faces[0] = face;
+
+            var output = processor.Process(input, context);
+
+            Assert.NotNull(output);
+            Assert.AreEqual(1, output.Faces.Count);
+
+            var outChain = output.Faces[0];
+            Assert.AreEqual(5, outChain.Count);
+
+            var width = 16;
+            var height = 8;
+
+            foreach (var outFace in outChain)
+            {
+                Assert.AreEqual(width, outFace.Width);
+                Assert.AreEqual(height, outFace.Height);
+
+                var bitmap = (PixelBitmapContent<Color>)outFace;
+                for (var y = 0; y < height; y++)
+                    for (var x = 0; x < width; x++)
+                        Assert.AreEqual(Color.Red, bitmap.GetPixel(x, y));
+
+                if (width > 1)
+                    width /= 2;
+                if (height > 1)
+                    height /= 2;
+            }
+        }
+
+        [Test]
+        public void MipmapNonSquareNonPowerOfTwo()
+        {
+            var context = new TestProcessorContext(TargetPlatform.Windows, "dummy.xnb");
+
+            var processor = new TextureProcessor
+            {
+                ColorKeyEnabled = false,
+                GenerateMipmaps = true,
+                PremultiplyAlpha = false,
+                ResizeToPowerOfTwo = false,
+                TextureFormat = TextureProcessorOutputFormat.Color
+            };
+
+            var face = new PixelBitmapContent<Color>(23, 5);
+            Fill(face, Color.Red);
+            var input = new Texture2DContent();
+            input.Faces[0] = face;
+
+            var output = processor.Process(input, context);
+
+            Assert.NotNull(output);
+            Assert.AreEqual(1, output.Faces.Count);
+
+            var outChain = output.Faces[0];
+            Assert.AreEqual(5, outChain.Count);
+
+            var width = 23;
+            var height = 5;
+
+            foreach (var outFace in outChain)
+            {
+                Assert.AreEqual(width, outFace.Width);
+                Assert.AreEqual(height, outFace.Height);
+
+                var bitmap = (PixelBitmapContent<Color>)outFace;
+                for (var y = 0; y < height; y++)
+                    for (var x = 0; x < width; x++)
+                        Assert.AreEqual(Color.Red, bitmap.GetPixel(x, y));
+
+                if (width > 1)
+                    width /= 2;
+                if (height > 1)
+                    height /= 2;
             }
         }
 
@@ -157,7 +251,7 @@ namespace MonoGame.Tests.ContentPipeline
             var processor = new TextureProcessor
             {
                 ColorKeyEnabled = false,
-                GenerateMipmaps = false,
+                GenerateMipmaps = true,
                 PremultiplyAlpha = false,
                 ResizeToPowerOfTwo = false,
                 TextureFormat = TextureProcessorOutputFormat.Compressed
@@ -172,7 +266,7 @@ namespace MonoGame.Tests.ContentPipeline
 
             Assert.NotNull(output);
             Assert.AreEqual(1, output.Faces.Count);
-            Assert.AreEqual(1, output.Faces[0].Count);
+            Assert.AreEqual(5, output.Faces[0].Count);
 
             Assert.IsAssignableFrom<T>(output.Faces[0][0]);
         }


### PR DESCRIPTION
- Mipmaps are now generated correctly down to 1x1 in the content pipeline.
- Mipmaps are generated in the content pipeline in one location before it gets to the TextureProfile, avoiding duplication of functionality.
- Mipmaps are generated before compression, not during.
- Texture2D.OpenGL construction no longer generates mipmaps, but allocates mipmaps for population by SetData.
- Added more texture processing tests for non-square, power-of-two and non-square, non-power-of-two textures with mipmaps.
- Added Texture2D PlatformSetData overload for optimization of setting of an entire mip level.

Not tested on Android or iOS yet as I'm having Xamarin license issues.