### PR TITLE
Remove forgotten touches

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchPanelState.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanelState.cs
@@ -48,8 +48,15 @@ namespace Microsoft.Xna.Framework.Input.Touch
             get { return _currentTimestamp; }
             set
             {
-                _previousTimestamp = _currentTimestamp;
-                _currentTimestamp = value;
+                if (_currentTimestamp != value)
+                {
+                    if (_currentTimestamp > _previousTimestamp)
+                        _previousTimestamp = _currentTimestamp;
+                    _currentTimestamp = value;
+                    // handle time rewinding
+                    if (_currentTimestamp < _previousTimestamp)
+                        _previousTimestamp = _currentTimestamp;
+                }
             }
         }
         private static TimeSpan _currentTimestamp;

--- a/MonoGame.Framework/Input/Touch/TouchPanelState.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanelState.cs
@@ -43,7 +43,17 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <summary>
         /// The current timestamp that we use for setting the timestamp of new TouchLocations
         /// </summary>
-        internal static TimeSpan CurrentTimestamp { get; set; }
+        internal static TimeSpan CurrentTimestamp
+        {
+            get { return _currentTimestamp; }
+            set
+            {
+                _previousTimestamp = _currentTimestamp;
+                _currentTimestamp = value;
+            }
+        }
+        private static TimeSpan _currentTimestamp;
+        private static TimeSpan _previousTimestamp;
 
         /// <summary>
         /// The mapping between platform specific touch ids
@@ -144,6 +154,11 @@ namespace Microsoft.Xna.Framework.Input.Touch
                 {
                     _touchState.RemoveAt(i);
                 }
+                // Remove forgotten-old touches
+                else if (touch.Timestamp < _previousTimestamp 
+                    && touch.State != TouchLocationState.Released
+                    && touch.State != TouchLocationState.Invalid)
+                    _touchState.RemoveAt(i);
             }
 
             var result = (_touchState.Count > 0) ? new TouchCollection(_touchState.ToArray()) : TouchCollection.Empty;


### PR DESCRIPTION
Quickfix for a problem I encontered. Sometimes old touch events weren't removed and got stuck indefinitely. This crude fix removes orphaned touches that weren't updated for at least two frames.

I was testing on windows with EnableMouseTouchPoint & EnableMouseGestures.