### PR TITLE
[Gamepad] Add Id and DisplayName properties

### DIFF
--- a/MonoGame.Framework/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Input/GamePad.SDL.cs
@@ -122,40 +122,90 @@ namespace Microsoft.Xna.Framework.Input
             if (!Gamepads.ContainsKey(index))
                 return new GamePadCapabilities();
 
-            if (Sdl.GameController.GetName(Gamepads[index].Device) == "Unknown Gamepad")
-                return new GamePadCapabilities
-                {
-                    IsConnected = true
-                };
+            var gamecontroller = Gamepads[index].Device;
+            var caps = new GamePadCapabilities();
+            var mapping = Sdl.GameController.GetMapping(gamecontroller).Split(',');
 
-            return new GamePadCapabilities
+            caps.IsConnected = true;
+            caps.DisplayName = Sdl.GameController.GetName(gamecontroller);
+            caps.Identifier = Sdl.Joystick.GetGUID(Sdl.GameController.GetJoystick(gamecontroller)).ToString();
+            caps.HasLeftVibrationMotor = caps.HasRightVibrationMotor = (Gamepads[index].HapticType != 0);
+
+            foreach (var map in mapping)
             {
-                IsConnected = true,
-                HasAButton = true,
-                HasBButton = true,
-                HasXButton = true,
-                HasYButton = true,
-                HasBackButton = true,
-                HasStartButton = true,
-                HasDPadDownButton = true,
-                HasDPadLeftButton = true,
-                HasDPadRightButton = true,
-                HasDPadUpButton = true,
-                HasLeftShoulderButton = true,
-                HasRightShoulderButton = true,
-                HasLeftStickButton = true,
-                HasRightStickButton = true,
-                HasLeftTrigger = true,
-                HasRightTrigger = true,
-                HasLeftXThumbStick = true,
-                HasLeftYThumbStick = true,
-                HasRightXThumbStick = true,
-                HasRightYThumbStick = true,
-                HasLeftVibrationMotor = true,
-                HasRightVibrationMotor = true,
-                HasVoiceSupport = true,
-                HasBigButton = true
-            };
+                var split = map.Split(':');
+                if (split.Length != 2)
+                    continue;
+
+                switch (split[0])
+                {
+                    case "a":
+                        caps.HasAButton = true;
+                        break;
+                    case "b":
+                        caps.HasBButton = true;
+                        break;
+                    case "x":
+                        caps.HasXButton = true;
+                        break;
+                    case "y":
+                        caps.HasYButton = true;
+                        break;
+                    case "back":
+                        caps.HasBackButton = true;
+                        break;
+                    case "guide":
+                        caps.HasBigButton = true;
+                        break;
+                    case "start":
+                        caps.HasStartButton = true;
+                        break;
+                    case "dpleft":
+                        caps.HasDPadLeftButton = true;
+                        break;
+                    case "dpdown":
+                        caps.HasDPadDownButton = true;
+                        break;
+                    case "dpright":
+                        caps.HasDPadRightButton = true;
+                        break;
+                    case "dpup":
+                        caps.HasDPadUpButton = true;
+                        break;
+                    case "leftshoulder":
+                        caps.HasLeftShoulderButton = true;
+                        break;
+                    case "lefttrigger":
+                        caps.HasLeftTrigger = true;
+                        break;
+                    case "rightshoulder":
+                        caps.HasRightShoulderButton = true;
+                        break;
+                    case "righttrigger":
+                        caps.HasRightTrigger = true;
+                        break;
+                    case "leftstick":
+                        caps.HasLeftStickButton = true;
+                        break;
+                    case "rightstick":
+                        caps.HasRightStickButton = true;
+                        break;
+                    case "leftx":
+                        caps.HasLeftXThumbStick = true;
+                        break;
+                    case "lefty":
+                        caps.HasLeftYThumbStick = true;
+                        break;
+                    case "rightx":
+                        caps.HasRightXThumbStick = true;
+                        break;
+                    case "righty":
+                        caps.HasRightYThumbStick = true;
+                        break;
+                }
+            }
+
+            return caps;
         }
 
         private static float GetFromSdlAxis(int axis)

--- a/MonoGame.Framework/Input/GamePad.Web.cs
+++ b/MonoGame.Framework/Input/GamePad.Web.cs
@@ -32,10 +32,10 @@ namespace Microsoft.Xna.Framework.Input
         {
             var jcap = Joystick.GetCapabilities(index);
 
-            if (!GamePadCache.ContainsKey(jcap.Id))
-                GamePadCache.Add(jcap.Id, Configurations.ContainsKey(jcap.Id) ? new GamepadTranslator(Configurations[jcap.Id]) : new GamepadTranslator(""));
+            if (!GamePadCache.ContainsKey(jcap.Identifier))
+                GamePadCache.Add(jcap.Identifier, Configurations.ContainsKey(jcap.Identifier) ? new GamepadTranslator(Configurations[jcap.Identifier]) : new GamepadTranslator(""));
 
-            var gpc = GamePadCache[jcap.Id];
+            var gpc = GamePadCache[jcap.Identifier];
 
             return new GamePadCapabilities 
             {
@@ -78,10 +78,10 @@ namespace Microsoft.Xna.Framework.Input
 
                 var jstate = Joystick.GetState(index);
 
-                if (!GamePadCache.ContainsKey(jcap.Id))
-                    GamePadCache.Add(jcap.Id, Configurations.ContainsKey(jcap.Id) ? new GamepadTranslator(Configurations[jcap.Id]) : new GamepadTranslator(""));
+                if (!GamePadCache.ContainsKey(jcap.Identifier))
+                    GamePadCache.Add(jcap.Identifier, Configurations.ContainsKey(jcap.Identifier) ? new GamepadTranslator(Configurations[jcap.Identifier]) : new GamepadTranslator(""));
 
-                var gpc = GamePadCache[jcap.Id];
+                var gpc = GamePadCache[jcap.Identifier];
 
                 Buttons buttons = 
                     (gpc.ButtonPressed("a", jstate) ? Buttons.A : 0) |

--- a/MonoGame.Framework/Input/GamePadCapabilities.cs
+++ b/MonoGame.Framework/Input/GamePadCapabilities.cs
@@ -16,6 +16,22 @@ namespace Microsoft.Xna.Framework.Input
         public bool IsConnected { get; internal set; }
 
         /// <summary>
+        /// Gets the gamepad display name.
+        /// 
+        /// This property is not available in XNA.
+        /// </summary>
+        /// <value>String representing the display name of the gamepad.</value>
+        public string DisplayName { get; internal set; }
+
+        /// <summary>
+        /// Gets the unique identifier of the gamepad.
+        /// 
+        /// This property is not available in XNA.
+        /// </summary>
+        /// <value>String representing the unique identifier of the gamepad.</value>
+        public string Identifier { get; internal set; }
+
+        /// <summary>
         /// Gets a value indicating whether the controller has the button A.
         /// </summary>
         /// <value><c>true</c> if it has the button A; otherwise, <c>false</c>.</value>
@@ -176,6 +192,8 @@ namespace Microsoft.Xna.Framework.Input
         {
             var eq = true;
 
+            eq &= (left.DisplayName == right.DisplayName);
+            eq &= (left.Identifier == right.Identifier);
             eq &= (left.IsConnected == right.IsConnected);
             eq &= (left.HasAButton == right.HasAButton);
             eq &= (left.HasBackButton == right.HasBackButton);
@@ -236,65 +254,7 @@ namespace Microsoft.Xna.Framework.Input
         /// hash table.</returns>
         public override int GetHashCode()
         {
-            var hash = 0;
-
-            if (IsConnected)
-                hash |= (1 << 0);
-            if (HasAButton)
-                hash |= (1 << 1);
-            if (HasBackButton)
-                hash |= (1 << 2);
-            if (HasBButton)
-                hash |= (1 << 3);
-            if (HasDPadDownButton)
-                hash |= (1 << 4);
-            if (HasDPadLeftButton)
-                hash |= (1 << 5);
-            if (HasDPadRightButton)
-                hash |= (1 << 6);
-            if (HasDPadUpButton)
-                hash |= (1 << 7);
-            if (HasLeftShoulderButton)
-                hash |= (1 << 8);
-            if (HasLeftStickButton)
-                hash |= (1 << 9);
-            if (HasRightShoulderButton)
-                hash |= (1 << 10);
-            if (HasRightStickButton)
-                hash |= (1 << 11);
-            if (HasStartButton)
-                hash |= (1 << 12);
-            if (HasXButton)
-                hash |= (1 << 13);
-            if (HasYButton)
-                hash |= (1 << 14);
-            if (HasBigButton)
-                hash |= (1 << 15);
-            if (HasLeftXThumbStick)
-                hash |= (1 << 16);
-            if (HasLeftYThumbStick)
-                hash |= (1 << 17);
-            if (HasRightXThumbStick)
-                hash |= (1 << 18);
-            if (HasRightYThumbStick)
-                hash |= (1 << 19);
-            if (HasStartButton)
-                hash |= (1 << 20);
-            if (HasLeftTrigger)
-                hash |= (1 << 21);
-            if (HasRightTrigger)
-                hash |= (1 << 22);
-            if (HasLeftVibrationMotor)
-                hash |= (1 << 23);
-            if (HasRightVibrationMotor)
-                hash |= (1 << 24);
-            if (HasVoiceSupport)
-                hash |= (1 << 25);
-
-            unchecked
-            {
-                return (hash * 397) ^ (int)GamePadType;
-            }
+            return Identifier.GetHashCode();
         }
 
         /// <summary>
@@ -304,6 +264,8 @@ namespace Microsoft.Xna.Framework.Input
         public override string ToString()
         {
             return "[GamePadCapabilities: IsConnected=" + IsConnected +
+                ", DisplayName=" + DisplayName +
+                ", Identifier=" + Identifier +
                 ", HasAButton=" + HasAButton +
                 ", HasBackButton=" + HasBackButton +
                 ", HasBButton=" + HasBButton +
@@ -333,4 +295,3 @@ namespace Microsoft.Xna.Framework.Input
         }
     }
 }
-

--- a/MonoGame.Framework/Input/Joystick.SDL.cs
+++ b/MonoGame.Framework/Input/Joystick.SDL.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Xna.Framework.Input
                 return new JoystickCapabilities
                 {
                     IsConnected = false,
-                    Id = "",
+                    Identifier = "",
                     AxisCount = 0,
                     ButtonCount = 0,
                     HatCount = 0
@@ -66,7 +66,7 @@ namespace Microsoft.Xna.Framework.Input
             return new JoystickCapabilities
             {
                 IsConnected = true,
-                Id = Sdl.Joystick.GetGUID(jdevice).ToString(),
+                Identifier = Sdl.Joystick.GetGUID(jdevice).ToString(),
                 AxisCount = Sdl.Joystick.NumAxes(jdevice),
                 ButtonCount = Sdl.Joystick.NumButtons(jdevice),
                 HatCount = Sdl.Joystick.NumHats(jdevice)

--- a/MonoGame.Framework/Input/Joystick.Web.cs
+++ b/MonoGame.Framework/Input/Joystick.Web.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Xna.Framework.Input
             return new JoystickCapabilities()
             {
                 IsConnected = connected,
-                Id = id,
+                Identifier = id,
                 AxisCount = axiscount,
                 ButtonCount = buttoncount,
                 HatCount = 0

--- a/MonoGame.Framework/Input/JoystickCapabilities.cs
+++ b/MonoGame.Framework/Input/JoystickCapabilities.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Xna.Framework.Input
         /// Gets the unique identifier of the joystick.
         /// </summary>
         /// <value>String representing the unique identifier of the joystick.</value>
-        public string Id { get; internal set; }
+        public string Identifier { get; internal set; }
 
         /// <summary>
         /// Gets the axis count.
@@ -46,7 +46,7 @@ namespace Microsoft.Xna.Framework.Input
         /// hash table.</returns>
         public override int GetHashCode()
         {
-            return Id.GetHashCode();
+            return Identifier.GetHashCode();
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <returns>A <see cref="T:System.String"/> that represents the current <see cref="T:Microsoft.Xna.Framework.Input.JoystickCapabilities"/>.</returns>
         public override string ToString()
         {
-            return "[JoystickCapabilities: IsConnected=" + IsConnected + ", Id=" + Id + ", AxisCount=" + AxisCount + ", ButtonCount=" + ButtonCount + ", HatCount=" + HatCount + "]";
+            return "[JoystickCapabilities: IsConnected=" + IsConnected + ", Identifier=" + Identifier + ", AxisCount=" + AxisCount + ", ButtonCount=" + ButtonCount + ", HatCount=" + HatCount + "]";
         }
     }
 }

--- a/MonoGame.Framework/SDL/SDL2.cs
+++ b/MonoGame.Framework/SDL/SDL2.cs
@@ -20,11 +20,11 @@ internal static class Sdl
         if (handle == IntPtr.Zero)
             return "";
 
-        var ptr = (byte*) handle;
+        var ptr = (byte*)handle;
         while (*ptr != 0)
             ptr++;
 
-        var bytes = new byte[ptr - (byte*) handle];
+        var bytes = new byte[ptr - (byte*)handle];
         Marshal.Copy(handle, bytes, 0, bytes.Length);
 
         return Encoding.UTF8.GetString(bytes);
@@ -759,8 +759,7 @@ internal static class Sdl
             public int Which;
         }
 
-        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl,
-            EntryPoint = "SDL_GameControllerAddMapping")]
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GameControllerAddMapping")]
         public static extern int AddMapping(string mappingString);
 
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GameControllerClose")]
@@ -792,6 +791,14 @@ internal static class Sdl
 
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_IsGameController")]
         public static extern byte IsGameController(int joystickIndex);
+
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GameControllerMapping")]
+        private static extern IntPtr SDL_GameControllerMapping(IntPtr gamecontroller);
+
+        public static string GetMapping(IntPtr gamecontroller)
+        {
+            return GetString(SDL_GameControllerMapping(gamecontroller));
+        }
 
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GameControllerOpen")]
         private static extern IntPtr SDL_GameControllerOpen(int joystickIndex);


### PR DESCRIPTION
Notes:
 - We need to use string for Id and not guid because not all platforms will return a guid.
 - ~~I like Id more than Identifier.. do tell me if you want it changed.~~
   - It's named `Identifier` now

CC. @tomspilman 