### PR TITLE
Fix the paths so they work on android-n+.

### DIFF
--- a/MonoGame.Framework/Graphics/OpenGL.Android.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.Android.cs
@@ -33,9 +33,9 @@ namespace OpenGL
 
 	internal static class EntryPointHelper {
 		
-		static IntPtr libES1 = DL.Open("/system/lib/libGLESv1_CM.so");
-		static IntPtr libES2 = DL.Open("/system/lib/libGLESv2.so");
-		static IntPtr libGL = DL.Open("/system/lib/libGL.so");
+		static IntPtr libES1 = DL.Open("libGLESv1_CM.so");
+		static IntPtr libES2 = DL.Open("libGLESv2.so");
+		static IntPtr libGL = DL.Open("libGL.so");
 	
 		public static IntPtr GetAddress(String function)
 		{


### PR DESCRIPTION
Android N changed the way native libraries are used. You can
no longer directly load from /system/lib. Instead it seems we
need to just provide the library name and let the OS do its
thing.