### PR TITLE
Allow loading from user's local fonts library

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 
 #if WINDOWS || LINUX
 #if WINDOWS
-			fontName = FindFontFileFromFontName(fontName, fontDirectory);
+			fontName = FindFontFileFromFontName(fontName, FontsDirectory);
 #elif LINUX
             fontName = FindFontFileFromFontName(fontName, input.Style.ToString());
 #endif

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -246,11 +246,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 			return glyphs.ToArray();
 		}
 
-		List<string> GetFontDirectories()
-		{
-
-		}
-
 #if WINDOWS
 		string FindFontFileFromFontName (string fontName, string fontDirectory)
 		{

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -27,6 +27,34 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         [DefaultValue(typeof(TextureProcessorOutputFormat), "Compressed")]
         public virtual TextureProcessorOutputFormat TextureFormat { get; set; }
 
+		string FontsDirectory
+		{
+			get
+			{
+#if WINDOWS
+				var windowsDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+				return Path.Combine(windowsDirectory, "Fonts");
+#elif MAC
+				return "/Library/Fonts";
+#else
+				return null;
+#endif
+			}
+		}
+
+		string LocalFontsDirectory
+		{
+			get
+			{
+#if MAC
+				var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+				return Path.Combine(homeDirectory, "Library/Fonts");
+#else
+				return null;
+#endif
+			}
+		}
+
         public FontDescriptionProcessor()
         {
             PremultiplyAlpha = true;
@@ -42,28 +70,26 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 
 #if WINDOWS || LINUX
 #if WINDOWS
-			var windowsfolder = Environment.GetFolderPath (Environment.SpecialFolder.Windows);
-		    var fontDirectory = Path.Combine(windowsfolder,"Fonts");
-			fontName = FindFontFileFromFontName (fontName, fontDirectory);
+			fontName = FindFontFileFromFontName(fontName, fontDirectory);
 #elif LINUX
             fontName = FindFontFileFromFontName(fontName, input.Style.ToString());
 #endif
 			if (string.IsNullOrWhiteSpace(fontName)) {
 				fontName = input.FontName;
 #endif
-				
-			var directory = Path.GetDirectoryName (input.Identity.SourceFilename);
 
-			var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-			var localFontsDirectory = Path.Combine(homeDirectory, "Library/Fonts");
+			var directory = Path.GetDirectoryName (input.Identity.SourceFilename);
 
 			List<string> directories = new List<string>();
 			directories.Add(directory);
-			directories.Add(localFontsDirectory);
-			directories.Add("/Library/Fonts");
-#if WINDOWS
-			directories.Add(fontDirectory);
-#endif
+			if (LocalFontsDirectory != null)
+			{
+				directories.Add(LocalFontsDirectory);
+			}
+			if (FontsDirectory != null)
+			{
+				directories.Add(FontsDirectory);
+			}
 
 			foreach( var dir in directories) {
 				if (File.Exists(Path.Combine(dir,fontName+".ttf"))) {

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -54,8 +54,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 				
 			var directory = Path.GetDirectoryName (input.Identity.SourceFilename);
 
+			var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+			var localFontsDirectory = Path.Combine(homeDirectory, "Library/Fonts");
+
 			List<string> directories = new List<string>();
 			directories.Add(directory);
+			directories.Add(localFontsDirectory);
 			directories.Add("/Library/Fonts");
 #if WINDOWS
 			directories.Add(fontDirectory);

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -27,34 +27,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         [DefaultValue(typeof(TextureProcessorOutputFormat), "Compressed")]
         public virtual TextureProcessorOutputFormat TextureFormat { get; set; }
 
-		string FontsDirectory
-		{
-			get
-			{
-#if WINDOWS
-				var windowsDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-				return Path.Combine(windowsDirectory, "Fonts");
-#elif MAC
-				return "/Library/Fonts";
-#else
-				return null;
-#endif
-			}
-		}
-
-		string LocalFontsDirectory
-		{
-			get
-			{
-#if MAC
-				var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-				return Path.Combine(homeDirectory, "Library/Fonts");
-#else
-				return null;
-#endif
-			}
-		}
-
         public FontDescriptionProcessor()
         {
             PremultiplyAlpha = true;
@@ -78,20 +50,22 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 				fontName = input.FontName;
 #endif
 
-			var directory = Path.GetDirectoryName (input.Identity.SourceFilename);
-
 			List<string> directories = new List<string>();
-			directories.Add(directory);
-			if (LocalFontsDirectory != null)
-			{
-				directories.Add(LocalFontsDirectory);
-			}
-			if (FontsDirectory != null)
-			{
-				directories.Add(FontsDirectory);
-			}
 
-			foreach( var dir in directories) {
+			var directory = Path.GetDirectoryName(input.Identity.SourceFilename);
+			directories.Add(directory);
+#if MAC
+			var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+			var localFontsDirectory = Path.Combine(homeDirectory, "Library/Fonts");
+			directories.Add(localFontsDirectory);
+			directories.Add("/Library/Fonts");
+#elif WINDOWS
+			var windowsDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+			var fontsDirectory = Path.Combine(windowsDirectory, "Fonts");
+			directories.Add(fontsDirectory);
+#endif
+
+			foreach (var dir in directories) {
 				if (File.Exists(Path.Combine(dir,fontName+".ttf"))) {
 					fontName += ".ttf";
 					directory = dir;
@@ -270,6 +244,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 			}
 
 			return glyphs.ToArray();
+		}
+
+		List<string> GetFontDirectories()
+		{
+
 		}
 
 #if WINDOWS

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -40,16 +40,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 
 			var fontName = input.FontName;
 
-#if WINDOWS || LINUX
-#if WINDOWS
-			fontName = FindFontFileFromFontName(fontName, FontsDirectory);
-#elif LINUX
-            fontName = FindFontFileFromFontName(fontName, input.Style.ToString());
-#endif
-			if (string.IsNullOrWhiteSpace(fontName)) {
-				fontName = input.FontName;
-#endif
-
 			List<string> directories = new List<string>();
 
 			var directory = Path.GetDirectoryName(input.Identity.SourceFilename);
@@ -63,6 +53,16 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 			var windowsDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
 			var fontsDirectory = Path.Combine(windowsDirectory, "Fonts");
 			directories.Add(fontsDirectory);
+#endif
+
+#if WINDOWS || LINUX
+#if WINDOWS
+			fontName = FindFontFileFromFontName(fontName, fontsDirectory);
+#elif LINUX
+            fontName = FindFontFileFromFontName(fontName, input.Style.ToString());
+#endif
+			if (string.IsNullOrWhiteSpace(fontName)) {
+				fontName = input.FontName;
 #endif
 
 			foreach (var dir in directories) {


### PR DESCRIPTION
By default, fonts install to a user's local ~/Library/Fonts library. Now, the Content Pipeline will also check this directory when trying to process a font description.

It seems like it'd make sense to check this local directory after the game directory, but before the computer's global font library.

(It had taken me a while to figure out why I couldn't get my font to work.)