### PR TITLE
Locking of touchPanelState

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchPanel.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanel.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 		public static GestureSample ReadGesture()
         {
             // Return the next gesture.
-            return PrimaryWindow.TouchPanelState.GestureList.Dequeue();			
+            return PrimaryWindow.TouchPanelState.ReadGesture();			
         }
 
         /// <summary>


### PR DESCRIPTION
When testing the PR that removes OpenTK for Android we noticed that if Android game loop is running on the worker thread instead of the UI thread that the TouchPanelState class is accessed from the worker and UI thread at the same time without locking.

This works fine in 99.999999% of cases but we managed to get a bug just once (which is what led us to this PR) - due to where the bug happened I assume the internal touch state was being converted to an array while it was modified in the 'GetState' function: new TouchCollection (_touchState.ToArray ())

How it was tested so far:

This PR was build and tested on AWS device farm on a Random Salad Games game. The game was running on the UI thread. It passed all tests.

Same as 1) but this time 'RenderOnUIThread' was set to false. This time it crashed with an error in the OpenTK lib. I assume it was because OpenTK doesn't support game loop in worker thread properly? If this is so, then this isn't a problem since OpenTK is getting removed.

Since the goal of this PR is to be able to work when game loop is on a worker thread we tested this with my fixed version of PR #5410 . It passed all tests.