### PR TITLE
Implemented Microphone for OpenAL platforms

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -413,6 +413,14 @@
     </Compile>
     <Compile Include="Audio\SoundEffectInstancePool.cs" />
     <Compile Include="Audio\SoundState.cs" />
+	<Compile Include="Audio\Microphone.cs" />
+	<Compile Include="Audio\Microphone.OpenAL.cs">
+      <Services>OpenALAudio</Services>
+    </Compile>
+	<Compile Include="Audio\Microphone.Default.cs">
+      <Services>XAudioAudio,WebAudio</Services>
+    </Compile>
+	<Compile Include="Audio\NoMicrophoneConnectedException.cs" />
 
 
     <!-- Microsoft.Xna.Framework.Audio Xact-->

--- a/MonoGame.Framework/Audio/Microphone.Default.cs
+++ b/MonoGame.Framework/Audio/Microphone.Default.cs
@@ -2,7 +2,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using OpenAL;
 using System;
 using System.Collections.Generic;
 

--- a/MonoGame.Framework/Audio/Microphone.Default.cs
+++ b/MonoGame.Framework/Audio/Microphone.Default.cs
@@ -1,0 +1,33 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using OpenAL;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Audio
+{ 
+    public sealed partial class Microphone
+    {
+        internal void PlatformStart()
+        {
+			throw new NotImplementedException();
+        }
+
+        internal void PlatformStop()
+        {
+			throw new NotImplementedException();
+        }
+		
+		internal void Update()
+		{
+			throw new NotImplementedException();
+		}
+		
+		internal int PlatformGetData(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MonoGame.Framework/Audio/Microphone.Default.cs
+++ b/MonoGame.Framework/Audio/Microphone.Default.cs
@@ -6,7 +6,10 @@ using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Audio
-{ 
+{
+    /// <summary>
+    /// Provides microphones capture features. 
+    /// </summary>	
     public sealed partial class Microphone
     {
         internal void PlatformStart()

--- a/MonoGame.Framework/Audio/Microphone.OpenAL.cs
+++ b/MonoGame.Framework/Audio/Microphone.OpenAL.cs
@@ -1,0 +1,141 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using OpenAL;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Microsoft.Xna.Framework.Audio
+{
+    /// <summary>
+    /// Provides properties, methods, and fields and events for capturing audio data with microphones. 
+    /// </summary>
+    public sealed partial class Microphone
+    {
+        private IntPtr _captureDevice = IntPtr.Zero;
+
+        internal void CheckALCError(string operation)
+        {
+            AlcError error = Alc.GetError(_captureDevice);
+
+            if (error == AlcError.NoError)
+                return;
+
+            string errorFmt = "OpenAL Error: {0}";
+
+            throw new NoMicrophoneConnectedException(String.Format("{0} - {1}",
+                            operation,
+                            string.Format(errorFmt, error)));
+        }
+       
+        internal static void PopulateCaptureDevices()
+        {
+            // clear microphones
+            if (_allMicrophones != null)
+                _allMicrophones.Clear();
+            else
+                _allMicrophones = new List<Microphone>();
+
+            _default = null;
+
+            // default device
+            string defaultDevice = Alc.GetString(IntPtr.Zero, AlcGetString.CaptureDefaultDeviceSpecifier);
+
+            // enumarating capture devices
+            IntPtr deviceList = Alc.alGetString(IntPtr.Zero, (int)AlcGetString.CaptureDeviceSpecifier);
+            // we need to marshal a string array
+            string deviceIdentifier = Marshal.PtrToStringAnsi(deviceList);
+            while (!String.IsNullOrEmpty(deviceIdentifier))
+            {  
+                Microphone microphone = new Microphone(deviceIdentifier);
+                _allMicrophones.Add(microphone);                
+                if (deviceIdentifier == defaultDevice)
+                    _default = microphone;
+                deviceList += deviceIdentifier.Length + 1;
+                deviceIdentifier = Marshal.PtrToStringAnsi(deviceList);
+            }
+        }
+
+        internal void PlatformStart()
+        {
+            if (_state == MicrophoneState.Started)
+                return;
+
+            _captureDevice = Alc.OpenCaptureDevice(
+                Name,
+                (uint)_sampleRate,
+                ALFormat.Mono16,
+                GetSameSizeInBytes(_bufferDuration));
+
+            CheckALCError("Failed to open capture device.");
+
+            if (_captureDevice != IntPtr.Zero)
+            {
+                Alc.CaptureStart(Name);
+                CheckALCError("Failed to start capture.");
+
+                _state = MicrophoneState.Started;
+            }
+			else
+            {
+                throw new NoMicrophoneConnectedException("Failed to open capture device.");
+            }
+        }
+
+        internal void PlatformStop()
+        {
+            if (_state == MicrophoneState.Started)
+            {
+                Alc.CaptureStop(Name);
+                CheckALCError("Failed to stop capture.");
+                Alc.CaptureCloseDevice(Name);
+                CheckALCError("Failed to close capture device.");
+                _captureDevice = IntPtr.Zero;
+            }
+            _state = MicrophoneState.Stopped;
+        }
+
+        internal int GetQueuedSampleCount()
+        {
+            if (_state == MicrophoneState.Stopped || BufferReady == null)
+                return 0;
+
+            int[] values = new int[1];
+            Alc.GetIntegerv(_captureDevice, AlcGetString.CaptureSamples, 1, values); // always returns 0?!
+
+            CheckALCError("Failed to query capture samples.");
+
+            return values[0];
+        }
+
+        internal void Update()
+        {
+            if (GetQueuedSampleCount() > 0)
+            {
+                BufferReady.Invoke(this, EventArgs.Empty);                
+            }
+        }
+
+        internal int PlatformGetData(byte[] buffer, int offset, int count)
+        {
+            int sampleCount = GetQueuedSampleCount();
+            sampleCount = Math.Min(count / 2, sampleCount); // 16bit adjust
+
+            if (sampleCount > 0)
+            {
+                GCHandle handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+                Alc.CaptureSamples(_captureDevice, handle.AddrOfPinnedObject() + offset, sampleCount);
+                handle.Free();
+
+                CheckALCError("Failed to capture samples.");
+
+                return sampleCount * 2; // 16bit adjust
+            }
+
+            return 0;
+        }
+    }
+}

--- a/MonoGame.Framework/Audio/Microphone.OpenAL.cs
+++ b/MonoGame.Framework/Audio/Microphone.OpenAL.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Xna.Framework.Audio
 
             if (_captureDevice != IntPtr.Zero)
             {
-                Alc.CaptureStart(Name);
+                Alc.CaptureStart(_captureDevice);
                 CheckALCError("Failed to start capture.");
 
                 _state = MicrophoneState.Started;
@@ -106,9 +106,9 @@ namespace Microsoft.Xna.Framework.Audio
         {
             if (_state == MicrophoneState.Started)
             {
-                Alc.CaptureStop(Name);
+                Alc.CaptureStop(_captureDevice);
                 CheckALCError("Failed to stop capture.");
-                Alc.CaptureCloseDevice(Name);
+                Alc.CaptureCloseDevice(_captureDevice);
                 CheckALCError("Failed to close capture device.");
                 _captureDevice = IntPtr.Zero;
             }

--- a/MonoGame.Framework/Audio/Microphone.OpenAL.cs
+++ b/MonoGame.Framework/Audio/Microphone.OpenAL.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 #if MONOMAC && PLATFORM_MACOS_LEGACY
 using MonoMac.AudioToolbox;
@@ -129,7 +128,7 @@ namespace Microsoft.Xna.Framework.Audio
                 return 0;
 
             int[] values = new int[1];
-            Alc.GetInteger(_captureDevice, AlcGetInteger.CaptureSamples, 1, values); // always returns 0?!
+            Alc.GetInteger(_captureDevice, AlcGetInteger.CaptureSamples, 1, values);
 
             CheckALCError("Failed to query capture samples.");
 

--- a/MonoGame.Framework/Audio/Microphone.OpenAL.cs
+++ b/MonoGame.Framework/Audio/Microphone.OpenAL.cs
@@ -2,11 +2,28 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using OpenAL;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
+
+#if MONOMAC && PLATFORM_MACOS_LEGACY
+using MonoMac.AudioToolbox;
+using MonoMac.AudioUnit;
+using MonoMac.OpenAL;
+#elif OPENAL
+#if GLES || MONOMAC
+using OpenTK.Audio;
+using OpenTK.Audio.OpenAL;
+#else
+using OpenAL;
+#endif
+#if IOS || MONOMAC
+using AudioToolbox;
+using AudioUnit;
+using AVFoundation;
+#endif
+#endif
 
 namespace Microsoft.Xna.Framework.Audio
 {

--- a/MonoGame.Framework/Audio/Microphone.OpenAL.cs
+++ b/MonoGame.Framework/Audio/Microphone.OpenAL.cs
@@ -27,7 +27,7 @@ using AVFoundation;
 namespace Microsoft.Xna.Framework.Audio
 {
     /// <summary>
-    /// Provides properties, methods, and fields and events for capturing audio data with microphones. 
+    /// Provides microphones capture features.  
     /// </summary>
     public sealed partial class Microphone
     {

--- a/MonoGame.Framework/Audio/Microphone.cs
+++ b/MonoGame.Framework/Audio/Microphone.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// </summary>
         /// <param name="duration">TimeSpan object that contains the duration of the audio sample. </param>
         /// <returns>Size (10 ms block aligned), in bytes, of the audio buffer.</returns>
-        public int GetSameSizeInBytes(TimeSpan duration)
+        public int GetSampleSizeInBytes(TimeSpan duration)
         {
             // this should be 10ms aligned
             // this assumes 16bit mono data

--- a/MonoGame.Framework/Audio/Microphone.cs
+++ b/MonoGame.Framework/Audio/Microphone.cs
@@ -211,15 +211,17 @@ namespace Microsoft.Xna.Framework.Audio
         internal static void UpdateMicrophones()
         {
             // querying all running microphones for new samples available
-            for (int i = 0; i < _allMicrophones.Count; i++)
-                _allMicrophones[i].Update();
+            if (_allMicrophones != null)
+                for (int i = 0; i < _allMicrophones.Count; i++)
+                    _allMicrophones[i].Update();
         }
 
         internal static void StopMicrophones()
         {
             // stopping all running microphones before shutting down audio devices
-            for (int i = 0; i < _allMicrophones.Count; i++)
-                _allMicrophones[i].Stop();
+            if (_allMicrophones != null)
+                for (int i = 0; i < _allMicrophones.Count; i++)
+                    _allMicrophones[i].Stop();
         }
 
         #endregion

--- a/MonoGame.Framework/Audio/Microphone.cs
+++ b/MonoGame.Framework/Audio/Microphone.cs
@@ -1,0 +1,227 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.Xna.Framework.Audio
+{
+    /// <summary>
+    /// Enumeration that indicates whether the recording state of the Microphone has started or stopped. 
+    /// </summary>
+    public enum MicrophoneState
+    {
+        Started,
+        Stopped
+    }
+
+    /// <summary>
+    /// Provides properties, methods, and fields and events for capturing audio data with microphones. 
+    /// </summary>
+    public sealed partial class Microphone
+    {
+        #region Internal Constructors
+
+        internal Microphone()
+        {
+
+        }
+
+        internal Microphone(string name)
+        {
+            Name = name;
+        }
+
+        #endregion
+
+        #region Public Fields
+
+        /// <summary>
+        /// Returns the friendly name of the microphone.
+        /// </summary>
+        public readonly string Name;
+
+        #endregion
+
+        #region Public Properties
+
+        private TimeSpan _bufferDuration = TimeSpan.FromMilliseconds(500.0); // what's the XNA default? 
+
+        /// <summary>
+        /// Gets or sets audio capture buffer duration of the microphone.
+        /// </summary>
+        public TimeSpan BufferDuration
+        {
+            get { return _bufferDuration; }
+            set
+            {
+                if (value.TotalMilliseconds < 100 || value.TotalMilliseconds > 1000)
+                    throw new ArgumentOutOfRangeException("Buffer duration must be a value between 100 and 1000 milliseconds.");
+                if (value.TotalMilliseconds % 10 != 0)
+                    throw new ArgumentOutOfRangeException("Buffer duration must be 10ms aligned (BufferDuration % 10 == 0)");
+                _bufferDuration = value;
+            }
+        }
+
+        // always true on mobile, this can't be queried on any platform (it was most probably only set to true if the headset was plugged in an XInput controller)
+#if IOS || ANDROID
+        private const bool _isHeadset = true;
+#else
+        private const bool _isHeadset = false;
+#endif
+        /// <summary>
+        /// Determines if the microphone is a wired headset or a Bluetooth device.
+        /// Note: this is always true on mobile platforms, and always false otherwise
+        /// </summary>
+        public bool IsHeadset
+        {
+            get { return _isHeadset; }
+        }
+
+        private int _sampleRate = 44100; // XNA default is 44100, don't know if it supports any other rates
+
+        /// <summary>
+        /// Returns the sample rate at which the microphone is capturing audio data. 
+        /// </summary>
+        public int SampleRate
+        {
+            get { return _sampleRate; }
+        }
+
+        private MicrophoneState _state = MicrophoneState.Stopped;
+
+        /// <summary>
+        /// Returns the recording state of the Microphone object. 
+        /// </summary>
+        public MicrophoneState State
+        {
+            get { return _state; }
+        }
+
+        #endregion
+
+        #region Static Members
+
+        private static List<Microphone> _allMicrophones = null;
+
+        /// <summary>
+        /// Returns the collection of all currently-available microphones.
+        /// </summary>
+        public static ReadOnlyCollection<Microphone> All
+        {
+            get
+            {
+                if (_allMicrophones == null)
+                    _allMicrophones = new List<Microphone>();
+                return _allMicrophones.AsReadOnly();
+            }
+        }
+
+        private static Microphone _default = null;
+
+        /// <summary>
+        /// Returns the default attached microphone.
+        /// </summary>
+        public static Microphone Default
+        {
+            get { return _default; }
+        }       
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Returns the duration of audio playback based on the size of the buffer.
+        /// </summary>
+        /// <param name="sizeInBytes">Size, in bytes, of the audio data.</param>
+        /// <returns>TimeSpan object that represents the duration of the audio playback.</returns>
+        public TimeSpan GetSampleDuration(int sizeInBytes)
+        {
+            // this should be 10ms aligned
+            // this assumes 16bit mono data
+            return SoundEffect.GetSampleDuration(sizeInBytes, _sampleRate, AudioChannels.Mono);
+        }
+
+        /// <summary>
+        /// Returns the size of the byte array required to hold the specified duration of audio for this microphone object. 
+        /// </summary>
+        /// <param name="duration">TimeSpan object that contains the duration of the audio sample. </param>
+        /// <returns>Size (10 ms block aligned), in bytes, of the audio buffer.</returns>
+        public int GetSameSizeInBytes(TimeSpan duration)
+        {
+            // this should be 10ms aligned
+            // this assumes 16bit mono data
+            return SoundEffect.GetSampleSizeInBytes(duration, _sampleRate, AudioChannels.Mono);
+        }
+
+        /// <summary>
+        /// Starts microphone audio capture.
+        /// </summary>
+        public void Start()
+        {
+            PlatformStart();
+        }
+
+        /// <summary>
+        /// Stops microphone audio capture.
+        /// </summary>
+        public void Stop()
+        {
+            PlatformStop();
+        }
+
+        /// <summary>
+        /// Gets the latest recorded data from the microphone based on the audio capture buffer.
+        /// </summary>
+        /// <param name="buffer">Buffer, in bytes, containing the captured audio data. The audio format must be PCM wave data.</param>
+        /// <returns>The buffer size, in bytes, of the audio data.</returns>
+        public int GetData(byte[] buffer)
+        {
+            return GetData(buffer, 0, buffer.Length);
+        }
+
+        /// <summary>
+        /// Gets the latest captured audio data from the microphone based on the specified offset and byte count.
+        /// </summary>
+        /// <param name="buffer">Buffer, in bytes, containing the captured audio data. The audio format must be PCM wave data.</param>
+        /// <param name="offset">Offset, in bytes, to the starting position of the data. </param>
+        /// <param name="count">Amount, in bytes, of desired audio data. </param>
+        /// <returns>The buffer size, in bytes, of the audio data.</returns>
+        public int GetData(byte[] buffer, int offset, int count)
+        {
+            return PlatformGetData(buffer, offset, count);
+        }
+
+        #endregion
+
+        #region Public Events
+
+        /// <summary>
+        /// Event that occurs when the audio capture buffer is ready to processed.
+        /// </summary>
+        public event EventHandler<EventArgs> BufferReady;
+
+        #endregion
+
+        #region Static Methods
+
+        internal static void UpdateMicrophones()
+        {
+            // querying all running microphones for new samples available
+            for (int i = 0; i < _allMicrophones.Count; i++)
+                _allMicrophones[i].Update();
+        }
+
+        internal static void StopMicrophones()
+        {
+            // stopping all running microphones before shutting down audio devices
+            for (int i = 0; i < _allMicrophones.Count; i++)
+                _allMicrophones[i].Stop();
+        }
+
+        #endregion
+    }
+}

--- a/MonoGame.Framework/Audio/Microphone.cs
+++ b/MonoGame.Framework/Audio/Microphone.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         #region Public Properties
 
-        private TimeSpan _bufferDuration = TimeSpan.FromMilliseconds(500.0); // what's the XNA default? 
+        private TimeSpan _bufferDuration = TimeSpan.FromMilliseconds(1000.0);
 
         /// <summary>
         /// Gets or sets audio capture buffer duration of the microphone.

--- a/MonoGame.Framework/Audio/Microphone.cs
+++ b/MonoGame.Framework/Audio/Microphone.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Xna.Framework.Audio
             {
                 if (_allMicrophones == null)
                     _allMicrophones = new List<Microphone>();
-                return _allMicrophones.AsReadOnly();
+                return new ReadOnlyCollection<Microphone>(_allMicrophones);
             }
         }
 

--- a/MonoGame.Framework/Audio/Microphone.cs
+++ b/MonoGame.Framework/Audio/Microphone.cs
@@ -9,7 +9,7 @@ using System.Collections.ObjectModel;
 namespace Microsoft.Xna.Framework.Audio
 {
     /// <summary>
-    /// Enumeration that indicates whether the recording state of the Microphone has started or stopped. 
+    /// Microphone state. 
     /// </summary>
     public enum MicrophoneState
     {
@@ -18,7 +18,7 @@ namespace Microsoft.Xna.Framework.Audio
     }
 
     /// <summary>
-    /// Provides properties, methods, and fields and events for capturing audio data with microphones. 
+    /// Provides microphones capture features. 
     /// </summary>
     public sealed partial class Microphone
     {
@@ -50,7 +50,7 @@ namespace Microsoft.Xna.Framework.Audio
         private TimeSpan _bufferDuration = TimeSpan.FromMilliseconds(1000.0);
 
         /// <summary>
-        /// Gets or sets audio capture buffer duration of the microphone.
+        /// Gets or sets the capture buffer duration. This value must be greater than 100 milliseconds, lower than 1000 milliseconds, and must be 10 milliseconds aligned (BufferDuration % 10 == 10).
         /// </summary>
         public TimeSpan BufferDuration
         {
@@ -72,8 +72,9 @@ namespace Microsoft.Xna.Framework.Audio
         private const bool _isHeadset = false;
 #endif
         /// <summary>
-        /// Determines if the microphone is a wired headset or a Bluetooth device.
-        /// Note: this is always true on mobile platforms, and always false otherwise
+        /// Determines if the microphone is a wired headset.
+        /// Note: XNA could know if a headset microphone was plugged in an Xbox 360 controller but MonoGame can't.
+        /// Hence, this is always true on mobile platforms, and always false otherwise.
         /// </summary>
         public bool IsHeadset
         {
@@ -83,7 +84,8 @@ namespace Microsoft.Xna.Framework.Audio
         private int _sampleRate = 44100; // XNA default is 44100, don't know if it supports any other rates
 
         /// <summary>
-        /// Returns the sample rate at which the microphone is capturing audio data. 
+        /// Returns the sample rate of the captured audio.
+        /// Note: default value is 44100hz
         /// </summary>
         public int SampleRate
         {
@@ -93,7 +95,7 @@ namespace Microsoft.Xna.Framework.Audio
         private MicrophoneState _state = MicrophoneState.Stopped;
 
         /// <summary>
-        /// Returns the recording state of the Microphone object. 
+        /// Returns the state of the Microphone. 
         /// </summary>
         public MicrophoneState State
         {
@@ -107,7 +109,7 @@ namespace Microsoft.Xna.Framework.Audio
         private static List<Microphone> _allMicrophones = null;
 
         /// <summary>
-        /// Returns the collection of all currently-available microphones.
+        /// Returns all compatible microphones.
         /// </summary>
         public static ReadOnlyCollection<Microphone> All
         {
@@ -122,7 +124,7 @@ namespace Microsoft.Xna.Framework.Audio
         private static Microphone _default = null;
 
         /// <summary>
-        /// Returns the default attached microphone.
+        /// Returns the default microphone.
         /// </summary>
         public static Microphone Default
         {
@@ -134,10 +136,10 @@ namespace Microsoft.Xna.Framework.Audio
         #region Public Methods
 
         /// <summary>
-        /// Returns the duration of audio playback based on the size of the buffer.
+        /// Returns the duration based on the size of the buffer (assuming 16-bit PCM data).
         /// </summary>
-        /// <param name="sizeInBytes">Size, in bytes, of the audio data.</param>
-        /// <returns>TimeSpan object that represents the duration of the audio playback.</returns>
+        /// <param name="sizeInBytes">Size, in bytes</param>
+        /// <returns>TimeSpan of the duration.</returns>
         public TimeSpan GetSampleDuration(int sizeInBytes)
         {
             // this should be 10ms aligned
@@ -146,10 +148,10 @@ namespace Microsoft.Xna.Framework.Audio
         }
 
         /// <summary>
-        /// Returns the size of the byte array required to hold the specified duration of audio for this microphone object. 
+        /// Returns the size, in bytes, of the array required to hold the specified duration of 16-bit PCM data. 
         /// </summary>
-        /// <param name="duration">TimeSpan object that contains the duration of the audio sample. </param>
-        /// <returns>Size (10 ms block aligned), in bytes, of the audio buffer.</returns>
+        /// <param name="duration">TimeSpan of the duration of the sample.</param>
+        /// <returns>Size, in bytes, of the buffer.</returns>
         public int GetSampleSizeInBytes(TimeSpan duration)
         {
             // this should be 10ms aligned
@@ -158,7 +160,7 @@ namespace Microsoft.Xna.Framework.Audio
         }
 
         /// <summary>
-        /// Starts microphone audio capture.
+        /// Starts microphone capture.
         /// </summary>
         public void Start()
         {
@@ -166,7 +168,7 @@ namespace Microsoft.Xna.Framework.Audio
         }
 
         /// <summary>
-        /// Stops microphone audio capture.
+        /// Stops microphone capture.
         /// </summary>
         public void Stop()
         {
@@ -174,22 +176,22 @@ namespace Microsoft.Xna.Framework.Audio
         }
 
         /// <summary>
-        /// Gets the latest recorded data from the microphone based on the audio capture buffer.
+        /// Gets the latest available data from the microphone.
         /// </summary>
-        /// <param name="buffer">Buffer, in bytes, containing the captured audio data. The audio format must be PCM wave data.</param>
-        /// <returns>The buffer size, in bytes, of the audio data.</returns>
+        /// <param name="buffer">Buffer, in bytes, of the captured data (16-bit PCM).</param>
+        /// <returns>The buffer size, in bytes, of the captured data.</returns>
         public int GetData(byte[] buffer)
         {
             return GetData(buffer, 0, buffer.Length);
         }
 
         /// <summary>
-        /// Gets the latest captured audio data from the microphone based on the specified offset and byte count.
+        /// Gets the latest available data from the microphone.
         /// </summary>
-        /// <param name="buffer">Buffer, in bytes, containing the captured audio data. The audio format must be PCM wave data.</param>
-        /// <param name="offset">Offset, in bytes, to the starting position of the data. </param>
-        /// <param name="count">Amount, in bytes, of desired audio data. </param>
-        /// <returns>The buffer size, in bytes, of the audio data.</returns>
+        /// <param name="buffer">Buffer, in bytes, of the captured data (16-bit PCM).</param>
+        /// <param name="offset">Byte offset.</param>
+        /// <param name="count">Amount, in bytes.</param>
+        /// <returns>The buffer size, in bytes, of the captured data.</returns>
         public int GetData(byte[] buffer, int offset, int count)
         {
             return PlatformGetData(buffer, offset, count);
@@ -200,7 +202,7 @@ namespace Microsoft.Xna.Framework.Audio
         #region Public Events
 
         /// <summary>
-        /// Event that occurs when the audio capture buffer is ready to processed.
+        /// Event fired when the audio data are available.
         /// </summary>
         public event EventHandler<EventArgs> BufferReady;
 

--- a/MonoGame.Framework/Audio/NoMicrophoneConnectedException.cs
+++ b/MonoGame.Framework/Audio/NoMicrophoneConnectedException.cs
@@ -1,0 +1,36 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Xna.Framework.Audio
+{
+
+    /// <summary>
+    /// The exception thrown when no audio hardware is present, or driver issues are detected.
+    /// </summary>
+    [DataContract]
+#if WINRT
+    public sealed class NoMicrophoneConnectedException : Exception
+#else
+    public sealed class NoMicrophoneConnectedException : ExternalException
+#endif
+    {
+        /// <param name="msg">A message describing the error.</param>
+        public NoMicrophoneConnectedException(string msg)
+            : base(msg)
+        {
+        }
+
+        /// <param name="msg">A message describing the error.</param>
+        /// <param name="innerException">The exception that is the underlying cause of the current exception. If not null, the current exception is raised in a try/catch block that handled the innerException.</param>
+        public NoMicrophoneConnectedException(string msg, Exception innerException)
+            : base(msg, innerException)
+        {
+        }
+    }
+}
+

--- a/MonoGame.Framework/Audio/NoMicrophoneConnectedException.cs
+++ b/MonoGame.Framework/Audio/NoMicrophoneConnectedException.cs
@@ -3,7 +3,6 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework.Audio
@@ -13,11 +12,7 @@ namespace Microsoft.Xna.Framework.Audio
     /// The exception thrown when no audio hardware is present, or driver issues are detected.
     /// </summary>
     [DataContract]
-#if WINRT
     public sealed class NoMicrophoneConnectedException : Exception
-#else
-    public sealed class NoMicrophoneConnectedException : ExternalException
-#endif
     {
         /// <param name="msg">A message describing the error.</param>
         public NoMicrophoneConnectedException(string msg)

--- a/MonoGame.Framework/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Audio/OpenAL.cs
@@ -105,8 +105,12 @@ namespace OpenAL
     {
         CaptureDeviceSpecifier = 0x0310,
         CaptureDefaultDeviceSpecifier = 0x0311,
-        CaptureSamples = 0x0312,
         Extensions = 0x1006,
+    }
+
+    public enum AlcGetInteger
+    {
+        CaptureSamples = 0x0312,
     }
 
     public enum EfxFilteri
@@ -448,7 +452,7 @@ namespace OpenAL
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcGetIntegerv")]
         internal static extern void alcGetIntegerv(IntPtr device, int param, int size, int[] values);
 
-        public static void GetIntegerv(IntPtr device, AlcGetString param, int size, int[] values)
+        public static void GetInteger(IntPtr device, AlcGetInteger param, int size, int[] values)
         {
             alcGetIntegerv(device, (int)param, size, values);
         }
@@ -477,7 +481,7 @@ namespace OpenAL
         internal static extern IntPtr alcCaptureOpenDevice([In()] [MarshalAs(UnmanagedType.LPStr)] string device, uint sampleRate, int format, int sampleSize);
 
         [CLSCompliant(false)]
-        public static IntPtr OpenCaptureDevice(string device, uint sampleRate, ALFormat format, int sampleSize)
+        public static IntPtr CaptureOpenDevice(string device, uint sampleRate, ALFormat format, int sampleSize)
         {
             return alcCaptureOpenDevice(device, sampleRate, (int)format, sampleSize);
         }

--- a/MonoGame.Framework/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Audio/OpenAL.cs
@@ -484,7 +484,7 @@ namespace OpenAL
 
         [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureStart")]
-        public static extern IntPtr CaptureStart([MarshalAs(UnmanagedType.LPStr)]  string device);
+        public static extern IntPtr CaptureStart(IntPtr device);
 
         [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureSamples")]
@@ -492,11 +492,11 @@ namespace OpenAL
 
         [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureStop")]
-        public static extern IntPtr CaptureStop([MarshalAs(UnmanagedType.LPStr)]  string device);
+        public static extern IntPtr CaptureStop(IntPtr device);
 
         [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureCloseDevice")]
-        public static extern IntPtr CaptureCloseDevice([MarshalAs(UnmanagedType.LPStr)]  string device);
+        public static extern IntPtr CaptureCloseDevice(IntPtr device);
 
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcIsExtensionPresent")]
         public static extern bool IsExtensionPresent (IntPtr device, [MarshalAs (UnmanagedType.LPStr)] string extensionName);

--- a/MonoGame.Framework/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Audio/OpenAL.cs
@@ -103,6 +103,9 @@ namespace OpenAL
 
     public enum AlcGetString
     {
+        CaptureDeviceSpecifier = 0x0310,
+        CaptureDefaultDeviceSpecifier = 0x0311,
+        CaptureSamples = 0x0312,
         Extensions = 0x1006,
     }
 
@@ -442,6 +445,14 @@ namespace OpenAL
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcGetError")]
         public static extern AlcError GetError (IntPtr device);
 
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcGetIntegerv")]
+        internal static extern void alcGetIntegerv(IntPtr device, int param, int size, int[] values);
+
+        public static void GetIntegerv(IntPtr device, AlcGetString param, int size, int[] values)
+        {
+            alcGetIntegerv(device, (int)param, size, values);
+        }
+
         [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcGetCurrentContext")]
         public static extern IntPtr GetCurrentContext ();
@@ -461,6 +472,31 @@ namespace OpenAL
         [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcOpenDevice")]
         public static extern IntPtr OpenDevice ([MarshalAs (UnmanagedType.LPStr)]  string device);
+
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureOpenDevice")]
+        internal static extern IntPtr alcCaptureOpenDevice([In()] [MarshalAs(UnmanagedType.LPStr)] string device, uint sampleRate, int format, int sampleSize);
+
+        [CLSCompliant(false)]
+        public static IntPtr OpenCaptureDevice(string device, uint sampleRate, ALFormat format, int sampleSize)
+        {
+            return alcCaptureOpenDevice(device, sampleRate, (int)format, sampleSize);
+        }
+
+        [CLSCompliant(false)]
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureStart")]
+        public static extern IntPtr CaptureStart([MarshalAs(UnmanagedType.LPStr)]  string device);
+
+        [CLSCompliant(false)]
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureSamples")]
+        public static extern void CaptureSamples(IntPtr device, IntPtr buffer, int samples);
+
+        [CLSCompliant(false)]
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureStop")]
+        public static extern IntPtr CaptureStop([MarshalAs(UnmanagedType.LPStr)]  string device);
+
+        [CLSCompliant(false)]
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureCloseDevice")]
+        public static extern IntPtr CaptureCloseDevice([MarshalAs(UnmanagedType.LPStr)]  string device);
 
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcIsExtensionPresent")]
         public static extern bool IsExtensionPresent (IntPtr device, [MarshalAs (UnmanagedType.LPStr)] string extensionName);

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Xna.Framework.Audio
 
             // We have hardware here and it is ready
 
-            allSourcesArray = new int[MAX_NUMBER_OF_SOURCES];
+			allSourcesArray = new int[MAX_NUMBER_OF_SOURCES];
 			AL.GenSources(allSourcesArray);
             ALHelper.CheckError("Failed to generate sources.");
             Filter = 0;

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -122,9 +122,12 @@ namespace Microsoft.Xna.Framework.Audio
                 throw new NoAudioHardwareException("OpenAL device could not be initialized, see console output for details.");
             }
 
+            if (Alc.IsExtensionPresent(_device, "ALC_EXT_CAPTURE"))
+                Microphone.PopulateCaptureDevices();
+
             // We have hardware here and it is ready
 
-			allSourcesArray = new int[MAX_NUMBER_OF_SOURCES];
+            allSourcesArray = new int[MAX_NUMBER_OF_SOURCES];
 			AL.GenSources(allSourcesArray);
             ALHelper.CheckError("Failed to generate sources.");
             Filter = 0;
@@ -391,6 +394,7 @@ namespace Microsoft.Xna.Framework.Audio
                     if (Filter != 0 && Efx.IsInitialized)
                         Efx.DeleteFilter (Filter);
 #endif
+                    Microphone.StopMicrophones();
                     CleanUpOpenAL();                    
                 }
                 _isDisposed = true;

--- a/MonoGame.Framework/FrameworkDispatcher.cs
+++ b/MonoGame.Framework/FrameworkDispatcher.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Xna.Framework
         {
             DynamicSoundEffectInstanceManager.UpdatePlayingInstances();
             SoundEffectInstancePool.Update();
+            Microphone.UpdateMicrophones();
         }
 
         private static void Initialize()


### PR DESCRIPTION
Hi there,

This is a first pass on implementing ```Microsoft.Xna.Framework.Audio.Microphone``` for OpenAL platforms (```Microphone.Default.cs``` is an unimplemented service).

Any help debugging this would be very welcome (as well as looking into DirectX platforms).
Contributions to unit tests / accuracy versus XNA would also be welcome.

Note on not using SDL (which has recording features since 2.0.5): I preferred to use OpenAL for its maturity and availability for Microphone support on mobile platforms.

EDIT: fixed the initial issue I was facing.

Fixes #1729 .


@dellis1972 @cra0zy @tomspilman 