### PR TITLE
Implement GetHashCode on Vertex types

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/VertexPosition.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPosition.cs
@@ -26,10 +26,10 @@ namespace Microsoft.Xna.Framework.Graphics
 			get { return VertexDeclaration; }
 		}
 
-		public override int GetHashCode()
-		{
-		    return Position.GetHashCode();
-		}
+	    public override int GetHashCode()
+	    {
+	        return Position.GetHashCode();
+	    }
 
 		public override string ToString()
 		{

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
@@ -32,8 +32,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public override int GetHashCode()
 		{
-			// TODO: Fix gethashcode
-			return 0;
+			return Position.GetHashCode() ^ Color.GetHashCode();
 		}
 
 		public override string ToString()

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
 	    public override int GetHashCode()
 	    {
-	        unchecked {
+	        unchecked
+            {
 	            return (Position.GetHashCode() * 397) ^ Color.GetHashCode();
 	        }
 	    }

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Xna.Framework.Graphics
 	    public override int GetHashCode()
 	    {
 	        unchecked
-            {
+	        {
 	            return (Position.GetHashCode() * 397) ^ Color.GetHashCode();
 	        }
 	    }

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
@@ -30,12 +30,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
-		public override int GetHashCode()
-		{
-			return Position.GetHashCode() ^ Color.GetHashCode();
-		}
+	    public override int GetHashCode()
+	    {
+	        unchecked {
+	            return (Position.GetHashCode() * 397) ^ Color.GetHashCode();
+	        }
+	    }
 
-		public override string ToString()
+	    public override string ToString()
 		{
             return "{{Position:" + this.Position + " Color:" + this.Color + "}}";
 		}

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
@@ -27,8 +27,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public override int GetHashCode()
         {
-            // TODO: FIc gethashcode
-            return 0;
+            return Position.GetHashCode() ^ Color.GetHashCode() ^ TextureCoordinate.GetHashCode();
         }
 
         public override string ToString()

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public override int GetHashCode()
         {
-            unchecked {
+            unchecked
+            {
                 var hashCode = Position.GetHashCode();
                 hashCode = (hashCode * 397) ^ Color.GetHashCode();
                 hashCode = (hashCode * 397) ^ TextureCoordinate.GetHashCode();

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
@@ -27,7 +27,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public override int GetHashCode()
         {
-            return Position.GetHashCode() ^ Color.GetHashCode() ^ TextureCoordinate.GetHashCode();
+            unchecked {
+                var hashCode = Position.GetHashCode();
+                hashCode = (hashCode * 397) ^ Color.GetHashCode();
+                hashCode = (hashCode * 397) ^ TextureCoordinate.GetHashCode();
+                return hashCode;
+            }
         }
 
         public override string ToString()

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
@@ -25,8 +25,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
         public override int GetHashCode()
         {
-            // TODO: FIc gethashcode
-            return 0;
+            return Position.GetHashCode() ^ Normal.GetHashCode() ^ TextureCoordinate.GetHashCode();
         }
 
         public override string ToString()

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public override int GetHashCode()
         {
-            unchecked {
+            unchecked
+            {
                 var hashCode = Position.GetHashCode();
                 hashCode = (hashCode * 397) ^ Normal.GetHashCode();
                 hashCode = (hashCode * 397) ^ TextureCoordinate.GetHashCode();

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
@@ -23,9 +23,15 @@ namespace Microsoft.Xna.Framework.Graphics
                 return VertexDeclaration;
             }
         }
+
         public override int GetHashCode()
         {
-            return Position.GetHashCode() ^ Normal.GetHashCode() ^ TextureCoordinate.GetHashCode();
+            unchecked {
+                var hashCode = Position.GetHashCode();
+                hashCode = (hashCode * 397) ^ Normal.GetHashCode();
+                hashCode = (hashCode * 397) ^ TextureCoordinate.GetHashCode();
+                return hashCode;
+            }
         }
 
         public override string ToString()

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public override int GetHashCode()
         {
-            unchecked {
+            unchecked
+            {
                 return (Position.GetHashCode() * 397) ^ TextureCoordinate.GetHashCode();
             }
         }

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
         public override int GetHashCode()
         {
-            // TODO: Fix get hashcode
-            return 0;
+            return Position.GetHashCode() ^ TextureCoordinate.GetHashCode();
         }
 
         public override string ToString()

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
@@ -21,9 +21,12 @@ namespace Microsoft.Xna.Framework.Graphics
                 return VertexDeclaration;
             }
         }
+
         public override int GetHashCode()
         {
-            return Position.GetHashCode() ^ TextureCoordinate.GetHashCode();
+            unchecked {
+                return (Position.GetHashCode() * 397) ^ TextureCoordinate.GetHashCode();
+            }
         }
 
         public override string ToString()

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -520,7 +520,9 @@ namespace Microsoft.Xna.Framework
         /// <returns>Hash code of this <see cref="Vector2"/>.</returns>
         public override int GetHashCode()
         {
-            return X.GetHashCode() + Y.GetHashCode();
+            unchecked {
+                return (X.GetHashCode() * 397) ^ Y.GetHashCode();
+            }
         }
 
         /// <summary>

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -520,7 +520,8 @@ namespace Microsoft.Xna.Framework
         /// <returns>Hash code of this <see cref="Vector2"/>.</returns>
         public override int GetHashCode()
         {
-            unchecked {
+            unchecked
+            {
                 return (X.GetHashCode() * 397) ^ Y.GetHashCode();
             }
         }

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -521,7 +521,8 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <returns>Hash code of this <see cref="Vector3"/>.</returns>
         public override int GetHashCode() {
-            unchecked {
+            unchecked
+            {
                 var hashCode = X.GetHashCode();
                 hashCode = (hashCode * 397) ^ Y.GetHashCode();
                 hashCode = (hashCode * 397) ^ Z.GetHashCode();

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -520,9 +520,13 @@ namespace Microsoft.Xna.Framework
         /// Gets the hash code of this <see cref="Vector3"/>.
         /// </summary>
         /// <returns>Hash code of this <see cref="Vector3"/>.</returns>
-        public override int GetHashCode()
-        {
-            return (int)(this.X + this.Y + this.Z);
+        public override int GetHashCode() {
+            unchecked {
+                var hashCode = X.GetHashCode();
+                hashCode = (hashCode * 397) ^ Y.GetHashCode();
+                hashCode = (hashCode * 397) ^ Z.GetHashCode();
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -479,7 +479,8 @@ namespace Microsoft.Xna.Framework
         /// <returns>Hash code of this <see cref="Vector4"/>.</returns>
         public override int GetHashCode()
         {
-            unchecked {
+            unchecked
+            {
                 var hashCode = W.GetHashCode();
                 hashCode = (hashCode * 397) ^ X.GetHashCode();
                 hashCode = (hashCode * 397) ^ Y.GetHashCode();

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -479,7 +479,13 @@ namespace Microsoft.Xna.Framework
         /// <returns>Hash code of this <see cref="Vector4"/>.</returns>
         public override int GetHashCode()
         {
-            return (int)(this.W + this.X + this.Y + this.Y);
+            unchecked {
+                var hashCode = W.GetHashCode();
+                hashCode = (hashCode * 397) ^ X.GetHashCode();
+                hashCode = (hashCode * 397) ^ Y.GetHashCode();
+                hashCode = (hashCode * 397) ^ Z.GetHashCode();
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/Test/Framework/Vector2Test.cs
+++ b/Test/Framework/Vector2Test.cs
@@ -384,6 +384,33 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual("1024,5; 2048,75", converter.ConvertToString(null, otherCulture, new Vector2(1024.5f, 2048.75f)));
         }
 
+        [Test]
+        public void HashCode()
+        {
+            // Checking for overflows in hash calculation.
+            var max = new Vector2(float.MaxValue, float.MaxValue);
+            var min = new Vector2(float.MinValue, float.MinValue);
+            Assert.AreNotEqual(max.GetHashCode(), Vector2.Zero.GetHashCode());
+            Assert.AreNotEqual(min.GetHashCode(), Vector2.Zero.GetHashCode());
+
+            // Common values
+            var a = new Vector2(0f, 0f);
+            Assert.AreEqual(a.GetHashCode(), Vector2.Zero.GetHashCode());
+            Assert.AreNotEqual(a.GetHashCode(), Vector2.One.GetHashCode());
+
+            // Individual properties alter hash
+            var xa = new Vector2(2f, 1f);
+            var xb = new Vector2(3f, 1f);
+            var ya = new Vector2(1f, 2f);
+            var yb = new Vector2(1f, 3f);
+            Assert.AreNotEqual(xa.GetHashCode(), xb.GetHashCode(), "Different properties should change hash.");
+            Assert.AreNotEqual(ya.GetHashCode(), yb.GetHashCode(), "Different properties should change hash.");
+            Assert.AreNotEqual(xa.GetHashCode(), ya.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(xb.GetHashCode(), yb.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(xa.GetHashCode(), yb.GetHashCode());
+            Assert.AreNotEqual(ya.GetHashCode(), xb.GetHashCode());
+        }
+
 #if !XNA
         [Test]
         public void ToPoint()

--- a/Test/Framework/Vector3Test.cs
+++ b/Test/Framework/Vector3Test.cs
@@ -76,5 +76,38 @@ namespace MonoGame.Tests.Framework
             Assert.That(expectedResult1, Is.EqualTo(result1).Using(Vector3Comparer.Epsilon));
             Assert.That(expectedResult2, Is.EqualTo(result2).Using(Vector3Comparer.Epsilon));
         }
+
+        [Test]
+        public void HashCode() {
+            // Checking for overflows in hash calculation.
+            var max = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
+            var min = new Vector3(float.MinValue, float.MinValue, float.MinValue);
+            Assert.AreNotEqual(max.GetHashCode(), Vector3.Zero.GetHashCode());
+            Assert.AreNotEqual(min.GetHashCode(), Vector3.Zero.GetHashCode());
+
+            // Common values
+            var a = new Vector3(0f, 0f, 0f);
+            Assert.AreEqual(a.GetHashCode(), Vector3.Zero.GetHashCode());
+            Assert.AreNotEqual(a.GetHashCode(), Vector3.One.GetHashCode());
+
+            // Individual properties alter hash
+            var xa = new Vector3(2f, 1f, 1f);
+            var xb = new Vector3(3f, 1f, 1f);
+            var ya = new Vector3(1f, 2f, 1f);
+            var yb = new Vector3(1f, 3f, 1f);
+            var za = new Vector3(1f, 1f, 2f);
+            var zb = new Vector3(1f, 1f, 3f);
+            Assert.AreNotEqual(xa.GetHashCode(), xb.GetHashCode(), "Different properties should change hash.");
+            Assert.AreNotEqual(ya.GetHashCode(), yb.GetHashCode(), "Different properties should change hash.");
+            Assert.AreNotEqual(za.GetHashCode(), zb.GetHashCode(), "Different properties should change hash.");
+            Assert.AreNotEqual(xa.GetHashCode(), ya.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(xb.GetHashCode(), yb.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(xb.GetHashCode(), zb.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(yb.GetHashCode(), zb.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(xa.GetHashCode(), yb.GetHashCode());
+            Assert.AreNotEqual(ya.GetHashCode(), xb.GetHashCode());
+            Assert.AreNotEqual(xa.GetHashCode(), zb.GetHashCode());
+        }
+
     }
 }

--- a/Test/Framework/Vector4Test.cs
+++ b/Test/Framework/Vector4Test.cs
@@ -129,5 +129,43 @@ namespace MonoGame.Tests.Framework
         {
             StringAssert.IsMatch("{X:10 Y:20 Z:3.5 W:-100}", new Vector4(10, 20, 3.5f, -100).ToString());
         }
+
+        [Test]
+        public void HashCode() {
+            // Checking for overflows in hash calculation.
+            var max = new Vector4(float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue);
+            var min = new Vector4(float.MinValue, float.MinValue, float.MinValue, float.MinValue);
+            Assert.AreNotEqual(max.GetHashCode(), Vector4.Zero.GetHashCode());
+            Assert.AreNotEqual(min.GetHashCode(), Vector4.Zero.GetHashCode());
+
+            // Common values
+            var a = new Vector4(0f, 0f, 0f, 0f);
+            Assert.AreEqual(a.GetHashCode(), Vector4.Zero.GetHashCode(), "Shouldn't do object id compare.");
+            Assert.AreNotEqual(a.GetHashCode(), Vector4.One.GetHashCode());
+
+            // Individual properties alter hash
+            var xa = new Vector4(2f, 1f, 1f, 1f);
+            var xb = new Vector4(3f, 1f, 1f, 1f);
+            var ya = new Vector4(1f, 2f, 1f, 1f);
+            var yb = new Vector4(1f, 3f, 1f, 1f);
+            var za = new Vector4(1f, 1f, 2f, 1f);
+            var zb = new Vector4(1f, 1f, 3f, 1f);
+            var wa = new Vector4(1f, 1f, 1f, 2f);
+            var wb = new Vector4(1f, 1f, 1f, 3f);
+            Assert.AreNotEqual(xa.GetHashCode(), xb.GetHashCode(), "Different properties should change hash.");
+            Assert.AreNotEqual(ya.GetHashCode(), yb.GetHashCode(), "Different properties should change hash.");
+            Assert.AreNotEqual(za.GetHashCode(), zb.GetHashCode(), "Different properties should change hash.");
+            Assert.AreNotEqual(wa.GetHashCode(), wb.GetHashCode(), "Different properties should change hash.");
+            Assert.AreNotEqual(xa.GetHashCode(), ya.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(xb.GetHashCode(), yb.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(xb.GetHashCode(), zb.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(yb.GetHashCode(), zb.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(xb.GetHashCode(), wb.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(yb.GetHashCode(), wb.GetHashCode(), "Identical values on different properties should have different hashes.");
+            Assert.AreNotEqual(xa.GetHashCode(), yb.GetHashCode());
+            Assert.AreNotEqual(ya.GetHashCode(), xb.GetHashCode());
+            Assert.AreNotEqual(xa.GetHashCode(), zb.GetHashCode());
+            Assert.AreNotEqual(xa.GetHashCode(), wb.GetHashCode());
+        }
     }
 }


### PR DESCRIPTION
This may help someone's perf if they are using a vertices as a key in a dictionary, because lookup usually goes from "O(1)" to O(n) when keys collide.  I wasn't doing that, I just saw the TODO and thought it would be a quick fix.