### PR TITLE
Remove GraphicsDevice.GetHighestSupportedGraphicsProfile()

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1485,31 +1485,6 @@ namespace Microsoft.Xna.Framework.Graphics
             _d3dContext.Flush();
         }
 
-        private static GraphicsProfile PlatformGetHighestSupportedGraphicsProfile(GraphicsDevice graphicsDevice)
-        {
-            FeatureLevel featureLevel;
-            try
-            {
-                if (graphicsDevice == null || graphicsDevice._d3dDevice == null || graphicsDevice._d3dDevice.NativePointer == null)
-                    featureLevel = SharpDX.Direct3D11.Device.GetSupportedFeatureLevel();
-                else
-                    featureLevel = graphicsDevice._d3dDevice.FeatureLevel;
-            }
-            catch (SharpDXException)
-            {
-                featureLevel = FeatureLevel.Level_9_1; //Minimum defined level
-            }
-
-            GraphicsProfile graphicsProfile;
-
-            if (featureLevel >= FeatureLevel.Level_10_0 || GraphicsAdapter.UseReferenceDevice)
-                graphicsProfile = GraphicsProfile.HiDef;
-            else
-                graphicsProfile = GraphicsProfile.Reach;
-
-            return graphicsProfile;
-        }
-
 #if WINDOWS_STOREAPP || WINDOWS_UAP
         internal void Trim()
         {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -1058,11 +1058,6 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new NotImplementedException("GraphicsDevice.DrawInstancedPrimitives is not yet implemented for OpenGL.");
         }
 
-        private static GraphicsProfile PlatformGetHighestSupportedGraphicsProfile(GraphicsDevice graphicsDevice)
-        {
-           return GraphicsProfile.HiDef;
-        }
-        
         private static Rectangle PlatformGetTitleSafeArea(int x, int y, int width, int height)
         {
             return new Rectangle(x, y, width, height);

--- a/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
@@ -99,11 +99,6 @@ namespace Microsoft.Xna.Framework.Graphics
         {
         }
 
-        private static GraphicsProfile PlatformGetHighestSupportedGraphicsProfile(GraphicsDevice graphicsDevice)
-        {
-            return GraphicsProfile.HiDef;
-        }
-        
         private static Rectangle PlatformGetTitleSafeArea(int x, int y, int width, int height)
         {
             return new Rectangle(x, y, width, height);

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1292,11 +1292,6 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new NotSupportedException();
         }
 
-        internal static GraphicsProfile GetHighestSupportedGraphicsProfile(GraphicsDevice graphicsDevice)
-        {
-            return PlatformGetHighestSupportedGraphicsProfile(graphicsDevice);
-        }
-
         // uniformly scales down the given rectangle by 10%
         internal static Rectangle GetDefaultTitleSafeArea(int x, int y, int width, int height)
         {

--- a/MonoGame.Framework/GraphicsDeviceManager.Legacy.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.Legacy.cs
@@ -65,7 +65,9 @@ namespace Microsoft.Xna.Framework
             _preferredDepthStencilFormat = DepthFormat.Depth24;
             _synchronizedWithVerticalRetrace = true;
 
-            GraphicsProfile = GraphicsDevice.GetHighestSupportedGraphicsProfile(null);
+            // XNA would read this from the manifest, but it would always default
+            // to Reach unless changed.  So lets mimic that without the manifest bit.
+            GraphicsProfile = GraphicsProfile.Reach;
 
             if (_game.Services.GetService(typeof(IGraphicsDeviceManager)) != null)
                 throw new ArgumentException("Graphics Device Manager Already Present");


### PR DESCRIPTION
Platforms that use the `GraphicsDeviceManager.Legacy.cs` (GL?) will
default to Reach profile. Just like the DX platforms since 3.6.