### PR TITLE
Use GraphicsCapabilities.MaxTextureAnisotropy on SamplerState

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.DirectX.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Xna.Framework.Graphics
             SupportsDepthClamp = device.GraphicsProfile == GraphicsProfile.HiDef;
             SupportsVertexTextures = device.GraphicsProfile == GraphicsProfile.HiDef;
 
+            MaxTextureAnisotropy = (device.GraphicsProfile == GraphicsProfile.Reach) ? 2 : 16;
+
             _maxMultiSampleCount = GetMaxMultiSampleCount(device);
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.OpenGL.cs
@@ -38,13 +38,6 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         internal bool SupportsFramebufferObjectEXT { get; private set; }
 
-        /// <summary>
-        /// Gets the max texture anisotropy. This value typically lies
-        /// between 0 and 16, where 0 means anisotropic filtering is not
-        /// supported.
-        /// </summary>
-        internal int MaxTextureAnisotropy { get; private set; }
-
         private void PlatformInitialize(GraphicsDevice device)
         {
 #if GLES

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -76,6 +76,13 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal bool SupportsVertexTextures { get; private set; }
 
+        /// <summary>
+        /// Gets the max texture anisotropy. This value typically lies
+        /// between 0 and 16, where 0 means anisotropic filtering is not
+        /// supported.
+        /// </summary>
+        internal int MaxTextureAnisotropy { get; private set; }
+
         // The highest possible MSCount
         private const int MultiSampleCountLimit = 32;
         private int _maxMultiSampleCount;

--- a/MonoGame.Framework/Graphics/States/SamplerState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.DirectX.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				desc.BorderColor = BorderColor.ToColor4();
 #endif
 				desc.Filter = GetFilter(Filter, FilterMode);
-                desc.MaximumAnisotropy = MaxAnisotropy;
+                desc.MaximumAnisotropy = Math.Min(MaxAnisotropy, device.GraphicsCapabilities.MaxTextureAnisotropy);
                 desc.MipLodBias = MipMapLevelOfDetailBias;
                 desc.ComparisonFunction = ComparisonFunction.ToComparison();
 


### PR DESCRIPTION
-Move property MaxTextureAnisotropy from GraphicsCapabilities.OpenGL.cs
to GraphicsCapabilities.cs
-Enforce MaxAnisotropy limit when we create SamplerState [DX].
GL already does something similar:
https://github.com/MonoGame/MonoGame/blob/7c3d6870a38f8a5e479e64d935d692f2610e1cda/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs#L72

Feature level 9.1 Max Anisotropy = 2.
Feature level 9.2 and up, Max Anisotropy = 16.

Fixes: #5674