### PR TITLE
Extend WritePcmFile

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
@@ -278,15 +278,18 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
             return data;
         }
 
-        public static void WritePcmFile(AudioContent content, string saveToFile)
+        public static void WritePcmFile(AudioContent content, string saveToFile, int bitRate = 192000, int? sampeRate = null)
         {
             string ffmpegStdout, ffmpegStderr;
             var ffmpegExitCode = ExternalTool.Run(
                 "ffmpeg",
                 string.Format(
-                    "-y -i \"{0}\" -vn -c:a pcm_s16le -b:a 192000 -f:a wav -strict experimental \"{1}\"",
+                    "-y -i \"{0}\" -vn -c:a pcm_s16le -b:a {2} {3} -f:a wav -strict experimental \"{1}\"",
                     content.FileName,
-                    saveToFile),
+                    saveToFile,
+                    bitRate,
+                    sampeRate != null ? "-ar " + sampeRate.Value : ""
+                    ),
                 out ffmpegStdout,
                 out ffmpegStderr);
             if (ffmpegExitCode != 0)


### PR DESCRIPTION
Added support for changing bitrate and sample rate in the internal utility method `WritePcmFile`.  Makes it a bit more flexible for use within the pipeline.

