### PR TITLE
XACT sound streaming

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -436,6 +436,9 @@
     <Compile Include="Audio\Xact\SoundBank.cs" />
     <Compile Include="Audio\Xact\VolumeEvent.cs" />
     <Compile Include="Audio\Xact\WaveBank.cs" />
+    <Compile Include="Audio\Xact\WaveBank.Default.cs">	
+      <Platforms>Android,Angle,iOS,Linux,MacOS,Windows,Windows8,WindowsGL,WindowsPhone81,WindowsUniversal,Web,tvOS</Platforms>
+    </Compile>
     <Compile Include="Audio\Xact\XactClip.cs" />
     <Compile Include="Audio\Xact\XactHelpers.cs" />
     <Compile Include="Audio\Xact\XactSound.cs" />

--- a/MonoGame.Framework/Audio/Xact/PlayWaveEvent.cs
+++ b/MonoGame.Framework/Audio/Xact/PlayWaveEvent.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Xna.Framework.Audio
         private int _loopIndex;
 
         private SoundEffectInstance _wav;
+        private bool _streaming;
 
         public PlayWaveEvent(   XactClip clip, float timeStamp, float randomOffset, SoundBank soundBank,
                                 int[] waveBanks, int[] tracks, byte[] weights, int totalWeights,
@@ -155,7 +156,7 @@ namespace Microsoft.Xna.Framework.Audio
                 };
             }
 
-            _wav = _soundBank.GetSoundEffectInstance(_waveBanks[_wavIndex], _tracks[_wavIndex]);
+            _wav = _soundBank.GetSoundEffectInstance(_waveBanks[_wavIndex], _tracks[_wavIndex], out _streaming);
             if (_wav == null)
             {
                 // We couldn't create a sound effect instance, most likely
@@ -195,6 +196,8 @@ namespace Microsoft.Xna.Framework.Audio
             if (_wav != null)
             {
                 _wav.Stop();
+                if (_streaming)
+                    _wav.Dispose();
                 _wav = null;
             }
             _loopIndex = 0;
@@ -265,6 +268,8 @@ namespace Microsoft.Xna.Framework.Audio
                 // limit then we can stop.
                 if (_loopCount == 0 || _loopIndex >= _loopCount)
                 {
+                    if (_streaming)
+                        _wav.Dispose();
                     _wav = null;
                     _loopIndex = 0;
                 }

--- a/MonoGame.Framework/Audio/Xact/SoundBank.cs
+++ b/MonoGame.Framework/Audio/Xact/SoundBank.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Xna.Framework.Audio
             }
         }
 
-        internal SoundEffectInstance GetSoundEffectInstance(int waveBankIndex, int trackIndex)
+        internal SoundEffectInstance GetSoundEffectInstance(int waveBankIndex, int trackIndex, out bool streaming)
         {
             var waveBank = _waveBanks[waveBankIndex];
 
@@ -231,8 +231,7 @@ namespace Microsoft.Xna.Framework.Audio
                 _waveBanks[waveBankIndex] = waveBank;                
             }
 
-            var sound = waveBank.GetSoundEffect(trackIndex);
-            return sound.GetPooledInstance(true);
+            return waveBank.GetSoundEffectInstance(trackIndex, out streaming);
         }
         
         /// <summary>

--- a/MonoGame.Framework/Audio/Xact/WaveBank.Default.cs
+++ b/MonoGame.Framework/Audio/Xact/WaveBank.Default.cs
@@ -1,0 +1,17 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+namespace Microsoft.Xna.Framework.Audio
+{
+    partial class WaveBank
+    {
+        private SoundEffectInstance PlatformCreateStream(StreamInfo stream)
+        {
+            throw new NotImplementedException("XACT streaming is not implemented on this platform.");
+        }
+    }
+}
+

--- a/MonoGame.Framework/Audio/Xact/XactSound.cs
+++ b/MonoGame.Framework/Audio/Xact/XactSound.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Xna.Framework.Audio
         private readonly bool _useReverb;
 
         private SoundEffectInstance _wave;
+        private bool _streaming;
 
         private float _cueVolume = 1;
         private float _cuePitch = 0;
@@ -150,7 +151,7 @@ namespace Microsoft.Xna.Framework.Audio
                 if (_wave != null && _wave.State != SoundState.Stopped && _wave.IsLooped)
                     _wave.Stop();
                 else
-                    _wave = _soundBank.GetSoundEffectInstance(_waveBankIndex, _trackIndex);
+                    _wave = _soundBank.GetSoundEffectInstance(_waveBankIndex, _trackIndex, out _streaming);
 
                 if (_wave == null)
                 {
@@ -176,7 +177,11 @@ namespace Microsoft.Xna.Framework.Audio
             else
             {
                 if (_wave != null && _wave.State == SoundState.Stopped)
+                {
+                    if (_streaming)
+                        _wave.Dispose();
                     _wave = null;
+                }
             }
         }
 
@@ -192,6 +197,8 @@ namespace Microsoft.Xna.Framework.Audio
                 if (_wave != null)
                 {
                     _wave.Stop();
+                    if (_streaming)
+                        _wave.Dispose();
                     _wave = null;
                 }
             }
@@ -209,6 +216,8 @@ namespace Microsoft.Xna.Framework.Audio
                 if (_wave != null)
                 {
                     _wave.Stop();
+                    if (_streaming)
+                        _wave.Dispose();
                     _wave = null;
                 }
             }


### PR DESCRIPTION
This PR has the initial required plumbing for streaming sounds in XACT.

Platform specific streaming solutions still need to be worked out.  For now all platforms throw a `NotImplementedException` to alert the user.
