### PR TITLE
Remove Song absolute uri check

### DIFF
--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -74,18 +74,17 @@ namespace Microsoft.Xna.Framework.Media
 			get { return _name; }
 		}
 
+        /// <summary>
+        /// Returns a song that can be played via <see cref="MediaPlayer"/>.
+        /// </summary>
+        /// <param name="name">The name for the song. See <see cref="Song.Name"/>.</param>
+        /// <param name="uri">The path to the song file.</param>
+        /// <returns></returns>
         public static Song FromUri(string name, Uri uri)
         {
-            if (!uri.IsAbsoluteUri)
-            {
-                var song = new Song(uri.OriginalString);
-                song._name = name;
-                return song;
-            }
-            else
-            {
-                throw new NotImplementedException("Loading songs from an absolute path is not implemented");
-            }
+            var song = new Song(uri.OriginalString);
+            song._name = name;
+            return song;
         }
 		
 		public void Dispose()


### PR DESCRIPTION
This PR removes the unnecessary absolute uri check in `Song.FromUri`. 

Not sure how this was determined to be needed before, but it isn't documented to be the case.

Plus the check interferes with consoles where the path might be absolute.