### PR TITLE
RPC curves are now updated before Cue is played

### DIFF
--- a/MonoGame.Framework/Audio/Xact/Cue.cs
+++ b/MonoGame.Framework/Audio/Xact/Cue.cs
@@ -135,7 +135,9 @@ namespace Microsoft.Xna.Framework.Audio
             var index = XactHelpers.Random.Next(_sounds.Length);
             _curSound = _sounds[index];
 
-            _curSound.Play(1.0f, _engine);
+            var volume = UpdateRpcCurves();
+
+            _curSound.Play(volume, _engine);
             _played = true;
             IsPrepared = false;
         }
@@ -253,14 +255,22 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal void Update(float dt)
         {
-            if (_curSound != null)
-                _curSound.Update(dt);
+            if (_curSound == null)
+                return;
+
+            _curSound.Update(dt);
+
+            UpdateRpcCurves();
+        }
+
+        private float UpdateRpcCurves()
+        {
+            var volume = 1.0f;
 
             // Evaluate the runtime parameter controls.
             var rpcCurves = _curSound.RpcCurves;
             if (rpcCurves.Length > 0)
             {
-                var volume = 1.0f;
                 var pitch = 0.0f;
                 var reverbMix = 1.0f;
                 float? filterFrequency = null;
@@ -305,8 +315,12 @@ namespace Microsoft.Xna.Framework.Audio
                     }
                 }
 
+                pitch = MathHelper.Clamp(pitch, -1.0f, 1.0f);
+
                 _curSound.UpdateState(_engine, volume, pitch, reverbMix, filterFrequency, filterQFactor);
             }
+
+            return volume;
         }
         
         /// <summary>

--- a/MonoGame.Framework/Audio/Xact/SoundBank.cs
+++ b/MonoGame.Framework/Audio/Xact/SoundBank.cs
@@ -116,8 +116,6 @@ namespace Microsoft.Xna.Framework.Audio
                     stream.Seek(complexCuesOffset, SeekOrigin.Begin);
                     for (int i = 0; i < numComplexCues; i++)
                     {
-                        //Cue cue;
-
                         byte flags = reader.ReadByte();
                         if (((flags >> 2) & 1) != 0)
                         {
@@ -348,9 +346,6 @@ namespace Microsoft.Xna.Framework.Audio
 
             if (disposing)
             {
-                //foreach (var cue in _cues.Values)
-                //    cue.Dispose();
-
                 IsInUse = false;
 
                 if (Disposing != null)

--- a/MonoGame.Framework/Audio/Xact/XactSound.cs
+++ b/MonoGame.Framework/Audio/Xact/XactSound.cs
@@ -126,7 +126,6 @@ namespace Microsoft.Xna.Framework.Audio
         {
             _cueVolume = volume;
             var category = engine.Categories[_categoryID];
-            UpdateCategoryVolume(category._volume[0]);
 
             var curInstances = category.GetPlayingInstanceCount();
             if (curInstances >= category.maxInstances)
@@ -141,10 +140,17 @@ namespace Microsoft.Xna.Framework.Audio
                 }
             }
 
+            float finalVolume = _volume * _cueVolume * category._volume[0];
+            float finalPitch = _pitch + _cuePitch;
+            float finalMix = _useReverb ? _cueReverbMix : 0.0f;
+
             if (_complexSound) 
             {
                 foreach (XactClip clip in _soundClips)
+                {
+                    clip.UpdateState(finalVolume, finalPitch, finalMix, _cueFilterFrequency, _cueFilterQFactor);
                     clip.Play();
+                }
             } 
             else 
             {
@@ -160,9 +166,9 @@ namespace Microsoft.Xna.Framework.Audio
                     return;
                 }
 
-                _wave.Pitch = _pitch + _cuePitch;
-                _wave.Volume = _volume * _cueVolume * category._volume[0];
-                _wave.PlatformSetReverbMix(_useReverb ? _cueReverbMix : 0.0f);
+                _wave.Pitch = finalPitch;
+                _wave.Volume = finalVolume;
+                _wave.PlatformSetReverbMix(finalMix);
                 _wave.Play();
             }
         }
@@ -295,6 +301,7 @@ namespace Microsoft.Xna.Framework.Audio
             {
                 _wave.PlatformSetReverbMix(_useReverb ? _cueReverbMix : 0.0f);
                 _wave.Pitch = finalPitch;
+                _wave.Volume = finalVolume;
             }
         }
 


### PR DESCRIPTION
This PR fixes XAct to ensure RPC curve values are updated before a cue us played.