### PR TITLE
simplify CharComparer.GetHashCode(char b)

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 			public int GetHashCode(char b)
 			{
-				return (b | (b << 16));
+				return (b);
 			}
 
 			static public readonly CharComparer Default = new CharComparer();


### PR DESCRIPTION
CharComparer.GetHashCode() is used for fast character lookup in the Dictionary<char, Glyph>.

I don't think we need to do anything other that returning `b` here. Char is 16bit anyway. The idea behind the CharComparer was to provide a faster GetHashCode() to Dictionary<char, Glyph> as an alternative to Char.GetHashCode().

I found the following code 7.9% faster.
```
            this.fpsCounter.StartDrawTimer();
            for (var i = 20; i < 480; i += 20)
            {
                this.spriteBatch.DrawString(this.fpsCounter.spriteFont, "abcdefghijklmnopqrstuvwxyz1234567890 some words here on the end test amazing testing letters to the edge of the screen", new Vector2(0, i), Color.Black);
            }
            this.fpsCounter.EndDrawTimer(gameTime);
```