### PR TITLE
Use Mono properties for pipeline platform prefix

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -34,8 +34,9 @@
       <MonoGameContentBuilderCmd>&quot;$(MonoGameContentBuilderExe)&quot;</MonoGameContentBuilderCmd>
       <MonoGameContentBuilderCmd Condition=" '$(OS)' != 'Windows_NT' ">$(MonoExe) $(MonoGameContentBuilderCmd)</MonoGameContentBuilderCmd>
 
-      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'">Resources\</PlatformResourcePrefix>
-      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">Assets\</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX'">$(MonoMacResourcePrefix)\</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'iOS'">$(IPhoneResourcePrefix)\</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">$(MonoAndroidAssetsPrefix)\</PlatformResourcePrefix>
       <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' == ''"></PlatformResourcePrefix>
 
       <Header>/platform:$(MonoGamePlatform) /outputDir:&quot;$(ParentOutputDir)&quot; /intermediateDir:&quot;$(ParentIntermediateDir)&quot; /quiet</Header>


### PR DESCRIPTION
With the current `MonoGame.Content.Builder.targets` implementation, the build breaks as soon as any of the platform specific resource prefixes are modified:

- `IPhoneResourcePrefix`
- `MonoAndroidAssetsPrefix`
- `MonoMacResourcePrefix`

This is because the directory (`PlatformResourcePrefix`) is hardcoded.

It is also not customisable from the project that imports it, since the conditional logic always sets the property on the affected platforms (iOS, Android, macOS).

I do not believe a fallback value is required since the variables are set by default on each platform.
See [Xamarin.Mac.Common.props](https://github.com/xamarin/xamarin-macios/blob/master/msbuild/Xamarin.Mac.Tasks/Xamarin.Mac.Common.props) and cousins, but my assumption may be wrong.

In case a dependency on these properties are preferred to be avoided, a customisable user property is the least that should be provided.