### PR TITLE
Updated reflection to be backward compatible with .Net 4.0

### DIFF
--- a/Build/AdditionalProjectTransforms.xslt
+++ b/Build/AdditionalProjectTransforms.xslt
@@ -1,5 +1,5 @@
 <xsl:if test="/Input/Properties/DefineNET4DetectionConstant = 'True'">
   <PropertyGroup>
-    <DefineConstants Condition="$([System.Version]::Parse('$(TargetFrameworkVersion.Substring(1))').CompareTo($([System.Version]::Parse('4.0'))))   &gt;= 0">$(DefineConstants);NET4</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">NET4</DefineConstants>
   </PropertyGroup>
 </xsl:if>

--- a/Build/AdditionalProjectTransforms.xslt
+++ b/Build/AdditionalProjectTransforms.xslt
@@ -1,5 +1,5 @@
 <xsl:if test="/Input/Properties/DefineNET4DetectionConstant = 'True'">
   <PropertyGroup>
-    <DefineConstants Condition="$([System.Version]::Parse('$(TargetFrameworkVersion.Substring(1))').CompareTo($([System.Version]::Parse('4.5'))))   &gt;= 0">$(DefineConstants);NET45</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkVersion)' != 'v4.0' And '$(TargetFrameworkVersion)' != 'v3.5' And '$(TargetFrameworkVersion)' != 'v3.0' And '$(TargetFrameworkVersion)' != 'v2.0' ">$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
 </xsl:if>

--- a/Build/AdditionalProjectTransforms.xslt
+++ b/Build/AdditionalProjectTransforms.xslt
@@ -1,0 +1,5 @@
+<xsl:if test="/Input/Properties/DefineNET4DetectionConstant = 'True'">
+  <PropertyGroup>
+    <DefineConstants Condition="$([System.Version]::Parse('$(TargetFrameworkVersion.Substring(1))').CompareTo($([System.Version]::Parse('4.0'))))   &gt;= 0">$(DefineConstants);NET4</DefineConstants>
+  </PropertyGroup>
+</xsl:if>

--- a/Build/AdditionalProjectTransforms.xslt
+++ b/Build/AdditionalProjectTransforms.xslt
@@ -1,5 +1,5 @@
 <xsl:if test="/Input/Properties/DefineNET4DetectionConstant = 'True'">
   <PropertyGroup>
-    <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">NET4</DefineConstants>
+    <DefineConstants Condition="$([System.Version]::Parse('$(TargetFrameworkVersion.Substring(1))').CompareTo($([System.Version]::Parse('4.5'))))   &gt;= 0">$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
 </xsl:if>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -49,6 +49,8 @@
       <Platform Name="WindowsUniversal">TRACE;NETFX_CORE;WINDOWS_UAP;WINRT;DIRECTX;DIRECTX11_1;WINDOWS_MEDIA_ENGINE</Platform>
       <Platform Name="Web">TRACE;WEB</Platform>
     </CustomDefinitions>
+	
+	<DefineNET4DetectionConstant>True</DefineNET4DetectionConstant>
 
     <FrameworkVersions>
 	  <Platform Name="Windows8">

--- a/MonoGame.Framework/Content/ContentExtensions.cs
+++ b/MonoGame.Framework/Content/ContentExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Xna.Framework.Content
     {
         public static ConstructorInfo GetDefaultConstructor(this Type type)
         {
-#if !NET4
+#if NET45
             var typeInfo = type.GetTypeInfo();
             var ctor = typeInfo.DeclaredConstructors.FirstOrDefault(c => !c.IsStatic && c.GetParameters().Length == 0);
             return ctor;
@@ -26,7 +26,7 @@ namespace Microsoft.Xna.Framework.Content
             // all properties in this list are defined in this class by comparing
             // its get method with that of it's base class. If they're the same
             // Then it's an overridden property.
-#if !NET4
+#if NET45
             PropertyInfo[] infos= type.GetTypeInfo().DeclaredProperties.ToArray();
             var nonStaticPropertyInfos = from p in infos
                                          where (p.GetMethod != null) && (!p.GetMethod.IsStatic) &&
@@ -44,7 +44,7 @@ namespace Microsoft.Xna.Framework.Content
 
         public static FieldInfo[] GetAllFields(this Type type)
         {
-#if !NET4
+#if NET45
             FieldInfo[] fields= type.GetTypeInfo().DeclaredFields.ToArray();
             var nonStaticFields = from field in fields
                     where !field.IsStatic
@@ -58,7 +58,7 @@ namespace Microsoft.Xna.Framework.Content
 
         public static bool IsClass(this Type type)
         {
-#if !NET4
+#if NET45
             return type.GetTypeInfo().IsClass;
 #else
             return type.IsClass;

--- a/MonoGame.Framework/Content/ContentExtensions.cs
+++ b/MonoGame.Framework/Content/ContentExtensions.cs
@@ -2,17 +2,13 @@
 using System.Reflection;
 using System.Linq;
 
-#if WINRT
-using System.Reflection.Emit;
-#endif
-
 namespace Microsoft.Xna.Framework.Content
 {
     internal static class ContentExtensions
     {
         public static ConstructorInfo GetDefaultConstructor(this Type type)
         {
-#if WINRT
+#if !NET4
             var typeInfo = type.GetTypeInfo();
             var ctor = typeInfo.DeclaredConstructors.FirstOrDefault(c => !c.IsStatic && c.GetParameters().Length == 0);
             return ctor;
@@ -30,7 +26,7 @@ namespace Microsoft.Xna.Framework.Content
             // all properties in this list are defined in this class by comparing
             // its get method with that of it's base class. If they're the same
             // Then it's an overridden property.
-#if WINRT
+#if !NET4
             PropertyInfo[] infos= type.GetTypeInfo().DeclaredProperties.ToArray();
             var nonStaticPropertyInfos = from p in infos
                                          where (p.GetMethod != null) && (!p.GetMethod.IsStatic) &&
@@ -48,7 +44,7 @@ namespace Microsoft.Xna.Framework.Content
 
         public static FieldInfo[] GetAllFields(this Type type)
         {
-#if WINRT
+#if !NET4
             FieldInfo[] fields= type.GetTypeInfo().DeclaredFields.ToArray();
             var nonStaticFields = from field in fields
                     where !field.IsStatic
@@ -62,7 +58,7 @@ namespace Microsoft.Xna.Framework.Content
 
         public static bool IsClass(this Type type)
         {
-#if WINRT
+#if !NET4
             return type.GetTypeInfo().IsClass;
 #else
             return type.IsClass;

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -397,11 +397,7 @@ namespace Microsoft.Xna.Framework.Content
                 if (asset.Key == null)
                     ReloadAsset(asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()));
 
-#if WINDOWS_STOREAPP || WINDOWS_UAP
-                var methodInfo = typeof(ContentManager).GetType().GetTypeInfo().GetDeclaredMethod("ReloadAsset");
-#else
-                var methodInfo = typeof(ContentManager).GetMethod("ReloadAsset", BindingFlags.NonPublic | BindingFlags.Instance);
-#endif
+                var methodInfo = ReflectionHelpers.GetMethodInfo(typeof(ContentManager), "ReloadAsset");
                 var genericMethod = methodInfo.MakeGenericMethod(asset.Value.GetType());
                 genericMethod.Invoke(this, new object[] { asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()) }); 
             }

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -30,6 +30,7 @@ using System.Collections;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
@@ -48,12 +49,7 @@ namespace Microsoft.Xna.Framework.Content
 		{
             _locker = new object();
             _contentReadersCache = new Dictionary<Type, ContentTypeReader>(255);
-
-#if WINRT
-            _assemblyName = typeof(ContentTypeReaderManager).GetTypeInfo().Assembly.FullName;
-#else
-            _assemblyName = typeof(ContentTypeReaderManager).Assembly.FullName;
-#endif
+            _assemblyName = ReflectionHelpers.GetAssembly(typeof(ContentTypeReaderManager)).FullName;
         }
 
         public ContentTypeReader GetTypeReader(Type targetType)

--- a/MonoGame.Framework/Graphics/Effect/EffectResource.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectResource.cs
@@ -2,12 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
+using Microsoft.Xna.Framework.Utilities;
 using System.IO;
-
-#if WINRT
-using System.Reflection;
-#endif
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -42,11 +38,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     {
                         if (_bytecode != null)
                             return _bytecode;
-#if WINRT
-                        var assembly = typeof(EffectResource).GetTypeInfo().Assembly;
-#else
-                        var assembly = typeof(EffectResource).Assembly;
-#endif
+
+                        var assembly = ReflectionHelpers.GetAssembly(typeof(EffectResource));
+
                         var stream = assembly.GetManifestResourceStream(_name);
                         using (var ms = new MemoryStream())
                         {

--- a/MonoGame.Framework/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Input/GamePad.SDL.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using Microsoft.Xna.Framework.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -35,7 +36,7 @@ namespace Microsoft.Xna.Framework.Input
 
         public static void InitDatabase()
         {
-            using (var stream = typeof(GamePad).GetTypeInfo().Assembly.GetManifestResourceStream("gamecontrollerdb.txt"))
+            using (var stream = ReflectionHelpers.GetAssembly(typeof(GamePad)).GetManifestResourceStream("gamecontrollerdb.txt"))
             {
                 if (stream != null)
                 {

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Utilities
 {
@@ -13,10 +11,10 @@ namespace Microsoft.Xna.Framework.Utilities
             {
                 throw new NullReferenceException("Must supply the targetType parameter");
             }
-#if WINRT
-            return targetType.GetTypeInfo().IsValueType;
+#if NET4
+            return targetType.IsValueType;    
 #else
-            return targetType.IsValueType;
+            return targetType.GetTypeInfo().IsValueType;
 #endif
         }
 
@@ -26,12 +24,27 @@ namespace Microsoft.Xna.Framework.Utilities
             {
                 throw new NullReferenceException("Must supply the targetType parameter");
             }
-#if WINRT
-            var type = targetType.GetTypeInfo().BaseType;
+#if NET4
+            return targetType.BaseType;
 #else
-            var type = targetType.BaseType;
+            return targetType.GetTypeInfo().BaseType;
 #endif
-            return type;
+        }
+
+        /// <summary>
+        /// Returns the Assembly of a Type
+        /// </summary>
+        public static Assembly GetAssembly(Type targetType)
+        {
+            if (targetType == null)
+            {
+                throw new NullReferenceException("Must supply the targetType parameter");
+            }
+#if NET4
+            return targetType.Assembly;
+#else
+            return targetType.GetTypeInfo().Assembly;
+#endif
         }
 
         /// <summary>
@@ -46,15 +59,24 @@ namespace Microsoft.Xna.Framework.Utilities
 
             if (t == typeof(object))
                 return false;
-#if WINRT
+#if NET4
+            if (t.IsClass && !t.IsAbstract)
+                return true;
+#else            
             var ti = t.GetTypeInfo();
             if (ti.IsClass && !ti.IsAbstract)
                 return true;
-#else
-            if (t.IsClass && !t.IsAbstract)
-                return true;
 #endif
             return false;
+        }
+
+        public static MethodInfo GetMethodInfo(Type type, string methodName)
+        {
+#if NET4
+            return type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+#else
+            return type.GetTypeInfo().GetDeclaredMethod(methodName);
+#endif
         }
 
         public static MethodInfo GetPropertyGetMethod(PropertyInfo property)
@@ -64,10 +86,10 @@ namespace Microsoft.Xna.Framework.Utilities
                 throw new NullReferenceException("Must supply the property parameter");
             }
 
-#if WINRT
-            return property.GetMethod;
-#else
+#if NET4
             return property.GetGetMethod();
+#else
+            return property.GetMethod;
 #endif
         }
 
@@ -78,10 +100,10 @@ namespace Microsoft.Xna.Framework.Utilities
                 throw new NullReferenceException("Must supply the property parameter");
             }
 
-#if WINRT
-            return property.SetMethod;
-#else
+#if NET4
             return property.GetSetMethod();
+#else
+            return property.SetMethod;
 #endif
         }
 
@@ -90,10 +112,10 @@ namespace Microsoft.Xna.Framework.Utilities
             if (member == null)
                 throw new NullReferenceException("Must supply the member parameter");
 
-#if WINRT
-            return member.GetCustomAttribute(typeof(T)) as T;
-#else
+#if NET4
             return Attribute.GetCustomAttribute(member, typeof(T)) as T;
+#else
+            return member.GetCustomAttribute(typeof(T)) as T;
 #endif
         }
 
@@ -139,12 +161,12 @@ namespace Microsoft.Xna.Framework.Utilities
                 throw new ArgumentNullException("type");
             if (objectType == null)
                 throw new ArgumentNullException("objectType");
-#if WINRT
-            if (type.GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
-                return true;
-#else
+#if NET4
             if (type.IsAssignableFrom(objectType))
                 return true;
+#else
+            if (type.GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
+                return true;            
 #endif
             return false;
         }

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Xna.Framework.Utilities
             {
                 throw new NullReferenceException("Must supply the targetType parameter");
             }
-#if NET4
-            return targetType.IsValueType;    
-#else
+#if NET45            
             return targetType.GetTypeInfo().IsValueType;
+#else
+            return targetType.IsValueType;
 #endif
         }
 
@@ -24,10 +24,10 @@ namespace Microsoft.Xna.Framework.Utilities
             {
                 throw new NullReferenceException("Must supply the targetType parameter");
             }
-#if NET4
-            return targetType.BaseType;
-#else
+#if NET45            
             return targetType.GetTypeInfo().BaseType;
+#else
+            return targetType.BaseType;
 #endif
         }
 
@@ -40,10 +40,10 @@ namespace Microsoft.Xna.Framework.Utilities
             {
                 throw new NullReferenceException("Must supply the targetType parameter");
             }
-#if NET4
-            return targetType.Assembly;
-#else
+#if NET45            
             return targetType.GetTypeInfo().Assembly;
+#else
+            return targetType.Assembly;
 #endif
         }
 
@@ -59,12 +59,12 @@ namespace Microsoft.Xna.Framework.Utilities
 
             if (t == typeof(object))
                 return false;
-#if NET4
-            if (t.IsClass && !t.IsAbstract)
-                return true;
-#else            
+#if NET45            
             var ti = t.GetTypeInfo();
             if (ti.IsClass && !ti.IsAbstract)
+                return true;
+#else            
+            if (t.IsClass && !t.IsAbstract)
                 return true;
 #endif
             return false;
@@ -72,10 +72,10 @@ namespace Microsoft.Xna.Framework.Utilities
 
         public static MethodInfo GetMethodInfo(Type type, string methodName)
         {
-#if NET4
-            return type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
-#else
+#if NET45            
             return type.GetTypeInfo().GetDeclaredMethod(methodName);
+#else
+            return type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
 #endif
         }
 
@@ -86,10 +86,10 @@ namespace Microsoft.Xna.Framework.Utilities
                 throw new NullReferenceException("Must supply the property parameter");
             }
 
-#if NET4
-            return property.GetGetMethod();
-#else
+#if NET45            
             return property.GetMethod;
+#else
+            return property.GetGetMethod();
 #endif
         }
 
@@ -100,10 +100,10 @@ namespace Microsoft.Xna.Framework.Utilities
                 throw new NullReferenceException("Must supply the property parameter");
             }
 
-#if NET4
-            return property.GetSetMethod();
-#else
+#if NET45            
             return property.SetMethod;
+#else
+            return property.GetSetMethod();
 #endif
         }
 
@@ -112,10 +112,10 @@ namespace Microsoft.Xna.Framework.Utilities
             if (member == null)
                 throw new NullReferenceException("Must supply the member parameter");
 
-#if NET4
-            return Attribute.GetCustomAttribute(member, typeof(T)) as T;
-#else
+#if NET45            
             return member.GetCustomAttribute(typeof(T)) as T;
+#else
+            return Attribute.GetCustomAttribute(member, typeof(T)) as T;
 #endif
         }
 
@@ -161,12 +161,12 @@ namespace Microsoft.Xna.Framework.Utilities
                 throw new ArgumentNullException("type");
             if (objectType == null)
                 throw new ArgumentNullException("objectType");
-#if NET4
-            if (type.IsAssignableFrom(objectType))
+#if NET45
+            if (type.GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
                 return true;
 #else
-            if (type.GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
-                return true;            
+            if (type.IsAssignableFrom(objectType))
+                return true;     
 #endif
             return false;
         }


### PR DESCRIPTION
This is a follow up / rework of #5607 (cc @cra0zy for being the initial author) by using a custom protobuild transform to add conditional constant for detecting .Net 4.0 (it defines ```NET4``` if the target framework version is "v4.0").

Fixes #5716

@tomspilman @KonajuGames 