### PR TITLE
Improvements to VideoPlayer for Desktop DirectX.

### DIFF
--- a/MonoGame.Framework/Media/VideoPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.WMS.cs
@@ -153,7 +153,10 @@ namespace Microsoft.Xna.Framework.Media
                 _volumeController.Dispose();
                 _volumeController = null;
             }
-            _clock.Dispose();
+            if (_clock != null)
+            {
+                _clock.Dispose();
+            }
             _clock = null;
         }
 

--- a/MonoGame.Framework/Media/VideoPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.WMS.cs
@@ -50,6 +50,8 @@ namespace Microsoft.Xna.Framework.Media
             public WorkQueueId WorkQueueId { get; private set; }
         }
 
+        private Texture2D _videoCache;
+
         private void PlatformInitialize()
         {
             // The GUID is specified in a GuidAttribute attached to the class
@@ -57,6 +59,7 @@ namespace Microsoft.Xna.Framework.Media
 
             MediaManagerState.CheckStartup();
             MediaFactory.CreateMediaSession(null, out _session);
+
         }
 
         private Texture2D PlatformGetTexture()
@@ -68,13 +71,12 @@ namespace Microsoft.Xna.Framework.Media
             if (texData == null)
                 return null;
 
-            // TODO: This could likely be optimized if we held on to the SharpDX Surface/Texture data,
-            // and set it on an XNA one rather than constructing a new one every time this is called.
-            var retTex = new Texture2D(Game.Instance.GraphicsDevice, _currentVideo.Width, _currentVideo.Height, false, SurfaceFormat.Bgr32);
+            // NOTE: It's entirely possible that we could lose the d3d context and therefore lose this texture, but it's better than allocating a new texture each call!
+            _videoCache = _videoCache ?? new Texture2D(Game.Instance.GraphicsDevice, _currentVideo.Width, _currentVideo.Height, false, SurfaceFormat.Bgr32);
+
+            _videoCache.SetData(texData);
             
-            retTex.SetData(texData);
-            
-            return retTex;
+            return _videoCache;
         }
 
         private void PlatformGetState(ref MediaState result)
@@ -136,6 +138,9 @@ namespace Microsoft.Xna.Framework.Media
             // Start playing.
             var varStart = new Variant();
             _session.Start(null, varStart);
+
+            // Create cached texture
+            _videoCache = new Texture2D(Game.Instance.GraphicsDevice, _currentVideo.Width, _currentVideo.Height, false, SurfaceFormat.Bgr32);
         }
 
         private void PlatformResume()
@@ -203,6 +208,10 @@ namespace Microsoft.Xna.Framework.Media
 
         private void PlatformDispose(bool disposing)
         {
+            if (_videoCache != null)
+            {
+                _videoCache.Dispose();
+            }
         }
 
         private void OnTopologyReady()


### PR DESCRIPTION
A game project I'm working on requires the video player. I tried playing a 1080p mp4 file in Debug and Release but in either case the playback was unacceptable. Lots of choppiness, and in some cases it was so slow that the program became inoperable and would not respond. For reference, my dev machine has a GTX 660 with 4GB of VRAM.

I went for an easy fix here, per the comment that was left in `GetTexture()`, and just cached a Texture2D. This  pretty much resolved my playback issues, although I am certain there's more to optimize here. Any and all feedback here would be greatly appreciated!

**Changes**

- DX VideoPlayer now caches a Texture2D instead of new-ing one for each call to GetTexture()
- Fixed null pointer exception if Stop() is called twice in a row ([XNA](https://msdn.microsoft.com/en-us/library/microsoft.xna.framework.media.videoplayer.stop.aspx) documentation seems to suggest that doing this would fail silently.)