### PR TITLE
keyboard fix when keyboard stops working when window focus is lost so…

### DIFF
--- a/MonoGame.Framework/Windows8/InputEvents.cs
+++ b/MonoGame.Framework/Windows8/InputEvents.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Xna.Framework
                         coreIndependentInputSource = ((SwapChainBackgroundPanel)inputElement).CreateCoreIndependentInputSource(inputDevices);
                     else
                         coreIndependentInputSource = ((SwapChainPanel)inputElement).CreateCoreIndependentInputSource(inputDevices);
-                                        
+
                     coreIndependentInputSource.PointerPressed += CoreWindow_PointerPressed;
                     coreIndependentInputSource.PointerMoved += CoreWindow_PointerMoved;
                     coreIndependentInputSource.PointerReleased += CoreWindow_PointerReleased;
@@ -159,7 +159,7 @@ namespace Microsoft.Xna.Framework
             var isTouch = pointerPoint.PointerDevice.PointerDeviceType == PointerDeviceType.Touch;
 
             _touchQueue.Enqueue((int)pointerPoint.PointerId, TouchLocationState.Pressed, pos, !isTouch);
-            
+
             if (!isTouch)
             {
                 // Mouse or stylus event.
@@ -216,7 +216,7 @@ namespace Microsoft.Xna.Framework
 
             var state = point.Properties;
 
-            Mouse.PrimaryWindow.MouseState = new MouseState(x, y, 
+            Mouse.PrimaryWindow.MouseState = new MouseState(x, y,
                 Mouse.PrimaryWindow.MouseState.ScrollWheelValue + state.MouseWheelDelta,
                 state.IsLeftButtonPressed ? ButtonState.Pressed : ButtonState.Released,
                 state.IsMiddleButtonPressed ? ButtonState.Pressed : ButtonState.Released,
@@ -243,11 +243,11 @@ namespace Microsoft.Xna.Framework
                 case Windows.System.VirtualKey.Shift:
                     // we can detect right shift by checking the scancode value.
                     // left shift is 0x2A, right shift is 0x36. IsExtendedKey is always false.
-                    return (keyStatus.ScanCode==0x36) ? Keys.RightShift : Keys.LeftShift;
+                    return (keyStatus.ScanCode == 0x36) ? Keys.RightShift : Keys.LeftShift;
                 // Note that the Alt key is now refered to as Menu.
                 // ALT key doesn't get fired by KeyUp/KeyDown events.
                 // One solution could be to check CoreWindow.GetKeyState(...) on every tick.
-                case Windows.System.VirtualKey.Menu:                    
+                case Windows.System.VirtualKey.Menu:
                     return Keys.LeftAlt;
 
                 default:
@@ -274,6 +274,10 @@ namespace Microsoft.Xna.Framework
             // If the window is resized then also 
             // drop any current key states.
             Keyboard.Clear();
+
+            // required of input can stop working if we change focus
+            Window.Current.CoreWindow.IsInputEnabled = true;
+            CoreWindow.GetForCurrentThread().IsInputEnabled = true;
         }
 
         private void CoreWindow_Activated(CoreWindow sender, WindowActivatedEventArgs args)
@@ -282,6 +286,10 @@ namespace Microsoft.Xna.Framework
             // receive key events for them while we are in the background
             if (args.WindowActivationState == CoreWindowActivationState.Deactivated)
                 Keyboard.Clear();
+
+            // required of input can stop working if we change focus
+            Window.Current.CoreWindow.IsInputEnabled = true;
+            CoreWindow.GetForCurrentThread().IsInputEnabled = true;
         }
 
         private void CoreWindow_VisibilityChanged(CoreWindow sender, VisibilityChangedEventArgs args)
@@ -290,6 +298,10 @@ namespace Microsoft.Xna.Framework
             // receive key events for them while we are in the background
             if (!args.Visible)
                 Keyboard.Clear();
+
+            // required of input can stop working if we change focus
+            Window.Current.CoreWindow.IsInputEnabled = true;
+            CoreWindow.GetForCurrentThread().IsInputEnabled = true;
         }
     }
 }


### PR DESCRIPTION
For UWP: Sometimes when the window loses focus keyboard keyDown/up/character recieved events stop working.

The added calls to IsInputEnabled = true fix it.

These values are always true though if we print them, so calling them seems to reset something internaly.

Using "CoreWindow.GetForCurrentThread()" instead of "window" in InputEvents ctor does not fix it.

Does anyone else have any idea why this happen?