### PR TITLE
Use SharpDX NuGet packages from our NuGet packages

### DIFF
--- a/NuGetPackages/MonoGame.Framework.Windows8.nuspec
+++ b/NuGetPackages/MonoGame.Framework.Windows8.nuspec
@@ -16,9 +16,17 @@ This package provides you with MonoGame Framework that works on Windows 8 as a n
     <summary>This package provides you with MonoGame Framework that works on Windows 8 as a native store app.</summary>
     <copyright>Copyright © 2009-2017 The MonoGame Team</copyright>
     <language>en-US</language>
-    <references>
-      <reference file="MonoGame.Framework.dll" />
-    </references>		
+    <dependencies>
+        <group targetFramework=".NETCore0.0">
+            <dependency id="SharpDX" version="3.0.0" />
+            <dependency id="SharpDX.Direct2D1" version="3.0.0" />
+            <dependency id="SharpDX.Direct3D11" version="3.0.0" />
+            <dependency id="SharpDX.DXGI" version="3.0.0" />
+            <dependency id="SharpDX.XAudio2" version="3.0.0" />
+            <dependency id="SharpDX.MediaFoundation" version="3.0.0" />
+            <dependency id="SharpDX.XInput" version="3.0.0" />
+        </group>
+    </dependencies>	
   </metadata>
   <files>
     <file src="..\..\NuGetPackages\build\Windows8\MonoGame.Framework.Windows8.targets" target="build\MonoGame.Framework.Windows8.targets" />
@@ -28,12 +36,5 @@ This package provides you with MonoGame Framework that works on Windows 8 as a n
     <file src="Windows8\AnyCPU\Release\MonoGame.Framework.dll" target="lib\netcore\MonoGame.Framework.dll" />
     <file src="Windows8\AnyCPU\Release\MonoGame.Framework.xml" target="lib\netcore\MonoGame.Framework.xml" />
     <file src="Windows8\AnyCPU\Release\MonoGame.Framework.pri" target="lib\netcore\MonoGame.Framework.pri" />
-    <file src="Windows8\AnyCPU\Release\SharpDX.Direct2D1.dll" target="lib\netcore\SharpDX.Direct2D1.dll" />
-    <file src="Windows8\AnyCPU\Release\SharpDX.Direct3D11.dll" target="lib\netcore\SharpDX.Direct3D11.dll" />
-    <file src="Windows8\AnyCPU\Release\SharpDX.dll" target="lib\netcore\SharpDX.dll" />
-    <file src="Windows8\AnyCPU\Release\SharpDX.DXGI.dll" target="lib\netcore\SharpDX.DXGI.dll" />
-    <file src="Windows8\AnyCPU\Release\SharpDX.MediaFoundation.dll" target="lib\netcore\SharpDX.MediaFoundation.dll" />
-    <file src="Windows8\AnyCPU\Release\SharpDX.XAudio2.dll" target="lib\netcore\SharpDX.XAudio2.dll" />
-    <file src="Windows8\AnyCPU\Release\SharpDX.XInput.dll" target="lib\netcore\SharpDX.XInput.dll" />
   </files>
 </package>

--- a/NuGetPackages/MonoGame.Framework.WindowsDX.nuspec
+++ b/NuGetPackages/MonoGame.Framework.WindowsDX.nuspec
@@ -16,9 +16,19 @@ This package provides you with MonoGame Framework that uses DirectX for renderin
     <summary>This package provides you with MonoGame Framework that uses DirectX for rendering and works on Windows.</summary>
     <copyright>Copyright © 2009-2017 The MonoGame Team</copyright>
     <language>en-US</language>
-    <references>
-      <reference file="MonoGame.Framework.dll" />
-    </references>
+    <dependencies>
+        <group targetFramework=".NETFramework4.5">
+            <dependency id="SharpDX" version="3.0.0" />
+            <dependency id="SharpDX.Direct2D1" version="3.0.0" />
+            <dependency id="SharpDX.Direct3D11" version="3.0.0" />
+            <dependency id="SharpDX.DXGI" version="3.0.0" />
+            <dependency id="SharpDX.XAudio2" version="3.0.0" />
+            <dependency id="SharpDX.MediaFoundation" version="3.0.0" />
+            <dependency id="SharpDX.XInput" version="3.0.0" />
+            <dependency id="SharpDX.RawInput" version="3.0.0" />
+            <dependency id="SharpDX.Direct3D9" version="3.0.0" />
+        </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\NuGetPackages\build\WindowsDX\MonoGame.Framework.WindowsDX.targets" target="build\MonoGame.Framework.WindowsDX.targets" />
@@ -26,14 +36,5 @@ This package provides you with MonoGame Framework that uses DirectX for renderin
     <!-- C# Assemblies -->
     <file src="Windows\AnyCPU\Release\MonoGame.Framework.dll" target="lib\net45\MonoGame.Framework.dll" />
     <file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\net45\MonoGame.Framework.xml" />
-    <file src="Windows\AnyCPU\Release\SharpDX.Direct2D1.dll" target="lib\net45\SharpDX.Direct2D1.dll" />
-    <file src="Windows\AnyCPU\Release\SharpDX.Direct3D11.dll" target="lib\net45\SharpDX.Direct3D11.dll" />
-    <file src="Windows\AnyCPU\Release\SharpDX.Direct3D9.dll" target="lib\net45\SharpDX.Direct3D9.dll" />
-    <file src="Windows\AnyCPU\Release\SharpDX.dll" target="lib\net45\SharpDX.dll" />
-    <file src="Windows\AnyCPU\Release\SharpDX.DXGI.dll" target="lib\net45\SharpDX.DXGI.dll" />
-    <file src="Windows\AnyCPU\Release\SharpDX.MediaFoundation.dll" target="lib\net45\SharpDX.MediaFoundation.dll" />
-    <file src="Windows\AnyCPU\Release\SharpDX.RawInput.dll" target="lib\net45\SharpDX.RawInput.dll" />
-    <file src="Windows\AnyCPU\Release\SharpDX.XAudio2.dll" target="lib\net45\SharpDX.XAudio2.dll" />
-    <file src="Windows\AnyCPU\Release\SharpDX.XInput.dll" target="lib\net45\SharpDX.XInput.dll" />
   </files>
 </package>

--- a/NuGetPackages/MonoGame.Framework.WindowsPhone81.nuspec
+++ b/NuGetPackages/MonoGame.Framework.WindowsPhone81.nuspec
@@ -16,9 +16,17 @@ This package provides you with MonoGame Framework that works on Windows Phone 8.
     <summary>This package provides you with MonoGame Framework that works on Windows Phone 8.1.</summary>
     <copyright>Copyright © 2009-2017 The MonoGame Team</copyright>
     <language>en-US</language>
-    <references>
-      <reference file="MonoGame.Framework.dll" />
-    </references>
+    <dependencies>
+        <group targetFramework="WindowsPhoneApp8.1">
+            <dependency id="SharpDX" version="3.0.0" />
+            <dependency id="SharpDX.Direct2D1" version="3.0.0" />
+            <dependency id="SharpDX.Direct3D11" version="3.0.0" />
+            <dependency id="SharpDX.DXGI" version="3.0.0" />
+            <dependency id="SharpDX.XAudio2" version="3.0.0" />
+            <dependency id="SharpDX.MediaFoundation" version="3.0.0" />
+            <dependency id="SharpDX.XInput" version="3.0.0" />
+        </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\NuGetPackages\build\WindowsPhone81\MonoGame.Framework.WindowsPhone81.targets" target="build\MonoGame.Framework.WindowsPhone81.targets" />
@@ -29,11 +37,5 @@ This package provides you with MonoGame Framework that works on Windows Phone 8.
     <file src="WindowsPhone81\AnyCPU\Release\MonoGame.Framework.dll" target="lib\wpa81/MonoGame.Framework.dll" />
     <file src="WindowsPhone81\AnyCPU\Release\MonoGame.Framework.xml" target="lib\wpa81/MonoGame.Framework.xml" />
     <file src="WindowsPhone81\AnyCPU\Release\MonoGame.Framework.pri" target="lib\wpa81/MonoGame.Framework.pri" />
-    <file src="WindowsPhone81\AnyCPU\Release\SharpDX.Direct2D1.dll" target="lib\wpa81\SharpDX.Direct2D1.dll" />
-    <file src="WindowsPhone81\AnyCPU\Release\SharpDX.Direct3D11.dll" target="lib\wpa81\SharpDX.Direct3D11.dll" />
-    <file src="WindowsPhone81\AnyCPU\Release\SharpDX.dll" target="lib\wpa81\SharpDX.dll" />
-    <file src="WindowsPhone81\AnyCPU\Release\SharpDX.DXGI.dll" target="lib\wpa81\SharpDX.DXGI.dll" />
-    <file src="WindowsPhone81\AnyCPU\Release\SharpDX.MediaFoundation.dll" target="lib\wpa81\SharpDX.MediaFoundation.dll" />
-    <file src="WindowsPhone81\AnyCPU\Release\SharpDX.XAudio2.dll" target="lib\wpa81\SharpDX.XAudio2.dll" />
   </files>
 </package>

--- a/NuGetPackages/MonoGame.Framework.WindowsUniversal.nuspec
+++ b/NuGetPackages/MonoGame.Framework.WindowsUniversal.nuspec
@@ -1,36 +1,39 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata>
-    <id>MonoGame.Framework.WindowsUniversal</id>
-    <version>0.0.0.0</version>
-    <title>MonoGame.Framework.WindowsUniversal</title>
-    <authors>MonoGame Team</authors>
-    <owners>MonoGame Team</owners>
-    <licenseUrl>https://github.com/mono/MonoGame/blob/develop/LICENSE.txt</licenseUrl>
-    <projectUrl>http://monogame.net/</projectUrl>
-    <iconUrl>https://pbs.twimg.com/profile_images/487954549441691649/O3KsHAsb_400x400.png</iconUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>MonoGame is an open source implementation of the Microsoft XNA 4.x Framework. The goal is to make it easy for XNA developers to create cross-platform games with extremely high code reuse.
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+    <metadata>
+        <id>MonoGame.Framework.WindowsUniversal</id>
+        <version>0.0.0.0</version>
+        <title>MonoGame.Framework.WindowsUniversal</title>
+        <authors>MonoGame Team</authors>
+        <owners>MonoGame Team</owners>
+        <licenseUrl>https://github.com/mono/MonoGame/blob/develop/LICENSE.txt</licenseUrl>
+        <projectUrl>http://monogame.net/</projectUrl>
+        <iconUrl>https://pbs.twimg.com/profile_images/487954549441691649/O3KsHAsb_400x400.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>MonoGame is an open source implementation of the Microsoft XNA 4.x Framework. The goal is to make it easy for XNA developers to create cross-platform games with extremely high code reuse.
 
 This package provides you with MonoGame Framework that works on Windows 10, Windows Phone 10 and Xbox One using UWP(Universal Windows Platform).</description>
-    <summary>This package provides you with MonoGame Framework that works on Windows 10, Windows Phone 10 and Xbox One using UWP(Universal Windows Platform).</summary>
-    <copyright>Copyright © 2009-2017 The MonoGame Team</copyright>
-    <language>en-US</language>
-  </metadata>
-  <files>
-    <file src="..\..\NuGetPackages\build\WindowsUniversal\MonoGame.Framework.WindowsUniversal.targets" target="build\MonoGame.Framework.WindowsUniversal.targets" />
-    
-    <!-- C# Assemblies -->
-    <file src="WindowsUniversal\AnyCPU\Release\Themes\generic.xbf" target="lib\netcore\MonoGame.Framework\Themes/generic.xbf" />
-    <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.dll" target="lib\netcore\MonoGame.Framework.dll" />
-    <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.xml" target="lib\netcore\MonoGame.Framework.xml" />
-    <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.pri" target="lib\netcore\MonoGame.Framework.pri" />
-    <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.xr.xml" target="lib\netcore\MonoGame.Framework/MonoGame.Framework.xr.xml" />
-    <file src="WindowsUniversal\AnyCPU\Release\SharpDX.Direct2D1.dll" target="lib\netcore\SharpDX.Direct2D1.dll" />
-    <file src="WindowsUniversal\AnyCPU\Release\SharpDX.Direct3D11.dll" target="lib\netcore\SharpDX.Direct3D11.dll" />
-    <file src="WindowsUniversal\AnyCPU\Release\SharpDX.dll" target="lib\netcore\SharpDX.dll" />
-    <file src="WindowsUniversal\AnyCPU\Release\SharpDX.DXGI.dll" target="lib\netcore\SharpDX.DXGI.dll" />
-    <file src="WindowsUniversal\AnyCPU\Release\SharpDX.MediaFoundation.dll" target="lib\netcore\SharpDX.MediaFoundation.dll" />
-    <file src="WindowsUniversal\AnyCPU\Release\SharpDX.XAudio2.dll" target="lib\netcore\SharpDX.XAudio2.dll" />
-  </files>
+        <summary>This package provides you with MonoGame Framework that works on Windows 10, Windows Phone 10 and Xbox One using UWP(Universal Windows Platform).</summary>
+        <copyright>Copyright © 2009-2017 The MonoGame Team</copyright>
+        <language>en-US</language>
+        <dependencies>
+            <group targetFramework=".NETCore0.0">
+                <dependency id="SharpDX" version="3.0.0" />
+                <dependency id="SharpDX.Direct2D1" version="3.0.0" />
+                <dependency id="SharpDX.Direct3D11" version="3.0.0" />
+                <dependency id="SharpDX.DXGI" version="3.0.0" />
+                <dependency id="SharpDX.XAudio2" version="3.0.0" />
+                <dependency id="SharpDX.MediaFoundation" version="3.0.0" />
+                <dependency id="SharpDX.XInput" version="3.0.0" />
+            </group>
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\..\NuGetPackages\build\WindowsUniversal\MonoGame.Framework.WindowsUniversal.targets" target="build\MonoGame.Framework.WindowsUniversal.targets" />
+        <file src="WindowsUniversal\AnyCPU\Release\Themes\generic.xbf" target="lib\netcore\MonoGame.Framework\Themes/generic.xbf" />
+        <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.dll" target="lib\netcore\MonoGame.Framework.dll" />
+        <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.pri" target="lib\netcore\MonoGame.Framework.pri" />
+        <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.xml" target="lib\netcore\MonoGame.Framework.xml" />
+        <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.xr.xml" target="lib\netcore\MonoGame.Framework/MonoGame.Framework.xr.xml" />
+    </files>
 </package>


### PR DESCRIPTION
The NuGet's now inherit SharpDX direct from NuGet instead of including the dll's directly.

Of note, I had to use the Version 3.0.0 packages (same as what MonoGame uses now), anything higher and it simply didn't work.  No errors, it just didn't draw anything so I suspect we have an issue somewhere