### PR TITLE
Added the Portable reference to the platform NuGets to resolve #5724

### DIFF
--- a/NuGetPackages/MonoGame.Framework.Android.nuspec
+++ b/NuGetPackages/MonoGame.Framework.Android.nuspec
@@ -23,5 +23,9 @@ This package provides you with MonoGame Framework that works on Android.</descri
     <!-- C# Assemblies -->
     <file src="Android\AnyCPU\Release\MonoGame.Framework.dll" target="lib\MonoAndroid\MonoGame.Framework.dll" />
     <file src="Android\AnyCPU\Release\MonoGame.Framework.xml" target="lib\MonoAndroid\MonoGame.Framework.xml" />
+
+    <!-- Portable Libs -->		
+	<file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.dll" />
+	<file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.xml" />
   </files>
 </package>

--- a/NuGetPackages/MonoGame.Framework.DesktopGL.nuspec
+++ b/NuGetPackages/MonoGame.Framework.DesktopGL.nuspec
@@ -36,5 +36,9 @@ This package provides you with MonoGame Framework that uses OpenGL for rendering
     <file src="WindowsGL\AnyCPU\Release\x86\libSDL2-2.0.so.0" target="build\native\x86\libSDL2-2.0.so.0" />
     <file src="WindowsGL\AnyCPU\Release\x86\SDL2.dll" target="build\native\x86\SDL2.dll" />
     <file src="WindowsGL\AnyCPU\Release\x86\soft_oal.dll" target="build\native\x86\soft_oal.dll" />
+
+    <!-- Portable Libs -->		
+	<file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.dll" />
+	<file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.xml" />
   </files>
 </package>

--- a/NuGetPackages/MonoGame.Framework.Windows8.nuspec
+++ b/NuGetPackages/MonoGame.Framework.Windows8.nuspec
@@ -36,5 +36,9 @@ This package provides you with MonoGame Framework that works on Windows 8 as a n
     <file src="Windows8\AnyCPU\Release\MonoGame.Framework.dll" target="lib\netcore\MonoGame.Framework.dll" />
     <file src="Windows8\AnyCPU\Release\MonoGame.Framework.xml" target="lib\netcore\MonoGame.Framework.xml" />
     <file src="Windows8\AnyCPU\Release\MonoGame.Framework.pri" target="lib\netcore\MonoGame.Framework.pri" />
+
+    <!-- Portable Libs -->		
+	<file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.dll" />
+	<file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.xml" />
   </files>
 </package>

--- a/NuGetPackages/MonoGame.Framework.WindowsDX.nuspec
+++ b/NuGetPackages/MonoGame.Framework.WindowsDX.nuspec
@@ -36,5 +36,9 @@ This package provides you with MonoGame Framework that uses DirectX for renderin
     <!-- C# Assemblies -->
     <file src="Windows\AnyCPU\Release\MonoGame.Framework.dll" target="lib\net45\MonoGame.Framework.dll" />
     <file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\net45\MonoGame.Framework.xml" />
+
+    <!-- Portable Libs -->		
+	<file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.dll" />
+	<file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.xml" />
   </files>
 </package>

--- a/NuGetPackages/MonoGame.Framework.WindowsPhone81.nuspec
+++ b/NuGetPackages/MonoGame.Framework.WindowsPhone81.nuspec
@@ -37,5 +37,9 @@ This package provides you with MonoGame Framework that works on Windows Phone 8.
     <file src="WindowsPhone81\AnyCPU\Release\MonoGame.Framework.dll" target="lib\wpa81/MonoGame.Framework.dll" />
     <file src="WindowsPhone81\AnyCPU\Release\MonoGame.Framework.xml" target="lib\wpa81/MonoGame.Framework.xml" />
     <file src="WindowsPhone81\AnyCPU\Release\MonoGame.Framework.pri" target="lib\wpa81/MonoGame.Framework.pri" />
+
+    <!-- Portable Libs -->		
+	<file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.dll" />
+	<file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.xml" />
   </files>
 </package>

--- a/NuGetPackages/MonoGame.Framework.WindowsUniversal.nuspec
+++ b/NuGetPackages/MonoGame.Framework.WindowsUniversal.nuspec
@@ -29,11 +29,16 @@ This package provides you with MonoGame Framework that works on Windows 10, Wind
         </dependencies>
     </metadata>
     <files>
-        <file src="..\..\NuGetPackages\build\WindowsUniversal\MonoGame.Framework.WindowsUniversal.targets" target="build\MonoGame.Framework.WindowsUniversal.targets" />
+		<!-- C# Assemblies -->
+		<file src="..\..\NuGetPackages\build\WindowsUniversal\MonoGame.Framework.WindowsUniversal.targets" target="build\MonoGame.Framework.WindowsUniversal.targets" />
         <file src="WindowsUniversal\AnyCPU\Release\Themes\generic.xbf" target="lib\netcore\MonoGame.Framework\Themes/generic.xbf" />
         <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.dll" target="lib\netcore\MonoGame.Framework.dll" />
         <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.pri" target="lib\netcore\MonoGame.Framework.pri" />
         <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.xml" target="lib\netcore\MonoGame.Framework.xml" />
         <file src="WindowsUniversal\AnyCPU\Release\MonoGame.Framework.xr.xml" target="lib\netcore\MonoGame.Framework/MonoGame.Framework.xr.xml" />
+
+		<!-- Portable Libs -->		
+	    <file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.dll" />
+		<file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.xml" />
     </files>
 </package>

--- a/NuGetPackages/MonoGame.Framework.iOS.nuspec
+++ b/NuGetPackages/MonoGame.Framework.iOS.nuspec
@@ -23,5 +23,9 @@ This package provides you with MonoGame Framework that works on iOS.</descriptio
     <!-- C# Assemblies -->
     <file src="iOS\iPhoneSimulator\Release\MonoGame.Framework.dll" target="lib\XamariniOS\MonoGame.Framework.dll" />
     <file src="iOS\iPhoneSimulator\Release\MonoGame.Framework.xml" target="lib\XamariniOS\MonoGame.Framework.xml" />
+
+    <!-- Portable Libs -->		
+	<file src="Portable\AnyCPU\MonoGame.Framework.dll" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.dll" />
+	<file src="Windows\AnyCPU\Release\MonoGame.Framework.xml" target="lib\portable-net45+win8+wpa81\MonoGame.Framework.xml" />
   </files>
 </package>


### PR DESCRIPTION
Added the Portable reference to the platform NuGets to resolve #5724

This ensures projects using the newer .csproj formats won't get confused. 

Users will now only add the same NuGet to both PCL and Platform in cases where this affects.