### PR TITLE
throw NoSuitableGraphicsDeviceException when OpenGL version not found

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -300,6 +300,10 @@ namespace Microsoft.Xna.Framework.Graphics
             try
             {
                 string version = GL.GetString(StringName.Version);
+
+                if (string.IsNullOrEmpty(version))
+                    throw new NoSuitableGraphicsDeviceException("Unable to retrieve OpenGL version");
+
                 string[] versionSplit = version.Split(' ');
                 if(versionSplit.Length > 2 && versionSplit[0].Equals("OpenGL") && versionSplit[1].Equals("ES"))
                 {
@@ -322,6 +326,10 @@ namespace Microsoft.Xna.Framework.Graphics
             try
             {
                 string version = GL.GetString(StringName.Version);
+
+                if (string.IsNullOrEmpty(version))
+                    throw new NoSuitableGraphicsDeviceException("Unable to retrieve OpenGL version");
+
                 glMajorVersion = Convert.ToInt32(version.Substring(0, 1));
                 glMinorVersion = Convert.ToInt32(version.Substring(2, 1));
             }


### PR DESCRIPTION
Throw NoSuitableGraphicsDeviceException when GL.GetString(StringName.Version) returns null.
Currently throws a NullReferenceException.

This may happen in case of drivers problems.