### PR TITLE
Add PlatformDispose partial methods to States

### DIFF
--- a/MonoGame.Framework/Graphics/States/DepthStencilState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.DirectX.cs
@@ -102,11 +102,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        protected override void Dispose(bool disposing)
+        partial void PlatformDispose()
         {
-            if (disposing)
-                SharpDX.Utilities.Dispose(ref _state);
-            base.Dispose(disposing);
+            SharpDX.Utilities.Dispose(ref _state);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -269,6 +269,17 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             return new DepthStencilState(this);
         }
-	}
+
+        partial void PlatformDispose();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+            {
+                PlatformDispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
 }
 

--- a/MonoGame.Framework/Graphics/States/RasterizerState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.DirectX.cs
@@ -92,11 +92,9 @@ namespace Microsoft.Xna.Framework.Graphics
             device._d3dContext.Rasterizer.State = _state;
         }
 
-        protected override void Dispose(bool disposing)
+        partial void PlatformDispose()
         {
-            if (disposing)
-                SharpDX.Utilities.Dispose(ref _state);
-            base.Dispose(disposing);
+            SharpDX.Utilities.Dispose(ref _state);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/States/RasterizerState.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.cs
@@ -151,5 +151,16 @@ namespace Microsoft.Xna.Framework.Graphics
 	    {
 	        return new RasterizerState(this);
 	    }
+
+        partial void PlatformDispose();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+            {
+                PlatformDispose();
+            }
+            base.Dispose(disposing);
+        }
     }
 }

--- a/MonoGame.Framework/Graphics/States/SamplerState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.DirectX.cs
@@ -154,11 +154,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        protected override void Dispose(bool disposing)
+        partial void PlatformDispose()
         {
-            if (disposing)
-                SharpDX.Utilities.Dispose(ref _state);
-            base.Dispose(disposing);
+            SharpDX.Utilities.Dispose(ref _state);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -202,5 +202,16 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             return new SamplerState(this);
         }
+
+        partial void PlatformDispose();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+            {
+                PlatformDispose();
+            }
+            base.Dispose(disposing);
+        }
     }
 }


### PR DESCRIPTION
Added a partial PlatformDispose method to DepthStencilState, RasterizerState and SamplerState to make them consistent with the recent changes to BlendState.