### PR TITLE
Fix PvrtcRgb2BitmapContent.TryGetFormat()

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcRgb2BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcRgb2BitmapContent.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         /// <returns>The GPU texture format of the bitmap type.</returns>
         public override bool TryGetFormat(out SurfaceFormat format)
         {
-            format = SurfaceFormat.RgbPvrtc4Bpp;
+            format = SurfaceFormat.RgbPvrtc2Bpp;
             return true;
         }
 


### PR DESCRIPTION
TryGetFormat was returning the incorrect SurfaceFormat value.