### PR TITLE
Fix enum that doesn't exist in OpenGL ES 2.0

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -663,9 +663,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)wrap);
                 GraphicsExtensions.CheckGLError();
                 // Set mipmap levels
-#if GLES
-                GL.TexParameter(TextureTarget.Texture2D, (TextureParameterName)0x813C, 0);
-#else
+#if !GLES
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
 #endif
                 GraphicsExtensions.CheckGLError();


### PR DESCRIPTION
GL_TEXTURE_BASE_LEVEL is not defined for OpenGL ES 2.0, so don't try to use it. A value of zero is assumed to be the default.

Fixes #5773