### PR TITLE
Updating the Windows DX NuGet package

### DIFF
--- a/NuGetPackages/MonoGame.Framework.WindowsDX.nuspec
+++ b/NuGetPackages/MonoGame.Framework.WindowsDX.nuspec
@@ -18,14 +18,14 @@ This package provides you with MonoGame Framework that uses DirectX for renderin
     <language>en-US</language>
     <dependencies>
         <group targetFramework=".NETFramework4.5">
-            <dependency id="SharpDX" version="3.0.0" />
-            <dependency id="SharpDX.Direct2D1" version="3.0.0" />
-            <dependency id="SharpDX.Direct3D11" version="3.0.0" />
-            <dependency id="SharpDX.DXGI" version="3.0.0" />
-            <dependency id="SharpDX.XAudio2" version="3.0.0" />
-            <dependency id="SharpDX.MediaFoundation" version="3.0.0" />
-            <dependency id="SharpDX.XInput" version="3.0.0" />
-            <dependency id="SharpDX.Direct3D9" version="3.0.0" />
+            <dependency id="SharpDX" version="2.6.3" />
+            <dependency id="SharpDX.Direct2D1" version="2.6.3" />
+            <dependency id="SharpDX.Direct3D11" version="2.6.3" />
+            <dependency id="SharpDX.DXGI" version="2.6.3" />
+            <dependency id="SharpDX.XAudio2" version="2.6.3" />
+            <dependency id="SharpDX.MediaFoundation" version="2.6.3" />
+            <dependency id="SharpDX.XInput" version="2.6.3" />
+            <dependency id="SharpDX.Direct3D9" version="2.6.3" />
         </group>
     </dependencies>
   </metadata>

--- a/NuGetPackages/build/WindowsDX/MonoGame.Framework.WindowsDX.targets
+++ b/NuGetPackages/build/WindowsDX/MonoGame.Framework.WindowsDX.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MonoGamePlatform>WindowsDX</MonoGamePlatform>
+    <MonoGamePlatform>Windows</MonoGamePlatform>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixed the TargetPlatform Identifier in the .targets file (WindowsDX -> Windows)

Downgraded the SharpDX reference from 3.0.0 -> 2.6.3 due to concerns with 3 on this platform (#5726)

Resolves #5775