### PR TITLE
Remove all MonoMac supporting code

### DIFF
--- a/MonoGame.Framework/Audio/DynamicSoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/DynamicSoundEffectInstance.OpenAL.cs
@@ -4,10 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.OpenAL;
-#endif
-#if MONOMAC && !PLATFORM_MACOS_LEGACY
+#if MONOMAC
 using OpenTK.Audio.OpenAL;
 #endif
 #if GLES

--- a/MonoGame.Framework/Audio/Microphone.OpenAL.cs
+++ b/MonoGame.Framework/Audio/Microphone.OpenAL.cs
@@ -6,11 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.AudioToolbox;
-using MonoMac.AudioUnit;
-using MonoMac.OpenAL;
-#elif OPENAL
+#if OPENAL
 #if GLES || MONOMAC
 using OpenTK.Audio;
 using OpenTK.Audio.OpenAL;

--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -4,10 +4,7 @@
 
 using System;
 
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.OpenAL;
-#endif
-#if MONOMAC && !PLATFORM_MACOS_LEGACY
+#if MONOMAC
 using OpenTK.Audio.OpenAL;
 #endif
 

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -5,10 +5,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using MonoGame.Utilities;
 
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.OpenAL;
-#endif
-#if MONOMAC && !PLATFORM_MACOS_LEGACY
+#if MONOMAC
 using OpenTK.Audio.OpenAL;
 using OpenTK.Audio;
 #endif

--- a/MonoGame.Framework/Audio/OpenALSupport.cs
+++ b/MonoGame.Framework/Audio/OpenALSupport.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-#if IOS || (MONOMAC && !PLATFORM_MACOS_LEGACY)
+#if IOS || MONOMAC
 #if IOS
 using UIKit;
 #else
@@ -13,16 +13,6 @@ using AudioToolbox;
 using AudioUnit;
 
 using OpenTK.Audio.OpenAL;
-
-#elif MONOMAC
-
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreFoundation;
-using MonoMac.AudioToolbox;
-using MonoMac.AudioUnit;
-
-using MonoMac.OpenAL;
 #endif
 
 namespace Microsoft.Xna.Framework.Audio

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -5,11 +5,7 @@
 using System;
 using System.IO;
 
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.AudioToolbox;
-using MonoMac.AudioUnit;
-using MonoMac.OpenAL;
-#elif OPENAL
+#if OPENAL
 #if GLES || MONOMAC
 using OpenTK.Audio.OpenAL;
 #else 

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -4,10 +4,7 @@
 
 using System;
 
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.OpenAL;
-#endif
-#if MONOMAC && !PLATFORM_MACOS_LEGACY
+#if MONOMAC
 using OpenTK.Audio.OpenAL;
 #endif
 #if GLES

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
@@ -7,13 +7,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-#else
 using AppKit;
 using Foundation;
-#endif
 #elif IOS
 using UIKit;
 #elif ANDROID

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.OpenGL.cs
@@ -4,15 +4,9 @@
 
 #if OPENGL
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-using GetParamName = MonoMac.OpenGL.All;
-using GetPName = MonoMac.OpenGL.GetPName;
-#else
 using OpenTK.Graphics.OpenGL;
 using GetParamName = OpenTK.Graphics.OpenGL.All;
 using GetPName = OpenTK.Graphics.OpenGL.GetPName;
-#endif
 #elif GLES
 using OpenTK.Graphics.ES20;
 using GetParamName = OpenTK.Graphics.ES20.All;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
@@ -10,13 +10,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac;
-using MonoMac.OpenGL;
-#else
 using ObjCRuntime;
 using OpenTK.Graphics.OpenGL;
-#endif
 #endif
 
 #if (WINDOWS || DESKTOPGL) && !GLES

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -8,13 +8,8 @@ using System.Runtime.InteropServices;
 using System.Diagnostics;
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-using GLPrimitiveType = MonoMac.OpenGL.BeginMode;
-#else
 using OpenTK.Graphics.OpenGL;
 using GLPrimitiveType = OpenTK.Graphics.OpenGL.BeginMode;
-#endif
 #endif
 
 #if DESKTOPGL

--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -7,15 +7,9 @@ using System.Diagnostics;
 
 #if OPENGL
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-using GLPixelFormat = MonoMac.OpenGL.All;
-using PixelFormat = MonoMac.OpenGL.PixelFormat;
-#else
 using OpenTK.Graphics.OpenGL;
 using GLPixelFormat = OpenTK.Graphics.OpenGL.All;
 using PixelFormat = OpenTK.Graphics.OpenGL.PixelFormat;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 using GLPixelFormat = OpenGL.PixelFormat;

--- a/MonoGame.Framework/Graphics/IRenderTarget.cs
+++ b/MonoGame.Framework/Graphics/IRenderTarget.cs
@@ -41,10 +41,7 @@ using SharpDX.Direct3D11;
 #endif
 
 #if OPENGL
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#endif
-#if (MONOMAC && !PLATFORM_MACOS_LEGACY)
+#if MONOMAC
 using OpenTK.Graphics.OpenGL;
 #endif
 #if GLES

--- a/MonoGame.Framework/Graphics/OcclusionQuery.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OcclusionQuery.OpenGL.cs
@@ -4,11 +4,7 @@
 
 #if MONOMAC
 using System.Runtime.InteropServices;
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#else
 using OpenTK.Graphics.OpenGL;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 #elif GLES

--- a/MonoGame.Framework/Graphics/PresentationParameters.cs
+++ b/MonoGame.Framework/Graphics/PresentationParameters.cs
@@ -9,11 +9,7 @@ using Windows.UI.Xaml.Controls;
 #endif
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.AppKit;
-#else
 using AppKit;
-#endif
 #elif IOS
 using UIKit;
 using Microsoft.Xna.Framework.Input.Touch;

--- a/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
@@ -3,12 +3,8 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#else
 using OpenGL;
 using OpenTK.Graphics.OpenGL;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 using System;

--- a/MonoGame.Framework/Graphics/RenderTargetCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.OpenGL.cs
@@ -2,10 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#endif
-#if (MONOMAC && !PLATFORM_MACOS_LEGACY)
+#if MONOMAC
 using OpenTK.Graphics.OpenGL;
 #endif
 #if GLES

--- a/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
@@ -5,11 +5,7 @@
 // Author: Kenneth James Pouncey
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#else
 using OpenTK.Graphics.OpenGL;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 #elif GLES

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
@@ -5,11 +5,7 @@
 using System;
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#else
 using OpenTK.Graphics.OpenGL;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 #elif GLES

--- a/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
@@ -6,13 +6,8 @@ using System;
 using System.IO;
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-using Bool = MonoMac.OpenGL.Boolean;
-#else
 using OpenTK.Graphics.OpenGL;
 using Bool = OpenTK.Graphics.OpenGL.Boolean;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 #elif GLES

--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -4,15 +4,9 @@ using System;
 using System.Collections.Generic;
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-using GetProgramParameterName = MonoMac.OpenGL.ProgramParameter;
-using Bool = MonoMac.OpenGL.Boolean;
-#else
 using OpenTK.Graphics.OpenGL;
 using GetProgramParameterName = OpenTK.Graphics.OpenGL.ProgramParameter;
 using Bool = OpenTK.Graphics.OpenGL.Boolean;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 #elif WINRT

--- a/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
@@ -3,11 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#else
 using OpenTK.Graphics.OpenGL;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 #elif GLES

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
@@ -3,13 +3,8 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-using GLStencilFunction = MonoMac.OpenGL.StencilFunction;
-#else
 using OpenTK.Graphics.OpenGL;
 using GLStencilFunction = OpenTK.Graphics.OpenGL.StencilFunction;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 #elif GLES

--- a/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
@@ -5,11 +5,7 @@
 using System;
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#else
 using OpenTK.Graphics.OpenGL;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 #elif GLES

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -6,11 +6,7 @@ using System;
 using System.Diagnostics;
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#else
 using OpenTK.Graphics.OpenGL;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 #elif GLES

--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -2,10 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#endif
-#if (MONOMAC && !PLATFORM_MACOS_LEGACY)
+#if MONOMAC
 using OpenTK.Graphics.OpenGL;
 #endif
 #if DESKTOPGL

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -10,15 +10,9 @@ using MonoGame.Utilities;
 using MonoGame.Utilities.Png;
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.AppKit;
-using MonoMac.CoreGraphics;
-using MonoMac.Foundation;
-#else
 using AppKit;
 using CoreGraphics;
 using Foundation;
-#endif
 #endif
 
 #if IOS
@@ -29,16 +23,10 @@ using Foundation;
 
 #if OPENGL
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-using GLPixelFormat = MonoMac.OpenGL.All;
-using PixelFormat = MonoMac.OpenGL.PixelFormat;
-#else
 using OpenTK.Graphics.OpenGL;
 using GLPixelFormat = OpenTK.Graphics.OpenGL.All;
 using PixelFormat = OpenTK.Graphics.OpenGL.PixelFormat;
 using PixelInternalFormat = OpenTK.Graphics.OpenGL.PixelFormat;
-#endif
 #endif
 
 #if DESKTOPGL
@@ -59,7 +47,7 @@ using Android.Graphics;
 #endif
 #endif // OPENGL
 
-#if MONOMAC || PLATFORM_MACOS_LEGACY || IOS
+#if MONOMAC || IOS
 using System.Drawing;
 #endif
 
@@ -296,11 +284,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #if IOS
 				var cgImage = uiImage.CGImage;
 #elif MONOMAC
-#if PLATFORM_MACOS_LEGACY
-				var rectangle = RectangleF.Empty;
-#else
                 var rectangle = CGRect.Empty;
-#endif
                 var cgImage = nsImage.AsCGImage (ref rectangle, null, null);
 #endif
 
@@ -389,11 +373,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #if MONOMAC
         public static Texture2D FromStream(GraphicsDevice graphicsDevice, NSImage nsImage)
         {
-#if PLATFORM_MACOS_LEGACY
-            var rectangle = RectangleF.Empty;
-#else
             var rectangle = CGRect.Empty;
-#endif
 		    var cgImage = nsImage.AsCGImage (ref rectangle, null, null);
             return PlatformFromStream(graphicsDevice, cgImage);
         }
@@ -409,7 +389,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             var colorSpace = CGColorSpace.CreateDeviceRGB();
             var bitmapContext = new CGBitmapContext(data, width, height, 8, width * 4, colorSpace, CGBitmapFlags.PremultipliedLast);
-#if PLATFORM_MACOS_LEGACY || IOS
+#if IOS
             bitmapContext.DrawImage(new RectangleF(0, 0, width, height), cgImage);
 #else
             bitmapContext.DrawImage(new CGRect(0, 0, width, height), cgImage);

--- a/MonoGame.Framework/Graphics/Texture3D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.OpenGL.cs
@@ -7,11 +7,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#else
 using OpenTK.Graphics.OpenGL;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 #endif

--- a/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
@@ -3,11 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#else
 using OpenTK.Graphics.OpenGL;
-#endif
 #elif DESKTOPGL
 using OpenGL;
 #elif GLES

--- a/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
@@ -5,12 +5,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework.Utilities;
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-using GLPixelFormat = MonoMac.OpenGL.All;
-using Bool = MonoMac.OpenGL.Boolean;
-#endif
-#if (MONOMAC && !PLATFORM_MACOS_LEGACY)
+#if MONOMAC
 using OpenTK.Graphics.OpenGL;
 using GLPixelFormat = OpenTK.Graphics.OpenGL.All;
 using PixelInternalFormat = OpenTK.Graphics.OpenGL.PixelFormat;

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -8,10 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
 
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#endif
-#if MONOMAC && !PLATFORM_MACOS_LEGACY
+#if MONOMAC
 using OpenTK.Graphics.OpenGL;
 #endif
 #if GLES

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -8,10 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework.Utilities;
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#endif
-#if MONOMAC && !PLATFORM_MACOS_LEGACY
+#if MONOMAC
 using OpenTK.Graphics.OpenGL;
 #endif
 #if DESKTOPGL

--- a/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
@@ -5,10 +5,7 @@
 using System;
 using System.Collections.Generic;
 
-#if MONOMAC && PLATFORM_MACOS_LEGACY
-using MonoMac.OpenGL;
-#endif
-#if (MONOMAC && !PLATFORM_MACOS_LEGACY)
+#if MONOMAC
 using OpenTK.Graphics.OpenGL;
 #endif
 #if DESKTOPGL

--- a/MonoGame.Framework/Input/Mouse.MacOS.cs
+++ b/MonoGame.Framework/Input/Mouse.MacOS.cs
@@ -6,32 +6,19 @@ using System;
 using System.Runtime.InteropServices;
 using System.Drawing;
 
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.Foundation;
-using MonoMac.AppKit;
-#else
 using Foundation;
 using AppKit;
 using PointF = CoreGraphics.CGPoint;
-#endif
 
 namespace Microsoft.Xna.Framework.Input
 {
     public static partial class Mouse
     {
-#if PLATFORM_MACOS_LEGACY
-        [DllImport (MonoMac.Constants.CoreGraphicsLibrary)]
-        extern static void CGWarpMouseCursorPosition(PointF newCursorPosition);
-        
-        [DllImport (MonoMac.Constants.CoreGraphicsLibrary)]
-        extern static void CGSetLocalEventsSuppressionInterval(double seconds);
-#else
         [DllImport(ObjCRuntime.Constants.CoreGraphicsLibrary)]
         extern static void CGWarpMouseCursorPosition(CoreGraphics.CGPoint newCursorPosition);
 
         [DllImport(ObjCRuntime.Constants.CoreGraphicsLibrary)]
         extern static void CGSetLocalEventsSuppressionInterval(double seconds);
-#endif
 
         internal static GameWindow Window;
         internal static float ScrollWheelValue;

--- a/MonoGame.Framework/MacOS/GameWindow.cs
+++ b/MonoGame.Framework/MacOS/GameWindow.cs
@@ -45,15 +45,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.CoreAnimation;
-using MonoMac.Foundation;
-using MonoMac.ObjCRuntime;
-using MonoMac.OpenGL;
-using MonoMac.AppKit;
-using NSViewResizingMaskClass = MonoMac.AppKit.NSViewResizingMask;
-using RectF = System.Drawing.RectangleF;
-#else
 using CoreAnimation;
 using Foundation;
 using ObjCRuntime;
@@ -65,7 +56,6 @@ using NSViewResizingMaskClass = AppKit.NSViewResizingMask;
 using RectF = CoreGraphics.CGRect;
 using PointF = CoreGraphics.CGPoint;
 using SizeF = CoreGraphics.CGSize;
-#endif
 
 using Microsoft.Xna.Framework.Input;
 using Microsoft.Xna.Framework.Input.Touch;

--- a/MonoGame.Framework/MacOS/GamerServices/MonoGameGamerServicesHelper.cs
+++ b/MonoGame.Framework/MacOS/GamerServices/MonoGameGamerServicesHelper.cs
@@ -4,16 +4,10 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Drawing;
 
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.Foundation;
-using MonoMac.AppKit;
-using RectF = System.Drawing.RectangleF;
-#else
 using Foundation;
 using AppKit;
 using RectF = CoreGraphics.CGRect;
 using PointF = CoreGraphics.CGPoint;
-#endif
 
 namespace Microsoft.Xna.Framework.GamerServices
 {

--- a/MonoGame.Framework/MacOS/GamerServices/SignedInGamer.cs
+++ b/MonoGame.Framework/MacOS/GamerServices/SignedInGamer.cs
@@ -41,13 +41,8 @@ purpose and non-infringement.
 #region Statement
 ﻿using System;
 
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.Foundation;
-using MonoMac.AppKit;
-#else
 using Foundation;
 using AppKit;
-#endif
 
 #endregion Statement
 

--- a/MonoGame.Framework/MacOS/GamerServices/SigninController.cs
+++ b/MonoGame.Framework/MacOS/GamerServices/SigninController.cs
@@ -4,19 +4,12 @@ using System.Linq;
 
 using System.Drawing;
 
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.Foundation;
-using MonoMac.AppKit;
-using MonoMac.ObjCRuntime;
-using RectF = System.Drawing.RectangleF;
-#else
 using Foundation;
 using AppKit;
 using ObjCRuntime;
 using RectF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
 using PointF = CoreGraphics.CGPoint;
-#endif
 
 namespace Microsoft.Xna.Framework.GamerServices
 {
@@ -201,7 +194,6 @@ namespace Microsoft.Xna.Framework.GamerServices
 			this.controller = controller;
 		}
 		
-        #if MONOMAC && !PLATFORM_MACOS_LEGACY
 		public override nint GetRowCount (NSTableView tableView)
 		{
 			return controller.gamerList.Count;
@@ -221,27 +213,6 @@ namespace Microsoft.Xna.Framework.GamerServices
                 controller.gamerList[(int)row].DisplayName = theObject.ToString();
             }
         }
-        #else
-        public override int GetRowCount (NSTableView tableView)
-        {
-            return controller.gamerList.Count;
-        }
-
-        public override NSObject GetObjectValue (NSTableView tableView, NSTableColumn tableColumn, int row)
-        {
-            return new NSString(controller.gamerList[row].Gamertag);
-        }
-
-        public override void SetObjectValue (NSTableView tableView, NSObject theObject, NSTableColumn tableColumn, int row)
-        {
-            var proposedValue = theObject.ToString();
-            if (proposedValue.Trim().Length > 0)
-            {
-                controller.gamerList[row].Gamertag = theObject.ToString();
-                controller.gamerList[row].DisplayName = theObject.ToString();
-            }
-        }
-        #endif
 	}
 	
 	[CLSCompliant(false)]
@@ -254,11 +225,7 @@ namespace Microsoft.Xna.Framework.GamerServices
 			this.controller = controller;
 		}
 
-#if MONOMAC && !PLATFORM_MACOS_LEGACY
 		public override bool ShouldSelectRow (NSTableView tableView, nint row)
-#else
-        public override bool ShouldSelectRow (NSTableView tableView, int row)
-#endif
 		{
             var profile = controller.gamerList[(int)row];
 			foreach (var gamer in Gamer.SignedInGamers) {

--- a/MonoGame.Framework/MacOS/KeyUtil.cs
+++ b/MonoGame.Framework/MacOS/KeyUtil.cs
@@ -30,11 +30,7 @@
 using System;
 using System.Linq;
 using System.Collections;
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.AppKit;
-#else
 using AppKit;
-#endif
 
 using Microsoft.Xna.Framework.Input;
 
@@ -88,23 +84,13 @@ namespace Microsoft.Xna.Framework
 			keyNames.Add (NSKey.LeftBracket, Keys.OemOpenBrackets);
 			keyNames.Add (NSKey.Minus, Keys.OemMinus);
 			keyNames.Add (NSKey.Mute, Keys.VolumeMute);
-#if PLATFORM_MACOS_LEGACY
-            keyNames.Add (NSKey.Next, Keys.MediaNextTrack);
-#endif
 			keyNames.Add (NSKey.Option, Keys.LeftAlt);
-#if PLATFORM_MACOS_LEGACY
-			keyNames.Add (NSKey.Pause, Keys.MediaPlayPause);
-			keyNames.Add (NSKey.Prev, Keys.MediaPreviousTrack);
-#endif
 			keyNames.Add (NSKey.Quote, Keys.OemQuotes);
 			keyNames.Add (NSKey.RightArrow, Keys.Right);
 			keyNames.Add (NSKey.RightBracket, Keys.OemCloseBrackets);
 			keyNames.Add (NSKey.RightControl, Keys.RightControl);
 			keyNames.Add (NSKey.RightOption, Keys.RightAlt);
 			keyNames.Add (NSKey.RightShift, Keys.RightShift);
-#if PLATFORM_MACOS_LEGACY
-			keyNames.Add (NSKey.ScrollLock, Keys.Scroll);
-#endif
 			keyNames.Add (NSKey.Semicolon, Keys.OemSemicolon);
 			keyNames.Add (NSKey.Slash, Keys.OemQuestion);
 			keyNames.Add (NSKey.UpArrow, Keys.Up);

--- a/MonoGame.Framework/MacOS/MacGameNSWindow.cs
+++ b/MonoGame.Framework/MacOS/MacGameNSWindow.cs
@@ -40,15 +40,9 @@ purpose and non-infringement.
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using RectF = System.Drawing.RectangleF;
-#else
 using AppKit;
 using Foundation;
 using RectF = CoreGraphics.CGRect;
-#endif
 
 /// <summary>
 /// Mac game window.

--- a/MonoGame.Framework/MacOS/MacGamePlatform+Synchronous.cs
+++ b/MonoGame.Framework/MacOS/MacGamePlatform+Synchronous.cs
@@ -69,15 +69,9 @@ non-infringement.
 using System;
 using System.Runtime.InteropServices;
 
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using PointF = System.Drawing.PointF;
-#else
 using AppKit;
 using Foundation;
 using PointF = CoreGraphics.CGPoint;
-#endif
 
 namespace Microsoft.Xna.Framework {
 	partial class MacGamePlatform {

--- a/MonoGame.Framework/MacOS/MacGamePlatform.cs
+++ b/MonoGame.Framework/MacOS/MacGamePlatform.cs
@@ -70,17 +70,10 @@ using System;
 using System.Drawing;
 using System.IO;
 
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using RectF = System.Drawing.RectangleF;
-using _float = System.Single;
-#else
 using AppKit;
 using Foundation;
 using RectF = CoreGraphics.CGRect;
 using _float = System.nfloat;
-#endif
 
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
@@ -519,11 +512,7 @@ namespace Microsoft.Xna.Framework
                     _owner.State = MacGamePlatform.RunState.Exited);
             }
 
-            #if PLATFORM_MACOS_LEGACY
-            public override bool ShouldZoom (NSWindow window, RectangleF newFrame)
-            #else
             public override bool ShouldZoom(NSWindow window, CoreGraphics.CGRect newFrame)
-            #endif
 			{
 				return _owner.AllowUserResizing;
 			}

--- a/MonoGame.Framework/Media/Video.MacOS.cs
+++ b/MonoGame.Framework/Media/Video.MacOS.cs
@@ -5,15 +5,9 @@
 using System;
 using System.IO;
 
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.ObjCRuntime;
-using MonoMac.QTKit;
-using MonoMac.Foundation;
-#else
 using ObjCRuntime;
 using QTKit;
 using Foundation;
-#endif
 
 namespace Microsoft.Xna.Framework.Media
 {

--- a/MonoGame.Framework/Media/VideoPlayer.MacOS.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.MacOS.cs
@@ -3,15 +3,9 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.Foundation;
-using MonoMac.QTKit;
-using RectF = System.Drawing.RectangleF;
-#else
 using Foundation;
 using QTKit;
 using RectF = CoreGraphics.CGRect;
-#endif
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Media

--- a/MonoGame.Framework/Threading.cs
+++ b/MonoGame.Framework/Threading.cs
@@ -154,11 +154,7 @@ namespace Microsoft.Xna.Framework
 #else
             ManualResetEventSlim resetEvent = new ManualResetEventSlim(false);
 #if MONOMAC
-#if PLATFORM_MACOS_LEGACY
-            MonoMac.AppKit.NSApplication.SharedApplication.BeginInvokeOnMainThread(() =>
-#else
             AppKit.NSApplication.SharedApplication.BeginInvokeOnMainThread(() =>
-#endif
 #else
             Add(() =>
 #endif

--- a/MonoGame.Framework/TitleContainer.MacOS.cs
+++ b/MonoGame.Framework/TitleContainer.MacOS.cs
@@ -8,11 +8,7 @@ using System.IO;
 using Foundation;
 using UIKit;
 #elif MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.Foundation;
-#else
 using Foundation;
-#endif
 #endif
 
 namespace Microsoft.Xna.Framework

--- a/Test/Runner/MacOS/Program.cs
+++ b/Test/Runner/MacOS/Program.cs
@@ -68,13 +68,8 @@ non-infringement
 
 using System;
 
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.Foundation;
-using MonoMac.AppKit;
-#else
 using Foundation;
 using AppKit;
-#endif
 
 namespace MonoGame.Tests {
 	static class Program {


### PR DESCRIPTION
This removes all PLATFORM_MACOS_LEGACY code branches in preparation for the removal of MonoMac support.

See #4693 and https://github.com/Protobuild/Protobuild/issues/164.  I intend to move forward with removing MonoMac and the legacy XamMac support in Protobuild very soon.