### PR TITLE
Add GraphicsDebug class for retrieving DirectX debug messages

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -622,6 +622,14 @@
     <Compile Include="Graphics\GraphicsContext.SDL.cs">
       <Platforms>WindowsGL,Linux</Platforms>
     </Compile>
+    <Compile Include="Graphics\GraphicsDebug.cs" />
+    <Compile Include="Graphics\GraphicsDebug.DirectX.cs">
+      <Services>DirectXGraphics</Services>
+    </Compile>
+    <Compile Include="Graphics\GraphicsDebug.Default.cs">
+      <Services>OpenGLGraphics,WebGraphics,ANGLEGraphics</Services>
+    </Compile>
+    <Compile Include="Graphics\GraphicsDebugMessage.cs" />
     <Compile Include="Graphics\GraphicsDevice.cs" />
     <Compile Include="Graphics\GraphicsDevice.DirectX.cs">
       <Services>DirectXGraphics</Services>

--- a/MonoGame.Framework/Graphics/GraphicsDebug.Default.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.Default.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Xna.Framework.Graphics
+{
+    public partial class GraphicsDebug
+    {
+        private bool PlatformTryDequeueMessage(out GraphicsDebugMessage message)
+        {
+            message = null;
+            return false;
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/GraphicsDebug.Default.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.Default.cs
@@ -1,4 +1,8 @@
-﻿namespace Microsoft.Xna.Framework.Graphics
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class GraphicsDebug
     {

--- a/MonoGame.Framework/Graphics/GraphicsDebug.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.DirectX.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private readonly GraphicsDevice _device;
         private readonly InfoQueue _infoQueue;
         private readonly Queue<GraphicsDebugMessage> _cachedMessages;
+        private bool _hasPushedFilters = false;
 
         public GraphicsDebug(GraphicsDevice device)
         {
@@ -15,8 +16,12 @@ namespace Microsoft.Xna.Framework.Graphics
             _infoQueue = _device._d3dDevice.QueryInterfaceOrNull<InfoQueue>();
             _cachedMessages = new Queue<GraphicsDebugMessage>();
 
-            _infoQueue.PushEmptyRetrievalFilter();
-            _infoQueue.PushEmptyStorageFilter();
+            if (_infoQueue != null)
+            {
+                _infoQueue.PushEmptyRetrievalFilter();
+                _infoQueue.PushEmptyStorageFilter();
+                _hasPushedFilters = true;
+            }
         }
 
         private bool PlatformTryDequeueMessage(out GraphicsDebugMessage message)
@@ -25,6 +30,13 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 message = null;
                 return false;
+            }
+
+            if (!_hasPushedFilters)
+            {
+                _infoQueue.PushEmptyRetrievalFilter();
+                _infoQueue.PushEmptyStorageFilter();
+                _hasPushedFilters = true;
             }
 
             if (_cachedMessages.Count > 0)

--- a/MonoGame.Framework/Graphics/GraphicsDebug.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.DirectX.cs
@@ -1,0 +1,66 @@
+﻿using SharpDX.Direct3D11;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public partial class GraphicsDebug
+    {
+        private readonly GraphicsDevice _device;
+        private readonly InfoQueue _infoQueue;
+        private readonly Queue<GraphicsDebugMessage> _cachedMessages;
+
+        public GraphicsDebug(GraphicsDevice device)
+        {
+            _device = device;
+            _infoQueue = _device._d3dDevice.QueryInterfaceOrNull<InfoQueue>();
+            _cachedMessages = new Queue<GraphicsDebugMessage>();
+
+            _infoQueue.PushEmptyRetrievalFilter();
+            _infoQueue.PushEmptyStorageFilter();
+        }
+
+        private bool PlatformTryDequeueMessage(out GraphicsDebugMessage message)
+        {
+            if (_infoQueue == null)
+            {
+                message = null;
+                return false;
+            }
+
+            if (_cachedMessages.Count > 0)
+            {
+                message = _cachedMessages.Dequeue();
+                return true;
+            }
+
+            if (_infoQueue.NumStoredMessagesAllowedByRetrievalFilter > 0)
+            {
+                // Grab all current messages and put them in the cached messages queue.
+                for (var i = 0; i < _infoQueue.NumStoredMessagesAllowedByRetrievalFilter; i++)
+                {
+                    var dxMessage = _infoQueue.GetMessage(i);
+                    _cachedMessages.Enqueue(new GraphicsDebugMessage
+                    {
+                        Message = dxMessage.Description,
+                        Id = (int)dxMessage.Id,
+                        IdName = dxMessage.Id.ToString(),
+                        Severity = dxMessage.Severity.ToString(),
+                        Category = dxMessage.Category.ToString()
+                    });
+                }
+
+                _infoQueue.ClearStoredMessages();
+            }
+            
+            if (_cachedMessages.Count > 0)
+            {
+                message = _cachedMessages.Dequeue();
+                return true;
+            }
+            
+            // No messages to grab from DirectX.
+            message = null;
+            return false;
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/GraphicsDebug.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.DirectX.cs
@@ -1,4 +1,8 @@
-﻿using SharpDX.Direct3D11;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using SharpDX.Direct3D11;
 using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/GraphicsDebug.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.cs
@@ -1,0 +1,20 @@
+﻿namespace Microsoft.Xna.Framework.Graphics
+{
+    public partial class GraphicsDebug
+    {
+        /// <summary>
+        /// Attempt to dequeue a debugging message from the graphics subsystem.
+        /// </summary>
+        /// <remarks>
+        /// When running on a graphics device with debugging enabled, this allows you to retrieve
+        /// subsystem-specific (e.g. DirectX, OpenGL, etc.) debugging messages including information
+        /// about improper usage of shaders and APIs.
+        /// </remarks>
+        /// <param name="message">The graphics debugging message if retrieved, null otherwise.</param>
+        /// <returns>True if a graphics debugging message was retrieved, false otherwise.</returns>
+        public bool TryDequeueMessage(out GraphicsDebugMessage message)
+        {
+            return PlatformTryDequeueMessage(out message);
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/GraphicsDebug.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.cs
@@ -1,4 +1,8 @@
-﻿namespace Microsoft.Xna.Framework.Graphics
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class GraphicsDebug
     {

--- a/MonoGame.Framework/Graphics/GraphicsDebugMessage.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebugMessage.cs
@@ -1,0 +1,15 @@
+﻿namespace Microsoft.Xna.Framework.Graphics
+{
+    public class GraphicsDebugMessage
+    {
+        public string Message { get; set; }
+
+        public string Severity { get; set; }
+
+        public int Id { get; set; }
+
+        public string IdName { get; set; }
+
+        public string Category { get; set; }
+    }
+}

--- a/MonoGame.Framework/Graphics/GraphicsDebugMessage.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebugMessage.cs
@@ -1,4 +1,8 @@
-﻿namespace Microsoft.Xna.Framework.Graphics
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Graphics
 {
     public class GraphicsDebugMessage
     {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -671,6 +671,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Get Direct3D 11.1 context
             _d3dContext = _d3dDevice.ImmediateContext.QueryInterface<SharpDX.Direct3D11.DeviceContext>();
+            
+            // Create a new instance of GraphicsDebug because we support it on Windows platforms.
+            _graphicsDebug = new GraphicsDebug(this);
         }
 
         internal void SetHardwareFullscreen()

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -176,6 +176,13 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         public GraphicsMetrics Metrics { get { return _graphicsMetrics; } set { _graphicsMetrics = value; } }
 
+        private GraphicsDebug _graphicsDebug;
+
+        /// <summary>
+        /// Access debugging APIs for the graphics subsystem.
+        /// </summary>
+        public GraphicsDebug GraphicsDebug { get { return _graphicsDebug; } set { _graphicsDebug = value; } }
+
         internal GraphicsDevice(GraphicsDeviceInformation gdi)
             : this(gdi.Adapter, gdi.GraphicsProfile, gdi.PresentationParameters)
         {


### PR DESCRIPTION
This adds an initial GraphicsDebug class, which is surfaced as a `GraphicsDebug` property on the GraphicsDevice.  For debug builds, it allows developers to retrieve DirectX debugging messages directly in their game.

For a very long time now, Protobuild has by default generated projects with "Enable unmanaged code debugging" turned on, so that when you run and debug MonoGame games in Visual Studio, you can see the DirectX log messages in the Visual Studio output window.  These messages are essential to determining things like why a shader doesn't work, and for knowing when you're passing invalid parameters to APIs. 

However, this is a trade-off: when you enable unmanaged code debugging, Edit and Continue no longer works, which is a very useful part of the Visual Studio debugging experience. If you turn off unmanaged code debugging, you can't see the DirectX error messages.

By surfacing this API, we can turn unmanaged code debugging off by default in Protobuild, and developers can retrieve the DirectX messages directly in their game.  This allows Edit and Continue to work, while still being able to see critical DirectX warnings and errors about API usage.

This API only works in debug builds (because only in debug builds does MonoGame create a DirectX device with debug layers), and only works on DirectX 11 and higher (and I believe Windows 8 and later).

In future, I want to add APIs to this call that allow setting names on buffers and textures, so that these names (annotations as DirectX calls them) appear in graphics profiling and debugging tools.