### PR TITLE
Check if framebuffer is complete before calling GL.Clear under OpenGL

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -450,11 +450,15 @@ namespace Microsoft.Xna.Framework.Graphics
 				bufferMask = bufferMask | ClearBufferMask.DepthBufferBit;
 			}
 
+#if MONOMAC
             if (GL.CheckFramebufferStatus(FramebufferTarget.FramebufferExt) == FramebufferErrorCode.FramebufferComplete)
             {
+#endif
                 GL.Clear(bufferMask);
                 GraphicsExtensions.CheckGLError();
+#if MONOMAC
             }
+#endif
            		
             // Restore the previous render state.
 		    ScissorRectangle = prevScissorRect;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -450,9 +450,11 @@ namespace Microsoft.Xna.Framework.Graphics
 				bufferMask = bufferMask | ClearBufferMask.DepthBufferBit;
 			}
 
-
-			GL.Clear(bufferMask);
-            GraphicsExtensions.CheckGLError();
+            if (GL.CheckFramebufferStatus(FramebufferTarget.FramebufferExt) == FramebufferErrorCode.FramebufferComplete)
+            {
+                GL.Clear(bufferMask);
+                GraphicsExtensions.CheckGLError();
+            }
            		
             // Restore the previous render state.
 		    ScissorRectangle = prevScissorRect;


### PR DESCRIPTION
This fixes an issue where on macOS the GL.Clear called immediately after the GraphicsDevice is created throws a FrameBufferExt error, because the backbuffer isn't yet ready for writing.  Adding this check prevents GL.Clear from being called on an incomplete framebuffer.

I checked during game execution, and once the game is rendering this check passes and GL.Clear is called as expected.