### PR TITLE
Fix for android 7 nougat for black screen when split-screen is activated

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/Android/Activity1.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/Android/Activity1.cs
@@ -22,7 +22,8 @@ namespace ${Namespace}
 	           ConfigurationChanges = ConfigChanges.Orientation | 
 	                                  ConfigChanges.KeyboardHidden | 
 	                                  ConfigChanges.Keyboard |
-	                                  ConfigChanges.ScreenSize)]
+	                                  ConfigChanges.ScreenSize |
+                                      ConfigChanges.ScreenLayout)]
 	public class Activity1 : AndroidGameActivity
 	{
 		protected override void OnCreate (Bundle bundle)

--- a/ProjectTemplates/VisualStudio2010/Android/Activity1.cs
+++ b/ProjectTemplates/VisualStudio2010/Android/Activity1.cs
@@ -12,7 +12,7 @@ namespace $safeprojectname$
         , AlwaysRetainTaskState=true
         , LaunchMode=Android.Content.PM.LaunchMode.SingleInstance
         , ScreenOrientation = ScreenOrientation.FullUser
-        , ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden | ConfigChanges.ScreenSize)]
+        , ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.Keyboard | ConfigChanges.KeyboardHidden | ConfigChanges.ScreenSize | ConfigChanges.ScreenLayout)]
     public class Activity1 : Microsoft.Xna.Framework.AndroidGameActivity
     {
         protected override void OnCreate(Bundle bundle)


### PR DESCRIPTION
The new split-screen feature in Android 7 caused black screen when activated.

The reason for it was that monogame activity was restarted, so just adding the layoutChange orientation handler fixes this.