### PR TITLE
Support GraphicsDebug in OpenGL

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -628,8 +628,11 @@
     <Compile Include="Graphics\GraphicsDebug.DirectX.cs">
       <Services>DirectXGraphics</Services>
     </Compile>
+    <Compile Include="Graphics\GraphicsDebug.OpenGL.cs">
+      <Services>OpenGLGraphics</Services>
+    </Compile>
     <Compile Include="Graphics\GraphicsDebug.Default.cs">
-      <Services>OpenGLGraphics,WebGraphics,ANGLEGraphics</Services>
+      <Services>WebGraphics,ANGLEGraphics</Services>
     </Compile>
     <Compile Include="Graphics\GraphicsDebugMessage.cs" />
     <Compile Include="Graphics\GraphicsDevice.cs" />

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
@@ -174,6 +174,18 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </remarks>
         public static DriverType UseDriverType { get; set; }
 
+        /// <summary>
+        /// Used to request the graphics device should be created with debugging
+        /// features enabled.
+        /// </summary>
+        /// <remarks>
+        /// Debugging is enabled by default in Debug builds of MonoGame, while it
+        /// is disabled in Release builds. This option can only be used to enable
+        /// debugging in Release builds (i.e. setting it to false will not disable
+        /// debugging in Debug builds).
+        /// </remarks>
+        public static bool UseDebugLayers { get; set; }
+
         /*
 		public bool QueryRenderTargetFormat(
 			GraphicsProfile graphicsProfile,

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -78,6 +78,18 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </remarks>
         public static DriverType UseDriverType { get; set; }
 
+        /// <summary>
+        /// Used to request the graphics device should be created with debugging
+        /// features enabled.
+        /// </summary>
+        /// <remarks>
+        /// Debugging is enabled by default in Debug builds of MonoGame, while it
+        /// is disabled in Release builds. This option can only be used to enable
+        /// debugging in Release builds (i.e. setting it to false will not disable
+        /// debugging in Debug builds).
+        /// </remarks>
+        public static bool UseDebugLayers { get; set; }
+
         public string Description { get; private set; }
 
         public int DeviceId { get; private set; }

--- a/MonoGame.Framework/Graphics/GraphicsDebug.Default.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.Default.cs
@@ -6,10 +6,18 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class GraphicsDebug
     {
+        private void PlatformConstruct()
+        {
+        }
+
         private bool PlatformTryDequeueMessage(out GraphicsDebugMessage message)
         {
             message = null;
             return false;
+        }
+
+        private void PlatformDispose()
+        {
         }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDebug.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.DirectX.cs
@@ -3,20 +3,19 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using SharpDX.Direct3D11;
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class GraphicsDebug
     {
-        private readonly GraphicsDevice _device;
-        private readonly InfoQueue _infoQueue;
-        private readonly Queue<GraphicsDebugMessage> _cachedMessages;
+        private InfoQueue _infoQueue;
+        private Queue<GraphicsDebugMessage> _cachedMessages;
         private bool _hasPushedFilters = false;
 
-        public GraphicsDebug(GraphicsDevice device)
+        private void PlatformConstruct()
         {
-            _device = device;
             _infoQueue = _device._d3dDevice.QueryInterfaceOrNull<InfoQueue>();
             _cachedMessages = new Queue<GraphicsDebugMessage>();
 
@@ -77,6 +76,14 @@ namespace Microsoft.Xna.Framework.Graphics
             // No messages to grab from DirectX.
             message = null;
             return false;
+        }
+
+        private void PlatformDispose()
+        {
+            if (_infoQueue != null)
+            {
+                _infoQueue.Dispose();
+            }
         }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDebug.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.OpenGL.cs
@@ -1,0 +1,89 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using SharpDX.Direct3D11;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public partial class GraphicsDebug
+    {
+        private InfoQueue _infoQueue;
+        private Queue<GraphicsDebugMessage> _cachedMessages;
+        private bool _hasPushedFilters = false;
+
+        private void PlatformConstruct()
+        {
+            _infoQueue = _device._d3dDevice.QueryInterfaceOrNull<InfoQueue>();
+            _cachedMessages = new Queue<GraphicsDebugMessage>();
+
+            if (_infoQueue != null)
+            {
+                _infoQueue.PushEmptyRetrievalFilter();
+                _infoQueue.PushEmptyStorageFilter();
+                _hasPushedFilters = true;
+            }
+        }
+
+        private bool PlatformTryDequeueMessage(out GraphicsDebugMessage message)
+        {
+            if (_infoQueue == null)
+            {
+                message = null;
+                return false;
+            }
+
+            if (!_hasPushedFilters)
+            {
+                _infoQueue.PushEmptyRetrievalFilter();
+                _infoQueue.PushEmptyStorageFilter();
+                _hasPushedFilters = true;
+            }
+
+            if (_cachedMessages.Count > 0)
+            {
+                message = _cachedMessages.Dequeue();
+                return true;
+            }
+
+            if (_infoQueue.NumStoredMessagesAllowedByRetrievalFilter > 0)
+            {
+                // Grab all current messages and put them in the cached messages queue.
+                for (var i = 0; i < _infoQueue.NumStoredMessagesAllowedByRetrievalFilter; i++)
+                {
+                    var dxMessage = _infoQueue.GetMessage(i);
+                    _cachedMessages.Enqueue(new GraphicsDebugMessage
+                    {
+                        Message = dxMessage.Description,
+                        Id = (int)dxMessage.Id,
+                        IdName = dxMessage.Id.ToString(),
+                        Severity = dxMessage.Severity.ToString(),
+                        Category = dxMessage.Category.ToString()
+                    });
+                }
+
+                _infoQueue.ClearStoredMessages();
+            }
+            
+            if (_cachedMessages.Count > 0)
+            {
+                message = _cachedMessages.Dequeue();
+                return true;
+            }
+            
+            // No messages to grab from DirectX.
+            message = null;
+            return false;
+        }
+
+        private void PlatformDispose()
+        {
+            if (_infoQueue != null)
+            {
+                _infoQueue.Dispose();
+            }
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/GraphicsDebug.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.OpenGL.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
         }
 
+#if DESKTOPGL
         internal static void PlatformAppendMessage(int source, int type, uint id, int severity, int length, string errorMessage, IntPtr userParam)
         {
             _cachedMessages.Enqueue(new GraphicsDebugMessage
@@ -50,5 +51,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 UserdataPointer = userParam
             });
         }
+#endif
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDebug.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.cs
@@ -2,10 +2,35 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Graphics
 {
-    public partial class GraphicsDebug
+    public partial class GraphicsDebug : IDisposable
     {
+        private readonly GraphicsDevice _device;
+        private bool _isDisposed = false;
+
+        /// <summary>
+        /// Constructs a new instance of <see cref="GraphicsDebug"/>, which provides debugging APIs
+        /// for the underlying graphics hardware.
+        /// </summary>
+        /// <param name="device">The associated graphics device.</param>
+        public GraphicsDebug(GraphicsDevice device)
+        {
+            _device = device;
+
+            PlatformConstruct();
+        }
+
+        /// <summary>
+        /// Whether this instance has already had <see cref="Dispose()"/> called on it.
+        /// </summary>
+        public bool IsDisposed
+        {
+            get { return _isDisposed; }
+        }
+
         /// <summary>
         /// Attempt to dequeue a debugging message from the graphics subsystem.
         /// </summary>
@@ -19,6 +44,27 @@ namespace Microsoft.Xna.Framework.Graphics
         public bool TryDequeueMessage(out GraphicsDebugMessage message)
         {
             return PlatformTryDequeueMessage(out message);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    PlatformDispose();
+                }
+
+                _isDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Disposes the resources associated with this <see cref="GraphicsDebug"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDebugMessage.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebugMessage.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     public class GraphicsDebugMessage
@@ -10,10 +12,16 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public string Severity { get; set; }
 
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         public string IdName { get; set; }
 
         public string Category { get; set; }
+
+        public string Source { get; set; }
+
+        public string Type { get; set; }
+
+        public IntPtr UserdataPointer { get; set; }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -263,8 +263,20 @@ namespace Microsoft.Xna.Framework.Graphics
             // Windows requires BGRA support out of DX.
             var creationFlags = SharpDX.Direct3D11.DeviceCreationFlags.BgraSupport;
 #if DEBUG
-            creationFlags |= SharpDX.Direct3D11.DeviceCreationFlags.Debug;
+            var enableDebugLayers = true;
+#else 
+            var enableDebugLayers = false;
 #endif
+
+            if (GraphicsAdapter.UseDebugLayers)
+            {
+                enableDebugLayers = true;
+            }
+
+            if (enableDebugLayers)
+            {
+                creationFlags |= SharpDX.Direct3D11.DeviceCreationFlags.Debug;
+            }
 
             // Pass the preferred feature levels based on the
             // target profile that may have been set by the user.
@@ -281,11 +293,9 @@ namespace Microsoft.Xna.Framework.Graphics
             featureLevels.Add(FeatureLevel.Level_9_1);
 
             var driverType = GraphicsAdapter.UseReferenceDevice ? DriverType.Reference : DriverType.Hardware;
-
-#if DEBUG
+        
             try 
             {
-#endif
                 // Create the Direct3D device.
                 using (var defaultDevice = new SharpDX.Direct3D11.Device(driverType, creationFlags, featureLevels.ToArray()))
                     _d3dDevice = defaultDevice.QueryInterface<SharpDX.Direct3D11.Device1>();
@@ -293,7 +303,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 // Necessary to enable video playback
                 var multithread = _d3dDevice.QueryInterface<SharpDX.Direct3D.DeviceMultithread>();
                 multithread.SetMultithreadProtected(true);
-#if DEBUG
             }
             catch(SharpDXException)
             {
@@ -303,7 +312,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 using (var defaultDevice = new SharpDX.Direct3D11.Device(driverType, creationFlags, featureLevels.ToArray()))
                     _d3dDevice = defaultDevice.QueryInterface<SharpDX.Direct3D11.Device1>();
             }
-#endif
 
             // Get Direct3D 11.1 context
             _d3dContext = _d3dDevice.ImmediateContext.QueryInterface<SharpDX.Direct3D11.DeviceContext1>();
@@ -612,7 +620,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var enableDebugLayers = false;
 #endif
 
-            if (Environment.GetEnvironmentVariable("MONOGAME_ENABLE_DIRECTX_DEBUGGING") == "true")
+            if (GraphicsAdapter.UseDebugLayers)
             {
                 enableDebugLayers = true;
             }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -679,9 +679,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Get Direct3D 11.1 context
             _d3dContext = _d3dDevice.ImmediateContext.QueryInterface<SharpDX.Direct3D11.DeviceContext>();
-            
-            // Create a new instance of GraphicsDebug because we support it on Windows platforms.
-            _graphicsDebug = new GraphicsDebug(this);
         }
 
         internal void SetHardwareFullscreen()

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -178,11 +178,13 @@ namespace Microsoft.Xna.Framework.Graphics
             SetVertexAttributeArray(_newEnabledVertexAttributes);
         }
 
+#if DESKTOPGL
         private static void DebugMessageCallbackHandler(int source, int type, uint id, int severity, int length, IntPtr message, IntPtr userParam)
         {
             var errorMessage = Marshal.PtrToStringAnsi(message);
             Graphics.GraphicsDebug.PlatformAppendMessage(source, type, id, severity, length, errorMessage, userParam);
         }
+#endif
 
         private void PlatformSetup()
         {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Access debugging APIs for the graphics subsystem.
         /// </summary>
-        public GraphicsDebug GraphicsDebug { get { return _graphicsDebug; } set { _graphicsDebug = value; } }
+        public GraphicsDebug GraphicsDebug { get { return _graphicsDebug; } }
 
         internal GraphicsDevice(GraphicsDeviceInformation gdi)
             : this(gdi.Adapter, gdi.GraphicsProfile, gdi.PresentationParameters)
@@ -242,6 +242,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			_viewport.MaxDepth = 1.0f;
 
             PlatformSetup();
+            
+            _graphicsDebug = new GraphicsDebug(this);
 
             VertexTextures = new TextureCollection(this, MaxVertexTextureSlots, true);
             VertexSamplerStates = new SamplerStateCollection(this, MaxVertexTextureSlots, true);

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -531,6 +531,13 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 if (disposing)
                 {
+                    // Dispose the graphics debug API.
+                    if (_graphicsDebug != null)
+                    {
+                        _graphicsDebug.Dispose();
+                        _graphicsDebug = null;
+                    }
+
                     // Dispose of all remaining graphics resources before disposing of the graphics device
                     lock (_resourcesLock)
                     {

--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -458,6 +458,37 @@ namespace OpenGL
         ClampToBorder = 0x812D,
     }
 
+    public enum DebugSource
+    {
+        API = 0x8246,
+        WindowSystem = 0x8247,
+        ShaderCompiler = 0x8248,
+        ThirdParty = 0x8249,
+        Application = 0x824A,
+        Other = 0x824B,
+    }
+
+    public enum DebugType
+    {
+        Error = 0x824C,
+        DeprecatedBehaviour = 0x824D,
+        UndefinedBehaviour = 0x824E,
+        Portability = 0x824F,
+        Performance = 0x8250,
+        Other = 0x8251,
+        Marker = 0x8268,
+        PushGroup = 0x8269,
+        PopGroup = 0x826A,
+    }
+
+    public enum DebugSeverity
+    {
+        High = 0x9146,
+        Medium = 0x9147,
+        Low = 0x9148,
+        Notification = 0x826B,
+    }
+
     public partial class ColorFormat {
         public ColorFormat(int r, int g, int b, int a)
         {
@@ -1083,24 +1114,15 @@ namespace OpenGL
         public static VertexAttribDivisorDelegate VertexAttribDivisor;
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        delegate void DebugMessageCallbackProc(int source, int type, uint id, int severity, int length, IntPtr message, IntPtr userParam);
+        internal delegate void DebugMessageCallbackProc(int source, int type, uint id, int severity, int length, IntPtr message, IntPtr userParam);
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]
-        delegate void DebugMessageCallbackDelegate(DebugMessageCallbackProc callback, IntPtr userParam);
-        static DebugMessageCallbackDelegate DebugMessageCallback;
+        internal delegate void DebugMessageCallbackDelegate(DebugMessageCallbackProc callback, IntPtr userParam);
+        internal static DebugMessageCallbackDelegate DebugMessageCallback;
 
         public delegate void ErrorDelegate(string message);
+        [Obsolete("Use the GraphicsDebug property on GraphicsDevice instead", true)]
         public static event ErrorDelegate OnError;
-
-#if DEBUG
-        static void DebugMessageCallbackHandler(int source, int type, uint id, int severity, int length, IntPtr message, IntPtr userParam)
-        {
-            var errorMessage = Marshal.PtrToStringAnsi(message);
-            System.Diagnostics.Debug.WriteLine(errorMessage);
-            if (OnError != null)
-                OnError(errorMessage);
-        }
-#endif
 
         public static int SwapInterval { get; set; }
 
@@ -1258,9 +1280,6 @@ namespace OpenGL
             try
             {
                 DebugMessageCallback = (DebugMessageCallbackDelegate)LoadEntryPoint<DebugMessageCallbackDelegate>("glDebugMessageCallback");
-                DebugMessageCallback(DebugMessageCallbackHandler, IntPtr.Zero);
-                Enable(EnableCap.DebugOutput);
-                Enable(EnableCap.DebugOutputSynchronous);
             }
             catch (EntryPointNotFoundException)
             {


### PR DESCRIPTION
This adds support for retrieving graphics debug messages on OpenGL platforms using the new GraphicsDebug API.  This PR depends on both #5791 and #5792 being merged first.

There's some changes in OpenGL platform behaviour with this PR, and one breaking change as outlined below:

* The OpenGL implementation already captured messages on Debug builds of MonoGame, and emitted them using `System.Diagnostics.Debug`.  I updated the enablement of message capturing to align with DirectX; that is, enabled on Debug builds with the option to be enabled on Release builds by setting `UseDebugLayers` to true. This necessitated moving some code out of `GL`'s static constructor into the PlatformSetup for OpenGL.
* The OpenGL implementation appeared to call a static `OnError` callback in the `GL` class in response to messages being captured.  I've changed the code so this is no longer called, and added an `[Obsolete(..., true)]` attribute which will cause usages of this to emit a compilation error.  It wasn't used in MonoGame itself, and the nature of it's placement in the `GL` class makes it entirely platform specific, so I chose to forcefully deprecate it in favour of `GraphicsDebug`.  This can be changed to a soft deprecation (making the code still call it and changing the Obsolete to a warning) if desired.
* `GraphicsDebugMessage` got some new properties that match the data that OpenGL provides in it's debug messages, since this differs from the kind of information that DirectX provides.  I believe it's better to provide the data in fields that match the underlying subsystem, rather than trying to map things across and losing accuracy in the messages reported.

To test that this works, I ran the tests and set a breakpoint on the message capture function:

![image](https://user-images.githubusercontent.com/504826/27487914-88d244ce-5878-11e7-8400-e8fc98cbfaa7.png)

It's not really possible to write an automated test, since different systems may emit different debug messages or not emit messages at all.
