### PR TITLE
Fix for OpenGL texture construction not working from a thread

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -75,31 +75,34 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             this.glTarget = TextureTarget.Texture2D;
             format.GetGLFormat(GraphicsDevice, out glInternalFormat, out glFormat, out glType);
-            GenerateGLTextureIfRequired();
-            int w = width;
-            int h = height;
-            int level = 0;
-            while (true)
+            Threading.BlockOnUIThread(() =>
             {
-                if (glFormat == (PixelFormat)GLPixelFormat.CompressedTextureFormats)
+                GenerateGLTextureIfRequired();
+                int w = width;
+                int h = height;
+                int level = 0;
+                while (true)
                 {
-                    int blockSize = format.GetSize();
-                    int wBlocks = (w + 3) / 4;
-                    int hBlocks = (h + 3) / 4;
-                    GL.CompressedTexImage2D(TextureTarget.Texture2D, level, glInternalFormat, w, h, 0, wBlocks * hBlocks * blockSize, IntPtr.Zero);
-                }
-                else
-                    GL.TexImage2D(TextureTarget.Texture2D, level, glInternalFormat, w, h, 0, glFormat, glType, IntPtr.Zero);
-                GraphicsExtensions.CheckGLError();
+                    if (glFormat == (PixelFormat)GLPixelFormat.CompressedTextureFormats)
+                    {
+                        int blockSize = format.GetSize();
+                        int wBlocks = (w + 3) / 4;
+                        int hBlocks = (h + 3) / 4;
+                        GL.CompressedTexImage2D(TextureTarget.Texture2D, level, glInternalFormat, w, h, 0, wBlocks * hBlocks * blockSize, IntPtr.Zero);
+                    }
+                    else
+                        GL.TexImage2D(TextureTarget.Texture2D, level, glInternalFormat, w, h, 0, glFormat, glType, IntPtr.Zero);
+                    GraphicsExtensions.CheckGLError();
 
-                if ((w == 1 && h == 1) || !mipmap)
-                    break;
-                if (w > 1)
-                    w = w / 2;
-                if (h > 1)
-                    h = h / 2;
-                ++level;
-            }
+                    if ((w == 1 && h == 1) || !mipmap)
+                        break;
+                    if (w > 1)
+                        w = w / 2;
+                    if (h > 1)
+                        h = h / 2;
+                    ++level;
+                }
+            });
         }
 
         private void PlatformSetData<T>(int level, T[] data, int startIndex, int elementCount) where T : struct


### PR DESCRIPTION
Hello there,

This is a fix for a problem introduced in #5614 which prevented ```Texture2D``` to be loaded from a thread on OpenGL platforms.

```PlatformConstruct``` needs ```Threading.BlockOnUIThread``` to make sure that no GL operations are done from other threads.

@KonajuGames @tomspilman 