### PR TITLE
Allow disabling DirectX debug layers in Debug builds

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -82,12 +82,6 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Used to request the graphics device should be created with debugging
         /// features enabled.
         /// </summary>
-        /// <remarks>
-        /// Debugging is enabled by default in Debug builds of MonoGame, while it
-        /// is disabled in Release builds. This option can only be used to enable
-        /// debugging in Release builds (i.e. setting it to false will not disable
-        /// debugging in Debug builds).
-        /// </remarks>
         public static bool UseDebugLayers { get; set; }
 
         public string Description { get; private set; }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -614,18 +614,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Windows requires BGRA support out of DX.
             var creationFlags = SharpDX.Direct3D11.DeviceCreationFlags.BgraSupport;
-#if DEBUG
-            var enableDebugLayers = true;
-#else 
-            var enableDebugLayers = false;
-#endif
 
             if (GraphicsAdapter.UseDebugLayers)
-            {
-                enableDebugLayers = true;
-            }
-
-            if (enableDebugLayers)
             {
                 creationFlags |= SharpDX.Direct3D11.DeviceCreationFlags.Debug;
             }


### PR DESCRIPTION
GraphicsAdapter.UseDebugLayers has been added to allow enabling DirectX debug layers in Release builds, however I also which to be able to _disable_ them in Debug builds for performance reasons. This PR makes GraphicsAdapter.UseDebugLayers the sole authority on whether debug flags are sent to the d3dDevice in its creation flags. Here is my reasoning:

1. Having debug layers enabled causes draw calls to take orders of magnitude longer, it would be nice to be able to configure which aspects of the application we are debugging.
2. Additionally this makes the flag slightly less confusing, it will now always indicate whether debug layers are being used or not, rather than it being a combination of this flag and the DEBUG compiler flag.

My Visual Studio also complained about conflicting line endings and I included those changes which I can remove if you prefer.