### PR TITLE
Fixed a crash when a newer mono is installed.

### DIFF
--- a/Tools/Pipeline/MainWindow.cs
+++ b/Tools/Pipeline/MainWindow.cs
@@ -334,6 +334,9 @@ namespace MonoGame.Tools.Pipeline
                     OutputAppend("Cound not find mono. Please install the latest version from http://www.mono-project.com");
                 }
 
+                if (!Global.Linux)
+                    proc.StartInfo.EnvironmentVariables.Add("MONO_PATH", Path.GetDirectoryName(Path.GetFullPath(Path.Combine(monoLoc, ".."))));
+
                 proc.StartInfo.FileName = monoLoc;
 
                 if (PipelineController.Instance.LaunchDebugger)

--- a/default.build
+++ b/default.build
@@ -135,8 +135,8 @@
   <target name="build_mac" description="Build MacOS" depends="_prebuild">
     <if test="${os == 'MacOS'}">
       <exec program="mono" commandline="Protobuild.exe -generate MacOS" />
-      <exec program="mdtool" basedir="${mdtooldir}" commandline="build -t:Clean -c:Release MonoGame.Framework.MacOS.sln" />
-      <exec program="mdtool" basedir="${mdtooldir}" commandline="build -t:Build -c:Release MonoGame.Framework.MacOS.sln" />
+      <exec program="msbuild" commandline="MonoGame.Framework.MacOS.sln  /t:Clean /p:Configuration=Release" />
+      <exec program="msbuild" commandline="MonoGame.Framework.MacOS.sln  /t:Build /p:Configuration=Release" />
     </if>
   </target>
 


### PR DESCRIPTION
If a user has a different version of mono installed on a Mac
the Pipeline tool crashes when building. This is because the
mscorlib in the pipeline tool directory (which is used by default)
is not the same as the one the `mono` executable was built against.

This commit adds the setting of the `MONO_PATH` environment
variable to ensure that `mono` picks up the system version rather
than the one in the app itself.