### PR TITLE
Fixed a crash when a newer mono is installed.

### DIFF
--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -500,6 +500,12 @@ namespace MonoGame.Tools.Pipeline
 
         private void DoBuild(string commands)
         {
+            Encoding encoding;
+            try {
+                encoding = Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
+            } catch (NotSupportedException) {
+                encoding = Encoding.UTF8;
+            }
             try
             {
                 // Prepare the process.
@@ -509,7 +515,7 @@ namespace MonoGame.Tools.Pipeline
                 _buildProcess.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
                 _buildProcess.StartInfo.UseShellExecute = false;
                 _buildProcess.StartInfo.RedirectStandardOutput = true;
-                _buildProcess.StartInfo.StandardOutputEncoding = Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
+                _buildProcess.StartInfo.StandardOutputEncoding = encoding;
                 _buildProcess.OutputDataReceived += (sender, args) => View.OutputAppend(args.Data);
 
                 // Fire off the process.

--- a/Tools/Pipeline/Controls/BuildOutput.cs
+++ b/Tools/Pipeline/Controls/BuildOutput.cs
@@ -182,7 +182,7 @@ namespace MonoGame.Tools.Pipeline
                     _items[_items.Count - 1].AddDescription(_output.ErrorMessage);
                     break;
                 case OutputState.BuildEnd:
-                    if (_items[_items.Count - 1].Icon == _iconProcessing)
+                    if (_items.Count > 0 && _items[_items.Count - 1].Icon == _iconProcessing)
                         _items[_items.Count - 1].Icon = _iconSucceed;
 
                     _items.Add(new BuildItem

--- a/default.build
+++ b/default.build
@@ -135,8 +135,8 @@
   <target name="build_mac" description="Build MacOS" depends="_prebuild">
     <if test="${os == 'MacOS'}">
       <exec program="mono" commandline="Protobuild.exe -generate MacOS" />
-      <exec program="mdtool" basedir="${mdtooldir}" commandline="build -t:Clean -c:Release MonoGame.Framework.MacOS.sln" />
-      <exec program="mdtool" basedir="${mdtooldir}" commandline="build -t:Build -c:Release MonoGame.Framework.MacOS.sln" />
+      <exec program="msbuild" commandline="MonoGame.Framework.MacOS.sln  /t:Clean /p:Configuration=Release" />
+      <exec program="msbuild" commandline="MonoGame.Framework.MacOS.sln  /t:Build /p:Configuration=Release" />
     </if>
   </target>
 


### PR DESCRIPTION
If a user has a different version of mono installed on a Mac
the Pipeline tool crashes when building. This is because the
code page were are trying to use does not exist. So if we
cannot get that one we default to UTF8.

This PR also fixes another bug where if the build fails without
ANY items being processed the GUI crashes.

Also we upgrade to using msbuild for building the Mac platform.
This fixes a runtime issue when a different version of mono
is installed.