### PR TITLE
Upgrade to SharpDX 4.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/OutOfOrder/MonoKickstart.git
 [submodule "ThirdParty/Dependencies"]
 	path = ThirdParty/Dependencies
-	url = https://github.com/Mono-Game/MonoGame.Dependencies.git
+	url = https://github.com/vpenades/MonoGame.Dependencies.git
 [submodule "ThirdParty/NVorbis"]
 	path = ThirdParty/NVorbis
 url=https://github.com/MrHelmut/NVorbis.git

--- a/Build/Module.xml
+++ b/Build/Module.xml
@@ -10,7 +10,7 @@
   <GenerateNuGetRepositories>false</GenerateNuGetRepositories>
   <Packages>
     <Package Uri="https-git://github.com/OutOfOrder/MonoKickstart.git" Folder="ThirdParty/Kickstart" GitRef="master" />
-    <Package Uri="https-git://github.com/MonoGame/MonoGame.Dependencies.git" Folder="ThirdParty/Dependencies" GitRef="master" />
+    <Package Uri="https-git://github.com/vpenades/MonoGame.Dependencies.git" Folder="ThirdParty/Dependencies" GitRef="master" />
     <Package Uri="https-git://github.com/ioctlLR/NVorbis.git" Folder="ThirdParty/NVorbis" GitRef="master" />
   </Packages>
 </Module>

--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -54,8 +54,14 @@
       <Reference Include="System.Windows.Forms" />
       <Reference Include="System.Xml" />
       <Binary
+        Name="SharpDX.Desktop"
+        Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.Desktop.dll" />
+      <Binary
         Name="SharpDX"
         Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.dll" />
+      <Binary
+        Name="SharpDX.Mathematics"
+        Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.Mathematics.dll" />
       <Binary
         Name="SharpDX.Direct2D1"
         Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.Direct2D1.dll" />
@@ -157,6 +163,9 @@
       Name="SharpDX"
       Path="ThirdParty/Dependencies/SharpDX/Windows UAP/SharpDX.dll" />
     <Binary
+      Name="SharpDX.Mathematics"
+      Path="ThirdParty/Dependencies/SharpDX/Windows UAP/SharpDX.Mathematics.dll" />
+    <Binary
       Name="SharpDX.Direct2D1"
       Path="ThirdParty/Dependencies/SharpDX/Windows UAP/SharpDX.Direct2D1.dll" />
     <Binary
@@ -171,6 +180,9 @@
     <Binary
       Name="SharpDX.XAudio2"
       Path="ThirdParty/Dependencies/SharpDX/Windows UAP/SharpDX.XAudio2.dll" />
+    <Binary
+      Name="SharpDX.XInput"
+      Path="ThirdParty/Dependencies/SharpDX/Windows UAP/SharpDX.XInput.dll" />
   </Platform>
 	
   <Platform Type="Web">

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Xna.Framework.Audio
                     var details = MasterVoice.VoiceDetails;
                     _reverbVoice = new SubmixVoice(Device, details.InputChannelCount, details.InputSampleRate);
 
-                    var reverb = new SharpDX.XAudio2.Fx.Reverb();
+                    var reverb = new SharpDX.XAudio2.Fx.Reverb(Device);
                     var desc = new EffectDescriptor(reverb);
                     desc.InitialState = true;
                     desc.OutputChannelCount = details.InputChannelCount;
@@ -130,16 +130,16 @@ namespace Microsoft.Xna.Framework.Audio
 
                 if (MasterVoice == null)
                 {
-                    // Let windows autodetect number of channels and sample rate.
-                    MasterVoice = new MasteringVoice(Device, XAudio2.DefaultChannels, XAudio2.DefaultSampleRate, deviceId);
+                    // Let windows autodetect number of channels and sample rate.                    
+                    MasterVoice = new MasteringVoice(Device); // removed extra (unneeded?) paramaters to fix #5742
                 }
 
                 // The autodetected value of MasterVoice.ChannelMask corresponds to the speaker layout.
 #if WINRT
                 Speakers = (Speakers)MasterVoice.ChannelMask;
 #else
-                var deviceDetails = Device.GetDeviceDetails(deviceId);
-                Speakers = deviceDetails.OutputFormat.ChannelMask;
+                // changed the way to retrieve speakers to fix #5742
+                Speakers = (Speakers)MasterVoice.ChannelMask;
 #endif
             }
             catch

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
@@ -62,13 +62,8 @@ namespace Microsoft.Xna.Framework.Graphics
             adapter.SubSystemId = device.Description1.SubsystemId;
             adapter.MonitorHandle = monitor.Description.MonitorHandle;
 
-#if WINDOWS_UAP
             var desktopWidth = monitor.Description.DesktopBounds.Right - monitor.Description.DesktopBounds.Left;
             var desktopHeight = monitor.Description.DesktopBounds.Bottom - monitor.Description.DesktopBounds.Top;
-#else
-            var desktopWidth = monitor.Description.DesktopBounds.Width;
-            var desktopHeight = monitor.Description.DesktopBounds.Height;
-#endif
 
             var modes = new List<DisplayMode>();
 

--- a/MonoGame.Framework/Media/Song.WMS.cs
+++ b/MonoGame.Framework/Media/Song.WMS.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Xna.Framework.Media
 
             for (var i = 0; i < presDesc.StreamDescriptorCount; i++)
             {
-                Bool selected;
+                SharpDX.Mathematics.Interop.RawBool selected;
                 StreamDescriptor desc;
                 presDesc.GetStreamDescriptorByIndex(i, out selected, out desc);
 

--- a/MonoGame.Framework/Media/Video.WMS.cs
+++ b/MonoGame.Framework/Media/Video.WMS.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Xna.Framework.Media
 
             for (var i = 0; i < presDesc.StreamDescriptorCount; i++)
             {
-                Bool selected;
+                SharpDX.Mathematics.Interop.RawBool selected;
                 StreamDescriptor desc;
                 presDesc.GetStreamDescriptorByIndex(i, out selected, out desc);
 

--- a/Tools/2MGFX/EffectObject.hlsl.cs
+++ b/Tools/2MGFX/EffectObject.hlsl.cs
@@ -41,6 +41,14 @@ namespace TwoMGFX
                     null,
                     shaderInfo.FilePath);
 
+                // Apparently, there's a bug in SharpDX 4.0.1 in which invalid shaders
+                // don't report HasErrors == true, but the bytecode appears to be null.                
+                if (result.Bytecode == null)
+                {
+                    errorsAndWarnings += "ByteCode is NULL";
+                    throw new ShaderCompilerException();
+                }
+
                 // Store all the errors and warnings to log out later.
                 errorsAndWarnings += result.Message;
 


### PR DESCRIPTION
This is an upgrade of Monogame from SharpDX 2.6.3 to 4.0.1  ... it relies on a fork that includes that SharpDX 4.0.1 assemblies, so the Build/module.xml has been modified to point to the fork