### PR TITLE
Fixed back button problems in UWP

### DIFF
--- a/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Xna.Framework
 
         internal static ApplicationExecutionState PreviousExecutionState { get; set; }
 
+        private static bool _backPressed = false;
+
         public UAPGamePlatform(Game game)
             : base(game)
         {
@@ -121,7 +123,7 @@ namespace Microsoft.Xna.Framework
             if (KeyboardInput.IsVisible)
                 KeyboardInput.Cancel(null);
             else
-                GamePad.Back = true;
+                _backPressed = true;
 
             e.Handled = true;
         }
@@ -137,8 +139,9 @@ namespace Microsoft.Xna.Framework
             {
                 while (true)
                 {
+                    GamePad.Back = _backPressed;
+                    _backPressed = false;
                     UAPGameWindow.Instance.Tick();
-                    GamePad.Back = false;
                 }
             });
             var tickWorker = ThreadPool.RunAsync(workItemHandler, WorkItemPriority.High, WorkItemOptions.TimeSliced);

--- a/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
@@ -31,8 +31,6 @@ namespace Microsoft.Xna.Framework
 
         internal static ApplicationExecutionState PreviousExecutionState { get; set; }
 
-        private static bool _backPressed = false;
-
         public UAPGamePlatform(Game game)
             : base(game)
         {
@@ -99,8 +97,6 @@ namespace Microsoft.Xna.Framework
                 }
             }
 
-            SystemNavigationManager.GetForCurrentView().BackRequested += BackRequested;
-
             CoreApplication.Suspending += this.CoreApplication_Suspending;
 
             Game.PreviousExecutionState = PreviousExecutionState;
@@ -117,17 +113,6 @@ namespace Microsoft.Xna.Framework
             get { return GameRunBehavior.Synchronous; }
         }
 
-        private static void BackRequested(object sender, BackRequestedEventArgs e)
-        {
-            // We need to manually hide the keyboard input UI when the back button is pressed
-            if (KeyboardInput.IsVisible)
-                KeyboardInput.Cancel(null);
-            else
-                _backPressed = true;
-
-            e.Handled = true;
-        }
-
         public override void RunLoop()
         {
             UAPGameWindow.Instance.RunLoop();
@@ -139,8 +124,6 @@ namespace Microsoft.Xna.Framework
             {
                 while (true)
                 {
-                    GamePad.Back = _backPressed;
-                    _backPressed = false;
                     UAPGameWindow.Instance.Tick();
                 }
             });


### PR DESCRIPTION
The back button on Windows 10 Mobile was not always reliable because GamePad.Back could be changed by the UI thread during a tick. Sometimes the button would do nothing because the game checked GamePadState before GamePad.Back was changed, which was reset to false in the end of the tick.