### PR TITLE
Add back the 'm' Legacy XNA content identifier

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -35,8 +35,9 @@ namespace Microsoft.Xna.Framework.Content
 
         private static readonly List<char> targetPlatformIdentifiers = new List<char>()
         {
-            'w', // Windows (DirectX)
-            'x', // Xbox360
+            'w', // Windows (XNA & DirectX)
+            'x', // Xbox360 (XNA)
+            'm', // WindowsPhone7.0 (XNA)
             'i', // iOS
             'a', // Android
             'd', // DesktopGL


### PR DESCRIPTION
The ''m' identifier for XNB platform was removed from ContentManager along with WP8.0 support.
'm' was originally the identifier for XNA WP7.0. 
MG still supports XNA content for backward compatibility and Testing.

Issue: http://community.monogame.net/t/asset-does-not-appear-to-be-a-valid-xnb-file-did-you-process-your-content-for-windows/9464

FYI, @DDReaper , @KonajuGames  