### PR TITLE
[SDL] Fixes for initial window title and bounds

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -527,7 +527,7 @@ namespace Microsoft.Xna.Framework
         protected virtual void Initialize()
         {
             // TODO: This should be removed once all platforms use the new GraphicsDeviceManager
-#if !(WINDOWS && DIRECTX)
+#if !DESKTOPGL
             applyChanges(graphicsDeviceManager);
 #endif
 
@@ -618,8 +618,7 @@ namespace Microsoft.Xna.Framework
         // FIXME: We should work toward eliminating internal methods.  They
         //        break entirely the possibility that additional platforms could
         //        be added by third parties without changing MonoGame itself.
-
-#if !(WINDOWS && DIRECTX)
+#if !DESKTOPGL
         internal void applyChanges(GraphicsDeviceManager manager)
         {
 			Platform.BeginScreenDeviceChange(GraphicsDevice.PresentationParameters.IsFullScreen);

--- a/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
@@ -73,7 +73,7 @@ namespace MonoGame.OpenGL
             Sdl.GL.SwapWindow(_winHandle);
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (_disposed)
                 return;
@@ -89,6 +89,31 @@ namespace MonoGame.OpenGL
                 _winHandle = IntPtr.Zero;
             else
                 _winHandle = info.Handle;
+        }
+
+        public static GraphicsContext CreateDummy()
+        {
+            return Dummy.Create();
+        }
+
+        private class Dummy : GraphicsContext
+        {
+            private Dummy(IntPtr windowHandle) : base(new WindowInfo(windowHandle))
+            {
+            }
+
+            public static GraphicsContext Create()
+            {
+                var handle = Sdl.Window.Create(string.Empty, 0, 0, 1, 1,
+                    Sdl.Window.State.OpenGL | Sdl.Window.State.Hidden);
+                return new Dummy(handle);
+            }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+                Sdl.Window.Destroy(_winHandle);
+            }
         }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -253,8 +253,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
             Context.MakeCurrent(windowInfo);
             Context.SwapInterval = PresentationParameters.PresentationInterval.GetSwapInterval();
-
-            Context.MakeCurrent(windowInfo);
 #endif
             MaxTextureSlots = 16;
 
@@ -1240,6 +1238,9 @@ namespace Microsoft.Xna.Framework.Graphics
             Context.SwapInterval = PresentationParameters.PresentationInterval.GetSwapInterval();
 #endif
 
+            // TODO update GL context for new presentation parameters
+            //      we need to recreate the window if depth/back buffer format/ms count changed
+            Viewport = new Viewport(0, 0, PresentationParameters.BackBufferWidth, PresentationParameters.BackBufferHeight);
             ApplyRenderTargets(null);
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -281,25 +281,29 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal int GetClampedMultisampleCount(int multiSampleCount)
         {
-            if (multiSampleCount > 1)
-            {
-                // Round down MultiSampleCount to the nearest power of two
-                // hack from http://stackoverflow.com/a/2681094
-                // Note: this will return an incorrect, but large value
-                // for very large numbers. That doesn't matter because
-                // the number will get clamped below anyway in this case.
-                var msc = multiSampleCount;
-                msc = msc | (msc >> 1);
-                msc = msc | (msc >> 2);
-                msc = msc | (msc >> 4);
-                msc -= (msc >> 1);
-                // and clamp it to what the device can handle
-                if (msc > GraphicsCapabilities.MaxMultiSampleCount)
-                    msc = GraphicsCapabilities.MaxMultiSampleCount;
+            return GetClampedMultisampleCount(multiSampleCount, GraphicsCapabilities.MaxMultiSampleCount);
+        }
 
-                return msc;
-            }
-            else return 0;
+        internal static int GetClampedMultisampleCount(int multiSampleCount, int maxMsCount)
+        {
+            if (multiSampleCount <= 1)
+                return 0;
+
+            // Round down MultiSampleCount to the nearest power of two
+            // hack from http://stackoverflow.com/a/2681094
+            // Note: this will return an incorrect, but large value
+            // for very large numbers. That doesn't matter because
+            // the number will get clamped below anyway in this case.
+            var msc = multiSampleCount;
+            msc = msc | (msc >> 1);
+            msc = msc | (msc >> 2);
+            msc = msc | (msc >> 4);
+            msc -= (msc >> 1);
+            // and clamp it to what the device can handle
+            if (msc > maxMsCount)
+                msc = maxMsCount;
+
+            return msc;
         }
 
         internal void Initialize()

--- a/MonoGame.Framework/GraphicsDeviceManager.SDL.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.SDL.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Xna.Framework
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.ContextMajorVersion, 2);
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.ContextMinorVersion, 1);
 
-            ((SdlGameWindow)SdlGameWindow.Instance).CreateWindow();
+            ((SdlGameWindow)SdlGameWindow.Instance).CreateWindow(presentationParameters);
         }
     }
 }

--- a/MonoGame.Framework/GraphicsDeviceManager.SDL.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.SDL.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using Microsoft.Xna.Framework.Graphics;
+using MonoGame.OpenGL;
 
 namespace Microsoft.Xna.Framework
 {
@@ -10,40 +11,17 @@ namespace Microsoft.Xna.Framework
     {
         partial void PlatformInitialize(PresentationParameters presentationParameters)
         {
-            var surfaceFormat = _game.graphicsDeviceManager.PreferredBackBufferFormat.GetColorFormat();
-            var depthStencilFormat = _game.graphicsDeviceManager.PreferredDepthStencilFormat;
-
-            // TODO Need to get this data from the Presentation Parameters
-            Sdl.GL.SetAttribute(Sdl.GL.Attribute.RedSize, surfaceFormat.R);
-            Sdl.GL.SetAttribute(Sdl.GL.Attribute.GreenSize, surfaceFormat.G);
-            Sdl.GL.SetAttribute(Sdl.GL.Attribute.BlueSize, surfaceFormat.B);
-            Sdl.GL.SetAttribute(Sdl.GL.Attribute.AlphaSize, surfaceFormat.A);
-
-            switch (depthStencilFormat)
+            int maxMsCount;
+            using (GraphicsContext.CreateDummy())
             {
-                case DepthFormat.None:
-                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.DepthSize, 0);
-                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.StencilSize, 0);
-                    break;
-                case DepthFormat.Depth16:
-                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.DepthSize, 16);
-                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.StencilSize, 0);
-                    break;
-                case DepthFormat.Depth24:
-                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.DepthSize, 24);
-                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.StencilSize, 0);
-                    break;
-                case DepthFormat.Depth24Stencil8:
-                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.DepthSize, 24);
-                    Sdl.GL.SetAttribute(Sdl.GL.Attribute.StencilSize, 8);
-                    break;
+                GL.GetInteger(GetPName.MaxSamples, out maxMsCount);
+
+                // reported ms count seems to be one POT larger than what's actually supported
+                // TODO: verify this
+                maxMsCount >>= 1;
             }
-
-            Sdl.GL.SetAttribute(Sdl.GL.Attribute.DoubleBuffer, 1);
-            Sdl.GL.SetAttribute(Sdl.GL.Attribute.ContextMajorVersion, 2);
-            Sdl.GL.SetAttribute(Sdl.GL.Attribute.ContextMinorVersion, 1);
-
-            ((SdlGameWindow)SdlGameWindow.Instance).CreateWindow(presentationParameters);
+            GraphicsDevice.UpdateBackBufferPixelFormat(presentationParameters, maxMsCount);
+           ((SdlGameWindow)SdlGameWindow.Instance).CreateWindow(presentationParameters);
         }
-    }
+   }
 }

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -324,6 +324,7 @@ namespace Microsoft.Xna.Framework
                 // if the GraphicsProfile changed we need to create a new GraphicsDevice
                 DisposeGraphicsDevice();
                 CreateDevice(gdi);
+                OnPresentationChanged(this, new PresentationEventArgs(gdi.PresentationParameters));
                 return;
             }
 

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -63,6 +63,9 @@ namespace Microsoft.Xna.Framework
             _preferredDepthStencilFormat = DepthFormat.Depth24;
             _synchronizedWithVerticalRetrace = true;
 
+            // TODO We should get rid of this, the window size should be intialized to the back buffer size
+            //      not the other way around. At least for desktop platforms.
+#if !DESKTOPGL
             // Assume the window client size as the default back 
             // buffer resolution in the landscape orientation.
             var clientBounds = _game.Window.ClientBounds;
@@ -76,6 +79,10 @@ namespace Microsoft.Xna.Framework
                 _preferredBackBufferWidth = clientBounds.Height;
                 _preferredBackBufferHeight = clientBounds.Width;
             }
+#else
+            _preferredBackBufferWidth = DefaultBackBufferWidth;
+            _preferredBackBufferHeight = DefaultBackBufferHeight;
+#endif
 
             // Default to windowed mode... this is ignored on platforms that don't support it.
             _wantFullScreen = false;

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -95,6 +95,13 @@ namespace Microsoft.Xna.Framework
             var displayIndex = Sdl.Window.GetDisplayIndex(Window.Handle);
             var displayName = Sdl.Display.GetDisplayName(displayIndex);
             BeginScreenDeviceChange(pp.IsFullScreen);
+            if (_view.CheckRecreateWindow(pp))
+            {
+                // TODO create a new graphics context for the new window
+                throw new NotSupportedException("Changing the multisample count, surface format, depth or stencil buffer size" +
+                                                " of the backbuffer at runtime requires recreating the window under OpenGL. This" +
+                                                " is currently not implemented in MonoGame.");
+            }
             EndScreenDeviceChange(displayName, pp.BackBufferWidth, pp.BackBufferHeight);
         }
 


### PR DESCRIPTION
Setting window title or position before the window was created had no
effect on DesktopGL. This fixes that issue. I was reminded of this by a forum post: http://community.monogame.net/t/cant-set-window-title-in-game1-constructor/9465

This is a small subset of the fixes from #5522 (which was closed to split up the changes). Some of the other changes made in that PR depend on #5585.