### PR TITLE
MouseState race condition

### DIFF
--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework.Input;
 using Microsoft.Xna.Framework.Input.Touch;
 using System;
 using System.ComponentModel;
+using System.Threading;
 
 namespace Microsoft.Xna.Framework {
 	public abstract class GameWindow {
@@ -73,13 +74,26 @@ namespace Microsoft.Xna.Framework {
             }
         }
 
+        private object _mouseStateLock = new object();
         private MouseState _mouseState;
 	    internal TouchPanelState TouchPanelState;
 
         internal MouseState MouseState
         {
-            get { return _mouseState; }
-            set { _mouseState = value; }
+            get
+            {
+                lock (_mouseStateLock)
+                {
+                    return _mouseState;
+                }
+            }
+            set
+            {
+                lock (_mouseStateLock)
+                {
+                    _mouseState = value;
+                }
+            }
         }
 
         protected GameWindow()

--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -73,8 +73,14 @@ namespace Microsoft.Xna.Framework {
             }
         }
 
-        internal MouseState MouseState;
+        private MouseState _mouseState;
 	    internal TouchPanelState TouchPanelState;
+
+        internal MouseState MouseState
+        {
+            get { return _mouseState; }
+            set { _mouseState = value; }
+        }
 
         protected GameWindow()
         {

--- a/MonoGame.Framework/Input/Mouse.Default.cs
+++ b/MonoGame.Framework/Input/Mouse.Default.cs
@@ -20,8 +20,10 @@ namespace Microsoft.Xna.Framework.Input
 
         private static void PlatformSetPosition(int x, int y)
         {
-            PrimaryWindow.MouseState.X = x;
-            PrimaryWindow.MouseState.Y = y;
+            var newMouseState = PrimaryWindow.MouseState;
+            newMouseState.X = x;
+            newMouseState.Y = y;
+            PrimaryWindow.MouseState = newMouseState;
         }
 
         public static void PlatformSetCursor(MouseCursor cursor)

--- a/MonoGame.Framework/Input/Mouse.MacOS.cs
+++ b/MonoGame.Framework/Input/Mouse.MacOS.cs
@@ -53,8 +53,10 @@ namespace Microsoft.Xna.Framework.Input
 
         private static void PlatformSetPosition(int x, int y)
         {
-            PrimaryWindow.MouseState.X = x;
-            PrimaryWindow.MouseState.Y = y;
+            var newMouseState = PrimaryWindow.MouseState;
+            newMouseState.X = x;
+            newMouseState.Y = y;
+            PrimaryWindow.MouseState = newMouseState;
             
             var mousePt = NSEvent.CurrentMouseLocation;
             NSScreen currentScreen = null;

--- a/MonoGame.Framework/Input/Mouse.SDL.cs
+++ b/MonoGame.Framework/Input/Mouse.SDL.cs
@@ -25,37 +25,43 @@ namespace Microsoft.Xna.Framework.Input
                     Sdl.Mouse.GetGlobalState(out x, out y) :
                     Sdl.Mouse.GetState(out x, out y);
             
+            var newMouseState = window.MouseState;
+
             if ((winFlags & Sdl.Window.State.MouseFocus) != 0)
             {
-                window.MouseState.LeftButton = (state & Sdl.Mouse.Button.Left) != 0 ? ButtonState.Pressed : ButtonState.Released;
-                window.MouseState.MiddleButton = (state & Sdl.Mouse.Button.Middle) != 0 ? ButtonState.Pressed : ButtonState.Released;
-                window.MouseState.RightButton = (state & Sdl.Mouse.Button.Right) != 0 ? ButtonState.Pressed : ButtonState.Released;
-                window.MouseState.XButton1 = (state & Sdl.Mouse.Button.X1Mask) != 0 ? ButtonState.Pressed : ButtonState.Released;
-                window.MouseState.XButton2 = (state & Sdl.Mouse.Button.X2Mask) != 0 ? ButtonState.Pressed : ButtonState.Released;
+                newMouseState.LeftButton = (state & Sdl.Mouse.Button.Left) != 0 ? ButtonState.Pressed : ButtonState.Released;
+                newMouseState.MiddleButton = (state & Sdl.Mouse.Button.Middle) != 0 ? ButtonState.Pressed : ButtonState.Released;
+                newMouseState.RightButton = (state & Sdl.Mouse.Button.Right) != 0 ? ButtonState.Pressed : ButtonState.Released;
+                newMouseState.XButton1 = (state & Sdl.Mouse.Button.X1Mask) != 0 ? ButtonState.Pressed : ButtonState.Released;
+                newMouseState.XButton2 = (state & Sdl.Mouse.Button.X2Mask) != 0 ? ButtonState.Pressed : ButtonState.Released;
 
-                window.MouseState.HorizontalScrollWheelValue = ScrollX;
-                window.MouseState.ScrollWheelValue = ScrollY;
+                newMouseState.HorizontalScrollWheelValue = ScrollX;
+                newMouseState.ScrollWheelValue = ScrollY;
             }
 
             if (Sdl.Patch > 4)
             {
                 var clientBounds = window.ClientBounds;
-                window.MouseState.X = x - clientBounds.X;
-                window.MouseState.Y = y - clientBounds.Y;
+                newMouseState.X = x - clientBounds.X;
+                newMouseState.Y = y - clientBounds.Y;
             }
             else
             {
-                window.MouseState.X = x;
-                window.MouseState.Y = y;
+                newMouseState.X = x;
+                newMouseState.Y = y;
             }
+
+            window.MouseState = newMouseState;
 
             return window.MouseState;
         }
 
         private static void PlatformSetPosition(int x, int y)
         {
-            PrimaryWindow.MouseState.X = x;
-            PrimaryWindow.MouseState.Y = y;
+            var newMouseState = PrimaryWindow.MouseState;
+            newMouseState.X = x;
+            newMouseState.Y = y;
+            PrimaryWindow.MouseState = newMouseState;
             
             Sdl.Mouse.WarpInWindow(PrimaryWindow.Handle, x, y);
         }

--- a/MonoGame.Framework/Input/Mouse.Windows.cs
+++ b/MonoGame.Framework/Input/Mouse.Windows.cs
@@ -28,8 +28,10 @@ namespace Microsoft.Xna.Framework.Input
 
         private static void PlatformSetPosition(int x, int y)
         {
-            PrimaryWindow.MouseState.X = x;
-            PrimaryWindow.MouseState.Y = y;
+            var newMouseState = PrimaryWindow.MouseState;
+            newMouseState.X = x;
+            newMouseState.Y = y;
+            PrimaryWindow.MouseState = newMouseState;
             
             var pt = Window.PointToScreen(new System.Drawing.Point(x, y));
             SetCursorPos(pt.X, pt.Y);

--- a/MonoGame.Framework/Web/WebGameWindow.cs
+++ b/MonoGame.Framework/Web/WebGameWindow.cs
@@ -89,37 +89,45 @@ namespace Microsoft.Xna.Framework
         {
             var movementX = e.movementX || e.mozMovementX || e.webkitMovementX || 0;
             var movementY = e.movementY || e.mozMovementY || e.webkitMovementY || 0;
-
-            this.MouseState.X = Math.Min(Math.Max(this.MouseState.X + movementX, 0), glcanvas.clientWidth);
-            this.MouseState.Y = Math.Min(Math.Max(this.MouseState.Y + movementY, 0), glcanvas.clientHeight);
+                        
+            var newMouseState = MouseState;
+            newMouseState.X = Math.Min(Math.Max(this.MouseState.X + movementX, 0), glcanvas.clientWidth);
+            newMouseState.Y = Math.Min(Math.Max(this.MouseState.Y + movementY, 0), glcanvas.clientHeight);
+            MouseState = newMouseState;
         }
 
         private void OnMouseDown(dynamic e)
         {
+            var newMouseState = MouseState;
             if (e.button == 0)
-                this.MouseState.LeftButton = ButtonState.Pressed;
+                newMouseState.LeftButton = ButtonState.Pressed;
             else if (e.button == 1)
-                this.MouseState.MiddleButton = ButtonState.Pressed;
+                newMouseState.MiddleButton = ButtonState.Pressed;
             else if (e.button == 2)
-                this.MouseState.RightButton = ButtonState.Pressed;
+                newMouseState.RightButton = ButtonState.Pressed;
+            MouseState = newMouseState;
         }
 
         private void OnMouseUp(dynamic e)
         {
+            var newMouseState = MouseState;
             if (e.button == 0)
-                this.MouseState.LeftButton = ButtonState.Released;
+                newMouseState.LeftButton = ButtonState.Released;
             else if (e.button == 1)
-                this.MouseState.MiddleButton = ButtonState.Released;
+                newMouseState.MiddleButton = ButtonState.Released;
             else if (e.button == 2)
-                this.MouseState.RightButton = ButtonState.Released;
+                newMouseState.RightButton = ButtonState.Released;
+            MouseState = newMouseState;
         }
 
         private void OnMouseWheel(dynamic e)
         {
+            var newMouseState = MouseState;
             if (e.deltaY < 0)
-                this.MouseState.ScrollWheelValue += 120;
+                newMouseState.ScrollWheelValue += 120;
             else
-                this.MouseState.ScrollWheelValue -= 120;
+                newMouseState.ScrollWheelValue -= 120;
+            MouseState = newMouseState;
         }
 
         private void OnKeyDown(dynamic e)

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -220,12 +220,16 @@ namespace MonoGame.Framework
 
         private void OnMouseScroll(object sender, MouseEventArgs mouseEventArgs)
         {
-            MouseState.ScrollWheelValue += mouseEventArgs.Delta;
+            var newMouseState = MouseState;
+            newMouseState.ScrollWheelValue += mouseEventArgs.Delta;
+            MouseState = newMouseState;
         }
 
         private void OnMouseHorizontalScroll(object sender, HorizontalMouseWheelEventArgs mouseEventArgs)
         {
-            MouseState.HorizontalScrollWheelValue += mouseEventArgs.Delta;
+            var newMouseState = MouseState;
+            newMouseState.HorizontalScrollWheelValue += mouseEventArgs.Delta;            
+            MouseState = newMouseState;
         }
 
         private void UpdateMouseState()
@@ -240,13 +244,15 @@ namespace MonoGame.Framework
             var withinClient = Form.ClientRectangle.Contains(clientPos);
             var buttons = Control.MouseButtons;
 
-            var previousState = MouseState.LeftButton;
+            var newMouseState = MouseState;
+            var previousState = newMouseState.LeftButton;
 
-            MouseState.X = clientPos.X;
-            MouseState.Y = clientPos.Y;
-            MouseState.LeftButton = (buttons & MouseButtons.Left) == MouseButtons.Left ? ButtonState.Pressed : ButtonState.Released;
-            MouseState.MiddleButton = (buttons & MouseButtons.Middle) == MouseButtons.Middle ? ButtonState.Pressed : ButtonState.Released;
-            MouseState.RightButton = (buttons & MouseButtons.Right) == MouseButtons.Right ? ButtonState.Pressed : ButtonState.Released;
+            newMouseState.X = clientPos.X;
+            newMouseState.Y = clientPos.Y;
+            newMouseState.LeftButton = (buttons & MouseButtons.Left) == MouseButtons.Left ? ButtonState.Pressed : ButtonState.Released;
+            newMouseState.MiddleButton = (buttons & MouseButtons.Middle) == MouseButtons.Middle ? ButtonState.Pressed : ButtonState.Released;
+            newMouseState.RightButton = (buttons & MouseButtons.Right) == MouseButtons.Right ? ButtonState.Pressed : ButtonState.Released;
+            MouseState = newMouseState;
 
             // Don't process touch state if we're not active 
             // and the mouse is within the client area.

--- a/MonoGame.Framework/Windows8/InputEvents.cs
+++ b/MonoGame.Framework/Windows8/InputEvents.cs
@@ -224,14 +224,15 @@ namespace Microsoft.Xna.Framework
             else
                 verticalScrollDelta = state.MouseWheelDelta;
 
+            var prevMouseState = Mouse.PrimaryWindow.MouseState;
             Mouse.PrimaryWindow.MouseState = new MouseState(x, y, 
-                Mouse.PrimaryWindow.MouseState.ScrollWheelValue + verticalScrollDelta,
+                prevMouseState.ScrollWheelValue + verticalScrollDelta,
                 state.IsLeftButtonPressed ? ButtonState.Pressed : ButtonState.Released,
                 state.IsMiddleButtonPressed ? ButtonState.Pressed : ButtonState.Released,
                 state.IsRightButtonPressed ? ButtonState.Pressed : ButtonState.Released,
                 state.IsXButton1Pressed ? ButtonState.Pressed : ButtonState.Released,
                 state.IsXButton2Pressed ? ButtonState.Pressed : ButtonState.Released,
-                Mouse.PrimaryWindow.MouseState.HorizontalScrollWheelValue + horizontalScrollDelta);
+                prevMouseState.HorizontalScrollWheelValue + horizontalScrollDelta);
         }
 
         public void UpdateState()


### PR DESCRIPTION
On platforms where gameloop run on a seperate thread, it's possible to read a corrupted MouseState if an event is updating it while devCode is reading it.

This PR isolates & locks reading/writing to GameWindow. MouseState.


On terms of performs this is worst than before. 
I am open to suggestions. 

We need some internal methods like SetXY(), IncreaseScrollWheel(), to isolate/lock internal state instead of getting and reassigning MouseState (8 ints/enums) like this PR does. 
IMO those methods and the internal state (_x,_y, ...) belong to the Mouse class.

Locks can be `#if`ed for platforms that don'd need locking or have partial Mouse.Async.cs , if there's significant perf gains.
