### PR TITLE
Implement Mouse.WindowHandle under Windows DirectX

### DIFF
--- a/MonoGame.Framework/Input/Mouse.Default.cs
+++ b/MonoGame.Framework/Input/Mouse.Default.cs
@@ -8,9 +8,13 @@ namespace Microsoft.Xna.Framework.Input
 {
     public static partial class Mouse
     {
-        private static IntPtr PlatformGetHandle()
+        private static IntPtr PlatformGetWindowHandle()
         {
             return IntPtr.Zero;
+        }
+
+        private static void PlatformSetWindowHandle(IntPtr windowHandle)
+        {
         }
 
         private static MouseState PlatformGetState(GameWindow window)

--- a/MonoGame.Framework/Input/Mouse.MacOS.cs
+++ b/MonoGame.Framework/Input/Mouse.MacOS.cs
@@ -37,9 +37,13 @@ namespace Microsoft.Xna.Framework.Input
         internal static float HorizontalScrollWheelValue;
         internal static float ScrollWheelValue;
 
-        private static IntPtr PlatformGetHandle()
+        private static IntPtr PlatformGetWindowHandle()
         {
             return IntPtr.Zero;
+        }
+
+        private static void PlatformSetWindowHandle(IntPtr windowHandle)
+        {
         }
 
         private static MouseState PlatformGetState(GameWindow window)

--- a/MonoGame.Framework/Input/Mouse.SDL.cs
+++ b/MonoGame.Framework/Input/Mouse.SDL.cs
@@ -11,9 +11,13 @@ namespace Microsoft.Xna.Framework.Input
         internal static int ScrollX;
         internal static int ScrollY;
 
-        private static IntPtr PlatformGetHandle()
+        private static IntPtr PlatformGetWindowHandle()
         {
             return PrimaryWindow.Handle;
+        }
+        
+        private static void PlatformSetWindowHandle(IntPtr windowHandle)
+        {
         }
 
         private static MouseState PlatformGetState(GameWindow window)

--- a/MonoGame.Framework/Input/Mouse.Windows.cs
+++ b/MonoGame.Framework/Input/Mouse.Windows.cs
@@ -14,11 +14,16 @@ namespace Microsoft.Xna.Framework.Input
         [return: MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.Bool)]
         private static extern bool SetCursorPos(int X, int Y);
 
-        internal static Form Window;
+        private static Control _window;
 
-        private static IntPtr PlatformGetHandle()
+        private static IntPtr PlatformGetWindowHandle()
         {
-            return PrimaryWindow.Handle;
+            return _window.Handle;
+        }
+
+        private static void PlatformSetWindowHandle(IntPtr windowHandle)
+        {
+            _window = Control.FromHandle(windowHandle);
         }
 
         private static MouseState PlatformGetState(GameWindow window)
@@ -31,7 +36,7 @@ namespace Microsoft.Xna.Framework.Input
             PrimaryWindow.MouseState.X = x;
             PrimaryWindow.MouseState.Y = y;
             
-            var pt = Window.PointToScreen(new System.Drawing.Point(x, y));
+            var pt = _window.PointToScreen(new System.Drawing.Point(x, y));
             SetCursorPos(pt.X, pt.Y);
         }
 

--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -20,15 +20,8 @@ namespace Microsoft.Xna.Framework.Input
         /// </summary> 
         public static IntPtr WindowHandle
         {
-            get
-            {
-                return PlatformGetHandle();
-            }
-            set
-            {
-                // only for XNA compatibility, yet
-                IntPtr temp = value;
-            }
+            get { return PlatformGetWindowHandle(); }
+            set { PlatformSetWindowHandle(value); }
         }
 
         /// <summary>

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -23,8 +23,6 @@ namespace MonoGame.Framework
         {
             _window = new WinFormsGameWindow(this);
 
-            Mouse.Window = _window.Form;
-
             Window = _window;
         }
 

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -143,6 +143,7 @@ namespace MonoGame.Framework
             Form.StartPosition = FormStartPosition.Manual;
 
             // Capture mouse events.
+            Mouse.WindowHandle = Form.Handle;
             Form.MouseWheel += OnMouseScroll;
             Form.MouseHorizontalWheel += OnMouseHorizontalScroll;
             Form.MouseEnter += OnMouseEnter;
@@ -447,7 +448,7 @@ namespace MonoGame.Framework
             }
             _platform = null;
             Game = null;
-            Mouse.Window = null;
+            Mouse.WindowHandle = IntPtr.Zero;
         }
 
         public override void BeginScreenDeviceChange(bool willBeFullScreen)


### PR DESCRIPTION
-Assign Mouse.Window through .WindowHandle

-Move assign of Mouse.Window/WindowHandle
from WinformsGamePlatform ->WinformsGameWindow.

-Make Mouse.Window private (from internal)

 

-Any Control can me assigned to Mouse.WindowHandle. (Mouse.Window Changed from Form -> Control)
Mouse is still not usable from MG embeded in custom WinForms apps since all event handling and mousestate still live in WinFormsGameWindow.

