### PR TITLE
[SDL] Set default window position to system primary display

### DIFF
--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -102,11 +102,26 @@ namespace Microsoft.Xna.Framework
             _width = GraphicsDeviceManager.DefaultBackBufferWidth;
             _height = GraphicsDeviceManager.DefaultBackBufferHeight;
 
-            if (Sdl.Patch >= 4)
+            // look for the primary display
+            var rect = new Sdl.Rectangle();
+            var displayCount = Sdl.Display.GetNumVideoDisplays();
+            for (var i = 0; i < displayCount; i++)
             {
-                var display = GetMouseDisplay();
-                _winx = display.X + display.Width / 2;
-                _winy = display.Y + display.Height / 2;
+                Sdl.Display.GetBounds(i, out rect);
+
+                if (rect.X == 0 && rect.Y == 0) // primary display is always 0,0 on SDL
+                {
+                    _winx = rect.X + rect.Width / 2;
+                    _winy = rect.Y + rect.Height / 2;
+                    break;
+                }
+                // if we didn't found the primary display, default to the display where the mouse cursor is 
+                if (i == displayCount - 1 && Sdl.Patch >= 4)
+                {
+                    var display = GetMouseDisplay();
+                    _winx = display.X + display.Width / 2;
+                    _winy = display.Y + display.Height / 2;
+                }
             }
             
             Sdl.SetHint("SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS", "0");


### PR DESCRIPTION
Hello,

This PR sets the default window position to the primary display set in the system settings.
This is the default XNA behavior.
It was previously setting the position to the display where the mouse cursor is (and this is still used as a fallback in case the primary display isn't found, though I doubt this would fail).

Note that there is no function in SDL to query which display is the primary one. SDL assumes that the display with coordinate 0,0 is the primary one.

Tested on Windows & MacOS.

@cra0zy @KonajuGames @dellis1972 