### PR TITLE
UWP Templates use target version selected in wizard

### DIFF
--- a/ProjectTemplates/VisualStudio2017/WindowsUniversal10/Application.csproj
+++ b/ProjectTemplates/VisualStudio2017/WindowsUniversal10/Application.csproj
@@ -12,8 +12,8 @@
     <AssemblyName>$projectname$</AssemblyName>
     <DefaultLanguage>$currentuiculturename$</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-	<TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
-	<TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$targetplatformversion$</TargetPlatformVersion>
+    <TargetPlatformMinVersion>$targetplatformminversion$</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>
@@ -92,6 +92,16 @@
     <Prefer32Bit>true</Prefer32Bit>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
+$if$($targetplatformversion$ > 10.0.14393.0)
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+$else$
+  <ItemGroup>
+    <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
+    <None Include="project.json" />
+  </ItemGroup>
+$endif$
   <ItemGroup>
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
     <Reference Include="MonoGame.Framework">
@@ -107,9 +117,6 @@
     </Compile>
     <Compile Include="Game1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-  	<None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">


### PR DESCRIPTION
When creating a Windows 10 Universal project, a window for selecting the target and minimum SDK versions pops up. Currently the selection is ignored. You can not create a new project if only version 10.0.15063.0 is installed because the template requires 10.0.14393.0 and it will fail with errors before the project has even been created.
I took the important lines from the Empty App template.