### PR TITLE
Do not allow the Pipeline tool to delete files outside the content folder

### DIFF
--- a/Tools/Pipeline/Common/PipelineController.ExcludeAction.cs
+++ b/Tools/Pipeline/Common/PipelineController.ExcludeAction.cs
@@ -46,20 +46,25 @@ namespace MonoGame.Tools.Pipeline
 
                     if (_delete)
                     {
-                        try
+                        // Only delete if the item is in the project folder, otherwise we may (and have done!) delete files/folders outside of the project
+                        if (!item.OriginalPath.Contains(".."))
                         {
-                            if (item is DirectoryItem)
-                                Directory.Delete(_con.GetFullPath(item.OriginalPath), true);
-                            else
-                                File.Delete(_con.GetFullPath(item.OriginalPath));
-                        }
-                        catch (FileNotFoundException)
-                        {
-                            // No error needed in case file is not found
-                        }
-                        catch (Exception ex)
-                        {
-                            _con.View.ShowError("Error while trying to delete the file", ex.Message);
+                            var fullItemPath = _con.GetFullPath(item.OriginalPath);
+                            try
+                            {
+                                if (item is DirectoryItem)
+                                    Directory.Delete(_con.GetFullPath(item.OriginalPath), true);
+                                else
+                                    File.Delete(_con.GetFullPath(item.OriginalPath));
+                            }
+                            catch (FileNotFoundException)
+                            {
+                                // No error needed in case file is not found
+                            }
+                            catch (Exception ex)
+                            {
+                                _con.View.ShowError("Error while trying to delete the file", ex.Message);
+                            }
                         }
                     }
                 }

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -866,9 +866,14 @@ namespace MonoGame.Tools.Pipeline
 
         public void Exclude(bool delete)
         {
-            if (delete && !View.ShowDeleteDialog(SelectedItems))
+            // We don't want to show a delete confirmation for any items outside the project folder
+            var filteredItems = new List<IProjectItem>(SelectedItems.Where(i => !i.OriginalPath.Contains("..")));
+
+            if (filteredItems.Count > 0 && delete && !View.ShowDeleteDialog(filteredItems))
                 return;
 
+            // Still need to pass all items to the Exclude action so it can remove them from the view.
+            // Filtering is done internally so it only deletes files in the project folder
             var action = new ExcludeAction(this, SelectedItems, delete);
             if(action.Do())
                 _actionStack.Add(action);


### PR DESCRIPTION
Linking files outside the project folder would include them as relative paths. Deleting these linked files, once confirmed, would delete entire folder trees outside the project folder. This unfortunately has destroyed projects of users.

This change will not show files with a path containing ".." in the delete confirmation dialog, as we will never be deleting them. Then it also checks for the file path containing ".." before deleting the file or folder.