### PR TITLE
Upgrade SharpDX to 3.1.1

### DIFF
--- a/Build/Projects/2MGFXReferences.definition
+++ b/Build/Projects/2MGFXReferences.definition
@@ -4,10 +4,10 @@
   <Platform Type="Windows">
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.dll" />
     <Binary
       Name="SharpDX.D3DCompiler"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.D3DCompiler.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.D3DCompiler.dll" />
     <Binary
       Name="CppNet"
       Path="ThirdParty/Dependencies/CppNet/CppNet.dll" />

--- a/Build/Projects/2MGFXReferences.definition
+++ b/Build/Projects/2MGFXReferences.definition
@@ -4,10 +4,10 @@
   <Platform Type="Windows">
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
     <Binary
       Name="SharpDX.D3DCompiler"
-      Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.D3DCompiler.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.D3DCompiler.dll" />
     <Binary
       Name="CppNet"
       Path="ThirdParty/Dependencies/CppNet/CppNet.dll" />

--- a/Build/Projects/Framework.Content.Pipeline.References.definition
+++ b/Build/Projects/Framework.Content.Pipeline.References.definition
@@ -81,10 +81,10 @@
   <Platform Type="Windows">
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.dll" />
     <Binary
       Name="SharpDX.D3DCompiler"
-      Path="ThirdParty\Dependencies\SharpDX\SharpDX.D3DCompiler.dll" />
+      Path="ThirdParty\Dependencies\SharpDX\Desktop\SharpDX.D3DCompiler.dll" />
     <Binary
       Name="CppNet"
       Path="ThirdParty\Dependencies\CppNet\CppNet.dll" />

--- a/Build/Projects/Framework.Content.Pipeline.References.definition
+++ b/Build/Projects/Framework.Content.Pipeline.References.definition
@@ -81,10 +81,10 @@
   <Platform Type="Windows">
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
     <Binary
       Name="SharpDX.D3DCompiler"
-      Path="ThirdParty\Dependencies\SharpDX\Windows\SharpDX.D3DCompiler.dll" />
+      Path="ThirdParty\Dependencies\SharpDX\SharpDX.D3DCompiler.dll" />
     <Binary
       Name="CppNet"
       Path="ThirdParty\Dependencies\CppNet\CppNet.dll" />

--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -46,36 +46,6 @@
     <Reference Include="System" />
     <Reference Include="System.Runtime.Serialization" />
 	
-    <Service Name="MonoGame.Framework/DirectXGraphics">
-      <Reference Include="System.Core" />
-      <Reference Include="System.Drawing" />
-      <Reference Include="System.Web" />
-      <Reference Include="System.Web.Services" />
-      <Reference Include="System.Windows.Forms" />
-      <Reference Include="System.Xml" />
-      <Binary
-        Name="SharpDX"
-        Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.dll" />
-      <Binary
-        Name="SharpDX.Direct2D1"
-        Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.Direct2D1.dll" />
-      <Binary
-        Name="SharpDX.Direct3D11"
-        Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.Direct3D11.dll" />
-      <Binary
-        Name="SharpDX.DXGI"
-        Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.DXGI.dll" />
-      <Binary
-        Name="SharpDX.MediaFoundation"
-        Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.MediaFoundation.dll" />
-      <Binary
-        Name="SharpDX.XAudio2"
-        Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.XAudio2.dll" />
-      <Binary
-        Name="SharpDX.XInput"
-        Path="ThirdParty/Dependencies/SharpDX/Windows/SharpDX.XInput.dll" />
-    </Service>
-
     <Service Name="MonoGame.Framework/OpenGLGraphics">
       <Reference Include="System.Core" />
       <Reference Include="System.Web" />
@@ -85,94 +55,36 @@
     </Service>
   </Platform>
 
-  <Platform Type="Windows8">
-    <Reference Include="System" />
-    <Reference Include="System.Runtime.Serialization" />
-	
+  <Service Name="MonoGame.Framework/DirectXGraphics">
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/Windows 8 Metro/SharpDX.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
     <Binary
       Name="SharpDX.Direct2D1"
-      Path="ThirdParty/Dependencies/SharpDX/Windows 8 Metro/SharpDX.Direct2D1.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.Direct2D1.dll" />
     <Binary
       Name="SharpDX.Direct3D11"
-      Path="ThirdParty/Dependencies/SharpDX/Windows 8 Metro/SharpDX.Direct3D11.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.Direct3D11.dll" />
     <Binary
       Name="SharpDX.DXGI"
-      Path="ThirdParty/Dependencies/SharpDX/Windows 8 Metro/SharpDX.DXGI.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.DXGI.dll" />
     <Binary
       Name="SharpDX.MediaFoundation"
-      Path="ThirdParty/Dependencies/SharpDX/Windows 8 Metro/SharpDX.MediaFoundation.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.MediaFoundation.dll" />
     <Binary
       Name="SharpDX.XAudio2"
-      Path="ThirdParty/Dependencies/SharpDX/Windows 8 Metro/SharpDX.XAudio2.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.XAudio2.dll" />
     <Binary
       Name="SharpDX.XInput"
-      Path="ThirdParty/Dependencies/SharpDX/Windows 8 Metro/SharpDX.XInput.dll" />
-  </Platform>
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.XInput.dll" />
+  </Service>
 
-  <Platform Type="WindowsGL">
-    <Reference Include="System" />
-    <Reference Include="System.Runtime.Serialization" />
-	
-    <Service Name="MonoGame.Framework/OpenGLGraphics">
-      <Reference Include="System.Core" />
-      <Reference Include="System.Web" />
-      <Reference Include="System.Web.Services" />
-      <Reference Include="System.Windows.Forms" />
-      <Reference Include="System.Xml" />
-    </Service>
-  </Platform>
-
-  <Platform Type="WindowsPhone81">
-    <Reference Include="System" />
-    <Reference Include="System.Runtime.Serialization" />
-	
-    <Binary
-      Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/Windows Phone 8.1/SharpDX.dll" />
-    <Binary
-      Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/Windows Phone 8.1/SharpDX.Direct2D1.dll" />
-    <Binary
-      Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/Windows Phone 8.1/SharpDX.DXGI.dll" />
-    <Binary
-      Name="SharpDX.Direct3D11"
-      Path="ThirdParty/Dependencies/SharpDX/Windows Phone 8.1/SharpDX.Direct3D11.dll" />
-    <Binary
-      Name="SharpDX.DXGI"
-      Path="ThirdParty/Dependencies/SharpDX/Windows Phone 8.1/SharpDX.DXGI.dll" />
-    <Binary
-      Name="SharpDX.MediaFoundation"
-      Path="ThirdParty/Dependencies/SharpDX/Windows Phone 8.1/SharpDX.MediaFoundation.dll" />
-    <Binary
-      Name="SharpDX.XAudio2"
-      Path="ThirdParty/Dependencies/SharpDX/Windows Phone 8.1/SharpDX.XAudio2.dll" />
-  </Platform>
-	
-  <Platform Type="WindowsUniversal">
-    <Binary
-      Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/Windows UAP/SharpDX.dll" />
-    <Binary
-      Name="SharpDX.Direct2D1"
-      Path="ThirdParty/Dependencies/SharpDX/Windows UAP/SharpDX.Direct2D1.dll" />
-    <Binary
-      Name="SharpDX.Direct3D11"
-      Path="ThirdParty/Dependencies/SharpDX/Windows UAP/SharpDX.Direct3D11.dll" />
-    <Binary
-      Name="SharpDX.DXGI"
-      Path="ThirdParty/Dependencies/SharpDX/Windows UAP/SharpDX.DXGI.dll" />
-    <Binary
-      Name="SharpDX.MediaFoundation"
-      Path="ThirdParty/Dependencies/SharpDX/Windows UAP/SharpDX.MediaFoundation.dll" />
-    <Binary
-      Name="SharpDX.XAudio2"
-      Path="ThirdParty/Dependencies/SharpDX/Windows UAP/SharpDX.XAudio2.dll" />
-  </Platform>
-	
   <Platform Type="Web">
     <Reference Include="System" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -46,6 +46,36 @@
     <Reference Include="System" />
     <Reference Include="System.Runtime.Serialization" />
 	
+    <Service Name="MonoGame.Framework/DirectXGraphics">
+      <Reference Include="System.Core" />
+      <Reference Include="System.Drawing" />
+      <Reference Include="System.Web" />
+      <Reference Include="System.Web.Services" />
+      <Reference Include="System.Windows.Forms" />
+      <Reference Include="System.Xml" />
+      <Binary
+        Name="SharpDX"
+        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.dll" />
+      <Binary
+        Name="SharpDX.Direct2D1"
+        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.Direct2D1.dll" />
+      <Binary
+        Name="SharpDX.Direct3D11"
+        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.Direct3D11.dll" />
+      <Binary
+        Name="SharpDX.DXGI"
+        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.DXGI.dll" />
+      <Binary
+        Name="SharpDX.MediaFoundation"
+        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.MediaFoundation.dll" />
+      <Binary
+        Name="SharpDX.XAudio2"
+        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.XAudio2.dll" />
+      <Binary
+        Name="SharpDX.XInput"
+        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.XInput.dll" />
+    </Service>
+
     <Service Name="MonoGame.Framework/OpenGLGraphics">
       <Reference Include="System.Core" />
       <Reference Include="System.Web" />
@@ -55,36 +85,94 @@
     </Service>
   </Platform>
 
-  <Service Name="MonoGame.Framework/DirectXGraphics">
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Web.Services" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
+  <Platform Type="Windows8">
+    <Reference Include="System" />
+    <Reference Include="System.Runtime.Serialization" />
+	
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.dll" />
     <Binary
       Name="SharpDX.Direct2D1"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.Direct2D1.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.Direct2D1.dll" />
     <Binary
       Name="SharpDX.Direct3D11"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.Direct3D11.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.Direct3D11.dll" />
     <Binary
       Name="SharpDX.DXGI"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.DXGI.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.DXGI.dll" />
     <Binary
       Name="SharpDX.MediaFoundation"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.MediaFoundation.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.MediaFoundation.dll" />
     <Binary
       Name="SharpDX.XAudio2"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.XAudio2.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.XAudio2.dll" />
     <Binary
       Name="SharpDX.XInput"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.XInput.dll" />
-  </Service>
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.XInput.dll" />
+  </Platform>
 
+  <Platform Type="WindowsGL">
+    <Reference Include="System" />
+    <Reference Include="System.Runtime.Serialization" />
+	
+    <Service Name="MonoGame.Framework/OpenGLGraphics">
+      <Reference Include="System.Core" />
+      <Reference Include="System.Web" />
+      <Reference Include="System.Web.Services" />
+      <Reference Include="System.Windows.Forms" />
+      <Reference Include="System.Xml" />
+    </Service>
+  </Platform>
+
+  <Platform Type="WindowsPhone81">
+    <Reference Include="System" />
+    <Reference Include="System.Runtime.Serialization" />
+	
+    <Binary
+      Name="SharpDX"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.dll" />
+    <Binary
+      Name="SharpDX"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.Direct2D1.dll" />
+    <Binary
+      Name="SharpDX"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.DXGI.dll" />
+    <Binary
+      Name="SharpDX.Direct3D11"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.Direct3D11.dll" />
+    <Binary
+      Name="SharpDX.DXGI"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.DXGI.dll" />
+    <Binary
+      Name="SharpDX.MediaFoundation"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.MediaFoundation.dll" />
+    <Binary
+      Name="SharpDX.XAudio2"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.XAudio2.dll" />
+  </Platform>
+	
+  <Platform Type="WindowsUniversal">
+    <Binary
+      Name="SharpDX"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.dll" />
+    <Binary
+      Name="SharpDX.Direct2D1"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.Direct2D1.dll" />
+    <Binary
+      Name="SharpDX.Direct3D11"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.Direct3D11.dll" />
+    <Binary
+      Name="SharpDX.DXGI"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.DXGI.dll" />
+    <Binary
+      Name="SharpDX.MediaFoundation"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.MediaFoundation.dll" />
+    <Binary
+      Name="SharpDX.XAudio2"
+      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.XAudio2.dll" />
+  </Platform>
+	
   <Platform Type="Web">
     <Reference Include="System" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1412,6 +1412,9 @@
     <Compile Include="Windows8\MetroHelper.cs">
       <Platforms>Windows8,WindowsPhone81,WindowsUniversal</Platforms>
     </Compile>
+    <Compile Include="Windows\SharpDXHelper.cs">
+      <Platforms>Windows8,Windows,WindowsPhone81,WindowsUniversal</Platforms>
+    </Compile>
     <Compile Include="Windows8\XamlGame.cs">
       <Platforms>Windows8,WindowsPhone81</Platforms>
     </Compile>
@@ -1430,9 +1433,6 @@
 
 
     <!-- Windows Desktop Platfom -->
-    <Compile Include="Windows\SharpDXHelper.cs">
-      <Platforms>Windows8,Windows,WindowsPhone81,WindowsUniversal</Platforms>
-    </Compile>
     <Compile Include="Windows\WinFormsGameForm.cs">
       <Platforms>Windows</Platforms>
     </Compile>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1412,9 +1412,6 @@
     <Compile Include="Windows8\MetroHelper.cs">
       <Platforms>Windows8,WindowsPhone81,WindowsUniversal</Platforms>
     </Compile>
-    <Compile Include="Windows8\SharpDXHelper.cs">
-      <Platforms>Windows8,Windows,WindowsPhone81,WindowsUniversal</Platforms>
-    </Compile>
     <Compile Include="Windows8\XamlGame.cs">
       <Platforms>Windows8,WindowsPhone81</Platforms>
     </Compile>
@@ -1433,6 +1430,9 @@
 
 
     <!-- Windows Desktop Platfom -->
+    <Compile Include="Windows\SharpDXHelper.cs">
+      <Platforms>Windows8,Windows,WindowsPhone81,WindowsUniversal</Platforms>
+    </Compile>
     <Compile Include="Windows\WinFormsGameForm.cs">
       <Platforms>Windows</Platforms>
     </Compile>

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Xna.Framework.Audio
                     var details = MasterVoice.VoiceDetails;
                     _reverbVoice = new SubmixVoice(Device, details.InputChannelCount, details.InputSampleRate);
 
-                    var reverb = new SharpDX.XAudio2.Fx.Reverb();
+                    var reverb = new SharpDX.XAudio2.Fx.Reverb(Device);
                     var desc = new EffectDescriptor(reverb);
                     desc.InitialState = true;
                     desc.OutputChannelCount = details.InputChannelCount;
@@ -131,15 +131,16 @@ namespace Microsoft.Xna.Framework.Audio
                 if (MasterVoice == null)
                 {
                     // Let windows autodetect number of channels and sample rate.
-                    MasterVoice = new MasteringVoice(Device, XAudio2.DefaultChannels, XAudio2.DefaultSampleRate, deviceId);
+                    MasterVoice = new MasteringVoice(Device, XAudio2.DefaultChannels, XAudio2.DefaultSampleRate);
                 }
 
                 // The autodetected value of MasterVoice.ChannelMask corresponds to the speaker layout.
 #if WINRT
                 Speakers = (Speakers)MasterVoice.ChannelMask;
 #else
-                var deviceDetails = Device.GetDeviceDetails(deviceId);
-                Speakers = deviceDetails.OutputFormat.ChannelMask;
+                Speakers = Device.Version == XAudio2Version.Version27 ?
+                    Device.GetDeviceDetails(deviceId).OutputFormat.ChannelMask:
+                    (Speakers) MasterVoice.ChannelMask;
 #endif
             }
             catch

--- a/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
@@ -6,6 +6,7 @@ using System;
 using SharpDX.XAudio2;
 using SharpDX.X3DAudio;
 using SharpDX.Multimedia;
+using SharpDX.Mathematics.Interop;
 
 namespace Microsoft.Xna.Framework.Audio
 {
@@ -69,10 +70,10 @@ namespace Microsoft.Xna.Framework.Audio
             _voice.SetFrequencyRatio(dpsSettings.DopplerFactor);
         }
 
-        private SharpDX.X3DAudio.Emitter _dxEmitter;
-        private SharpDX.X3DAudio.Listener _dxListener;
+        private Emitter _dxEmitter;
+        private Listener _dxListener;
 
-        private SharpDX.X3DAudio.Emitter ToDXEmitter(AudioEmitter emitter)
+        private Emitter ToDXEmitter(AudioEmitter emitter)
         {
             // Pulling out Vector properties for efficiency.
             var pos = emitter.Position;
@@ -102,23 +103,15 @@ namespace Microsoft.Xna.Framework.Audio
             if (_dxEmitter == null)
                 _dxEmitter = new Emitter();
 
-#if WINDOWS_UAP
-            _dxEmitter.Position = new SharpDX.Mathematics.Interop.RawVector3 { X = pos.X, Y = pos.Y, Z = pos.Z };
-            _dxEmitter.Velocity =  new SharpDX.Mathematics.Interop.RawVector3 { X = vel.X, Y = vel.Y, Z = vel.Z };
-            _dxEmitter.OrientFront = new SharpDX.Mathematics.Interop.RawVector3 { X = forward.X, Y = forward.Y, Z = forward.Z };
-            _dxEmitter.OrientTop = new SharpDX.Mathematics.Interop.RawVector3 { X = up.X, Y = up.Y, Z = up.Z };
-            
-#else
-            _dxEmitter.Position = new SharpDX.Vector3(pos.X, pos.Y, pos.Z);
-            _dxEmitter.Velocity = new SharpDX.Vector3(vel.X, vel.Y, vel.Z);
-            _dxEmitter.OrientFront = new SharpDX.Vector3(forward.X, forward.Y, forward.Z);
-            _dxEmitter.OrientTop = new SharpDX.Vector3(up.X, up.Y, up.Z);
+            _dxEmitter.Position = new RawVector3(pos.X, pos.Y, pos.Z);
+            _dxEmitter.Velocity = new RawVector3(vel.X, vel.Y, vel.Z);
+            _dxEmitter.OrientFront = new RawVector3(forward.X, forward.Y, forward.Z);
+            _dxEmitter.OrientTop = new RawVector3(up.X, up.Y, up.Z);
             _dxEmitter.DopplerScaler = emitter.DopplerScale;
-#endif
             return _dxEmitter;
         }
 
-        private SharpDX.X3DAudio.Listener ToDXListener(AudioListener listener)
+        private Listener ToDXListener(AudioListener listener)
         {
             // Pulling out Vector properties for efficiency.
             var pos = listener.Position;
@@ -148,17 +141,10 @@ namespace Microsoft.Xna.Framework.Audio
             if (_dxListener == null)
                 _dxListener = new Listener();
 
-#if WINDOWS_UAP
-            _dxListener.Position = new SharpDX.Mathematics.Interop.RawVector3 { X = pos.X, Y = pos.Y, Z = pos.Z };
-            _dxListener.Velocity = new SharpDX.Mathematics.Interop.RawVector3 { X = vel.X, Y = vel.Y, Z = vel.Z };
-            _dxListener.OrientFront = new SharpDX.Mathematics.Interop.RawVector3 { X = forward.X, Y = forward.Y, Z = forward.Z };
-            _dxListener.OrientTop = new SharpDX.Mathematics.Interop.RawVector3 { X = up.X, Y = up.Y, Z = up.Z };
-#else
-            _dxListener.Position = new SharpDX.Vector3(pos.X, pos.Y, pos.Z);
-            _dxListener.Velocity = new SharpDX.Vector3(vel.X, vel.Y, vel.Z);
-            _dxListener.OrientFront = new SharpDX.Vector3(forward.X, forward.Y, forward.Z);
-            _dxListener.OrientTop = new SharpDX.Vector3(up.X, up.Y, up.Z);
-#endif
+            _dxListener.Position = new RawVector3 { X = pos.X, Y = pos.Y, Z = pos.Z };
+            _dxListener.Velocity = new RawVector3 { X = vel.X, Y = vel.Y, Z = vel.Z };
+            _dxListener.OrientFront = new RawVector3 { X = forward.X, Y = forward.Y, Z = forward.Z };
+            _dxListener.OrientTop = new RawVector3 { X = up.X, Y = up.Y, Z = up.Z };
             return _dxListener;
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using SharpDX.Direct3D;
-using SharpDX.DXGI;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -62,13 +61,8 @@ namespace Microsoft.Xna.Framework.Graphics
             adapter.SubSystemId = device.Description1.SubsystemId;
             adapter.MonitorHandle = monitor.Description.MonitorHandle;
 
-#if WINDOWS_UAP
             var desktopWidth = monitor.Description.DesktopBounds.Right - monitor.Description.DesktopBounds.Left;
             var desktopHeight = monitor.Description.DesktopBounds.Bottom - monitor.Description.DesktopBounds.Top;
-#else
-            var desktopWidth = monitor.Description.DesktopBounds.Width;
-            var desktopHeight = monitor.Description.DesktopBounds.Height;
-#endif
 
             var modes = new List<DisplayMode>();
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-
 using SharpDX;
 using SharpDX.Direct3D;
 using SharpDX.Mathematics.Interop;
@@ -15,6 +14,7 @@ using SharpDX.DXGI;
 using Windows.UI.Xaml.Controls;
 using Windows.Graphics.Display;
 using Windows.UI.Core;
+using System.Runtime.InteropServices;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -4,27 +4,17 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Diagnostics;
-using System.Linq;
 
 using SharpDX;
 using SharpDX.Direct3D;
-using SharpDX.Direct3D11;
+using SharpDX.Mathematics.Interop;
+using SharpDX.DXGI;
 
 #if WINDOWS_STOREAPP || WINDOWS_UAP
 using Windows.UI.Xaml.Controls;
 using Windows.Graphics.Display;
 using Windows.UI.Core;
-using SharpDX.DXGI;
-#endif
-
-#if WINDOWS_UAP
-using SharpDX.Mathematics.Interop;
-#endif
-
-#if WINDOWS
-using SharpDX.DXGI;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -931,11 +921,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     foreach (var view in _currentRenderTargets)
                     {
                         if (view != null)
-#if WINDOWS_UAP
 							_d3dContext.ClearRenderTargetView(view, new RawColor4(color.X, color.Y, color.Z, color.W));
-#else
-                            _d3dContext.ClearRenderTargetView(view, new Color4(color.X, color.Y, color.Z, color.W));
-#endif
                     }
                 }
 
@@ -1059,7 +1045,6 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (_d3dContext != null)
             {
-#if WINDOWS_UAP
 				var viewport = new RawViewportF
 				{
 					X = _viewport.X,
@@ -1069,9 +1054,6 @@ namespace Microsoft.Xna.Framework.Graphics
 					MinDepth = _viewport.MinDepth,
 					MaxDepth = _viewport.MaxDepth
 				};
-#else
-                var viewport = new SharpDX.ViewportF(_viewport.X, _viewport.Y, (float)_viewport.Width, (float)_viewport.Height, _viewport.MinDepth, _viewport.MaxDepth);
-#endif
                 lock (_d3dContext)
                     _d3dContext.Rasterizer.SetViewport(viewport);
             }
@@ -1168,7 +1150,6 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 lock (_d3dContext)
                 {
-#if WINDOWS_UAP
 					var viewport = new RawViewportF
 					{
 						X = _viewport.X,
@@ -1178,11 +1159,6 @@ namespace Microsoft.Xna.Framework.Graphics
 						MinDepth = _viewport.MinDepth,
 						MaxDepth = _viewport.MaxDepth
 					};
-#else
-                    var viewport = new SharpDX.ViewportF( _viewport.X, _viewport.Y, 
-                                                          _viewport.Width, _viewport.Height, 
-                                                          _viewport.MinDepth, _viewport.MaxDepth);
-#endif
                     _d3dContext.Rasterizer.SetViewport(viewport);
                     _d3dContext.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
                 }
@@ -1236,7 +1212,6 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-#if WINDOWS_UAP
         private SharpDX.Mathematics.Interop.RawColor4 GetBlendFactor()
         {
 			return new SharpDX.Mathematics.Interop.RawColor4(
@@ -1245,12 +1220,6 @@ namespace Microsoft.Xna.Framework.Graphics
 					BlendFactor.B / 255.0f,
 					BlendFactor.A / 255.0f);
         }
-#else
-        private Color4 GetBlendFactor()
-        {
-			return BlendFactor.ToColor4();
-        }
-#endif
 
         internal void PlatformApplyState(bool applyShaders)
         {

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -341,7 +341,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
         static unsafe SharpDX.Direct3D11.Texture2D CreateTex2DFromBitmap(BitmapSource bsource, GraphicsDevice device)
         {
-
             Texture2DDescription desc;
             desc.Width = bsource.Size.Width;
             desc.Height = bsource.Size.Height;

--- a/MonoGame.Framework/Media/Song.WMS.cs
+++ b/MonoGame.Framework/Media/Song.WMS.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Xna.Framework.Media
 
             for (var i = 0; i < presDesc.StreamDescriptorCount; i++)
             {
-                Bool selected;
+                SharpDX.Mathematics.Interop.RawBool selected;
                 StreamDescriptor desc;
                 presDesc.GetStreamDescriptorByIndex(i, out selected, out desc);
 

--- a/MonoGame.Framework/Media/Video.WMS.cs
+++ b/MonoGame.Framework/Media/Video.WMS.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Xna.Framework.Media
 
             for (var i = 0; i < presDesc.StreamDescriptorCount; i++)
             {
-                Bool selected;
+                SharpDX.Mathematics.Interop.RawBool selected;
                 StreamDescriptor desc;
                 presDesc.GetStreamDescriptorByIndex(i, out selected, out desc);
 

--- a/MonoGame.Framework/Media/VideoPlayer.WME.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.WME.cs
@@ -79,11 +79,7 @@ namespace Microsoft.Xna.Framework.Media
                                         SurfaceFormat.Bgra32, 
                                         Texture2D.SurfaceType.RenderTarget);
 
-#if WINDOWS_UAP
 			var region = new SharpDX.Mathematics.Interop.RawRectangle(0, 0, _currentVideo.Width, _currentVideo.Height);
-#else
-			var region = new SharpDX.Rectangle(0, 0, _currentVideo.Width, _currentVideo.Height);
-#endif
             _mediaEngine.TransferVideoFrame(_lastFrame._texture, null, region, null);
 
             return _lastFrame;

--- a/MonoGame.Framework/Windows/SharpDXHelper.cs
+++ b/MonoGame.Framework/Windows/SharpDXHelper.cs
@@ -5,7 +5,8 @@
 namespace Microsoft.Xna.Framework
 {
     using System;
-    using Microsoft.Xna.Framework.Graphics;
+    using Graphics;
+    using SharpDX.Mathematics.Interop;
 
     static internal class SharpDXHelper
     {
@@ -127,111 +128,24 @@ namespace Microsoft.Xna.Framework
             }
         }
 
-		static public SharpDX.Mathematics.Interop.RawVector2 ToVector2(this Vector2 vec)
+		static public RawVector2 ToVector2(this Vector2 vec)
         {
-            return new SharpDX.Mathematics.Interop.RawVector2(vec.X, vec.Y);
+            return new RawVector2(vec.X, vec.Y);
         }
 
-        static public SharpDX.Mathematics.Interop.RawVector3 ToVector3(this Vector3 vec)
+        static public RawVector3 ToVector3(this Vector3 vec)
         {
-            return new SharpDX.Mathematics.Interop.RawVector3(vec.X, vec.Y, vec.Z);
+            return new RawVector3(vec.X, vec.Y, vec.Z);
         }
 
-        static public SharpDX.Mathematics.Interop.RawVector4 ToVector4(this Vector4 vec)
+        static public RawVector4 ToVector4(this Vector4 vec)
         {
-            return new SharpDX.Mathematics.Interop.RawVector4(vec.X, vec.Y, vec.Z, vec.W);
+            return new RawVector4(vec.X, vec.Y, vec.Z, vec.W);
         }
 
-        static public SharpDX.Mathematics.Interop.RawColor4 ToColor4(this Color color)
+        static public RawColor4 ToColor4(this Color color)
         {
-            return new SharpDX.Mathematics.Interop.RawColor4(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
-        }
-
-		static public SharpDX.X3DAudio.Emitter ToEmitter(this Audio.AudioEmitter emitter)
-        {           
-            // Pulling out Vector properties for efficiency.
-            var pos = emitter.Position;
-            var vel = emitter.Velocity;
-            var forward = emitter.Forward;
-            var up = emitter.Up;
-
-            // From MSDN:
-            //  X3DAudio uses a left-handed Cartesian coordinate system, 
-            //  with values on the x-axis increasing from left to right, on the y-axis from bottom to top, 
-            //  and on the z-axis from near to far. 
-            //  Azimuths are measured clockwise from a given reference direction. 
-            //
-            // From MSDN:
-            //  The XNA Framework uses a right-handed coordinate system, 
-            //  with the positive z-axis pointing toward the observer when the positive x-axis is pointing to the right, 
-            //  and the positive y-axis is pointing up. 
-            //
-            // Programmer Notes:         
-            //  According to this description the z-axis (forward vector) is inverted between these two coordinate systems.
-            //  Therefore, we need to negate the z component of any position/velocity values, and negate any forward vectors.
-
-            forward *= -1.0f;
-            pos.Z *= -1.0f;
-            vel.Z *= -1.0f;
-
-            return new SharpDX.X3DAudio.Emitter()
-            {
-#if WINDOWS_UAP
-				Position = new SharpDX.Mathematics.Interop.RawVector3 { X = pos.X, Y = pos.Y, Z = pos.Z },
-				Velocity = new SharpDX.Mathematics.Interop.RawVector3 { X = vel.X, Y = vel.Y, Z = vel.Z },
-				OrientFront = new SharpDX.Mathematics.Interop.RawVector3 { X = forward.X, Y = forward.Y, Z = forward.Z },
-				OrientTop = new SharpDX.Mathematics.Interop.RawVector3 { X = up.X, Y = up.Y, Z = up.Z },
-#else
-				Position = new SharpDX.Mathematics.Interop.RawVector3( pos.X, pos.Y, pos.Z ),
-                Velocity = new SharpDX.Mathematics.Interop.RawVector3( vel.X, vel.Y, vel.Z ),
-                OrientFront = new SharpDX.Mathematics.Interop.RawVector3( forward.X, forward.Y, forward.Z ),
-                OrientTop = new SharpDX.Mathematics.Interop.RawVector3( up.X, up.Y, up.Z ),
-                DopplerScaler = emitter.DopplerScale,                   
-#endif
-			};
-        }
-
-        static public SharpDX.X3DAudio.Listener ToListener(this Audio.AudioListener listener)
-        {
-            // Pulling out Vector properties for efficiency.
-            var pos = listener.Position;
-            var vel = listener.Velocity;
-            var forward = listener.Forward;
-            var up = listener.Up;
-
-            // From MSDN:
-            //  X3DAudio uses a left-handed Cartesian coordinate system, 
-            //  with values on the x-axis increasing from left to right, on the y-axis from bottom to top, 
-            //  and on the z-axis from near to far. 
-            //  Azimuths are measured clockwise from a given reference direction. 
-            //
-            // From MSDN:
-            //  The XNA Framework uses a right-handed coordinate system, 
-            //  with the positive z-axis pointing toward the observer when the positive x-axis is pointing to the right, 
-            //  and the positive y-axis is pointing up. 
-            //
-            // Programmer Notes:         
-            //  According to this description the z-axis (forward vector) is inverted between these two coordinate systems.
-            //  Therefore, we need to negate the z component of any position/velocity values, and negate any forward vectors.
-
-            forward *= -1.0f;
-            pos.Z *= -1.0f;
-            vel.Z *= -1.0f;
-
-            return new SharpDX.X3DAudio.Listener()
-            {
-#if WINDOWS_UAP
-				Position = new SharpDX.Mathematics.Interop.RawVector3 { X = pos.X, Y = pos.Y, Z = pos.Z },
-				Velocity = new SharpDX.Mathematics.Interop.RawVector3 { X = vel.X, Y = vel.Y, Z = vel.Z },
-				OrientFront = new SharpDX.Mathematics.Interop.RawVector3 { X = forward.X, Y = forward.Y, Z = forward.Z },
-				OrientTop = new SharpDX.Mathematics.Interop.RawVector3 { X = up.X, Y = up.Y, Z = up.Z },
-#else
-				Position = new SharpDX.Mathematics.Interop.RawVector3(pos.X, pos.Y, pos.Z),
-                Velocity = new SharpDX.Mathematics.Interop.RawVector3(vel.X, vel.Y, vel.Z),
-                OrientFront = new SharpDX.Mathematics.Interop.RawVector3(forward.X, forward.Y, forward.Z),
-                OrientTop = new SharpDX.Mathematics.Interop.RawVector3(up.X, up.Y, up.Z),                
-#endif
-			};
+            return new RawColor4(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
         }
 
         static public SharpDX.Direct3D11.Comparison ToComparison(this CompareFunction compare)

--- a/MonoGame.Framework/Windows/SharpDXHelper.cs
+++ b/MonoGame.Framework/Windows/SharpDXHelper.cs
@@ -127,29 +127,25 @@ namespace Microsoft.Xna.Framework
             }
         }
 
-#if !WINDOWS_UAP
-
-		static public SharpDX.Vector2 ToVector2(this Vector2 vec)
+		static public SharpDX.Mathematics.Interop.RawVector2 ToVector2(this Vector2 vec)
         {
-            return new SharpDX.Vector2(vec.X, vec.Y);
+            return new SharpDX.Mathematics.Interop.RawVector2(vec.X, vec.Y);
         }
 
-        static public SharpDX.Vector3 ToVector3(this Vector3 vec)
+        static public SharpDX.Mathematics.Interop.RawVector3 ToVector3(this Vector3 vec)
         {
-            return new SharpDX.Vector3(vec.X, vec.Y, vec.Z);
+            return new SharpDX.Mathematics.Interop.RawVector3(vec.X, vec.Y, vec.Z);
         }
 
-        static public SharpDX.Vector4 ToVector4(this Vector4 vec)
+        static public SharpDX.Mathematics.Interop.RawVector4 ToVector4(this Vector4 vec)
         {
-            return new SharpDX.Vector4(vec.X, vec.Y, vec.Z, vec.W);
+            return new SharpDX.Mathematics.Interop.RawVector4(vec.X, vec.Y, vec.Z, vec.W);
         }
 
-        static public SharpDX.Color4 ToColor4(this Color color)
+        static public SharpDX.Mathematics.Interop.RawColor4 ToColor4(this Color color)
         {
-            return new SharpDX.Color4(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
+            return new SharpDX.Mathematics.Interop.RawColor4(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
         }
-
-#endif // !WINDOWS_UAP
 
 		static public SharpDX.X3DAudio.Emitter ToEmitter(this Audio.AudioEmitter emitter)
         {           
@@ -186,10 +182,10 @@ namespace Microsoft.Xna.Framework
 				OrientFront = new SharpDX.Mathematics.Interop.RawVector3 { X = forward.X, Y = forward.Y, Z = forward.Z },
 				OrientTop = new SharpDX.Mathematics.Interop.RawVector3 { X = up.X, Y = up.Y, Z = up.Z },
 #else
-				Position = new SharpDX.Vector3( pos.X, pos.Y, pos.Z ),
-                Velocity = new SharpDX.Vector3( vel.X, vel.Y, vel.Z ),
-                OrientFront = new SharpDX.Vector3( forward.X, forward.Y, forward.Z ),
-                OrientTop = new SharpDX.Vector3( up.X, up.Y, up.Z ),
+				Position = new SharpDX.Mathematics.Interop.RawVector3( pos.X, pos.Y, pos.Z ),
+                Velocity = new SharpDX.Mathematics.Interop.RawVector3( vel.X, vel.Y, vel.Z ),
+                OrientFront = new SharpDX.Mathematics.Interop.RawVector3( forward.X, forward.Y, forward.Z ),
+                OrientTop = new SharpDX.Mathematics.Interop.RawVector3( up.X, up.Y, up.Z ),
                 DopplerScaler = emitter.DopplerScale,                   
 #endif
 			};
@@ -230,10 +226,10 @@ namespace Microsoft.Xna.Framework
 				OrientFront = new SharpDX.Mathematics.Interop.RawVector3 { X = forward.X, Y = forward.Y, Z = forward.Z },
 				OrientTop = new SharpDX.Mathematics.Interop.RawVector3 { X = up.X, Y = up.Y, Z = up.Z },
 #else
-				Position = new SharpDX.Vector3(pos.X, pos.Y, pos.Z),
-                Velocity = new SharpDX.Vector3(vel.X, vel.Y, vel.Z),
-                OrientFront = new SharpDX.Vector3(forward.X, forward.Y, forward.Z),
-                OrientTop = new SharpDX.Vector3(up.X, up.Y, up.Z),                
+				Position = new SharpDX.Mathematics.Interop.RawVector3(pos.X, pos.Y, pos.Z),
+                Velocity = new SharpDX.Mathematics.Interop.RawVector3(vel.X, vel.Y, vel.Z),
+                OrientFront = new SharpDX.Mathematics.Interop.RawVector3(forward.X, forward.Y, forward.Z),
+                OrientTop = new SharpDX.Mathematics.Interop.RawVector3(up.X, up.Y, up.Z),                
 #endif
 			};
         }

--- a/Tools/2MGFX/EffectObject.hlsl.cs
+++ b/Tools/2MGFX/EffectObject.hlsl.cs
@@ -44,7 +44,7 @@ namespace TwoMGFX
                 // Store all the errors and warnings to log out later.
                 errorsAndWarnings += result.Message;
 
-                if (result.HasErrors)
+                if (result.Bytecode == null)
                     throw new ShaderCompilerException();
                 
                 shaderByteCode = result.Bytecode;


### PR DESCRIPTION
This should resolve #5742, #3240 and #5777 because these newer SharpDX versions check for for multiple version of XInput and XAudio instead of depending on old versions that are no longer shipped with Windows 10. 

From [SharpDX 3.0 changelog](https://github.com/sharpdx/SharpDX/releases/tag/v3.0.0):

> XInput and XAudio are now providing a backward compatible interface between the various versions. For Desktop, it means that the runtime will try to detect the correct versions for XInput (9.10, 1.3, 1.4) or XAudio (2.7 or 2.8). For Store Apps, the latest one will be used.

The changes in this PR are exactly the same as needed to upgrade to SharpDX 4, so that will be pretty much painless after this :) 

I cleaned up a lot of preprocessor stuff because the API is more unified now that all Windows platforms use the same SharpDX version. That needed to happen anyway when we upgrade to SharpDX 4, so I thought I might as well include it in here.

The [change in 2MGFX](https://github.com/MonoGame/MonoGame/compare/develop...Jjagg:dx3.1.1?expand=1#diff-19f639315aec8ef8a47c2e29acf039f1R47) is because `SharpDX.D3DCompiler.ShaderBytecode.Compile` does not correctly set `CompilationResult.HasErrors`, but we can detect failure by checking if the returned `ByteCode` is null.