### PR TITLE
Adding support for multi-dimensional arrays to the content pipeline.

### DIFF
--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -338,6 +338,7 @@
     <Compile Include="Serialization\Compiler\ListWriter.cs" />
     <Compile Include="Serialization\Compiler\MatrixWriter.cs" />
     <Compile Include="Serialization\Compiler\ModelWriter.cs" />
+    <Compile Include="Serialization\Compiler\MultiArrayWriter.cs" />
     <Compile Include="Serialization\Compiler\NullableWriter.cs" />
     <Compile Include="Serialization\Compiler\PlaneWriter.cs" />
     <Compile Include="Serialization\Compiler\PointWriter.cs" />

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -492,6 +492,7 @@
     <Compile Include="Content\ContentReaders\ListReader.cs" />
     <Compile Include="Content\ContentReaders\MatrixReader.cs" />
     <Compile Include="Content\ContentReaders\ModelReader.cs" />
+    <Compile Include="Content\ContentReaders\MultiArrayReader.cs" />
     <Compile Include="Content\ContentReaders\NullableReader.cs" />
     <Compile Include="Content\ContentReaders\PlaneReader.cs" />
     <Compile Include="Content\ContentReaders\PointReader.cs" />

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -207,6 +207,10 @@
     <Compile Include="Framework\Visual\VisualTestFixtureBase.cs" />
     <Compile Include="Framework\Visual\VisualTestGame.cs" />
 
+
+    <Compile Include="ContentPipeline\ArrayContentCompilerTest.cs">
+      <Platforms>Windows,MacOS,Linux</Platforms>
+    </Compile>
     <Compile Include="ContentPipeline\AssetTestClasses.cs">
         <Platforms>Windows,MacOS,Linux</Platforms>
     </Compile>

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentCompiler.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentCompiler.cs
@@ -72,7 +72,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
             ContentTypeWriter result = null;
             var contentTypeWriterType = typeof(ContentTypeWriter<>).MakeGenericType(type);
             Type typeWriterType;
-            if (typeWriterMap.TryGetValue(contentTypeWriterType, out typeWriterType))
+
+            if (type == typeof(Array))
+                result = new ArrayWriter<Array>();
+            else if (typeWriterMap.TryGetValue(contentTypeWriterType, out typeWriterType))
                 result = (ContentTypeWriter)Activator.CreateInstance(typeWriterType);
             else if (type.IsArray)
             {

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentCompiler.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentCompiler.cs
@@ -76,10 +76,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
                 result = (ContentTypeWriter)Activator.CreateInstance(typeWriterType);
             else if (type.IsArray)
             {
-                if (type.GetArrayRank() != 1)
-                    throw new NotSupportedException("We don't support multidimensional arrays!");
+                var writerType = type.GetArrayRank() == 1 ? typeof(ArrayWriter<>) : typeof(MultiArrayWriter<>);
 
-                result = (ContentTypeWriter)Activator.CreateInstance(typeof(ArrayWriter<>).MakeGenericType(type.GetElementType()));
+                result = (ContentTypeWriter)Activator.CreateInstance(writerType.MakeGenericType(type.GetElementType()));
                 typeWriterMap.Add(contentTypeWriterType, result.GetType());
             }
             else if (type.IsEnum)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/MultiArrayWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/MultiArrayWriter.cs
@@ -1,0 +1,75 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
+{
+    /// <summary>
+    /// Writes the array value to the output.
+    /// </summary>
+    [ContentTypeWriter]
+    class MultiArrayWriter<T> : BuiltInContentWriter<Array>
+    {
+        ContentTypeWriter _elementWriter;
+
+        /// <inheritdoc/>
+        internal override void OnAddedToContentWriter(ContentWriter output)
+        {
+            base.OnAddedToContentWriter(output);
+
+            _elementWriter = output.GetTypeWriter(typeof(T));
+        }
+
+        public override string GetRuntimeReader(TargetPlatform targetPlatform)
+        {
+            return string.Concat(typeof(ContentTypeReader).Namespace,
+                                    ".",
+                                    "MultiArrayReader`1[[",
+                                    _elementWriter.GetRuntimeType(targetPlatform),
+                                    "]]");
+        }
+
+        protected internal override void Write(ContentWriter output, Array value)
+        {
+            if (value == null)
+                throw new ArgumentNullException("value");
+
+            var rank = value.Rank;
+
+            // Dimension sizes
+            output.Write(rank);
+            for (int dimension = 0; dimension < rank; dimension++)
+                output.Write(value.GetLength(dimension));
+
+            // Values
+            var indices = new int[rank];
+            for (int i = 0; i < value.Length; i++)
+            {
+                CalcIndices(value, i, indices);
+                output.WriteObject(value.GetValue(indices), _elementWriter);
+            }
+        }
+
+        static void CalcIndices(Array array, int index, int[] indices)
+        {
+            if (array.Rank != indices.Length)
+                throw new Exception("indices");
+
+            for (int d = 0; d < indices.Length; d++)
+            {
+                if (index == 0)
+                    indices[d] = 0;
+                else
+                {
+                    indices[d] = index % array.GetLength(d);
+                    index /= array.GetLength(d);
+                }
+            }
+
+            if (index != 0)
+                throw new ArgumentOutOfRangeException("index");
+        }
+    }
+}

--- a/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
@@ -1,0 +1,83 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using Microsoft.Xna.Framework.Utilities;
+
+namespace Microsoft.Xna.Framework.Content
+{
+    internal class MultiArrayReader<T> : ContentTypeReader<Array>
+    {
+        ContentTypeReader elementReader;
+
+        public MultiArrayReader() { }
+
+        protected internal override void Initialize(ContentTypeReaderManager manager)
+        {
+            Type readerType = typeof(T);
+            elementReader = manager.GetTypeReader(readerType);
+        }
+
+        protected internal override Array Read(ContentReader input, Array existingInstance)
+        {
+            var rank = input.ReadInt32();
+            if (rank < 1)
+                throw new RankException();
+
+            var dimensions = new int[rank];
+            var count = 1;
+            for (int d = 0; d < dimensions.Length; d++)
+                count *= dimensions[d] = input.ReadInt32();
+
+
+            var array = existingInstance;
+            if (array == null)
+                array = Array.CreateInstance(typeof(T), dimensions);//new T[count];
+            else if (dimensions.Length != array.Rank)
+                throw new RankException("existingInstance");
+
+            var indices = new int[rank];
+
+            for (int i = 0; i < count; i++)
+            {
+                T value;
+                if (ReflectionHelpers.IsValueType(typeof(T)))
+                    value = input.ReadObject<T>(elementReader);
+                else
+                {
+                    var readerType = input.Read7BitEncodedInt();
+                    if (readerType > 0)
+                        value = input.ReadObject<T>(input.TypeReaders[readerType - 1]);
+                    else
+                        value = default(T);
+                }
+
+                CalcIndices(array, i, indices);
+                array.SetValue(value, indices);
+            }
+
+            return array;
+        }
+
+        static void CalcIndices(Array array, int index, int[] indices)
+        {
+            if (array.Rank != indices.Length)
+                throw new Exception("indices");
+
+            for (int d = 0; d < indices.Length; d++)
+            {
+                if (index == 0)
+                    indices[d] = 0;
+                else
+                {
+                    indices[d] = index % array.GetLength(d);
+                    index /= array.GetLength(d);
+                }
+            }
+
+            if (index != 0)
+                throw new ArgumentOutOfRangeException("index");
+        }
+    }
+}

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -146,7 +146,10 @@ namespace Microsoft.Xna.Framework.Content
             // We need to have a reader at this point.
             var reader = manager.GetTypeReader(elementType);
             if (reader == null)
-                throw new ContentLoadException(string.Format("Content reader could not be found for {0} type.", elementType.FullName));
+                if (elementType == typeof(System.Array))
+                    reader = new ArrayReader<Array>();
+                else
+                    throw new ContentLoadException(string.Format("Content reader could not be found for {0} type.", elementType.FullName));
 
             // We use the construct delegate to pick the correct existing 
             // object to be the target of deserialization.

--- a/Test/ContentPipeline/ArrayContentCompilerTest.cs
+++ b/Test/ContentPipeline/ArrayContentCompilerTest.cs
@@ -1,0 +1,256 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Content.Pipeline;
+using Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler;
+using Microsoft.Xna.Framework.Graphics;
+using NUnit.Framework;
+#if XNA
+using System.Reflection;
+#endif
+
+namespace MonoGame.Tests.ContentPipeline
+{
+    class ArrayContentCompilerTest
+    {
+        class TestContentManager : ContentManager
+        {
+            class FakeGraphicsService : IGraphicsDeviceService
+            {
+                public GraphicsDevice GraphicsDevice { get; private set; }
+
+#pragma warning disable 67
+                public event EventHandler<EventArgs> DeviceCreated;
+                public event EventHandler<EventArgs> DeviceDisposing;
+                public event EventHandler<EventArgs> DeviceReset;
+                public event EventHandler<EventArgs> DeviceResetting;
+#pragma warning restore 67
+            }
+
+            class FakeServiceProvider : IServiceProvider
+            {
+                public object GetService(Type serviceType)
+                {
+                    if (serviceType == typeof(IGraphicsDeviceService))
+                        return new FakeGraphicsService();
+
+                    throw new NotImplementedException();
+                }
+            }
+
+            private readonly MemoryStream _xnbStream;
+
+            public TestContentManager(MemoryStream xnbStream)
+                : base(new FakeServiceProvider(), "NONE")
+            {
+                _xnbStream = xnbStream;
+            }
+
+            protected override Stream OpenStream(string assetName)
+            {
+                return new MemoryStream(_xnbStream.GetBuffer(), false);
+            }
+        }
+        class TestDataClass : IEquatable<TestDataClass>
+        {
+            public int A;
+            public string B { get; set; }
+
+            public bool Equals(TestDataClass other)
+            {
+                return A == other.A
+                    && B == other.B;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is TestDataClass)
+                    return Equals(other: (TestDataClass)obj);
+                else
+                    return base.Equals(obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return A.GetHashCode() ^ B.GetHashCode();
+            }
+        }
+        struct TestDataStruct : IEquatable<TestDataStruct>
+        {
+            public int A;
+            public string B { get; set; }
+
+            public bool Equals(TestDataStruct other)
+            {
+                return A == other.A
+                    && B == other.B;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is TestDataStruct)
+                    return Equals(other: (TestDataStruct)obj);
+                else
+                    return base.Equals(obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return A.GetHashCode() ^ B.GetHashCode();
+            }
+        }
+
+        static readonly IReadOnlyCollection<TargetPlatform> Platforms = new[]
+        {
+            TargetPlatform.Windows,
+            TargetPlatform.Xbox360,
+            TargetPlatform.iOS,
+            TargetPlatform.Android,
+            TargetPlatform.DesktopGL,
+            TargetPlatform.MacOSX,
+            TargetPlatform.WindowsStoreApp,
+            TargetPlatform.NativeClient,
+
+            TargetPlatform.PlayStationMobile,
+
+            TargetPlatform.WindowsPhone8,
+            TargetPlatform.RaspberryPi,
+            TargetPlatform.PlayStation4,
+            TargetPlatform.PSVita,
+            TargetPlatform.XboxOne,
+            TargetPlatform.Switch
+        };
+        static readonly IReadOnlyCollection<GraphicsProfile> GraphicsProfiles = new[]
+        {
+            GraphicsProfile.HiDef,
+            GraphicsProfile.Reach
+        };
+        static readonly IReadOnlyCollection<bool> CompressContents = new[]
+        {
+            true,
+            false
+        };
+
+        ContentCompiler Compiler = new ContentCompiler();
+
+
+        void CompileAndLoadAssets<T>(T data, Action<T> validation)
+        {
+            foreach (var platform in Platforms)
+                foreach (var gfxProfile in GraphicsProfiles)
+                    foreach (var compress in CompressContents)
+                        using (var xnbStream = new MemoryStream())
+                        {
+                            Compiler.Compile(xnbStream, data, TargetPlatform.Windows, GraphicsProfile.HiDef, compress, "", "");
+                            using (var content = new TestContentManager(xnbStream))
+                            {
+                                var result = content.Load<T>("foo");
+                                validation(result);
+                            }
+                        }
+        }
+
+        [Test]
+        public void RoundTripJaggedArrayClass()
+        {
+            var expected = Enumerable.Range(0, 5).Select(a => Enumerable.Range(0, 3).Select(b => new TestDataClass { A = a * 42 << b, B = "index: " + a * 5 + b }).ToArray()).ToArray();
+
+            CompileAndLoadAssets(expected.ToArray(), result =>
+            {
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOf<TestDataClass[][]>(result);
+                Assert.AreEqual(1, result.Rank);
+                Assert.AreEqual(expected.Length, result.Length);
+                for (int i = 0; i < expected.Length; i++)
+                    CollectionAssert.AreEquivalent(expected[i], result[i]);
+            });
+
+        }
+
+        [Test]
+        public void RoundTrip1DArrayClass()
+        {
+            var expected = Enumerable.Range(0, 10).Select(i => new TestDataClass { A = i * 42, B = "index: " + i }).ToArray();
+
+            CompileAndLoadAssets(expected.ToArray(), result =>
+            {
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOf<TestDataClass[]>(result);
+                Assert.AreEqual(1, result.Rank);
+                Assert.AreEqual(expected.Length, result.Length);
+                CollectionAssert.AreEquivalent(expected, result);
+            });
+
+        }
+
+        [Test]
+        public void RoundTrip3DArrayClass()
+        {
+            var expected = new TestDataClass[3, 4, 2];
+            for (int z = 0; z < expected.GetLength(2); z++)
+                for (int y = 0; y < expected.GetLength(1); y++)
+                    for (int x = 0; x < expected.GetLength(0); x++)
+                        expected[x, y, z] = new TestDataClass { A = x + y * 10 + z * 100, B = string.Format("X: {0} Y: {1} Z: {2}", x, y, z) };
+
+            CompileAndLoadAssets((TestDataClass[,,])expected.Clone(), result =>
+            {
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOf<TestDataClass[,,]>(result);
+                Assert.AreEqual(result.Rank, 3);
+
+                for (int i = 0; i < result.Rank; i++)
+                    Assert.AreEqual(expected.GetLength(i), result.GetLength(i));
+
+                for (int z = 0; z < expected.GetLength(2); z++)
+                    for (int y = 0; y < expected.GetLength(1); y++)
+                        for (int x = 0; x < expected.GetLength(0); x++)
+                            Assert.AreEqual(expected[x, y, z], result[x, y, z]);
+            });
+        }
+
+        [Test]
+        public void RoundTrip1DArrayStruct()
+        {
+            var expected = Enumerable.Range(0, 10).Select(i => new TestDataStruct { A = i * 42, B = "index: " + i }).ToArray();
+
+            CompileAndLoadAssets(expected.ToArray(), result =>
+            {
+                Assert.IsInstanceOf<TestDataStruct[]>(result);
+                Assert.AreEqual(1, result.Rank);
+                Assert.AreEqual(expected.Length, result.Length);
+                CollectionAssert.AreEquivalent(expected, result);
+            });
+
+        }
+
+        [Test]
+        public void RoundTrip3DArrayStruct()
+        {
+            var expected = new TestDataStruct[3, 4, 2];
+            for (int z = 0; z < expected.GetLength(2); z++)
+                for (int y = 0; y < expected.GetLength(1); y++)
+                    for (int x = 0; x < expected.GetLength(0); x++)
+                        expected[x, y, z] = new TestDataStruct { A = x + y * 10 + z * 100, B = string.Format("X: {0} Y: {1} Z: {2}", x, y, z) };
+
+            CompileAndLoadAssets((TestDataStruct[,,])expected.Clone(), result =>
+            {
+                Assert.IsInstanceOf<TestDataStruct[,,]>(result);
+                Assert.AreEqual(result.Rank, 3);
+
+                for (int i = 0; i < result.Rank; i++)
+                    Assert.AreEqual(expected.GetLength(i), result.GetLength(i));
+
+                for (int z = 0; z < expected.GetLength(2); z++)
+                    for (int y = 0; y < expected.GetLength(1); y++)
+                        for (int x = 0; x < expected.GetLength(0); x++)
+                            Assert.AreEqual(expected[x, y, z], result[x, y, z]);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4908 by adding a reader/writer for multi-dimensional arrays instead of throwing an exception.