### PR TITLE
[XAudio] Check if master voice exists for XAudio SFXI's

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Xna.Framework.Audio
         private void PlatformApply3D(AudioListener listener, AudioEmitter emitter)
         {
             // If we have no voice then nothing to do.
-            if (_voice == null)
+            if (_voice == null || SoundEffect.MasterVoice == null)
                 return;
 
             // Convert from XNA Emitter to a SharpDX Emitter
@@ -150,14 +150,14 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformPause()
         {
-            if (_voice != null)
+            if (_voice != null && SoundEffect.MasterVoice != null)
                 _voice.Stop();
             _paused = true;
         }
 
         private void PlatformPlay()
         {
-            if (_voice != null)
+            if (_voice != null && SoundEffect.MasterVoice != null)
             {
                 // Choose the correct buffer depending on if we are looped.            
                 var buffer = _loop ? _effect._loopedBuffer : _effect._buffer;
@@ -177,7 +177,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformResume()
         {
-            if (_voice != null)
+            if (_voice != null && SoundEffect.MasterVoice != null)
             {
                 // Restart the sound if (and only if) it stopped playing
                 if (!_loop)
@@ -196,7 +196,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformStop(bool immediate)
         {
-            if (_voice != null)
+            if (_voice != null && SoundEffect.MasterVoice != null)
             {
                 if (immediate)
                 {
@@ -227,7 +227,7 @@ namespace Microsoft.Xna.Framework.Audio
             _pan = MathHelper.Clamp(value, -1.0f, 1.0f);
 
             // If we have no voice then nothing more to do.
-            if (_voice == null)
+            if (_voice == null || SoundEffect.MasterVoice == null)
                 return;
 
             UpdateOutputMatrix();
@@ -295,7 +295,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             _pitch = value;
 
-            if (_voice == null)
+            if (_voice == null || SoundEffect.MasterVoice == null)
                 return;
 
             // NOTE: This is copy of what XAudio2.SemitonesToFrequencyRatio() does
@@ -307,7 +307,7 @@ namespace Microsoft.Xna.Framework.Audio
         private SoundState PlatformGetState()
         {
             // If no voice or no buffers queued the sound is stopped.
-            if (_voice == null || _voice.State.BuffersQueued == 0)
+            if (_voice == null || SoundEffect.MasterVoice == null || _voice.State.BuffersQueued == 0)
                 return SoundState.Stopped;
 
             // Because XAudio2 does not actually provide if a SourceVoice is Started / Stopped
@@ -320,7 +320,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformSetVolume(float value)
         {
-            if (_voice != null)
+            if (_voice != null && SoundEffect.MasterVoice != null)
                 _voice.SetVolume(value, XAudio2.CommitNow);
         }
 
@@ -330,7 +330,7 @@ namespace Microsoft.Xna.Framework.Audio
             _reverbMix = MathHelper.Clamp(mix, 0, 2);
 
             // If we have no voice then nothing more to do.
-            if (_voice == null)
+            if (_voice == null || SoundEffect.MasterVoice == null)
                 return;
 
             if (!(_reverbMix > 0.0f))
@@ -346,7 +346,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal void PlatformSetFilter(FilterMode mode, float filterQ, float frequency)
         {
-            if (_voice == null)
+            if (_voice == null || SoundEffect.MasterVoice == null)
                 return;
 
             var filter = new FilterParameters 
@@ -360,7 +360,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal void PlatformClearFilter()
         {
-            if (_voice == null)
+            if (_voice == null || SoundEffect.MasterVoice == null)
                 return;
 
             var filter = new FilterParameters { Frequency = 1.0f, OneOverQ = 1.0f, Type = FilterType.LowPassFilter };
@@ -374,7 +374,7 @@ namespace Microsoft.Xna.Framework.Audio
                 if (_reverb != null)
                     _reverb.Dispose();
 
-                if (_voice != null)
+                if (_voice != null && SoundEffect.MasterVoice != null)
                 {
                     _voice.DestroyVoice();
                     _voice.Dispose();


### PR DESCRIPTION
Using the SourceVoice after disposing of the MasteringVoice threw an AccessViolationException. This adds checks so we don't use the SouceVoice after disposing the MasterVoice.

Fixes #5195.