### PR TITLE
OpenGL Mouse.SetCursor now works with alpha correctly

### DIFF
--- a/MonoGame.Framework/Input/Mouse.SDL.cs
+++ b/MonoGame.Framework/Input/Mouse.SDL.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Xna.Framework.Input
             Sdl.Mouse.WarpInWindow(PrimaryWindow.Handle, x, y);
         }
 
-        public static void PlatformSetCursor(MouseCursor cursor)
+        private static void PlatformSetCursor(MouseCursor cursor)
         {
             Sdl.Mouse.SetCursor(cursor.Handle);
         }

--- a/MonoGame.Framework/Input/MouseCursor.SDL.cs
+++ b/MonoGame.Framework/Input/MouseCursor.SDL.cs
@@ -34,9 +34,6 @@ namespace Microsoft.Xna.Framework.Input
 
         private static MouseCursor PlatformFromTexture2D(Texture2D texture, int originx, int originy)
         {
-            if (texture.Format != SurfaceFormat.Color && texture.Format != SurfaceFormat.ColorSRgb)
-                throw new ArgumentException("Only Color or ColorSrgb textures are accepted for mouse cursors", "texture");
-
             IntPtr surface = IntPtr.Zero;
             IntPtr handle = IntPtr.Zero;
             try

--- a/MonoGame.Framework/Input/MouseCursor.SDL.cs
+++ b/MonoGame.Framework/Input/MouseCursor.SDL.cs
@@ -34,21 +34,29 @@ namespace Microsoft.Xna.Framework.Input
 
         private static MouseCursor PlatformFromTexture2D(Texture2D texture, int originx, int originy)
         {
-            IntPtr handle;
+            if (texture.Format != SurfaceFormat.Color && texture.Format != SurfaceFormat.ColorSRgb)
+                throw new ArgumentException("Only Color or ColorSrgb textures are accepted for mouse cursors", "texture");
 
-            var stream = new MemoryStream();
-            texture.SaveAsImage(stream, texture.Width, texture.Height, ImageWriterFormat.Bmp);
-            stream.Position = 0;
-
-            using (var br = new BinaryReader(stream))
+            IntPtr surface = IntPtr.Zero;
+            IntPtr handle = IntPtr.Zero;
+            try
             {
-                var src = Sdl.RwFromMem(br.ReadBytes((int) stream.Length), (int) stream.Length);
-                var surface = Sdl.LoadBMP_RW(src, 1);
+                var bytes = new byte[texture.Width * texture.Height * 4];
+                texture.GetData(bytes);
+                surface = Sdl.CreateRGBSurfaceFrom(bytes, texture.Width, texture.Height, 32, texture.Width * 4, 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000);
+                if (surface == IntPtr.Zero)
+                    throw new InvalidOperationException("Failed to create surface for mouse cursor: " + Sdl.GetError());
+
                 handle = Sdl.Mouse.CreateColorCursor(surface, originx, originy);
-                Sdl.FreeSurface(surface);
+                if (handle == IntPtr.Zero)
+                    throw new InvalidOperationException("Failed to set surface for mouse cursor: " + Sdl.GetError());
+            }
+            finally
+            {
+                if (surface != IntPtr.Zero)
+                    Sdl.FreeSurface(surface);
             }
 
-            stream.Dispose();
             return new MouseCursor(handle);
         }
 

--- a/MonoGame.Framework/Input/MouseCursor.cs
+++ b/MonoGame.Framework/Input/MouseCursor.cs
@@ -80,6 +80,9 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="originy">Y cordinate of the image that will be used for mouse position.</param>
         public static MouseCursor FromTexture2D(Texture2D texture, int originx, int originy)
         {
+            if (texture.Format != SurfaceFormat.Color && texture.Format != SurfaceFormat.ColorSRgb)
+                throw new ArgumentException("Only Color or ColorSrgb textures are accepted for mouse cursors", "texture");
+
             return PlatformFromTexture2D(texture, originx, originy);
         }
 

--- a/MonoGame.Framework/SDL/SDL2.cs
+++ b/MonoGame.Framework/SDL/SDL2.cs
@@ -168,6 +168,21 @@ internal static class Sdl
         EventType minType,
         EventType maxType);
 
+    [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_CreateRGBSurfaceFrom")]
+    private static extern IntPtr SDL_CreateRGBSurfaceFrom(IntPtr pixels, int width, int height, int depth, int pitch, uint rMask, uint gMask, uint bMask, uint aMask);
+    public static IntPtr CreateRGBSurfaceFrom(byte[] pixels, int width, int height, int depth, int pitch, uint rMask, uint gMask, uint bMask, uint aMask)
+    {
+        var handle = GCHandle.Alloc(pixels, GCHandleType.Pinned);
+        try
+        {
+            return SDL_CreateRGBSurfaceFrom(handle.AddrOfPinnedObject(), width, height, depth, pitch, rMask, gMask, bMask, aMask);
+        }
+        finally
+        {
+            handle.Free();
+        }
+    }
+
     [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_FreeSurface")]
     public static extern void FreeSurface(IntPtr surface);
 


### PR DESCRIPTION
The previous implementation was saving the texture to a BMP in-memory, then loading that BMP into a SDL surface.  This process was losing the alpha channel.  It has been reimplemented to eliminate the BMP intermediate step and copy data direct from the Texture2D to the SDL surface.

Fixes #5822