### PR TITLE
Implement Mouse.SetCursor() for Windows

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1058,8 +1058,11 @@
     <Compile Include="Input\MouseCursor.SDL.cs">
       <Platforms>Linux,WindowsGL</Platforms>
     </Compile>
+    <Compile Include="Input\MouseCursor.Windows.cs">
+      <Platforms>Windows</Platforms>
+    </Compile>
     <Compile Include="Input\MouseCursor.Default.cs">
-      <ExcludePlatforms>Linux,WindowsGL</ExcludePlatforms>
+      <ExcludePlatforms>Linux,WindowsGL,Windows</ExcludePlatforms>
     </Compile>
     <Compile Include="Input\MouseState.cs" />
     <Compile Include="Input\Touch\GestureSample.cs" />

--- a/MonoGame.Framework/Input/Mouse.Windows.cs
+++ b/MonoGame.Framework/Input/Mouse.Windows.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Xna.Framework.Input
 
         public static void PlatformSetCursor(MouseCursor cursor)
         {
-
+            Window.Cursor = cursor.Cursor;
         }
     }
 }

--- a/MonoGame.Framework/Input/MouseCursor.Windows.cs
+++ b/MonoGame.Framework/Input/MouseCursor.Windows.cs
@@ -1,0 +1,97 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    public partial class MouseCursor
+    {
+        Cursor _cursor;
+        bool _needsDisposing;
+
+        internal Cursor Cursor { get { return _cursor; } }
+
+        private MouseCursor(Cursor cursor, bool needsDisposing = false)
+        {
+            _cursor = cursor;
+            _needsDisposing = needsDisposing;
+        }
+
+        private static void PlatformInitalize()
+        {
+            Arrow = new MouseCursor(Cursors.Arrow);
+            IBeam = new MouseCursor(Cursors.IBeam);
+            Wait = new MouseCursor(Cursors.WaitCursor);
+            Crosshair = new MouseCursor(Cursors.Cross);
+            WaitArrow = new MouseCursor(Cursors.AppStarting);
+            SizeNWSE = new MouseCursor(Cursors.SizeNWSE);
+            SizeNESW = new MouseCursor(Cursors.SizeNESW);
+            SizeWE = new MouseCursor(Cursors.SizeWE);
+            SizeNS = new MouseCursor(Cursors.SizeNS);
+            SizeAll = new MouseCursor(Cursors.SizeAll);
+            No = new MouseCursor(Cursors.No);
+            Hand = new MouseCursor(Cursors.Hand);
+        }
+
+        private static MouseCursor PlatformFromTexture2D(Texture2D texture, int originx, int originy)
+        {
+            var w = texture.Width;
+            var h = texture.Height;
+            Cursor cursor = null;
+            var bytes = new byte[w * h * 4];
+            texture.GetData(bytes);
+            var gcHandle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
+            try
+            {
+                using (var bitmap = new Bitmap(w, h, h * 4, PixelFormat.Format32bppArgb, gcHandle.AddrOfPinnedObject()))
+                {
+                    IconInfo iconInfo = new IconInfo();
+                    GetIconInfo(bitmap.GetHicon(), ref iconInfo);
+                    iconInfo.xHotspot = originx;
+                    iconInfo.yHotspot = originy;
+                    iconInfo.fIcon = false;
+                    cursor = new Cursor(CreateIconIndirect(ref iconInfo));
+                }
+            }
+            finally
+            {
+                gcHandle.Free();
+            }
+            return new MouseCursor(cursor, needsDisposing: true);
+        }
+
+        private void PlatformDispose()
+        {
+            if (_needsDisposing && _cursor != null)
+            {
+                _cursor.Dispose();
+                _cursor = null;
+                _needsDisposing = false;
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct IconInfo
+        {
+            public bool fIcon;
+            public int xHotspot;
+            public int yHotspot;
+            public IntPtr MaskBitmap;
+            public IntPtr ColorBitmap;
+        };
+
+        [DllImport("user32.dll")]
+        static extern IntPtr CreateIconIndirect([In] ref IconInfo iconInfo);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool GetIconInfo(IntPtr hIcon, ref IconInfo pIconInfo);
+    }
+}


### PR DESCRIPTION
The `Mouse.SetCursor(MouseCursor)` and `MouseCursor.FromTexture2D(Texture2D, int, int)` methods were previously unimplemented for the Windows DirectX platform.