### PR TITLE
Fixes to XACT sound effect pooling

### DIFF
--- a/MonoGame.Framework/Audio/Xact/AudioCategory.cs
+++ b/MonoGame.Framework/Audio/Xact/AudioCategory.cs
@@ -128,7 +128,12 @@ namespace Microsoft.Xna.Framework.Audio
         {
             if (volume < 0)
                 throw new ArgumentException("The volume must be positive.");
-            
+
+            // Updating all the sounds in a category can be
+            // very expensive... so avoid it if we can.
+            if (_volume[0] == volume)
+                return;
+
             _volume[0] = volume;
 
             foreach (var sound in _sounds)

--- a/MonoGame.Framework/Audio/Xact/AudioEngine.cs
+++ b/MonoGame.Framework/Audio/Xact/AudioEngine.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal readonly RpcCurve[] RpcCurves;
 
+        internal readonly object UpdateLock = new object();
+
         internal RpcVariable[] CreateCueVariables()
         {
             var clone = new RpcVariable[_cueVariables.Length];
@@ -266,20 +268,23 @@ namespace Microsoft.Xna.Framework.Audio
             var elapsed = cur - _lastUpdateTime;
             _lastUpdateTime = cur;
             var dt = (float)elapsed.TotalSeconds;
-            
-            for (var x = 0; x < ActiveCues.Count; )
+
+            lock (UpdateLock)
             {
-                var cue = ActiveCues[x];
-
-                cue.Update(dt);
-
-                if (cue.IsStopped)
+                for (var x = 0; x < ActiveCues.Count; )
                 {
-                    ActiveCues.Remove(cue);
-                    continue;
-                }
+                    var cue = ActiveCues[x];
 
-                x++;
+                    cue.Update(dt);
+
+                    if (cue.IsStopped || cue.IsDisposed)
+                    {
+                        ActiveCues.Remove(cue);
+                        continue;
+                    }
+
+                    x++;
+                }
             }
 
             // The only global curves we can process seem to be 
@@ -326,12 +331,14 @@ namespace Microsoft.Xna.Framework.Audio
             if (!_variableLookup.TryGetValue(name, out i) || !_variables[i].IsPublic)
                 throw new IndexOutOfRangeException("The specified variable index is invalid.");
 
-            return _variables[i].Value;
+            lock (UpdateLock)
+                return _variables[i].Value;
         }
 
         internal float GetGlobalVariable(int index)
         {
-            return _variables[index].Value;
+            lock (UpdateLock)
+                return _variables[index].Value;
         }
 
         /// <summary>Sets the value of a global variable.</summary>
@@ -346,7 +353,8 @@ namespace Microsoft.Xna.Framework.Audio
             if (!_variableLookup.TryGetValue(name, out i) || !_variables[i].IsPublic)
                 throw new IndexOutOfRangeException("The specified variable index is invalid.");
 
-            _variables[i].SetValue(value);
+            lock (UpdateLock)
+                _variables[i].SetValue(value);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Audio/Xact/Cue.cs
+++ b/MonoGame.Framework/Audio/Xact/Cue.cs
@@ -120,24 +120,31 @@ namespace Microsoft.Xna.Framework.Audio
         /// <summary>Pauses playback.</summary>
         public void Pause()
         {
-            if (_curSound != null)
-                _curSound.Pause();
+            lock (_engine.UpdateLock)
+            {
+                if (_curSound != null)
+                    _curSound.Pause();
+            }
         }
 
         /// <summary>Requests playback of a prepared or preparing Cue.</summary>
         /// <remarks>Calling Play when the Cue already is playing can result in an InvalidOperationException.</remarks>
         public void Play()
         {
-            if (!_engine.ActiveCues.Contains(this))
-                _engine.ActiveCues.Add(this);
-            
-            //TODO: Probabilities
-            var index = XactHelpers.Random.Next(_sounds.Length);
-            _curSound = _sounds[index];
+            lock (_engine.UpdateLock)
+            {
+                if (!_engine.ActiveCues.Contains(this))
+                    _engine.ActiveCues.Add(this);
 
-            var volume = UpdateRpcCurves();
+                //TODO: Probabilities
+                var index = XactHelpers.Random.Next(_sounds.Length);
+                _curSound = _sounds[index];
 
-            _curSound.Play(volume, _engine);
+                var volume = UpdateRpcCurves();
+
+                _curSound.Play(volume, _engine);
+            }
+
             _played = true;
             IsPrepared = false;
         }
@@ -145,18 +152,24 @@ namespace Microsoft.Xna.Framework.Audio
         /// <summary>Resumes playback of a paused Cue.</summary>
         public void Resume()
         {
-            if (_curSound != null)
-                _curSound.Resume();
+            lock (_engine.UpdateLock)
+            {
+                if (_curSound != null)
+                    _curSound.Resume();
+            }
         }
 
         /// <summary>Stops playback of a Cue.</summary>
         /// <param name="options">Specifies if the sound should play any pending release phases or transitions before stopping.</param>
         public void Stop(AudioStopOptions options)
         {
-            _engine.ActiveCues.Remove(this);
-            
-            if (_curSound != null)
-                _curSound.Stop(options);
+            lock (_engine.UpdateLock)
+            {
+                _engine.ActiveCues.Remove(this);
+
+                if (_curSound != null)
+                    _curSound.Stop(options);
+            }
 
             IsPrepared = false;
         }
@@ -230,25 +243,28 @@ namespace Microsoft.Xna.Framework.Audio
 
             var direction = listener.Position - emitter.Position;
 
-            // Set the distance for falloff.
-            var distance = direction.Length();
-            var i = FindVariable("Distance");
-            _variables[i].SetValue(distance);
+            lock (_engine.UpdateLock)
+            {
+                // Set the distance for falloff.
+                var distance = direction.Length();
+                var i = FindVariable("Distance");
+                _variables[i].SetValue(distance);
 
-            // Calculate the orientation.
-            if (distance > 0.0f)
-                direction /= distance;
-            var right = Vector3.Cross(listener.Up, listener.Forward);
-            var slope = Vector3.Dot(direction, listener.Forward);
-            var angle = MathHelper.ToDegrees((float)Math.Acos(slope));
-            var j = FindVariable("OrientationAngle");
-            _variables[j].SetValue(angle);
-            if (_curSound != null)
-                _curSound.SetCuePan(Vector3.Dot(direction, right));
+                // Calculate the orientation.
+                if (distance > 0.0f)
+                    direction /= distance;
+                var right = Vector3.Cross(listener.Up, listener.Forward);
+                var slope = Vector3.Dot(direction, listener.Forward);
+                var angle = MathHelper.ToDegrees((float)Math.Acos(slope));
+                var j = FindVariable("OrientationAngle");
+                _variables[j].SetValue(angle);
+                if (_curSound != null)
+                    _curSound.SetCuePan(Vector3.Dot(direction, right));
 
-            // Calculate doppler effect.
-            var relativeVelocity = emitter.Velocity - listener.Velocity;
-            relativeVelocity *= emitter.DopplerScale;
+                // Calculate doppler effect.
+                var relativeVelocity = emitter.Velocity - listener.Velocity;
+                relativeVelocity *= emitter.DopplerScale;
+            }
 
             _applied3D = true;
         }
@@ -316,6 +332,8 @@ namespace Microsoft.Xna.Framework.Audio
                 }
 
                 pitch = MathHelper.Clamp(pitch, -1.0f, 1.0f);
+                if (volume < 0.0f)
+                    volume = 0.0f;
 
                 _curSound.UpdateState(_engine, volume, pitch, reverbMix, filterFrequency, filterQFactor);
             }

--- a/MonoGame.Framework/Audio/Xact/PlayWaveEvent.cs
+++ b/MonoGame.Framework/Audio/Xact/PlayWaveEvent.cs
@@ -84,8 +84,16 @@ namespace Microsoft.Xna.Framework.Audio
 
         public override void Play() 
         {
-            if (_wav != null && _wav.State != SoundState.Stopped)
-                _wav.Stop();
+            if (_wav != null)
+            {
+                if (_wav.State != SoundState.Stopped)
+                    _wav.Stop();
+                if (_streaming)
+                    _wav.Dispose();
+				else					
+					_wav._isXAct = false;					
+                _wav = null;
+            }
 
             Play(true);
         }
@@ -198,6 +206,8 @@ namespace Microsoft.Xna.Framework.Audio
                 _wav.Stop();
                 if (_streaming)
                     _wav.Dispose();
+				else
+                	_wav._isXAct = false;				
                 _wav = null;
             }
             _loopIndex = 0;
@@ -270,6 +280,8 @@ namespace Microsoft.Xna.Framework.Audio
                 {
                     if (_streaming)
                         _wav.Dispose();
+					else
+	                    _wav._isXAct = false;						
                     _wav = null;
                     _loopIndex = 0;
                 }
@@ -284,7 +296,7 @@ namespace Microsoft.Xna.Framework.Audio
                 }
             }
 
-            return _wav != null && _wav.State != SoundState.Stopped;
+            return _wav != null;
         }
     }
 }

--- a/MonoGame.Framework/Audio/Xact/XactSound.cs
+++ b/MonoGame.Framework/Audio/Xact/XactSound.cs
@@ -154,9 +154,15 @@ namespace Microsoft.Xna.Framework.Audio
             } 
             else 
             {
-                if (_wave != null && _wave.State != SoundState.Stopped && _wave.IsLooped)
-                    _wave.Stop();
-                else
+                if (_wave != null)
+                {
+                    if (_streaming)
+                        _wave.Dispose();
+					else
+						_wave._isXAct = false;					
+                    _wave = null;
+                }
+
                     _wave = _soundBank.GetSoundEffectInstance(_waveBankIndex, _trackIndex, out _streaming);
 
                 if (_wave == null)
@@ -186,6 +192,8 @@ namespace Microsoft.Xna.Framework.Audio
                 {
                     if (_streaming)
                         _wave.Dispose();
+					else
+						_wave._isXAct = false;					
                     _wave = null;
                 }
             }
@@ -205,7 +213,9 @@ namespace Microsoft.Xna.Framework.Audio
                     _wave.Stop();
                     if (_streaming)
                         _wave.Dispose();
-                    _wave = null;
+ 					else
+						_wave._isXAct = false;					
+                   _wave = null;
                 }
             }
         }
@@ -224,6 +234,8 @@ namespace Microsoft.Xna.Framework.Audio
                     _wave.Stop();
                     if (_streaming)
                         _wave.Dispose();
+					else
+						_wave._isXAct = false;					
                     _wave = null;
                 }
             }
@@ -342,14 +354,20 @@ namespace Microsoft.Xna.Framework.Audio
             {
                 if (_complexSound)
                 {
-                    foreach (var clip in _soundClips)
-                        if (clip.State == SoundState.Stopped)
-                            return true;
+                    var notStopped = false;
 
-                    return false;
+                    // All clips must be stopped for the sound to be stopped.
+                    foreach (var clip in _soundClips)
+                    {
+                        if (clip.State != SoundState.Stopped)
+                            notStopped = true;
+                    }
+
+                    return !notStopped;
                 }
 
-                return _wave == null || _wave.State == SoundState.Stopped;
+                // We null the wave when it it stopped.
+                return _wave == null;
             }
         }
 


### PR DESCRIPTION
This fixes cases where `SoundEffectInstance`s for XACT were being prematurely returned to the `SoundEffectInstancePool` causing incorrect volumes or cues to suddenly stop playing.

Also some thread safety fixes to the `SoundEffectInstancePool` and XAct.