### PR TITLE
[DX] Dispose cached texture in WMS VideoPlayer

### DIFF
--- a/MonoGame.Framework/Media/VideoPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.WMS.cs
@@ -72,7 +72,8 @@ namespace Microsoft.Xna.Framework.Media
                 return null;
 
             // NOTE: It's entirely possible that we could lose the d3d context and therefore lose this texture, but it's better than allocating a new texture each call!
-            _videoCache = _videoCache ?? new Texture2D(Game.Instance.GraphicsDevice, _currentVideo.Width, _currentVideo.Height, false, SurfaceFormat.Bgr32);
+            if (_videoCache == null)
+                _videoCache = new Texture2D(Game.Instance.GraphicsDevice, _currentVideo.Width, _currentVideo.Height, false, SurfaceFormat.Bgr32);
 
             _videoCache.SetData(texData);
             
@@ -139,6 +140,9 @@ namespace Microsoft.Xna.Framework.Media
             var varStart = new Variant();
             _session.Start(null, varStart);
 
+            // we need to dispose of the old texture if we have one
+            if (_videoCache != null)
+                _videoCache.Dispose();
             // Create cached texture
             _videoCache = new Texture2D(Game.Instance.GraphicsDevice, _currentVideo.Width, _currentVideo.Height, false, SurfaceFormat.Bgr32);
         }


### PR DESCRIPTION
Texture was not disposed when a new one was created. 
Also a minor code style edit.