### PR TITLE
Simplify FontDescriptionProcessor code

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1211,7 +1211,7 @@
       <Platforms>Angle,Linux,MacOS,Windows,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Utilities\CurrentPlatform.cs">
-      <Platforms>WindowsGL,Linux</Platforms>
+      <Platforms>Windows,MacOS,WindowsGL,Linux</Platforms>
     </Compile>
     <Compile Include="Utilities\Hash.cs" />
     <Compile Include="Utilities\FileHelpers.cs" />

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -4,17 +4,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
-using SharpFont;
-using System.Runtime.InteropServices;
-using MonoGame.Framework.Content.Pipeline.Builder;
-using Glyph = Microsoft.Xna.Framework.Content.Pipeline.Graphics.Glyph;
-#if WINDOWS
 using Microsoft.Win32;
-#endif
+using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+using MonoGame.Utilities;
+using Glyph = Microsoft.Xna.Framework.Content.Pipeline.Graphics.Glyph;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 {
@@ -33,70 +29,48 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             TextureFormat = TextureProcessorOutputFormat.Compressed;
         }
 
-        public override SpriteFontContent Process(FontDescription input,
-            ContentProcessorContext context)
+        public override SpriteFontContent Process(FontDescription input, ContentProcessorContext context)
         {
             var output = new SpriteFontContent(input);
+            var fontFile = FindFont(input.FontName, input.Style.ToString());
 
-			var fontName = input.FontName;
+            if (string.IsNullOrWhiteSpace(fontFile))
+            {
+                var directories = new List<string> { Path.GetDirectoryName(input.Identity.SourceFilename) };
+                var extensions = new string[] { "", ".ttf", ".ttc", ".otf" };
 
-#if WINDOWS || LINUX
-#if WINDOWS
-			var windowsfolder = Environment.GetFolderPath (Environment.SpecialFolder.Windows);
-		    var fontDirectory = Path.Combine(windowsfolder,"Fonts");
-			fontName = FindFontFileFromFontName (fontName, fontDirectory);
-#elif LINUX
-            fontName = FindFontFileFromFontName(fontName, input.Style.ToString());
-#endif
-			if (string.IsNullOrWhiteSpace(fontName)) {
-				fontName = input.FontName;
-#endif
-				
-			var directory = Path.GetDirectoryName (input.Identity.SourceFilename);
+                // Add special per platform directories
+                if (CurrentPlatform.OS == OS.Windows)
+                    directories.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Fonts"));
+                else if (CurrentPlatform.OS == OS.MacOSX)
+                    directories.Add("/Library/Fonts");
 
-			List<string> directories = new List<string>();
-			directories.Add(directory);
-			directories.Add("/Library/Fonts");
-#if WINDOWS
-			directories.Add(fontDirectory);
-#endif
-
-			foreach( var dir in directories) {
-				if (File.Exists(Path.Combine(dir,fontName+".ttf"))) {
-					fontName += ".ttf";
-					directory = dir;
-					break;
-				}
-				if (File.Exists (Path.Combine(dir,fontName+".ttc"))) {
-					fontName += ".ttc";
-					directory = dir;
-					break;
-				}
-				if (File.Exists(Path.Combine(dir,fontName+".otf"))) {
-					fontName += ".otf";
-					directory = dir;
-					break;
-				}
+                foreach (var dir in directories)
+                {
+                    foreach(var ext in extensions)
+                    {
+                        fontFile = Path.Combine(dir, input.FontName + ext);
+                        if (File.Exists(fontFile))
+                            break;
+                    }
+                }
             }
 
-            fontName = Path.Combine (directory, fontName);
+            if (!File.Exists(fontFile))
+                throw new FileNotFoundException("Cound not find \"" + input.FontName + "\" font file.");
 
-#if WINDOWS || LINUX
-			}
-#endif
-
-			context.Logger.LogMessage ("Building Font {0}", fontName);
+			context.Logger.LogMessage ("Building Font {0}", fontFile);
             
             // Get the platform specific texture profile.
             var texProfile = TextureProfile.ForPlatform(context.TargetPlatform);
 
             {
-				if (!File.Exists(fontName)) {
-					throw new Exception(string.Format("Could not load {0}", fontName));
+				if (!File.Exists(fontFile)) {
+					throw new Exception(string.Format("Could not load {0}", fontFile));
 				}
 				var lineSpacing = 0f;
 				int yOffsetMin = 0;
-				var glyphs = ImportFont(input, out lineSpacing, out yOffsetMin, context, fontName);
+				var glyphs = ImportFont(input, out lineSpacing, out yOffsetMin, context, fontFile);
 
 				// Optimize.
 				foreach (Glyph glyph in glyphs)
@@ -181,7 +155,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             return output;
         }
 
-		static Glyph[] ImportFont(FontDescription options, out float lineSpacing, out int yOffsetMin, ContentProcessorContext context, string fontName)
+		private static Glyph[] ImportFont(FontDescription options, out float lineSpacing, out int yOffsetMin, ContentProcessorContext context, string fontName)
 		{
 			// Which importer knows how to read this source font?
 			IFontImporter importer;
@@ -242,46 +216,55 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 			return glyphs.ToArray();
 		}
 
-#if WINDOWS
-		string FindFontFileFromFontName (string fontName, string fontDirectory)
-		{
-			var key = Registry.LocalMachine.OpenSubKey (@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts", false);
-			foreach (var font in key.GetValueNames ().OrderBy (x => x)) {
-				if (font.StartsWith (fontName, StringComparison.OrdinalIgnoreCase)) {
-					var fontPath = key.GetValue (font).ToString ();
-					return Path.IsPathRooted (fontPath) ? fontPath : Path.Combine (fontDirectory, fontPath);
-				}
-			}
-			return String.Empty;
-		}
-#endif
-
-#if LINUX
-        string FindFontFileFromFontName(string fontname, string style)
+        private string FindFont(string name, string style)
         {
-            string s, e;
-            ExternalTool.Run("/bin/bash", string.Format ("-c \"fc-match -f '%{{file}}:%{{family}}\\n' '{0}:style={1}'\"", fontname, style), out s, out e);
-            s = s.Trim();
+            if (CurrentPlatform.OS == OS.Windows)
+            {
+                var fontDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Fonts");
+                var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts", false);
 
-            var split = s.Split (':');
-            if (split.Length < 2)
-                return String.Empty;
-
-            //check font family, fontconfig might return a fallback
-            if (split [1].Contains (",")) { //this file defines multiple family names
-                var families = split [1].Split (',');
-                foreach (var f in families) {
-                    if (f.ToLowerInvariant () == fontname.ToLowerInvariant ())
-                        return split [0];
+                foreach (var font in key.GetValueNames().OrderBy(x => x))
+                {
+                    if (font.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var fontPath = key.GetValue(font).ToString();
+                        return Path.IsPathRooted(fontPath) ? fontPath : Path.Combine(fontDirectory, fontPath);
+                    }
                 }
-                //didn't find it
-                return String.Empty;
-            } else {
-                if (split [1].ToLowerInvariant () != fontname.ToLowerInvariant ())
-                    return String.Empty;
             }
-            return split [0];
+            else if (CurrentPlatform.OS == OS.Linux)
+            {
+                string s, e;
+                ExternalTool.Run("/bin/bash", string.Format("-c \"fc-match -f '%{{file}}:%{{family}}\\n' '{0}:style={1}'\"", name, style), out s, out e);
+                s = s.Trim();
+
+                var split = s.Split(':');
+                if (split.Length < 2)
+                    return string.Empty;
+
+                // check font family, fontconfig might return a fallback
+                if (split[1].Contains(","))
+                {
+                    // this file defines multiple family names
+                    var families = split[1].Split(',');
+                    foreach (var f in families)
+                    {
+                        if (f.ToLowerInvariant() == name.ToLowerInvariant())
+                            return split[0];
+                    }
+                    // didn't find it
+                    return string.Empty;
+                }
+                else
+                {
+                    if (split[1].ToLowerInvariant() != name.ToLowerInvariant())
+                        return string.Empty;
+                }
+
+                return split[0];
+            }
+
+            return String.Empty;
         }
-#endif
     }
 }


### PR DESCRIPTION
Changes that have been made:
 - Adds extra error check at the end in case the font was not found, resolves #5790
 - Platform checking is done withing the code instead of using preprocessing params
 - Added check for extension of "", so that users can put in the actual font file name if they so desire