### PR TITLE
Improve shader error/warning parsing in Pipeline Tool

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             var errorsAndWarningArray = shaderErrorsAndWarnings.Split(new[] {"\n", "\r", Environment.NewLine},
                                                                       StringSplitOptions.RemoveEmptyEntries);
 
-            var errorOrWarning = new Regex(@"(.*)\(([0-9,]*)\)\s*:\s*(.*)", RegexOptions.Compiled);
+            var errorOrWarning = new Regex(@"(.*)\(([0-9]*(,[0-9]+(-[0-9]+)?)?)\)\s*:\s*(.*)", RegexOptions.Compiled);
             ContentIdentity identity = null;
             var allErrorsAndWarnings = string.Empty;
 

--- a/Tools/Pipeline/Common/OutputParser.cs
+++ b/Tools/Pipeline/Common/OutputParser.cs
@@ -39,8 +39,8 @@ namespace MonoGame.Tools.Pipeline
         Regex _reSkipping = new Regex(@"^(Skipping)\W(?<filename>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildAsset = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildError = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\W*?:\W*?error\W*?:\W*(?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        Regex _reFileErrorWithLineNum = new Regex(@"^(?<filename>.+?)(\((?<line>[0-9]+),(?<column>[0-9]+)\))?:\W*?(error)\W*(?<errorCode>[A-Z][0-9]+):\W*(?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        Regex _reFileWarningWithLineNum = new Regex(@"^(?<filename>.+?)(\((?<line>[0-9]+),(?<column>[0-9]+)\))?:\W*?(warning)\W*(?<warningCode>[A-Z][0-9]+):\W*(?<warningMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reFileErrorWithLineNum   = new Regex(@"^(?<filename>.+?)(\((?<line>[0-9]+),(?<column>[0-9]+)(-(?<columnEnd>[0-9]+))?\))?:\W*?(error)\W*(?<errorCode>[A-Z][0-9]+):\W*(?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reFileWarningWithLineNum = new Regex(@"^(?<filename>.+?)(\((?<line>[0-9]+),(?<column>[0-9]+)(-(?<columnEnd>[0-9]+))?\))?:\W*?(warning)\W*(?<warningCode>[A-Z][0-9]+):\W*(?<warningMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reFileError = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\W*?: (?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildEnd = new Regex(@"^(Build)\W+(?<buildInfo>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildTime = new Regex(@"^(Time elapsed)\W+(?<buildElapsedTime>.*?)\.\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -143,7 +143,11 @@ namespace MonoGame.Tools.Pipeline
                 State = OutputState.BuildError;
                 var m = _reFileErrorWithLineNum.Match(line);
                 var lineNum = m.Groups["line"];
-                var column = m.Groups["column"];
+                var columnBegin = m.Groups["column"];
+                var columnEnd = m.Groups["columnEnd"];
+                var column = columnBegin.Value;
+                if(columnEnd.Success)
+                    column += "-" + columnEnd.Value;
                 var errorCode = m.Groups["errorCode"];
                 Filename = m.Groups["filename"].Value.Replace("\\\\","/").Replace("\\", "/");
                 ErrorMessage = string.Format("{0} ({1},{2}): {3}", errorCode, lineNum, column, m.Groups["errorMessage"].Value);
@@ -153,7 +157,11 @@ namespace MonoGame.Tools.Pipeline
                 State = OutputState.BuildWarning;
                 var m = _reFileWarningWithLineNum.Match(line);
                 var lineNum = m.Groups["line"];
-                var column = m.Groups["column"];
+                var columnBegin = m.Groups["column"];
+                var columnEnd = m.Groups["columnEnd"];                
+                var column = columnBegin.Value;
+                if(columnEnd.Success)
+                    column += "-" + columnEnd.Value;
                 var errorCode = m.Groups["warningCode"];
                 Filename = m.Groups["filename"].Value.Replace("\\\\", "/").Replace("\\", "/");
                 ErrorMessage = string.Format("{0} ({1},{2}): {3}", errorCode, lineNum, column, m.Groups["warningMessage"].Value);


### PR DESCRIPTION
The new shader compiler produce errors/warnings that include the columnEnd. 
ex.  (26,9-25)

The RegEx was updated to recognize 
single lines, ex: `(26)`
line & column, ex: `(26,9)`
line & column begin & column end, ex: `(26,9-25)`

The RegEx is more strict than before and will fail on invalid strings, ex: `(26,)`  `(,9)`. `(,,,,,)`

Fix: #5846 

![effectwarning](https://user-images.githubusercontent.com/3018589/28709111-8019d5d4-7387-11e7-841e-dc36796b42e7.png)
