### PR TITLE
Improved disposal of OpenGL resources

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace OpenGL
 {
@@ -71,8 +72,9 @@ namespace OpenGL
         {
             if (_disposed)
                 return;
-            
-            Sdl.GL.DeleteContext(_context);
+
+            GraphicsDevice.DisposeContext(_context);
+            _context = IntPtr.Zero;
             _disposed = true;
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -115,7 +115,9 @@ namespace Microsoft.Xna.Framework.Graphics
                         }
                         break;
                     case ResourceType.Query:
+#if !GLES
                         GL.DeleteQueries(1, ref handle);
+#endif
                         break;
                     case ResourceType.Framebuffer:
                         GL.DeleteFramebuffers(1, ref handle);

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -45,11 +45,94 @@ namespace Microsoft.Xna.Framework.Graphics
         private DrawBuffersEnum[] _drawBuffers;
 #endif
 
-        static List<Action> disposeActions = new List<Action>();
-        static object disposeActionsLock = new object();
+        enum ResourceType
+        {
+            Texture,
+            Buffer,
+            Shader,
+            Program,
+            Query,
+            Framebuffer
+        }
 
-        private readonly ShaderProgramCache _programCache = new ShaderProgramCache();
+        struct ResourceHandle
+        {
+            public ResourceType type;
+            public int handle;
 
+            public static ResourceHandle Texture(int handle)
+            {
+                return new ResourceHandle() { type = ResourceType.Texture, handle = handle };
+            }
+
+            public static ResourceHandle Buffer(int handle)
+            {
+                return new ResourceHandle() { type = ResourceType.Buffer, handle = handle };
+            }
+
+            public static ResourceHandle Shader(int handle)
+            {
+                return new ResourceHandle() { type = ResourceType.Shader, handle = handle };
+            }
+
+            public static ResourceHandle Program(int handle)
+            {
+                return new ResourceHandle() { type = ResourceType.Program, handle = handle };
+            }
+
+            public static ResourceHandle Query(int handle)
+            {
+                return new ResourceHandle() { type = ResourceType.Query, handle = handle };
+            }
+
+            public static ResourceHandle Framebuffer(int handle)
+            {
+                return new ResourceHandle() { type = ResourceType.Framebuffer, handle = handle };
+            }
+
+            public void Free()
+            {
+                switch (type)
+                {
+                    case ResourceType.Texture:
+                        GL.DeleteTextures(1, ref handle);
+                        break;
+                    case ResourceType.Buffer:
+                        GL.DeleteBuffers(1, ref handle);
+                        break;
+                    case ResourceType.Shader:
+                        if (GL.IsShader(handle))
+                            GL.DeleteShader(handle);
+                        break;
+                    case ResourceType.Program:
+                        if (GL.IsProgram(handle))
+                        {
+#if MONOMAC
+                            GL.DeleteProgram(1, ref handle);
+#else
+                            GL.DeleteProgram(handle);
+#endif
+                        }
+                        break;
+                    case ResourceType.Query:
+                        GL.DeleteQueries(1, ref handle);
+                        break;
+                    case ResourceType.Framebuffer:
+                        GL.DeleteFramebuffers(1, ref handle);
+                        break;
+                }
+                GraphicsExtensions.CheckGLError();
+            }
+        }
+
+        List<ResourceHandle> _disposeThisFrame = new List<ResourceHandle>();
+        List<ResourceHandle> _disposeNextFrame = new List<ResourceHandle>();
+        object _disposeActionsLock = new object();
+
+        static List<IntPtr> _disposeContexts = new List<IntPtr>();
+        static object _disposeContextsLock = new object();
+
+        private ShaderProgramCache _programCache;
         private ShaderProgram _shaderProgram = null;
 
         static readonly float[] _posFixup = new float[4];
@@ -181,6 +264,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformSetup()
         {
 #if DESKTOPGL || ANGLE
+            _programCache = new ShaderProgramCache(this);
 
             var windowInfo = new WindowInfo(SdlGameWindow.Instance.Handle);
 
@@ -471,36 +555,98 @@ namespace Microsoft.Xna.Framework.Graphics
             // Free all the cached shader programs.
             _programCache.Dispose();
 
-            GraphicsDevice.AddDisposeAction(() =>
-                                            {
 #if DESKTOPGL || ANGLE
-                Context.Dispose();
-                Context = null;
+            Context.Dispose();
+            Context = null;
 #endif
-            });
         }
 
-        /// <summary>
-        /// Adds a dispose action to the list of pending dispose actions. These are executed at the end of each call to Present().
-        /// This allows GL resources to be disposed from other threads, such as the finalizer.
-        /// </summary>
-        /// <param name="disposeAction">The action to execute for the dispose.</param>
-        static private void AddDisposeAction(Action disposeAction)
+        internal void DisposeTexture(int handle)
         {
-            if (disposeAction == null)
-                throw new ArgumentNullException("disposeAction");
-            if (Threading.IsOnUIThread())
+            if (!_isDisposed)
             {
-                disposeAction();
-            }
-            else
-            {
-                lock (disposeActionsLock)
+                lock (_disposeActionsLock)
                 {
-                    disposeActions.Add(disposeAction);
+                    _disposeNextFrame.Add(ResourceHandle.Texture(handle));
                 }
             }
         }
+
+        internal void DisposeBuffer(int handle)
+        {
+            if (!_isDisposed)
+            {
+                lock (_disposeActionsLock)
+                {
+                    _disposeNextFrame.Add(ResourceHandle.Buffer(handle));
+                }
+            }
+        }
+
+        internal void DisposeShader(int handle)
+        {
+            if (!_isDisposed)
+            {
+                lock (_disposeActionsLock)
+                {
+                    _disposeNextFrame.Add(ResourceHandle.Shader(handle));
+                }
+            }
+        }
+
+        internal void DisposeProgram(int handle)
+        {
+            if (!_isDisposed)
+            {
+                lock (_disposeActionsLock)
+                {
+                    _disposeNextFrame.Add(ResourceHandle.Program(handle));
+                }
+            }
+        }
+
+        internal void DisposeQuery(int handle)
+        {
+            if (!_isDisposed)
+            {
+                lock (_disposeActionsLock)
+                {
+                    _disposeNextFrame.Add(ResourceHandle.Query(handle));
+                }
+            }
+        }
+
+        internal void DisposeFramebuffer(int handle)
+        {
+            if (!_isDisposed)
+            {
+                lock (_disposeActionsLock)
+                {
+                    _disposeNextFrame.Add(ResourceHandle.Framebuffer(handle));
+                }
+            }
+        }
+
+#if DESKTOPGL || ANGLE
+        static internal void DisposeContext(IntPtr resource)
+        {
+            lock (_disposeContextsLock)
+            {
+                _disposeContexts.Add(resource);
+            }
+        }
+
+        static internal void DisposeContexts()
+        {
+            lock (_disposeContextsLock)
+            {
+                int count = _disposeContexts.Count;
+                for (int i = 0; i < count; ++i)
+                    Sdl.GL.DeleteContext(_disposeContexts[i]);
+                _disposeContexts.Clear();
+            }
+        }
+#endif
 
         public void PlatformPresent()
         {
@@ -510,14 +656,17 @@ namespace Microsoft.Xna.Framework.Graphics
             GraphicsExtensions.CheckGLError();
 
             // Dispose of any GL resources that were disposed in another thread
-            lock (disposeActionsLock)
+            int count = _disposeThisFrame.Count;
+            for (int i = 0; i < count; ++i)
+                _disposeThisFrame[i].Free();
+            _disposeThisFrame.Clear();
+
+            lock (_disposeActionsLock)
             {
-                if (disposeActions.Count > 0)
-                {
-                    foreach (var action in disposeActions)
-                        action();
-                    disposeActions.Clear();
-                }
+                // Swap lists so resources added during this draw will be released after the next draw
+                var temp = _disposeThisFrame;
+                _disposeThisFrame = _disposeNextFrame;
+                _disposeNextFrame = temp;
             }
         }
 

--- a/MonoGame.Framework/Graphics/OcclusionQuery.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OcclusionQuery.OpenGL.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     partial class OcclusionQuery
     {
-        private int glQueryId;
+        private int glQueryId = -1;
 
         private void PlatformConstruct()
         {
@@ -77,11 +77,11 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (!IsDisposed)
             {
-                Threading.BlockOnUIThread(() =>
+                if (glQueryId > -1)
                 {
-                    GL.DeleteQueries(1, ref glQueryId);
-                    GraphicsExtensions.CheckGLError();
-                });
+                    GraphicsDevice.DisposeQuery(glQueryId);
+                    glQueryId = -1;
+                }
             }
 
             base.Dispose(disposing);

--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -691,7 +691,7 @@ namespace OpenGL
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BindBufferDelegate(BufferTarget target, uint buffer);
+        public delegate void BindBufferDelegate(BufferTarget target, int buffer);
         public static BindBufferDelegate BindBuffer;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
@@ -838,7 +838,7 @@ namespace OpenGL
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public unsafe delegate void ShaderSourceDelegate(uint shaderId, int count, IntPtr code, int* length);
+        public unsafe delegate void ShaderSourceDelegate(int shaderId, int count, IntPtr code, int* length);
         public static ShaderSourceDelegate ShaderSourceInternal;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
@@ -848,12 +848,12 @@ namespace OpenGL
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public unsafe delegate void GetShaderDelegate(uint shaderId, uint parameter, int* value);
+        public unsafe delegate void GetShaderDelegate(int shaderId, int parameter, int* value);
         public static GetShaderDelegate GetShaderiv;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GetShaderInfoLogDelegate(uint shader, int bufSize, IntPtr length, StringBuilder infoLog);
+        public delegate void GetShaderInfoLogDelegate(int shader, int bufSize, IntPtr length, StringBuilder infoLog);
         public static GetShaderInfoLogDelegate GetShaderInfoLogInternal;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
@@ -903,12 +903,12 @@ namespace OpenGL
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public unsafe delegate void GetProgramDelegate(int programId, uint name, int* linked);
+        public unsafe delegate void GetProgramDelegate(int programId, int name, int* linked);
         public static GetProgramDelegate GetProgramiv;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GetProgramInfoLogDelegate(uint program, int bufSize, IntPtr length, StringBuilder infoLog);
+        public delegate void GetProgramInfoLogDelegate(int program, int bufSize, IntPtr length, StringBuilder infoLog);
         public static GetProgramInfoLogDelegate GetProgramInfoLogInternal;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
@@ -1035,7 +1035,7 @@ namespace OpenGL
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GenBuffersDelegate(int count, out uint buffer);
+        public delegate void GenBuffersDelegate(int count, out int buffer);
         public static GenBuffersDelegate GenBuffers;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
@@ -1061,7 +1061,7 @@ namespace OpenGL
         [CLSCompliant (false)]
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DeleteBuffersDelegate (int count, [In] [Out] ref uint buffer);
+        public delegate void DeleteBuffersDelegate (int count, [In] [Out] ref int buffer);
         [CLSCompliant (false)]
         public static DeleteBuffersDelegate DeleteBuffers;
 
@@ -1083,7 +1083,7 @@ namespace OpenGL
         public static VertexAttribDivisorDelegate VertexAttribDivisor;
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        delegate void DebugMessageCallbackProc(int source, int type, uint id, int severity, int length, IntPtr message, IntPtr userParam);
+        delegate void DebugMessageCallbackProc(int source, int type, int id, int severity, int length, IntPtr message, IntPtr userParam);
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]
         delegate void DebugMessageCallbackDelegate(DebugMessageCallbackProc callback, IntPtr userParam);
@@ -1093,7 +1093,7 @@ namespace OpenGL
         public static event ErrorDelegate OnError;
 
 #if DEBUG
-        static void DebugMessageCallbackHandler(int source, int type, uint id, int severity, int length, IntPtr message, IntPtr userParam)
+        static void DebugMessageCallbackHandler(int source, int type, int id, int severity, int length, IntPtr message, IntPtr userParam)
         {
             var errorMessage = Marshal.PtrToStringAnsi(message);
             System.Diagnostics.Debug.WriteLine(errorMessage);
@@ -1352,7 +1352,7 @@ namespace OpenGL
             int length = 0;
             GetProgram(programId, GetProgramParameterName.LogLength, out length);
             var sb = new StringBuilder();
-            GetProgramInfoLogInternal ((uint)programId, length, IntPtr.Zero, sb);
+            GetProgramInfoLogInternal (programId, length, IntPtr.Zero, sb);
             return sb.ToString();
         }
             
@@ -1360,7 +1360,7 @@ namespace OpenGL
             int length = 0;
             GetShader(shaderId, ShaderParameter.LogLength, out length);
             var sb = new StringBuilder();
-            GetShaderInfoLogInternal ((uint)shaderId, length, IntPtr.Zero, sb);
+            GetShaderInfoLogInternal (shaderId, length, IntPtr.Zero, sb);
             return sb.ToString();
         }
             
@@ -1368,7 +1368,7 @@ namespace OpenGL
         {
             int length = code.Length;
             IntPtr intPtr = MarshalStringArrayToPtr (new string[] { code });
-            ShaderSourceInternal((uint)shaderId, 1, intPtr, &length);
+            ShaderSourceInternal(shaderId, 1, intPtr, &length);
             FreeStringArrayPtr(intPtr, 1);
         }
 
@@ -1376,7 +1376,7 @@ namespace OpenGL
         {
             fixed (int* ptr = &result)
             {
-                GetShaderiv((uint)shaderId, (uint)name, ptr);
+                GetShaderiv(shaderId, (int)name, ptr);
             }
         }
 
@@ -1384,7 +1384,7 @@ namespace OpenGL
         {
             fixed (int* ptr = &result)
             {
-                GetProgramiv((int)programId, (uint)name, ptr);
+                GetProgramiv(programId, (int)name, ptr);
             }
         }
 

--- a/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Diagnostics;
 
 #if MONOMAC
 #if PLATFORM_MACOS_LEGACY
@@ -61,13 +62,9 @@ namespace Microsoft.Xna.Framework.Graphics
             if (compiled != (int)Bool.True)
             {
                 var log = GL.GetShaderInfoLog(_shaderHandle);
-                Console.WriteLine(log);
+                Debug.WriteLine(log);
 
-                if (GL.IsShader(_shaderHandle))
-                {
-                    GL.DeleteShader(_shaderHandle);
-                    GraphicsExtensions.CheckGLError();
-                }
+                GraphicsDevice.DisposeShader(_shaderHandle);
                 _shaderHandle = -1;
 
                 throw new InvalidOperationException("Shader Compilation Failed");
@@ -114,11 +111,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (_shaderHandle != -1)
             {
-                if (GL.IsShader(_shaderHandle))
-                {
-                    GL.DeleteShader(_shaderHandle);
-                    GraphicsExtensions.CheckGLError();
-                }
+                GraphicsDevice.DisposeShader(_shaderHandle);
                 _shaderHandle = -1;
             }
         }
@@ -127,15 +120,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (!IsDisposed && _shaderHandle != -1)
             {
-                // Take a copy of the handle for use in the anonymous function and clear the class handle.
-                // This prevents any other disposal of the resource between now and the time the anonymous
-                // function is executed.
-                int handle = _shaderHandle;
-                Threading.BlockOnUIThread(() =>
-                {
-                    GL.DeleteShader(handle);
-                    GraphicsExtensions.CheckGLError();
-                });
+                GraphicsDevice.DisposeShader(_shaderHandle);
                 _shaderHandle = -1;
             }
 

--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -59,7 +59,13 @@ namespace Microsoft.Xna.Framework.Graphics
     internal class ShaderProgramCache : IDisposable
     {
         private readonly Dictionary<int, ShaderProgram> _programCache = new Dictionary<int, ShaderProgram>();
+        GraphicsDevice _graphicsDevice;
         bool disposed;
+
+        public ShaderProgramCache(GraphicsDevice graphicsDevice)
+        {
+            _graphicsDevice = graphicsDevice;
+        }
 
         ~ShaderProgramCache()
         {
@@ -73,15 +79,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             foreach (var pair in _programCache)
             {
-                if (GL.IsProgram(pair.Value.Program))
-                {
-#if MONOMAC
-                    GL.DeleteProgram(pair.Value.Program, null);
-#else
-                    GL.DeleteProgram(pair.Value.Program);
-#endif
-                    GraphicsExtensions.CheckGLError();
-                }
+                _graphicsDevice.DisposeProgram(pair.Value.Program);
             }
             _programCache.Clear();
         }
@@ -138,11 +136,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 Console.WriteLine(log);
                 GL.DetachShader(program, vertexShader.GetShaderHandle());
                 GL.DetachShader(program, pixelShader.GetShaderHandle());
-#if MONOMAC
-                GL.DeleteProgram(1, ref program);
-#else
-                GL.DeleteProgram(program);
-#endif
+                _graphicsDevice.DisposeProgram(program);
                 throw new InvalidOperationException("Unable to link effect program");
             }
 

--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -48,12 +48,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (glTexture > 0)
             {
-                int texture = glTexture;
-                Threading.BlockOnUIThread(() =>
-                {
-                    GL.DeleteTextures(1, ref texture);
-                    GraphicsExtensions.CheckGLError();
-                });
+                GraphicsDevice.DisposeTexture(glTexture);
             }
             glTexture = -1;
         }

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -221,11 +221,11 @@ namespace Microsoft.Xna.Framework.Graphics
             // TODO: check for for non renderable formats (formats that can't be attached to FBO)
 
             var framebufferId = 0;
-			#if (IOS || ANDROID)
+#if (IOS || ANDROID)
 			GL.GenFramebuffers(1, out framebufferId);
-			#else
+#else
             GL.GenFramebuffers(1, ref framebufferId);
-			#endif
+#endif
             GraphicsExtensions.CheckGLError();
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferId);
             GraphicsExtensions.CheckGLError();
@@ -234,8 +234,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             GL.ReadPixels(rect.X, rect.Y, rect.Width, rect.Height, this.glFormat, this.glType, data);
             GraphicsExtensions.CheckGLError();
-            GL.DeleteFramebuffers(1, ref framebufferId);
-            GraphicsExtensions.CheckGLError();
+            GraphicsDevice.DisposeFramebuffer(framebufferId);
 #else
             var tSizeInByte = ReflectionHelpers.SizeOf<T>.Get();
             GL.BindTexture(TextureTarget.Texture2D, this.glTexture);

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class IndexBuffer
     {
-		internal uint ibo;	
+		internal int ibo;	
 
         private void PlatformConstruct(IndexElementSize indexElementSize, int indexCount)
         {
@@ -152,13 +152,8 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (!IsDisposed)
             {
-                Threading.BlockOnUIThread(() =>
-                {
-                    GL.DeleteBuffers(1, ref ibo);
-                    GraphicsExtensions.CheckGLError();
-                });
+                GraphicsDevice.DisposeBuffer(ibo);
             }
-
             base.Dispose(disposing);
         }
 	}

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Xna.Framework.Graphics
     public partial class VertexBuffer
     {
 		//internal uint vao;
-		internal uint vbo;
+		internal int vbo;
 
         private void PlatformConstruct()
         {
@@ -187,16 +187,9 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (!IsDisposed)
             {
-                Threading.BlockOnUIThread(() =>
-                {
-                    if (!IsDisposed)
-                    {
-                        GL.DeleteBuffers(1, ref vbo);
-                        GraphicsExtensions.CheckGLError();
-                        base.Dispose(disposing);
-                    }
-                });
+                GraphicsDevice.DisposeBuffer(vbo);
             }
+            base.Dispose(disposing);
         }
     }
 }

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Xna.Framework
                 SdlRunLoop();
                 Game.Tick();
                 Threading.Run();
+                GraphicsDevice.DisposeContexts();
 
                 if (_isExiting > 0)
                     break;
@@ -228,6 +229,7 @@ namespace Microsoft.Xna.Framework
         {
             if (Game.GraphicsDevice != null)
                 Game.GraphicsDevice.Present();
+
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
GL resources (textures, buffers, effects, shaders, queries, framebuffers) are now queued by the GraphicsDevice and deleted after the Present on the next frame.  This gives them time to be released by any rendering operations and allows the GC to clean up the wrapper objects.
SDL GL contexts are treated separately since there won't be a GraphicsDevice around to clean them up.