### PR TITLE
Allow switching vsync at runtime in DesktopGL

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -197,11 +197,11 @@ namespace Microsoft.Xna.Framework.Graphics
                 Threading.BackgroundContext = GL.CreateContext(windowInfo);
                 Threading.WindowInfo = windowInfo;
                 Threading.BackgroundContext.MakeCurrent(null);
-            }*/
+            }
 
             Context.MakeCurrent(windowInfo);
 
-            /*GraphicsMode mode = GraphicsMode.Default;
+            GraphicsMode mode = GraphicsMode.Default;
             var wnd = OpenTK.Platform.Utilities.CreateSdl2WindowInfo(Game.Instance.Window.Handle);
 
             #if GLES
@@ -1181,6 +1181,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void OnPresentationChanged()
         {
+#if DESKTOPGL || ANGLE
+            Context.MakeCurrent(new WindowInfo(SdlGameWindow.Instance.Handle));
+            Context.SwapInterval = PresentationParameters.PresentationInterval.GetSwapInterval();
+#endif
+
             ApplyRenderTargets(null);
         }
 

--- a/Test/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceTest.cs
@@ -93,6 +93,29 @@ namespace MonoGame.Tests.Graphics
             Assert.AreEqual(0, devLostCount);
         }
 
+        [Test]
+        public void ResetDoesNotClearState()
+        {
+            gd.RasterizerState = RasterizerState.CullNone;
+            gd.BlendState = BlendState.NonPremultiplied;
+            gd.DepthStencilState = DepthStencilState.None;
+            gd.SamplerStates[0] = SamplerState.PointClamp;
+            var vbb = new VertexBufferBinding(new VertexBuffer(gd, VertexPositionColor.VertexDeclaration, 5, BufferUsage.WriteOnly));
+            gd.SetVertexBuffers(vbb);
+
+            gd.Reset();
+
+            Assert.AreEqual(RasterizerState.CullNone, gd.RasterizerState);
+            Assert.AreEqual(BlendState.NonPremultiplied, gd.BlendState);
+            Assert.AreEqual(DepthStencilState.None, gd.DepthStencilState);
+            Assert.AreEqual(SamplerState.PointClamp, gd.SamplerStates[0]);
+            // TODO GetVertexBuffers is not implemented in MG
+#if XNA
+            Assert.AreEqual(vbb, gd.GetVertexBuffers()[0]);
+#endif
+            vbb.VertexBuffer.Dispose();
+        }
+
         // TODO Make sure dynamic graphics resources are notified when graphics device is lost
         [Test, Ignore]
         public void ContentLostResources()


### PR DESCRIPTION
The title says it all. Changing PresentInterval then calling ApplyChanges previously did not work. The value was only checked when a new GraphicsDevice was created.

I added a test to check if graphics state is cleared on reset in XNA. It's not, which matched current MG behavior, so no further changes required there.