### PR TITLE
Fix casing for readme include in tests

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -34,7 +34,7 @@
 
   <Files>
 
-    <None Include="ReadMe.md" />
+    <None Include="README.md" />
 
     <Compile Include="Properties\AssemblyInfo.cs" />
 


### PR DESCRIPTION
Casing in the .definition file didn't match file name so the README.md file was not included in the project.