### PR TITLE
Improved performance of SpriteFont.MeasureString() & SpriteBatch.DrawString()

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -652,9 +652,9 @@ namespace Microsoft.Xna.Framework.Graphics
             float sortKey = (_sortMode == SpriteSortMode.Texture) ? spriteFont.Texture.SortingKey : 0;
 
             // Get the default glyph here once.
-            SpriteFont.Glyph? defaultGlyph = null;
+            int defaultGlyphIndex = -1;
             if (spriteFont.DefaultCharacter.HasValue)
-                defaultGlyph = spriteFont.TryGetGlyph(spriteFont.DefaultCharacter.Value);
+                spriteFont.TryGetGlyphIndex(spriteFont.DefaultCharacter.Value, out defaultGlyphIndex);
             
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
@@ -674,7 +674,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     continue;
                 }
  
-                var currentGlyph = spriteFont.GetGlyphOrDefault(c, defaultGlyph);
+                var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c, defaultGlyphIndex);
+                var currentGlyph = spriteFont.Glyphs[currentGlyphIndex];
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
@@ -822,9 +823,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
             // Get the default glyph here once.
-            SpriteFont.Glyph? defaultGlyph = null;
+            int defaultGlyphIndex = -1;
             if (spriteFont.DefaultCharacter.HasValue)
-                defaultGlyph = spriteFont.TryGetGlyph(spriteFont.DefaultCharacter.Value);
+                spriteFont.TryGetGlyphIndex(spriteFont.DefaultCharacter.Value, out defaultGlyphIndex);
             
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
@@ -844,7 +845,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     continue;
                 }
 
-                var currentGlyph = spriteFont.GetGlyphOrDefault(c, defaultGlyph);
+                var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c, defaultGlyphIndex);
+                var currentGlyph = spriteFont.Glyphs[currentGlyphIndex];
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
@@ -941,9 +943,9 @@ namespace Microsoft.Xna.Framework.Graphics
             float sortKey =  (_sortMode == SpriteSortMode.Texture) ? spriteFont.Texture.SortingKey : 0;
 
             // Get the default glyph here once.
-            SpriteFont.Glyph? defaultGlyph = null;
+            int defaultGlyphIndex = -1;
             if (spriteFont.DefaultCharacter.HasValue)
-                defaultGlyph = spriteFont.TryGetGlyph(spriteFont.DefaultCharacter.Value);
+                spriteFont.TryGetGlyphIndex(spriteFont.DefaultCharacter.Value, out defaultGlyphIndex);
             
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
@@ -963,7 +965,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     continue;
                 }
 
-                var currentGlyph = spriteFont.GetGlyphOrDefault(c, defaultGlyph);
+                var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c, defaultGlyphIndex);
+                var currentGlyph = spriteFont.Glyphs[currentGlyphIndex];
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
@@ -1110,9 +1113,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
             // Get the default glyph here once.
-            SpriteFont.Glyph? defaultGlyph = null;
+            int defaultGlyphIndex = -1;
             if (spriteFont.DefaultCharacter.HasValue)
-                defaultGlyph = spriteFont.TryGetGlyph(spriteFont.DefaultCharacter.Value);
+                spriteFont.TryGetGlyphIndex(spriteFont.DefaultCharacter.Value, out defaultGlyphIndex);
             
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
@@ -1132,7 +1135,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     continue;
                 }
 
-                var currentGlyph = spriteFont.GetGlyphOrDefault(c, defaultGlyph);
+                var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c, defaultGlyphIndex);
+                var currentGlyph = spriteFont.Glyphs[currentGlyphIndex];
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -645,7 +645,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="text">The text which will be drawn.</param>
         /// <param name="position">The drawing location on screen.</param>
         /// <param name="color">A color mask.</param>
-		public void DrawString (SpriteFont spriteFont, string text, Vector2 position, Color color)
+		public unsafe void DrawString (SpriteFont spriteFont, string text, Vector2 position, Color color)
 		{
             CheckValid(spriteFont, text);
             
@@ -659,6 +659,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
+            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.Glyphs)
             for (var i = 0; i < text.Length; ++i)
             {
                 var c = text[i];
@@ -675,45 +676,45 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
  
                 var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c, defaultGlyphIndex);
-                var currentGlyph = spriteFont.Glyphs[currentGlyphIndex];
+                var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
                 //  so that text does not hang off the left side of its rectangle.
                 if (firstGlyphOfLine)
                 {
-                    offset.X = Math.Max(currentGlyph.LeftSideBearing, 0);
+                    offset.X = Math.Max(pCurrentGlyph->LeftSideBearing, 0);
                     firstGlyphOfLine = false;
                 }
                 else
                 {
-                    offset.X += spriteFont.Spacing + currentGlyph.LeftSideBearing;
+                    offset.X += spriteFont.Spacing + pCurrentGlyph->LeftSideBearing;
                 }
 
                 var p = offset;                
-                p.X += currentGlyph.Cropping.X;                
-                p.Y += currentGlyph.Cropping.Y;
+                p.X += pCurrentGlyph->Cropping.X;
+                p.Y += pCurrentGlyph->Cropping.Y;
                 p += position;
 
                 var item = _batcher.CreateBatchItem();
                 item.Texture = spriteFont.Texture;
                 item.SortKey = sortKey;
             
-                _texCoordTL.X = currentGlyph.BoundsInTexture.X * spriteFont.Texture.TexelWidth;
-                _texCoordTL.Y = currentGlyph.BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
-                _texCoordBR.X = (currentGlyph.BoundsInTexture.X + currentGlyph.BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
-                _texCoordBR.Y = (currentGlyph.BoundsInTexture.Y + currentGlyph.BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
+                _texCoordTL.X = pCurrentGlyph->BoundsInTexture.X * spriteFont.Texture.TexelWidth;
+                _texCoordTL.Y = pCurrentGlyph->BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
+                _texCoordBR.X = (pCurrentGlyph->BoundsInTexture.X + pCurrentGlyph->BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
+                _texCoordBR.Y = (pCurrentGlyph->BoundsInTexture.Y + pCurrentGlyph->BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
 
                 item.Set(p.X,
                          p.Y,
-                         currentGlyph.BoundsInTexture.Width,
-                         currentGlyph.BoundsInTexture.Height,
+                         pCurrentGlyph->BoundsInTexture.Width,
+                         pCurrentGlyph->BoundsInTexture.Height,
                          color,
                          _texCoordTL,
                          _texCoordBR,
                          0);
                 
-                offset.X += currentGlyph.Width + currentGlyph.RightSideBearing;
+                offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
             }
 
 			// We need to flush if we're using Immediate sort mode.
@@ -752,7 +753,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="scale">A scaling of this string.</param>
         /// <param name="effects">Modificators for drawing. Can be combined.</param>
         /// <param name="layerDepth">A depth of the layer of this string.</param>
-		public void DrawString (
+		public unsafe void DrawString (
 			SpriteFont spriteFont, string text, Vector2 position, Color color,
             float rotation, Vector2 origin, Vector2 scale, SpriteEffects effects, float layerDepth)
 		{
@@ -830,6 +831,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
+            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.Glyphs)
             for (var i = 0; i < text.Length; ++i)
             {
                 var c = text[i];
@@ -846,30 +848,30 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c, defaultGlyphIndex);
-                var currentGlyph = spriteFont.Glyphs[currentGlyphIndex];
+                var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
                 //  so that text does not hang off the left side of its rectangle.
                 if (firstGlyphOfLine)
                 {
-                    offset.X = Math.Max(currentGlyph.LeftSideBearing, 0);
+                    offset.X = Math.Max(pCurrentGlyph->LeftSideBearing, 0);
                     firstGlyphOfLine = false;
                 }
                 else
                 {
-                    offset.X += spriteFont.Spacing + currentGlyph.LeftSideBearing;
+                    offset.X += spriteFont.Spacing + pCurrentGlyph->LeftSideBearing;
                 }
 
                 var p = offset;
 
                 if (flippedHorz)
-                    p.X += currentGlyph.BoundsInTexture.Width;
-                p.X += currentGlyph.Cropping.X;
+                    p.X += pCurrentGlyph->BoundsInTexture.Width;
+                p.X += pCurrentGlyph->Cropping.X;
 
                 if (flippedVert)
-                    p.Y += currentGlyph.BoundsInTexture.Height - spriteFont.LineSpacing;
-                p.Y += currentGlyph.Cropping.Y;
+                    p.Y += pCurrentGlyph->BoundsInTexture.Height - spriteFont.LineSpacing;
+                p.Y += pCurrentGlyph->Cropping.Y;
 
                 Vector2.Transform(ref p, ref transformation, out p);
 
@@ -877,10 +879,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 item.Texture = spriteFont.Texture;
                 item.SortKey = sortKey;
                 
-                _texCoordTL.X = currentGlyph.BoundsInTexture.X * spriteFont.Texture.TexelWidth;
-                _texCoordTL.Y = currentGlyph.BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
-                _texCoordBR.X = (currentGlyph.BoundsInTexture.X + currentGlyph.BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
-                _texCoordBR.Y = (currentGlyph.BoundsInTexture.Y + currentGlyph.BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
+                _texCoordTL.X = pCurrentGlyph->BoundsInTexture.X * spriteFont.Texture.TexelWidth;
+                _texCoordTL.Y = pCurrentGlyph->BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
+                _texCoordBR.X = (pCurrentGlyph->BoundsInTexture.X + pCurrentGlyph->BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
+                _texCoordBR.Y = (pCurrentGlyph->BoundsInTexture.Y + pCurrentGlyph->BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
                             
                 if ((effects & SpriteEffects.FlipVertically) != 0)
                 {
@@ -899,8 +901,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 {
                     item.Set(p.X,
                             p.Y,
-                            currentGlyph.BoundsInTexture.Width * scale.X,
-                            currentGlyph.BoundsInTexture.Height * scale.Y,
+                            pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                            pCurrentGlyph->BoundsInTexture.Height * scale.Y,
                             color,
                             _texCoordTL,
                             _texCoordBR,
@@ -912,8 +914,8 @@ namespace Microsoft.Xna.Framework.Graphics
                             p.Y,
                             0,
                             0,
-                            currentGlyph.BoundsInTexture.Width * scale.X,
-                            currentGlyph.BoundsInTexture.Height * scale.Y,
+                            pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                            pCurrentGlyph->BoundsInTexture.Height * scale.Y,
                             sin,
                             cos,
                             color,
@@ -922,7 +924,7 @@ namespace Microsoft.Xna.Framework.Graphics
                             layerDepth);
                 }
                 
-                offset.X += currentGlyph.Width + currentGlyph.RightSideBearing;
+                offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
             }
 
 			// We need to flush if we're using Immediate sort mode.
@@ -936,7 +938,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="text">The text which will be drawn.</param>
         /// <param name="position">The drawing location on screen.</param>
         /// <param name="color">A color mask.</param>
-		public void DrawString (SpriteFont spriteFont, StringBuilder text, Vector2 position, Color color)
+		public unsafe void DrawString (SpriteFont spriteFont, StringBuilder text, Vector2 position, Color color)
 		{
             CheckValid(spriteFont, text);
             
@@ -950,6 +952,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
+            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.Glyphs)
             for (var i = 0; i < text.Length; ++i)
             {
                 var c = text[i];
@@ -966,45 +969,45 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c, defaultGlyphIndex);
-                var currentGlyph = spriteFont.Glyphs[currentGlyphIndex];
+                var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
                 //  so that text does not hang off the left side of its rectangle.
                 if (firstGlyphOfLine)
                 {
-                    offset.X = Math.Max(currentGlyph.LeftSideBearing, 0);
+                    offset.X = Math.Max(pCurrentGlyph->LeftSideBearing, 0);
                     firstGlyphOfLine = false;
                 }
                 else
                 {
-                    offset.X += spriteFont.Spacing + currentGlyph.LeftSideBearing;
+                    offset.X += spriteFont.Spacing + pCurrentGlyph->LeftSideBearing;
                 }
 
                 var p = offset;                
-                p.X += currentGlyph.Cropping.X;                
-                p.Y += currentGlyph.Cropping.Y;
+                p.X += pCurrentGlyph->Cropping.X;
+                p.Y += pCurrentGlyph->Cropping.Y;
                 p += position;
                 
                 var item = _batcher.CreateBatchItem();
                 item.Texture = spriteFont.Texture;
                 item.SortKey = sortKey;
             
-                _texCoordTL.X = currentGlyph.BoundsInTexture.X * spriteFont.Texture.TexelWidth;
-                _texCoordTL.Y = currentGlyph.BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
-                _texCoordBR.X = (currentGlyph.BoundsInTexture.X + currentGlyph.BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
-                _texCoordBR.Y = (currentGlyph.BoundsInTexture.Y + currentGlyph.BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
+                _texCoordTL.X = pCurrentGlyph->BoundsInTexture.X * spriteFont.Texture.TexelWidth;
+                _texCoordTL.Y = pCurrentGlyph->BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
+                _texCoordBR.X = (pCurrentGlyph->BoundsInTexture.X + pCurrentGlyph->BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
+                _texCoordBR.Y = (pCurrentGlyph->BoundsInTexture.Y + pCurrentGlyph->BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
 
                 item.Set(p.X,
                          p.Y,
-                         currentGlyph.BoundsInTexture.Width,
-                         currentGlyph.BoundsInTexture.Height,
+                         pCurrentGlyph->BoundsInTexture.Width,
+                         pCurrentGlyph->BoundsInTexture.Height,
                          color,
                          _texCoordTL,
                          _texCoordBR,
                          0);
 
-                offset.X += currentGlyph.Width + currentGlyph.RightSideBearing;
+                offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
             }
 
 			// We need to flush if we're using Immediate sort mode.
@@ -1043,7 +1046,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="scale">A scaling of this string.</param>
         /// <param name="effects">Modificators for drawing. Can be combined.</param>
         /// <param name="layerDepth">A depth of the layer of this string.</param>
-		public void DrawString (
+		public unsafe void DrawString (
 			SpriteFont spriteFont, StringBuilder text, Vector2 position, Color color,
             float rotation, Vector2 origin, Vector2 scale, SpriteEffects effects, float layerDepth)
 		{
@@ -1120,6 +1123,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
+            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.Glyphs)
             for (var i = 0; i < text.Length; ++i)
             {
                 var c = text[i];
@@ -1136,30 +1140,30 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c, defaultGlyphIndex);
-                var currentGlyph = spriteFont.Glyphs[currentGlyphIndex];
+                var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
                 //  so that text does not hang off the left side of its rectangle.
                 if (firstGlyphOfLine)
                 {
-                    offset.X = Math.Max(currentGlyph.LeftSideBearing, 0);
+                    offset.X = Math.Max(pCurrentGlyph->LeftSideBearing, 0);
                     firstGlyphOfLine = false;
                 }
                 else
                 {
-                    offset.X += spriteFont.Spacing + currentGlyph.LeftSideBearing;
+                    offset.X += spriteFont.Spacing + pCurrentGlyph->LeftSideBearing;
                 }
 
                 var p = offset;
 
                 if (flippedHorz)
-                    p.X += currentGlyph.BoundsInTexture.Width;
-                p.X += currentGlyph.Cropping.X;
+                    p.X += pCurrentGlyph->BoundsInTexture.Width;
+                p.X += pCurrentGlyph->Cropping.X;
 
                 if (flippedVert)
-                    p.Y += currentGlyph.BoundsInTexture.Height - spriteFont.LineSpacing;
-                p.Y += currentGlyph.Cropping.Y;
+                    p.Y += pCurrentGlyph->BoundsInTexture.Height - spriteFont.LineSpacing;
+                p.Y += pCurrentGlyph->Cropping.Y;
 
                 Vector2.Transform(ref p, ref transformation, out p);
                 
@@ -1167,10 +1171,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 item.Texture = spriteFont.Texture;
                 item.SortKey = sortKey;
                 
-                _texCoordTL.X = currentGlyph.BoundsInTexture.X * (float)spriteFont.Texture.TexelWidth;
-                _texCoordTL.Y = currentGlyph.BoundsInTexture.Y * (float)spriteFont.Texture.TexelHeight;
-                _texCoordBR.X = (currentGlyph.BoundsInTexture.X + currentGlyph.BoundsInTexture.Width) * (float)spriteFont.Texture.TexelWidth;
-                _texCoordBR.Y = (currentGlyph.BoundsInTexture.Y + currentGlyph.BoundsInTexture.Height) * (float)spriteFont.Texture.TexelHeight;
+                _texCoordTL.X = pCurrentGlyph->BoundsInTexture.X * (float)spriteFont.Texture.TexelWidth;
+                _texCoordTL.Y = pCurrentGlyph->BoundsInTexture.Y * (float)spriteFont.Texture.TexelHeight;
+                _texCoordBR.X = (pCurrentGlyph->BoundsInTexture.X + pCurrentGlyph->BoundsInTexture.Width) * (float)spriteFont.Texture.TexelWidth;
+                _texCoordBR.Y = (pCurrentGlyph->BoundsInTexture.Y + pCurrentGlyph->BoundsInTexture.Height) * (float)spriteFont.Texture.TexelHeight;
                             
                 if ((effects & SpriteEffects.FlipVertically) != 0)
                 {
@@ -1189,8 +1193,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 {
                     item.Set(p.X,
                             p.Y,
-                            currentGlyph.BoundsInTexture.Width * scale.X,
-                            currentGlyph.BoundsInTexture.Height * scale.Y,
+                            pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                            pCurrentGlyph->BoundsInTexture.Height * scale.Y,
                             color,
                             _texCoordTL,
                             _texCoordBR,
@@ -1202,8 +1206,8 @@ namespace Microsoft.Xna.Framework.Graphics
                             p.Y,
                             0,
                             0,
-                            currentGlyph.BoundsInTexture.Width * scale.X,
-                            currentGlyph.BoundsInTexture.Height * scale.Y,
+                            pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                            pCurrentGlyph->BoundsInTexture.Height * scale.Y,
                             sin,
                             cos,
                             color,
@@ -1212,7 +1216,7 @@ namespace Microsoft.Xna.Framework.Graphics
                             layerDepth);
                 }
 
-                offset.X += currentGlyph.Width + currentGlyph.RightSideBearing;
+                offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
 			}
 
 			// We need to flush if we're using Immediate sort mode.

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -654,9 +654,8 @@ namespace Microsoft.Xna.Framework.Graphics
             // Get the default glyph here once.
             SpriteFont.Glyph? defaultGlyph = null;
             if (spriteFont.DefaultCharacter.HasValue)
-                defaultGlyph = spriteFont.Glyphs[spriteFont.DefaultCharacter.Value];
-
-            var currentGlyph = SpriteFont.Glyph.Empty;
+                defaultGlyph = spriteFont.TryGetGlyph(spriteFont.DefaultCharacter.Value);
+            
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
@@ -674,14 +673,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     firstGlyphOfLine = true;
                     continue;
                 }
-
-                if (!spriteFont.Glyphs.TryGetValue(c, out currentGlyph))
-                {
-                    if (!defaultGlyph.HasValue)
-                        throw new ArgumentException(SpriteFont.Errors.TextContainsUnresolvableCharacters, "text");
-
-                    currentGlyph = defaultGlyph.Value;
-                }
+ 
+                var currentGlyph = spriteFont.GetGlyphOrDefault(c, defaultGlyph);
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
@@ -831,9 +824,8 @@ namespace Microsoft.Xna.Framework.Graphics
             // Get the default glyph here once.
             SpriteFont.Glyph? defaultGlyph = null;
             if (spriteFont.DefaultCharacter.HasValue)
-                defaultGlyph = spriteFont.Glyphs[spriteFont.DefaultCharacter.Value];
-
-            var currentGlyph = SpriteFont.Glyph.Empty;
+                defaultGlyph = spriteFont.TryGetGlyph(spriteFont.DefaultCharacter.Value);
+            
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
@@ -852,13 +844,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     continue;
                 }
 
-                if (!spriteFont.Glyphs.TryGetValue(c, out currentGlyph))
-                {
-                    if (!defaultGlyph.HasValue)
-                        throw new ArgumentException(SpriteFont.Errors.TextContainsUnresolvableCharacters, "text");
-
-                    currentGlyph = defaultGlyph.Value;
-                }
+                var currentGlyph = spriteFont.GetGlyphOrDefault(c, defaultGlyph);
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
@@ -957,9 +943,8 @@ namespace Microsoft.Xna.Framework.Graphics
             // Get the default glyph here once.
             SpriteFont.Glyph? defaultGlyph = null;
             if (spriteFont.DefaultCharacter.HasValue)
-                defaultGlyph = spriteFont.Glyphs[spriteFont.DefaultCharacter.Value];
-
-            var currentGlyph = SpriteFont.Glyph.Empty;
+                defaultGlyph = spriteFont.TryGetGlyph(spriteFont.DefaultCharacter.Value);
+            
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
@@ -978,13 +963,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     continue;
                 }
 
-                if (!spriteFont.Glyphs.TryGetValue(c, out currentGlyph))
-                {
-                    if (!defaultGlyph.HasValue)
-                        throw new ArgumentException(SpriteFont.Errors.TextContainsUnresolvableCharacters, "text");
-
-                    currentGlyph = defaultGlyph.Value;
-                }
+                var currentGlyph = spriteFont.GetGlyphOrDefault(c, defaultGlyph);
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
@@ -1133,9 +1112,8 @@ namespace Microsoft.Xna.Framework.Graphics
             // Get the default glyph here once.
             SpriteFont.Glyph? defaultGlyph = null;
             if (spriteFont.DefaultCharacter.HasValue)
-                defaultGlyph = spriteFont.Glyphs[spriteFont.DefaultCharacter.Value];
-
-            var currentGlyph = SpriteFont.Glyph.Empty;
+                defaultGlyph = spriteFont.TryGetGlyph(spriteFont.DefaultCharacter.Value);
+            
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
@@ -1154,13 +1132,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     continue;
                 }
 
-                if (!spriteFont.Glyphs.TryGetValue(c, out currentGlyph))
-                {
-                    if (!defaultGlyph.HasValue)
-                        throw new ArgumentException(SpriteFont.Errors.TextContainsUnresolvableCharacters, "text");
-
-                    currentGlyph = defaultGlyph.Value;
-                }
+                var currentGlyph = spriteFont.GetGlyphOrDefault(c, defaultGlyph);
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -147,14 +147,13 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
             // Get the default glyph here once.
-            Glyph? defaultGlyph = null;
-            if ( DefaultCharacter.HasValue )
-                defaultGlyph = _glyphs[DefaultCharacter.Value];
+            SpriteFont.Glyph? defaultGlyph = null;
+            if (DefaultCharacter.HasValue)
+                defaultGlyph = TryGetGlyph(DefaultCharacter.Value);
 
 			var width = 0.0f;
 			var finalLineHeight = (float)LineSpacing;
-
-            var currentGlyph = Glyph.Empty;
+            
 			var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
@@ -175,13 +174,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     continue;
                 }
 
-                if (!_glyphs.TryGetValue(c, out currentGlyph))
-                {
-                    if (!defaultGlyph.HasValue)
-                        throw new ArgumentException(Errors.TextContainsUnresolvableCharacters, "text");
-
-                    currentGlyph = defaultGlyph.Value;
-                }
+                var currentGlyph = GetGlyphOrDefault(c, defaultGlyph);
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
@@ -209,6 +202,29 @@ namespace Microsoft.Xna.Framework.Graphics
             size.Y = offset.Y + finalLineHeight;
 		}
 
+        internal Glyph? TryGetGlyph(char c)
+        {   
+            Glyph glyph;
+            if (!_glyphs.TryGetValue(c, out glyph))
+                return null;
+            else
+                return glyph;
+        }
+
+        internal Glyph GetGlyphOrDefault(char c, Glyph? defaultGlyph)
+        {
+            Glyph currentGlyph;
+            if (!_glyphs.TryGetValue(c, out currentGlyph))
+            {
+                if (!defaultGlyph.HasValue)
+                    throw new ArgumentException(Errors.TextContainsUnresolvableCharacters, "text");
+
+                return defaultGlyph.Value;
+            }
+            else
+                return currentGlyph;
+        }
+        
         internal struct CharacterSource 
         {
 			private readonly string _string;

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Text;
 
 namespace Microsoft.Xna.Framework.Graphics 
@@ -199,6 +200,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 var currentGlyphIndex = GetGlyphIndexOrDefault(c, defaultGlyphIndex);
+                Debug.Assert(currentGlyphIndex >= 0 && currentGlyphIndex < Glyphs.Length, "currentGlyphIndex was outside the bounds of the array.");
                 var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                 // The first character on a line might have a negative left side bearing.

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -170,9 +170,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
             // Get the default glyph here once.
-            SpriteFont.Glyph? defaultGlyph = null;
+            int defaultGlyphIndex = -1;
             if (DefaultCharacter.HasValue)
-                defaultGlyph = TryGetGlyph(DefaultCharacter.Value);
+                TryGetGlyphIndex(DefaultCharacter.Value, out defaultGlyphIndex);
 
 			var width = 0.0f;
 			var finalLineHeight = (float)LineSpacing;
@@ -197,7 +197,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     continue;
                 }
 
-                var currentGlyph = GetGlyphOrDefault(c, defaultGlyph);
+                var currentGlyphIndex = GetGlyphIndexOrDefault(c, defaultGlyphIndex);
+                var currentGlyph = Glyphs[currentGlyphIndex];
 
                 // The first character on a line might have a negative left side bearing.
                 // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
@@ -264,27 +265,18 @@ namespace Microsoft.Xna.Framework.Graphics
             return true;
         }
 
-        internal Glyph? TryGetGlyph(char c)
-        {   
-            int glyphIdx;
-            if (!TryGetGlyphIndex(c, out glyphIdx))
-                return null;
-            else
-                return _glyphs[glyphIdx];
-        }
-
-        internal Glyph GetGlyphOrDefault(char c, Glyph? defaultGlyph)
+        internal int GetGlyphIndexOrDefault(char c, int defaultGlyphIndex)
         {
             int glyphIdx;
             if (!TryGetGlyphIndex(c, out glyphIdx))
             {
-                if (!defaultGlyph.HasValue)
+                if (defaultGlyphIndex == -1)
                     throw new ArgumentException(Errors.TextContainsUnresolvableCharacters, "text");
 
-                return defaultGlyph.Value;
+                return defaultGlyphIndex;
             }
             else
-                return _glyphs[glyphIdx];
+                return glyphIdx;
         }
         
         internal struct CharacterSource 

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Xna.Framework.Graphics
 				"Text contains characters that cannot be resolved by this SpriteFont.";
 		}
 
-        private readonly Dictionary<char, Glyph> _glyphsDictionary;
         private readonly Glyph[] _glyphs;
         private readonly CharacterRegion[] _regions;
 		
@@ -53,13 +52,12 @@ namespace Microsoft.Xna.Framework.Graphics
 			Spacing = spacing;
 			DefaultCharacter = defaultCharacter;
 
-            _glyphsDictionary = new Dictionary<char, Glyph>(characters.Count, CharComparer.Default);
             _glyphs = new Glyph[characters.Count];
             var regions = new Stack<CharacterRegion>();
 
 			for (var i = 0; i < characters.Count; i++) 
             {
-				var glyph = new Glyph 
+				_glyphs[i] = new Glyph 
                 {
 					BoundsInTexture = glyphBounds[i],
 					Cropping = cropping[i],
@@ -71,10 +69,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                     WidthIncludingBearings = kerning[i].X + kerning[i].Y + kerning[i].Z
 				};
-                _glyphsDictionary.Add (glyph.Character, glyph);
-
-                _glyphs[i] = glyph;
-
+                
                 if(regions.Count ==0 || regions.Peek().End +1 !=characters[i])
                 {
                     // Start a new region
@@ -107,7 +102,10 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <remarks>Can be used to calculate character bounds when implementing custom SpriteFont rendering.</remarks>
         public Dictionary<char, Glyph> GetGlyphs()
         {
-            return new Dictionary<char, Glyph>(_glyphsDictionary, _glyphsDictionary.Comparer);
+            var glyphsDictionary = new Dictionary<char, Glyph>(_glyphs.Length, CharComparer.Default);
+            foreach(var glyph in _glyphs)
+                glyphsDictionary.Add(glyph.Character, glyph);
+            return glyphsDictionary;
         }
 
 		/// <summary>


### PR DESCRIPTION
* Glyph lookup
Replace Dictionary<char, Glyph> with a Glyph[] array and a custom CharacterRegion struct. We use binary search to find the CharacterRegion and from it it's easy to map a char in the Glyph[] array. Perfarmance is still good even with many Regions. I assume charachers in XNB SpriteFont are ordered.
I borrowed the Binary Search algorythm from Utilities.ByteBufferPool, thanks @Jjagg!. 

* Glyph access
Instead of getting a copy of a Glyph, we access it directly from the array. We use a fixed pointer of the array to avoid bound checks.

MeasureString(String) +52.4%
DrawString(SpriteFont, Vector2, Color) +24.4%