### PR TITLE
Fix for WinForms null reference exception on startup

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -369,7 +369,7 @@ namespace MonoGame.Framework
         private void UpdateBackBufferSize()
         {
             var manager = Game.graphicsDeviceManager;
-            if (manager.GraphicsDevice == null)
+            if (manager == null || manager.GraphicsDevice == null)
                 return;
 
             var newSize = Form.ClientSize;


### PR DESCRIPTION
Single null check that prevents null reference exception on startup