### PR TITLE
Removed deprecated Rider settings from Linux installer

### DIFF
--- a/Installers/Linux/RUN/postinstall.sh
+++ b/Installers/Linux/RUN/postinstall.sh
@@ -96,24 +96,6 @@ ln -s "$IDIR" "/opt/MonoGameSDK"
 chmod +x "$IDIR/Tools/ffmpeg"
 chmod +x "$IDIR/Tools/ffprobe"
 
-# Rider stuff
-if type "rider" > /dev/null 2>&1
-then
-	echo "Installing Rider files..."
-	
-	FINDCOMMAND=$(type -a rider)
-	COMMAND=$(echo $FINDCOMMAND| cut -d' ' -f 3)
-	
-	FINDRIDER=$(cat $COMMAND | grep "RUN_PATH")
-	RIDER=$(echo $FINDRIDER| cut -d"'" -f 2)
-	
-	RIDERDIR=$(dirname $(dirname $RIDER))
-	RXBUILD="$RIDERDIR/lib/ReSharperHost/linux-x64/mono/lib/mono/xbuild/MonoGame"
-	
-	mkdir -p "$RXBUILD"
-	ln -s "$IDIR" "$RXBUILD/v3.0"
-fi
-
 # MonoDevelop addin
 if [ "$MONODEVELOP" != "?????" ]
 then


### PR DESCRIPTION
Rider properly checks system xbuild dir so there is no longer a need for us to create a symlink.