### PR TITLE
Fix for build hang with no mgcb file in project

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -88,10 +88,10 @@
           WorkingDirectory="%(ContentReferences.RootDir)%(ContentReferences.Directory)" />
 
 
-    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' != ''" AdditionalMetadata="ContentOutputDir=$([System.String]::Copy('%(ContentReferences.Link)').Replace('%(Filename)%(Extension)', ''))">
+    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' != '' And '%(ContentReferences.FullPath)' != ''" AdditionalMetadata="ContentOutputDir=$([System.String]::Copy('%(ContentReferences.Link)').Replace('%(Filename)%(Extension)', ''))">
       <Output TaskParameter="Include" ItemName="ExtraContent" />
     </CreateItem>
-    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' == ''" AdditionalMetadata="ContentOutputDir=%(ContentReferences.RelativeDir)">
+    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' == '' And '%(ContentReferences.FullPath)' != ''" AdditionalMetadata="ContentOutputDir=%(ContentReferences.RelativeDir)">
       <Output TaskParameter="Include" ItemName="ExtraContent" />
 
     </CreateItem>


### PR DESCRIPTION
If the project contains no mgcb file the targets file appears to cause the build to hang. What it actually seems to be doing is trying to include the entire drive recursively as content because `ContentReferences.ContentOutputDir` may be empty (from what I understand of the targets file syntax)