### PR TITLE
Fixes to switching away from exclusive full-screen

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -677,6 +677,11 @@ namespace Microsoft.Xna.Framework.Graphics
             _swapChain.SetFullscreenState(PresentationParameters.IsFullScreen && PresentationParameters.HardwareModeSwitch, null);
         }
 
+        internal void ClearHardwareFullscreen()
+        {
+            _swapChain.SetFullscreenState(false, null);
+        }
+
         internal void ResizeTargets()
         {
             var format = SharpDXHelper.ToFormat(PresentationParameters.BackBufferFormat);

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -218,8 +218,11 @@ namespace Microsoft.Xna.Framework
                 Sdl.Window.SetFullscreen(Handle, (_willBeFullScreen) ? fullscreenFlag : 0);
                 _hardwareSwitch = _game.graphicsDeviceManager.HardwareModeSwitch;
             }
-            // If going to exclusive full-screen mode, force the window to minimize on focus loss
-            Sdl.SetHint("SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS", _willBeFullScreen && _hardwareSwitch ? "1" : "0");
+            // If going to exclusive full-screen mode, force the window to minimize on focus loss (Windows only)
+            if (CurrentPlatform.OS == OS.Windows)
+            {
+                Sdl.SetHint("SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS", _willBeFullScreen && _hardwareSwitch ? "1" : "0");
+            }
 
             if (!_willBeFullScreen || _game.graphicsDeviceManager.HardwareModeSwitch)
             {

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Xna.Framework
 
             _width = GraphicsDeviceManager.DefaultBackBufferWidth;
             _height = GraphicsDeviceManager.DefaultBackBufferHeight;
-            
+
             Sdl.SetHint("SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS", "0");
             Sdl.SetHint("SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "1");
 
@@ -218,6 +218,8 @@ namespace Microsoft.Xna.Framework
                 Sdl.Window.SetFullscreen(Handle, (_willBeFullScreen) ? fullscreenFlag : 0);
                 _hardwareSwitch = _game.graphicsDeviceManager.HardwareModeSwitch;
             }
+            // If going to exclusive full-screen mode, force the window to minimize on focus loss
+            Sdl.SetHint("SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS", _willBeFullScreen && _hardwareSwitch ? "1" : "0");
 
             if (!_willBeFullScreen || _game.graphicsDeviceManager.HardwareModeSwitch)
             {

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -221,6 +221,9 @@ namespace MonoGame.Framework
 
         private void OnDeactivate(object sender, EventArgs eventArgs)
         {
+            // If in exclusive mode full-screen, force it out of exclusive mode and minimize the window
+            if (IsFullScreen && _platform.Game.GraphicsDevice.PresentationParameters.HardwareModeSwitch)
+                MinimizeFullScreen();
             _platform.IsActive = false;
             Keyboard.SetActive(false);
         }
@@ -591,11 +594,30 @@ namespace MonoGame.Framework
         {
             _switchingFullScreen = true;
 
-            _platform.Game.GraphicsDevice.SetHardwareFullscreen();
+            _platform.Game.GraphicsDevice.ClearHardwareFullscreen();
 
             IsBorderless = false;
             Form.WindowState = FormWindowState.Normal;
             _lastFormState = FormWindowState.Normal;
+            Form.Location = _locationBeforeFullScreen;
+            IsFullScreen = false;
+
+            // Windows does not always correctly redraw the desktop when exiting soft full screen, so force a redraw
+            if (!HardwareModeSwitch)
+                RedrawWindow(IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, 1);
+
+            _switchingFullScreen = false;
+        }
+
+        private void MinimizeFullScreen()
+        {
+            _switchingFullScreen = true;
+
+            _platform.Game.GraphicsDevice.ClearHardwareFullscreen();
+
+            IsBorderless = false;
+            Form.WindowState = FormWindowState.Minimized;
+            _lastFormState = FormWindowState.Minimized;
             Form.Location = _locationBeforeFullScreen;
             IsFullScreen = false;
 


### PR DESCRIPTION
Fixes DirectX switching away from exclusive full-screen mode by forcing the swapchain out of exclusive mode and minimizing the window.
Fixes OpenGL switching away from exclusive full-screen mode by enabling the SDL hint to minimize video on loss of focus when changing to exclusive full-screen mode, otherwise the hint is left disabled.

Fixes #5885