### PR TITLE
[MonoGame.Framework.Content.Pipeline] Pipeline fails to generate spritefont on OsX

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/Font/SharpFontImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Font/SharpFontImporter.cs
@@ -44,10 +44,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 					Glyphs = glyphList;
 
 					// Store the font height.
-					LineSpacing = face.Size.Metrics.Height >> 6;
+					LineSpacing = face.Size.Metrics.Height.Value >> 6;
 
 					// The height used to calculate the Y offset for each character.
-					YOffsetMin = -face.Size.Metrics.Ascender >> 6;
+					YOffsetMin = -face.Size.Metrics.Ascender.Value >> 6;
 			}
             finally
             {
@@ -131,8 +131,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             if (glyphBitmap == null) 
 			{
-				var gHA = face.Glyph.Metrics.HorizontalAdvance >> 6;
-				var gVA = face.Size.Metrics.Height >> 6;
+				var gHA = face.Glyph.Metrics.HorizontalAdvance.Value >> 6;
+				var gVA = face.Size.Metrics.Height.Value >> 6;
 
 				gHA = gHA > 0 ? gHA : gVA;
 				gVA = gVA > 0 ? gVA : gHA;
@@ -142,16 +142,16 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
 			// not sure about this at all
 			var abc = new ABCFloat ();
-			abc.A = face.Glyph.Metrics.HorizontalBearingX >> 6;
-			abc.B = face.Glyph.Metrics.Width >> 6;
-			abc.C = (face.Glyph.Metrics.HorizontalAdvance >> 6) - (abc.A + abc.B);
+			abc.A = face.Glyph.Metrics.HorizontalBearingX.Value >> 6;
+			abc.B = face.Glyph.Metrics.Width.Value >> 6;
+			abc.C = (face.Glyph.Metrics.HorizontalAdvance.Value >> 6) - (abc.A + abc.B);
 
 			// Construct the output Glyph object.
 			return new Glyph(character, glyphBitmap)
 			{
-				XOffset = -(face.Glyph.Advance.X >> 6),
-				XAdvance = face.Glyph.Metrics.HorizontalAdvance >> 6,
-                YOffset = -(face.Glyph.Metrics.HorizontalBearingY >> 6),
+				XOffset = -(face.Glyph.Advance.X.Value >> 6),
+				XAdvance = face.Glyph.Metrics.HorizontalAdvance.Value >> 6,
+				YOffset = -(face.Glyph.Metrics.HorizontalBearingY.Value >> 6),
 				CharacterWidths = abc
 			};
 		}

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -43,7 +43,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                 if (CurrentPlatform.OS == OS.Windows)
                     directories.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Fonts"));
                 else if (CurrentPlatform.OS == OS.MacOSX)
+                {
+                    directories.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library", "Fonts"));
                     directories.Add("/Library/Fonts");
+                }
 
                 foreach (var dir in directories)
                 {
@@ -53,6 +56,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                         if (File.Exists(fontFile))
                             break;
                     }
+                    if (File.Exists(fontFile))
+                        break;
                 }
             }
 


### PR DESCRIPTION
Fixes #5196

This is kinda weird. libfreetype and SharpFont just stop working on
MacOS but only in 64 bit. In this PR we upgrade to the latest version
of SharpFont to fix the problem. However the API has changed slightly
so we need to update our API usage to match.