### PR TITLE
Fixes #5892 - Fix xbuild.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -16,17 +16,17 @@
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
 
-  <Target Name="Prepare">
-    <PropertyGroup>
-      <!-- El Capitan Support -->
-      <MonoExe Condition=" '$(OS)' != 'Windows_NT' And Exists ('/Library/Frameworks/Mono.framework/Versions/Current/bin/mono') ">/Library/Frameworks/Mono.framework/Versions/Current/bin/mono</MonoExe>
-      <MonoExe Condition=" '$(OS)' != 'Windows_NT' And Exists ('/usr/local/bin/mono') ">/usr/local/bin/mono</MonoExe>
-      <MonoExe Condition=" '$(OS)' != 'Windows_NT' And Exists ('/usr/bin/mono') ">/usr/bin/mono</MonoExe>
-      <MonoExe Condition=" '$(OS)' != 'Windows_NT' And '$(MonoExe)' == '' ">mono</MonoExe>
-      <MonoGameContentBuilderExe Condition="'$(MonoGameContentBuilderExe)' == ''">$(MSBuildThisFileDirectory)Tools\MGCB.exe</MonoGameContentBuilderExe>
-      <MonoGameContentBuilderCmd>&quot;$(MonoGameContentBuilderExe)&quot;</MonoGameContentBuilderCmd>
-      <MonoGameContentBuilderCmd Condition=" '$(OS)' != 'Windows_NT' ">$(MonoExe) $(MonoGameContentBuilderCmd)</MonoGameContentBuilderCmd>
+  <PropertyGroup>
+    <TasksAssemblyFolderPath Condition="'$(TasksAssemblyFolderPath)' == '' AND '$(MSBuildThisFileDirectory)' == '' "></TasksAssemblyFolderPath>
+    <TasksAssemblyFolderPath Condition="'$(TasksAssemblyFolderPath)' == '' AND '$(MSBuildThisFileDirectory)' != '' ">$(MSBuildThisFileDirectory)Tools\</TasksAssemblyFolderPath>
+    <TasksAssemblyPath Condition="'$(TasksAssemblyPath)' == ''">$(TasksAssemblyFolderPath)MonoGame.Framework.MsBuildTasks.dll</TasksAssemblyPath>
+  </PropertyGroup>
 
+  <UsingTask TaskName="MonoGame.Framework.MsBuildTasks.ProcessContentBuildTask" AssemblyFile="$(TasksAssemblyPath)" />
+
+  <Target Name="Prepare">
+    <PropertyGroup>     
+      <MonoGameContentBuilderExe Condition="'$(MonoGameContentBuilderExe)' == ''">$(MSBuildThisFileDirectory)Tools\MGCB.exe</MonoGameContentBuilderExe>
       <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX'">$(MonoMacResourcePrefix)\</PlatformResourcePrefix>
       <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'iOS'">$(IPhoneResourcePrefix)\</PlatformResourcePrefix>
       <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">$(MonoAndroidAssetsPrefix)\</PlatformResourcePrefix>
@@ -37,10 +37,7 @@
     <!-- Get all Mono Game Content References and store them in a list -->
     <!-- We do this here so we are compatible with xbuild -->
     <ItemGroup>
-      <ContentReferences Include="@(MonoGameContentReference)">
-        <ContentOutputDir>$(ProjectDir)%(RelativeDir)bin\$(MonoGamePlatform)\%(Filename)</ContentOutputDir>
-        <ContentIntermediateOutputDir>$(ProjectDir)%(RelativeDir)obj\$(MonoGamePlatform)\%(Filename)</ContentIntermediateOutputDir>
-      </ContentReferences>
+      <ContentReferences Include="@(MonoGameContentReference)"/>
     </ItemGroup>
 
     <Error Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, WindowsStoreApp, WindowsPhone8, MacOSX, iOS, Linux, DesktopGL, RaspberryPi, Android, NativeClient, PlayStation4, or PlayStationMobile."
@@ -69,9 +66,21 @@
         Text="No Content References Found. Please make sure your .mgcb file has a build action of MonoGameContentReference"
         Condition=" '%(ContentReferences.FullPath)' == '' "
     />
+  </Target>
 
-    <MakeDir Directories="%(ContentReferences.ContentOutputDir)"/>
-    <MakeDir Directories="%(ContentReferences.ContentIntermediateOutputDir)"/>
+  <Target Name="ProcessContent">
+    <ProcessContentBuildTask
+     ProjectDirectory="$(MSBuildProjectDirectory)"
+     MgcbExePath="$(MonoGameContentBuilderExe)"
+     ContentReferenceItems="@(ContentReferences)"
+     Platform="$(MonoGamePlatform)"
+     PlatformResourcePrefix="$(PlatformResourcePrefix)"
+     Configuration="$(Configuration)"
+     IntermediateOutputPath="$(IntermediateOutputPath)">
+
+      <Output TaskParameter="ExtraContent" ItemName="ExtraContent"/>
+
+    </ProcessContentBuildTask>
 
   </Target>
 
@@ -81,32 +90,17 @@
       $(BuildDependsOn);
     </BuildDependsOn>
   </PropertyGroup>
+  <Target Name="BuildContent" DependsOnTargets="Prepare;ProcessContent"
+          Outputs="@(ExtraContent)">
 
-  <Target Name="RunContentBuilder">
-    <Exec Condition=" '%(ContentReferences.FullPath)' != '' "
-          Command="$(MonoGameContentBuilderCmd) /@:&quot;%(ContentReferences.FullPath)&quot; $(Header) /outputDir:&quot;%(ContentReferences.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReferences.ContentIntermediateOutputDir)&quot; /quiet"
-          WorkingDirectory="%(ContentReferences.RootDir)%(ContentReferences.Directory)" />
-
-
-    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' != '' And '%(ContentReferences.FullPath)' != ''" AdditionalMetadata="ContentOutputDir=$([System.String]::Copy('%(ContentReferences.Link)').Replace('%(Filename)%(Extension)', ''))">
-      <Output TaskParameter="Include" ItemName="ExtraContent" />
-    </CreateItem>
-    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' == '' And '%(ContentReferences.FullPath)' != ''" AdditionalMetadata="ContentOutputDir=%(ContentReferences.RelativeDir)">
-      <Output TaskParameter="Include" ItemName="ExtraContent" />
-
-    </CreateItem>
+    <ItemGroup Condition="'$(MonoGamePlatform)' != 'Android' And '$(MonoGamePlatform)' != 'iOS' And '$(MonoGamePlatform)' != 'MacOSX'">
+      <Content Include="@(ExtraContent)"/>
+    </ItemGroup>
+    <ItemGroup Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'">
+      <BundleResource Include="@(ExtraContent)"/>
+    </ItemGroup>
+    <ItemGroup Condition="'$(MonoGamePlatform)' == 'Android'">
+      <AndroidAsset Include="@(ExtraContent)"/>
+    </ItemGroup>
   </Target>
-
-  <Target Name="BuildContent" DependsOnTargets="Prepare;RunContentBuilder"
-          Outputs="%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension)">
-
-    <CreateItem Include="%(ExtraContent.FullPath)"
-         AdditionalMetadata="Link=$(PlatformResourcePrefix)%(ExtraContent.ContentOutputDir)%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension);CopyToOutputDirectory=PreserveNewest"
-         Condition="'%(ExtraContent.Filename)' != ''">
-      <Output TaskParameter="Include" ItemName="Content" Condition="'$(MonoGamePlatform)' != 'Android' And '$(MonoGamePlatform)' != 'iOS' And '$(MonoGamePlatform)' != 'MacOSX'" />
-      <Output TaskParameter="Include" ItemName="BundleResource" Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'" />
-      <Output TaskParameter="Include" ItemName="AndroidAsset" Condition="'$(MonoGamePlatform)' == 'Android'" />
-    </CreateItem>
-  </Target>
-
 </Project>

--- a/MonoGame.Framework.MsBuildTasks/MonoGame.Framework.MsBuildTasks.csproj
+++ b/MonoGame.Framework.MsBuildTasks/MonoGame.Framework.MsBuildTasks.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{939A2D55-CA91-440E-AFFA-B48A77F9109D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MonoGame.Framework.MsBuildTasks</RootNamespace>
+    <AssemblyName>MonoGame.Framework.MsBuildTasks</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ProcessContentBuildTask.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SilentProcessRunner.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/MonoGame.Framework.MsBuildTasks/ProcessContentBuildTask.cs
+++ b/MonoGame.Framework.MsBuildTasks/ProcessContentBuildTask.cs
@@ -1,0 +1,293 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace MonoGame.Framework.MsBuildTasks
+{
+    public class ProcessContentBuildTask : ITask
+    {
+
+        private static readonly char[] PathSperators = new char[] { '/', '\\' };
+
+        private System.Collections.Concurrent.ConcurrentBag<ITaskItem> _content;
+        //private System.Collections.Concurrent.ConcurrentBag<ITaskItem> _androidAssets;
+        //private System.Collections.Concurrent.ConcurrentBag<ITaskItem> _bundleResources;
+
+
+        public IBuildEngine BuildEngine { get; set; }
+
+        public ITaskHost HostObject { get; set; }
+
+        [Output]
+        public ITaskItem[] ExtraContent { get; set; }
+
+        //[Output]
+        //public ITaskItem[] ExtraAndroidAssets { get; set; }
+
+        //[Output]
+        //public ITaskItem[] ExtraBundleResources { get; set; }
+
+        [Required]
+        public string ProjectDirectory { get; set; }
+
+        //[Required]
+        //public string MonoExePath { get; set; }
+
+        [Required]
+        public string MgcbExePath { get; set; }
+
+        [Required]
+        public ITaskItem[] ContentReferenceItems { get; set; }
+
+        [Required]
+        public string Platform { get; set; }
+
+
+        public string PlatformResourcePrefix { get; set; }
+
+        [Required]
+        public string IntermediateOutputPath { get; set; }
+
+        [Required]
+        public string Configuration { get; set; }
+
+
+        public bool Execute()
+        {
+            _content = new ConcurrentBag<ITaskItem>();
+
+            var platformArgs = string.Format("/platform:{0}", Platform);
+
+            //  var tasks = new List<Tuple<ITaskItem, Task>>();
+            var tasks = new List<System.Threading.Tasks.Task>();
+
+            // process each content reference in parallel for perf.
+            foreach (var contentReference in ContentReferenceItems)
+            {
+                var fullPath = contentReference.GetMetadata("FullPath");
+                string outputDir = GetOutputDir(contentReference);
+                string intermediateOutputDir = GetIntermeditateOutputDir(contentReference);
+
+                // trailing slash in working dir arg is not handled by MCGB.exe so we have to remove it..
+                string workingDir = GetWorkingDir(contentReference).TrimEnd(PathSperators);
+
+                var commandArgs = string.Format(@"/workingDir:""{4}"" /@:""{0}"" {1} /outputDir:""{2}"" /intermediateDir:""{3}"" /quiet", fullPath, platformArgs, outputDir, intermediateOutputDir, workingDir);
+
+                var task = new System.Threading.Tasks.Task(() =>
+                {
+                    try
+                    {
+                        RunContentBuilderExecutable(workingDir, commandArgs, (output) =>
+                        {
+                            // Now gather the files as outputs.
+                            var outputItems = GatherOutputs(contentReference, outputDir);
+                            foreach (var item in outputItems)
+                            {
+                                _content.Add(item);
+                            }
+
+                        });
+                    }
+                    catch (Exception e)
+                    {
+
+                        throw;
+                    }
+
+                });
+                tasks.Add(task);
+                // tasks.Add(new Tuple<ITaskItem, Task>(contentReference, task));
+                task.Start();
+            }
+
+            System.Threading.Tasks.Task.WaitAll(tasks.ToArray());
+            ExtraContent = _content.ToArray();
+            return true;
+        }
+
+        private IEnumerable<ITaskItem> GatherOutputs(ITaskItem contentReference, string outputDir)
+        {
+            var items = new List<ITaskItem>();
+            var outputDirectoryInfo = new DirectoryInfo(outputDir);
+            var relativeDir = contentReference.GetMetadata("RelativeDir");
+            var link = contentReference.GetMetadata("Link");
+
+            VisitFiles(outputDir, (fileInfo) =>
+            {
+                var item = new TaskItem(fileInfo.FullName);
+                item.SetMetadata("ContentOutputDir", outputDirectoryInfo.FullName);
+                item.SetMetadata("RelativeContentOutputDir", relativeDir);
+
+                // We add RecursiveDir metadata, as if the directory portion of the file paths was resolved using a glob include, from the outputdir root.
+                // i.e include="$(outputDir)/**/*
+
+                if (string.IsNullOrWhiteSpace(fileInfo.FullName))
+                {
+                    return;
+                }
+
+                if (fileInfo.FullName.Length <= outputDirectoryInfo.FullName.Length)
+                {
+                    return;
+                }
+
+                var relativePath = fileInfo.FullName.Remove(0, outputDirectoryInfo.FullName.Length).TrimStart(PathSperators);
+                item.SetMetadata("RecursiveDir", relativePath);
+
+                if(string.IsNullOrWhiteSpace(link))
+                {
+                    var linkPath = string.Format("{0}{1}{2}", PlatformResourcePrefix, relativeDir, relativePath);
+                    item.SetMetadata("Link", linkPath);
+                }
+                else
+                {
+                    var linkRoot = Path.GetDirectoryName(link);
+                    var linkPath = string.Format("{0}\\{1}", linkRoot, relativePath).TrimStart(PathSperators);
+                    item.SetMetadata("Link", linkPath);
+                }
+               
+                item.SetMetadata("CopyToOutputDirectory", "PreserveNewest");
+
+           //     switch (Platform)
+           //     {
+           //         case "Android":
+           //             break;
+           //         case "MacOSX":
+           //         case "iOS":
+           //             break;
+           //         default:
+           //             _content.
+
+           //     }
+
+           //           < Output TaskParameter = "Include" ItemName = "Content" Condition = "'$(MonoGamePlatform)' != 'Android' And '$(MonoGamePlatform)' != 'iOS' And '$(MonoGamePlatform)' != 'MacOSX'" />
+
+
+           //< Output TaskParameter = "Include" ItemName = "BundleResource" Condition = "'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'" />
+
+
+                //< Output TaskParameter = "Include" ItemName = "AndroidAsset" Condition = "'$(MonoGamePlatform)' == 'Android'" />
+
+
+
+                               // % (ExtraContent.RecursiveDir)
+
+                               //todo: add following:
+                               //RecursiveDir
+                               //filename
+                               //extension
+
+                               items.Add(item);
+            });
+            return items;
+            //var link = contentReference.GetMetadata("Link");
+            //if (string.IsNullOrWhiteSpace(link))
+            //{
+            //    var item = new TaskItem()
+            //     var fileName = fileName
+            //    var path = link.Replace("",)
+            //            }
+
+            //              < CreateItem Include = "%(ContentReferences.ContentOutputDir)\**\*.*" Condition = "'%(ContentReferences.Link)' != '' And '%(ContentReferences.FullPath)' != ''" AdditionalMetadata = "ContentOutputDir=$([System.String]::Copy('%(ContentReferences.Link)').Replace('%(Filename)%(Extension)', ''))" >
+
+            //< Output TaskParameter = "Include" ItemName = "ExtraContent" />
+
+            // </ CreateItem >
+
+            // < CreateItem Include = "%(ContentReferences.ContentOutputDir)\**\*.*" Condition = "'%(ContentReferences.Link)' == '' And '%(ContentReferences.FullPath)' != ''" AdditionalMetadata = "ContentOutputDir=%(ContentReferences.RelativeDir)" >
+
+            //        < Output TaskParameter = "Include" ItemName = "ExtraContent" />
+
+            //         </ CreateItem >
+        }
+
+        private string GetWorkingDir(ITaskItem contentReference)
+        {
+            var rootDir = contentReference.GetMetadata("RootDir");
+            var dir = contentReference.GetMetadata("Directory");
+            var path = Path.Combine(rootDir, dir);
+            return path;
+        }
+
+        private string GetOutputDir(ITaskItem contentReference)
+        {
+            var relativeDir = contentReference.GetMetadata("RelativeDir");
+            var fileName = contentReference.GetMetadata("Filename");
+            var contentOutputDir = Path.Combine(ProjectDirectory, relativeDir, "bin", Platform, fileName);
+            contentReference.SetMetadata("ContentOutputDir", contentOutputDir);
+            return contentOutputDir;
+        }
+
+        private string GetIntermeditateOutputDir(ITaskItem contentReference)
+        {
+            var relativeDir = contentReference.GetMetadata("RelativeDir");
+            var fileName = contentReference.GetMetadata("Filename");
+            var contentOutputDir = Path.Combine(ProjectDirectory, relativeDir, "obj", Platform, fileName);
+            contentReference.SetMetadata("ContentIntermediateOutputDir", contentOutputDir);
+            return contentOutputDir;
+        }
+
+        public void RunContentBuilderExecutable(string workingDir, string commandLineArguments, Action<string> outputValidator)
+        {
+            //  var netFx = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+
+            if (!File.Exists(MgcbExePath))
+            {
+                // log error?
+                throw new FileNotFoundException("Could not find MGCB.exe at: " + MgcbExePath);
+            }
+
+            var allOutput = new StringBuilder();
+
+            Action<string> writer = (output) =>
+            {
+                allOutput.AppendLine(output);
+                // todo: log output to msbuild log?
+                //Console.WriteLine(output);
+            };
+
+            var result = SilentProcessRunner.ExecuteCommand(MgcbExePath, commandLineArguments, workingDir, writer, e => writer("ERROR: " + e));
+
+            if (result != 0)
+            {
+                throw new FileNotFoundException("Could not find MGCB.exe at: " + MgcbExePath);
+            }
+
+            if (outputValidator != null)
+            {
+                outputValidator(allOutput.ToString());
+            }
+        }
+
+        public static void VisitFiles(string root, Action<FileInfo> onVisit)
+        {
+            Stack<string> dirs = new Stack<string>(10);
+            if (!Directory.Exists(root))
+            {
+                return;
+            }
+
+            dirs.Push(root);
+            while (dirs.Count > 0)
+            {
+                string currentDir = dirs.Pop();
+                var subDirs = Directory.EnumerateDirectories(currentDir); //TopDirectoryOnly
+                foreach (string str in subDirs)
+                {
+                    dirs.Push(str);
+                }
+                var files = Directory.EnumerateFiles(currentDir);
+                foreach (string file in files)
+                {
+                    // Perform whatever action is required in your scenario.
+                    FileInfo fi = new FileInfo(file);
+                    onVisit(fi);
+                }
+            }
+        }
+    }
+}

--- a/MonoGame.Framework.MsBuildTasks/ProcessContentBuildTask.cs
+++ b/MonoGame.Framework.MsBuildTasks/ProcessContentBuildTask.cs
@@ -14,8 +14,6 @@ namespace MonoGame.Framework.MsBuildTasks
         private static readonly char[] PathSperators = new char[] { '/', '\\' };
 
         private System.Collections.Concurrent.ConcurrentBag<ITaskItem> _content;
-        //private System.Collections.Concurrent.ConcurrentBag<ITaskItem> _androidAssets;
-        //private System.Collections.Concurrent.ConcurrentBag<ITaskItem> _bundleResources;
 
 
         public IBuildEngine BuildEngine { get; set; }
@@ -25,17 +23,8 @@ namespace MonoGame.Framework.MsBuildTasks
         [Output]
         public ITaskItem[] ExtraContent { get; set; }
 
-        //[Output]
-        //public ITaskItem[] ExtraAndroidAssets { get; set; }
-
-        //[Output]
-        //public ITaskItem[] ExtraBundleResources { get; set; }
-
         [Required]
         public string ProjectDirectory { get; set; }
-
-        //[Required]
-        //public string MonoExePath { get; set; }
 
         [Required]
         public string MgcbExePath { get; set; }
@@ -45,7 +34,6 @@ namespace MonoGame.Framework.MsBuildTasks
 
         [Required]
         public string Platform { get; set; }
-
 
         public string PlatformResourcePrefix { get; set; }
 
@@ -100,7 +88,6 @@ namespace MonoGame.Framework.MsBuildTasks
 
                 });
                 tasks.Add(task);
-                // tasks.Add(new Tuple<ITaskItem, Task>(contentReference, task));
                 task.Start();
             }
 
@@ -122,9 +109,6 @@ namespace MonoGame.Framework.MsBuildTasks
                 item.SetMetadata("ContentOutputDir", outputDirectoryInfo.FullName);
                 item.SetMetadata("RelativeContentOutputDir", relativeDir);
 
-                // We add RecursiveDir metadata, as if the directory portion of the file paths was resolved using a glob include, from the outputdir root.
-                // i.e include="$(outputDir)/**/*
-
                 if (string.IsNullOrWhiteSpace(fileInfo.FullName))
                 {
                     return;
@@ -135,74 +119,28 @@ namespace MonoGame.Framework.MsBuildTasks
                     return;
                 }
 
-                var relativePath = fileInfo.FullName.Remove(0, outputDirectoryInfo.FullName.Length).TrimStart(PathSperators);
-                item.SetMetadata("RecursiveDir", relativePath);
+                // We add RecursiveDir metadata, as if the directory portion of the file paths was resolved using a glob include, from the outputdir root.
+                // i.e include="$(outputDir)/**/*
+                var recursiveDir = fileInfo.FullName.Remove(0, outputDirectoryInfo.FullName.Length).TrimStart(PathSperators);
+                item.SetMetadata("RecursiveDir", recursiveDir);
 
-                if(string.IsNullOrWhiteSpace(link))
+                if (string.IsNullOrWhiteSpace(link))
                 {
-                    var linkPath = string.Format("{0}{1}{2}", PlatformResourcePrefix, relativeDir, relativePath);
+                    var linkPath = string.Format("{0}{1}{2}", PlatformResourcePrefix, relativeDir, recursiveDir);
                     item.SetMetadata("Link", linkPath);
                 }
                 else
                 {
                     var linkRoot = Path.GetDirectoryName(link);
-                    var linkPath = string.Format("{0}\\{1}", linkRoot, relativePath).TrimStart(PathSperators);
+                    var linkPath = string.Format("{0}\\{1}", linkRoot, recursiveDir).TrimStart(PathSperators);
                     item.SetMetadata("Link", linkPath);
                 }
-               
+
                 item.SetMetadata("CopyToOutputDirectory", "PreserveNewest");
-
-           //     switch (Platform)
-           //     {
-           //         case "Android":
-           //             break;
-           //         case "MacOSX":
-           //         case "iOS":
-           //             break;
-           //         default:
-           //             _content.
-
-           //     }
-
-           //           < Output TaskParameter = "Include" ItemName = "Content" Condition = "'$(MonoGamePlatform)' != 'Android' And '$(MonoGamePlatform)' != 'iOS' And '$(MonoGamePlatform)' != 'MacOSX'" />
-
-
-           //< Output TaskParameter = "Include" ItemName = "BundleResource" Condition = "'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'" />
-
-
-                //< Output TaskParameter = "Include" ItemName = "AndroidAsset" Condition = "'$(MonoGamePlatform)' == 'Android'" />
-
-
-
-                               // % (ExtraContent.RecursiveDir)
-
-                               //todo: add following:
-                               //RecursiveDir
-                               //filename
-                               //extension
-
-                               items.Add(item);
+                items.Add(item);
             });
             return items;
-            //var link = contentReference.GetMetadata("Link");
-            //if (string.IsNullOrWhiteSpace(link))
-            //{
-            //    var item = new TaskItem()
-            //     var fileName = fileName
-            //    var path = link.Replace("",)
-            //            }
 
-            //              < CreateItem Include = "%(ContentReferences.ContentOutputDir)\**\*.*" Condition = "'%(ContentReferences.Link)' != '' And '%(ContentReferences.FullPath)' != ''" AdditionalMetadata = "ContentOutputDir=$([System.String]::Copy('%(ContentReferences.Link)').Replace('%(Filename)%(Extension)', ''))" >
-
-            //< Output TaskParameter = "Include" ItemName = "ExtraContent" />
-
-            // </ CreateItem >
-
-            // < CreateItem Include = "%(ContentReferences.ContentOutputDir)\**\*.*" Condition = "'%(ContentReferences.Link)' == '' And '%(ContentReferences.FullPath)' != ''" AdditionalMetadata = "ContentOutputDir=%(ContentReferences.RelativeDir)" >
-
-            //        < Output TaskParameter = "Include" ItemName = "ExtraContent" />
-
-            //         </ CreateItem >
         }
 
         private string GetWorkingDir(ITaskItem contentReference)
@@ -233,8 +171,6 @@ namespace MonoGame.Framework.MsBuildTasks
 
         public void RunContentBuilderExecutable(string workingDir, string commandLineArguments, Action<string> outputValidator)
         {
-            //  var netFx = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
-
             if (!File.Exists(MgcbExePath))
             {
                 // log error?

--- a/MonoGame.Framework.MsBuildTasks/Properties/AssemblyInfo.cs
+++ b/MonoGame.Framework.MsBuildTasks/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MonoGame.Framework.MsBuildTasks")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MonoGame.Framework.MsBuildTasks")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("939a2d55-ca91-440e-affa-b48a77f9109d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/MonoGame.Framework.MsBuildTasks/SilentProcessRunner.cs
+++ b/MonoGame.Framework.MsBuildTasks/SilentProcessRunner.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace MonoGame.Framework.MsBuildTasks
+{
+
+    public static class SilentProcessRunner
+    {
+
+        public static int ExecuteCommand(string executable, string arguments, string workingDirectory, Action<string> output, Action<string> error)
+        {
+
+            try
+            {
+
+                using (var process = new Process())
+                {
+
+                    process.StartInfo.FileName = executable;
+                    process.StartInfo.Arguments = arguments;
+                    process.StartInfo.WorkingDirectory = workingDirectory;
+                    process.StartInfo.UseShellExecute = false;
+                    process.StartInfo.CreateNoWindow = true;
+                    process.StartInfo.RedirectStandardOutput = true;
+                    process.StartInfo.RedirectStandardError = true;
+
+
+                    using (var outputWaitHandle = new AutoResetEvent(false))
+                    using (var errorWaitHandle = new AutoResetEvent(false))
+                    {
+                        process.OutputDataReceived += (sender, e) =>
+                        {
+                            if (e.Data == null)
+                            {
+                                outputWaitHandle.Set();
+                            }
+                            else
+                            {
+                                output(e.Data);
+                            }
+                        };
+
+                        process.ErrorDataReceived += (sender, e) =>
+                        {
+                            if (e.Data == null)
+                            {
+                                errorWaitHandle.Set();
+                            }
+                            else
+                            {
+                                error(e.Data);
+                            }
+                        };
+
+                        process.Start();
+                        process.BeginOutputReadLine();
+                        process.BeginErrorReadLine();
+                        process.WaitForExit();
+
+                        outputWaitHandle.WaitOne();
+                        errorWaitHandle.WaitOne();
+
+                        return process.ExitCode;
+
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(string.Format("Error when attempting to execute {0}: {1}", executable, ex.Message), ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I moved the complicated msbuild logic from the targets file, into a seperate msbuild task (c#), because:
1. xbuild can't handle it.
2. This opens a path to create some test coverage of the build logic through testing the msbuild task with nunit / xunit etc.

To test:

1. Build the `MonoGame.Framework.MsBuildTasks` project, and then put the `MonoGame.Framework.MsBuildTasks` dll in `C:\Program Files (x86)\MSBuild\MonoGame\v3.0\Tools\` folder.
2. Overwrite the `MonoGame.Content.Builder.targets` file in `C:\Program Files (x86)\MSBuild\MonoGame\v3.0\` with the version from this PR.

3. Create a new monogame project. 
4. Add some `mgcb`s. You can experiment by adding linked and non linked mgcb's, to different directories within the project.
5. Build the project.
6. Check the output directory for all the content.

## Debugging the msbuild task

2. In your sample monogame project, edit the csproj file, and add a `TasksAssemblyFolderPath` property which points to the bin/debug folder that contains the task assembly. For my sample project which I created in the monogame repo directory, it looks like this:
```
 <PropertyGroup>
    <TasksAssemblyFolderPath>$(MSBuildThisFileDirectory)..\MonoGame.Framework.MsBuildTasks\bin\Debug\</TasksAssemblyFolderPath>

```

Edit the project properties for the MsBuildTasks project, so that it builds the sample project using msbuild / xbuild when you run it. For me this looks like:

![image](https://user-images.githubusercontent.com/3176632/29594243-99f1262c-87a7-11e7-8775-bbcf4b548e21.png)


Now you can run the  msbuild tasks project, and set a break point in the msbuild task to debug.

## Other notes:

I build each mgcb in parallel as I thought would be better for performance. Seems to work well.