### PR TITLE
Fix a crash when building content in xbuild 

### DIFF
--- a/Build/Projects/MonoGame.Build.Tasks.definition
+++ b/Build/Projects/MonoGame.Build.Tasks.definition
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Name="MonoGame.Build.Tasks" Path="Tools/MonoGame.Build.Tasks" Type="Library" Platforms="Windows,MacOS,Linux">
+
+  <!-- Common assembly references -->
+  <References>
+    <Reference Include="System" />
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Tasks.v4.0"  />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+  </References>
+
+  <Properties>
+    
+    <LangVersion>Default</LangVersion>
+    <NoWarn>1591,0436</NoWarn>
+    <MonoDevelopPoliciesFile>Build/MonoDevelopPolicies.xml</MonoDevelopPoliciesFile>
+
+    <RootNamespace>MonoGame.Build.Tasks</RootNamespace>
+    <PlatformSpecificOutputFolder>True</PlatformSpecificOutputFolder>
+
+    <FrameworkVersions>
+      <Version>v4.5</Version>
+    </FrameworkVersions>
+
+  </Properties>
+
+  <Files>
+
+    <Compile Include="Tasks\CollectContentReferences.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+
+  </Files>
+</Project>

--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -24,6 +24,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="MonoGame.Build.Tasks" />
 
 	<!-- Platform specific and special references! -->
     <Reference Include="Framework.Content.Pipeline.References" />

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -68,12 +68,12 @@
     <None Include="..\ThirdParty\Dependencies\ffmpeg\MacOS\ffprobe" Condition="Exists ('/Applications/Utilities/Console.app/')">
       <Platforms>Linux</Platforms>
       <Link>ffprobe</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="..\ThirdParty\Dependencies\ffmpeg\MacOS\ffmpeg" Condition="Exists ('/Applications/Utilities/Console.app/')">
       <Platforms>Linux</Platforms>
       <Link>ffmpeg</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvtt.dylib" Condition="Exists ('/Applications/Utilities/Console.app/')">
       <Platforms>Linux</Platforms>

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -10,6 +10,7 @@
     <Reference Include="MonoGame.Framework.Content.Pipeline" />
     <Reference Include="MonoGame.Tests.References" />
     <Reference Include="MGCB" />
+    <Reference Include="MonoGame.Build.Tasks" />
   </References>
 
   <Properties>

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -9,6 +9,7 @@
     <Reference Include="MonoGame.Framework" />
     <Reference Include="MonoGame.Framework.Content.Pipeline" />
     <Reference Include="MonoGame.Tests.References" />
+    <Reference Include="MGCB" />
   </References>
 
   <Properties>
@@ -281,7 +282,9 @@
     <Compile Include="Framework\Visual\VisualTestFixtureBase.cs" />
     <Compile Include="Framework\Visual\VisualTestGame.cs" />
 
-
+    <Compile Include="ContentPipeline\BuilderTargetsTest.cs">
+      <Platforms>Windows,MacOS,Linux</Platforms>
+    </Compile>
     <Compile Include="ContentPipeline\ArrayContentCompilerTest.cs">
       <Platforms>Windows,MacOS,Linux</Platforms>
     </Compile>
@@ -1301,6 +1304,21 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Assets\Textures\red_128.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+
+    <Content Include="..\MonoGame.Framework.Content.Pipeline\MonoGame.Content.Builder.targets">
+      <Link>MonoGame.Content.Builder.targets</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+
+    <Content Include="Assets\Projects\BuildSimpleProject.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\Projects\Content\Content.mgcb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\Projects\Content\ContentFont.spritefont">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -11,6 +11,7 @@
     <Reference Include="MonoGame.Framework" />
     <Reference Include="MonoGame.Framework.Content.Pipeline" />
     <Reference Include="MGCB" />
+    <Reference Include="MonoGame.Build.Tasks" />
     
     <Reference Include="PipelineReferences" />
   </References>

--- a/Documentation/mgcb.md
+++ b/Documentation/mgcb.md
@@ -169,3 +169,25 @@ $if BuildEffects=Yes
 $endif
 ```
 
+### Customizing your Build Process
+
+When building content from your project via `msbuild` there are a few ways to can hook into the build process. The `MonoGame.Content.Builder.targets` runs a target called
+`BuildContent` just before your project builds. If you want to do any processing before or after this process you can use the `BeforeTargets` and `AfterTargets` mechanism provided
+by `msbuild` to run your own targest.
+
+```
+<Target Name="MyBeforeTarget" BeforeTargets="BuildContent">
+   <Message Text="MyBeforeTarget Ran"/>
+</Target>
+<Target Name="MyAfterTarget" AfterTargets="BuildContent">
+   <Message Text="MyAfterTarget Ran"/>
+</Target>
+``` 
+
+If you want to customise the arguements sent to the `MGCB.exe` as part of the build process you can use the `<MonoGameMGCBAdditionalArguments>` property to define those. 
+For example if you wanted to pass in the current project configuration you could define
+
+```
+<MonoGameMGCBAdditionalArguments>-config:$(Configuration)</MonoGameMGCBAdditionalArguments>
+```
+

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -5,7 +5,7 @@
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+  <UsingTask TaskName="MonoGame.Build.Tasks.CollectContentReferences" AssemblyFile="MonoGame.Build.Tasks.dll" />
   <!-- Add MonoGameContentReference to item type selection in Visual Studio -->
   <ItemGroup>
     <AvailableItemName Include="MonoGameContentReference" />
@@ -26,29 +26,20 @@
       <MonoGameContentBuilderExe Condition="'$(MonoGameContentBuilderExe)' == ''">$(MSBuildThisFileDirectory)Tools\MGCB.exe</MonoGameContentBuilderExe>
       <MonoGameContentBuilderCmd>&quot;$(MonoGameContentBuilderExe)&quot;</MonoGameContentBuilderCmd>
       <MonoGameContentBuilderCmd Condition=" '$(OS)' != 'Windows_NT' ">$(MonoExe) $(MonoGameContentBuilderCmd)</MonoGameContentBuilderCmd>
-      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX'">$(MonoMacResourcePrefix)\</PlatformResourcePrefix>
-      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'iOS'">$(IPhoneResourcePrefix)\</PlatformResourcePrefix>
-      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">$(MonoAndroidAssetsPrefix)\</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX'">$(MonoMacResourcePrefix)</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'iOS'">$(IPhoneResourcePrefix)</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">$(MonoAndroidAssetsPrefix)</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' != '' And !HasTrailingSlash('$(PlatformResourcePrefix)')">$(PlatformResourcePrefix)\</PlatformResourcePrefix>
       <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' == ''"></PlatformResourcePrefix>
-      <Header>/platform:$(MonoGamePlatform) </Header>
+      <MonoGameMGCBAdditionalArguments Condition="'$(MonoGameMGCBAdditionalArguments)' ==''">/quiet</MonoGameMGCBAdditionalArguments>
+      <Header>/platform:$(MonoGamePlatform) $(MonoGameMGCBAdditionalArguments)</Header>
     </PropertyGroup>
 
     <!-- Get all Mono Game Content References and store them in a list -->
     <!-- We do this here so we are compatible with xbuild -->
-
-    <CreateItem Include="@(MonoGameContentReference)"
-             Condition=" '%(RelativeDir)' != '%(RootDir)%(Directory)'"
-            AdditionalMetadata="ContentOutputDir=$(ProjectDir)%(RelativeDir)bin\$(MonoGamePlatform)\%(Filename);ContentIntermediateOutputDir=$(ProjectDir)%(RelativeDir)obj\$(MonoGamePlatform)\%(Filename)">
-        <Output TaskParameter="Include" ItemName="ContentReferences" />
-    </CreateItem>
-    <CreateItem Include="@(MonoGameContentReference)" Condition=" '%(RelativeDir)' == '%(RootDir)%(Directory)'"
-            AdditionalMetadata="ContentPath=$([System.String]::Copy('%(RelativeDir)').TrimEnd('\').TrimEnd('/'))">
-        <Output TaskParameter="Include" ItemName="SharedProjectContentReferences" />
-    </CreateItem>
-    <CreateItem Include="@(SharedProjectContentReferences)"
-            AdditionalMetadata="ContentOutputDir=%(ContentPath)\bin\$(MonoGamePlatform)\$([System.IO.Path]::GetFileName('%(ContentPath)'));ContentIntermediateOutputDir=obj\$(MonoGamePlatform)\$([System.IO.Path]::GetFileName('%(ContentPath)'))">
-        <Output TaskParameter="Include" ItemName="ContentReferences" />
-    </CreateItem>
+    <CollectContentReferences ContentReferences="@(MonoGameContentReference)" MonoGamePlatform="$(MonoGamePlatform)">
+        <Output TaskParameter="Output" ItemName="ContentReferences"/>
+    </CollectContentReferences>
 
     <Error Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, WindowsStoreApp, WindowsPhone8, MacOSX, iOS, Linux, DesktopGL, RaspberryPi, Android, Ouya, NativeClient, PlayStation4, PSVita, XboxOne or PlayStationMobile."
        Condition="	'$(MonoGamePlatform)' != 'Windows' And
@@ -91,20 +82,11 @@
 
   <Target Name="RunContentBuilder">
     <Exec Condition=" '%(ContentReferences.FullPath)' != '' "
-          Command="$(MonoGameContentBuilderCmd) /@:&quot;%(ContentReferences.FullPath)&quot; $(Header) /outputDir:&quot;%(ContentReferences.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReferences.ContentIntermediateOutputDir)&quot; /quiet"
+          Command="$(MonoGameContentBuilderCmd) /@:&quot;%(ContentReferences.FullPath)&quot; $(Header) /outputDir:&quot;%(ContentReferences.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReferences.ContentIntermediateOutputDir)&quot;"
           WorkingDirectory="%(ContentReferences.RootDir)%(ContentReferences.Directory)" />
-
-    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' != '' And '%(ContentReferences.FullPath)' != ''"
-            AdditionalMetadata="ContentOutputDir=$([System.String]::Copy('%(ContentReferences.Link)').Replace('%(Filename)%(Extension)', ''))">
-      <Output TaskParameter="Include" ItemName="ExtraContent" />
-    </CreateItem>
-    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' == '' And '%(ContentReferences.FullPath)' != '' And '%(ContentReferences.ContentPath)' == ''"
-            AdditionalMetadata="ContentOutputDir=%(ContentReferences.RelativeDir)">
-      <Output TaskParameter="Include" ItemName="ExtraContent" />
-    </CreateItem>
-    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.ContentPath)' != ''"
-            AdditionalMetadata="ContentOutputDir=$([System.IO.Path]::GetFileName('%(ContentReferences.ContentPath)'))\">
-      <Output TaskParameter="Include" ItemName="ExtraContent" />
+     <CreateItem Include="%(ContentReferences.RelativeFullPath)%(ContentReferences.ContentOutputDir)\**\*.*"
+            AdditionalMetadata="ContentOutputDir=%(ContentReferences.ContentDirectory)">
+        <Output TaskParameter="Include" ItemName="ExtraContent" />
     </CreateItem>
   </Target>
 

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -36,12 +36,10 @@
 
     <!-- Get all Mono Game Content References and store them in a list -->
     <!-- We do this here so we are compatible with xbuild -->
-    <ItemGroup>
-      <ContentReferences Include="@(MonoGameContentReference)">
-        <ContentOutputDir>$(ProjectDir)%(RelativeDir)bin\$(MonoGamePlatform)\%(Filename)</ContentOutputDir>
-        <ContentIntermediateOutputDir>$(ProjectDir)%(RelativeDir)obj\$(MonoGamePlatform)\%(Filename)</ContentIntermediateOutputDir>
-      </ContentReferences>
-    </ItemGroup>
+    <CreateItem Include="@(MonoGameContentReference)"
+            AdditionalMetadata="ContentOutputDir=$(ProjectDir)%(RelativeDir)bin\$(MonoGamePlatform)\%(Filename);ContentIntermediateOutputDir=$(ProjectDir)%(RelativeDir)obj\$(MonoGamePlatform)\%(Filename)">
+        <Output TaskParameter="Include" ItemName="ContentReferences" />
+    </CreateItem>
 
     <Error Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, WindowsStoreApp, WindowsPhone8, MacOSX, iOS, Linux, DesktopGL, RaspberryPi, Android, NativeClient, PlayStation4, or PlayStationMobile."
        Condition="	'$(MonoGamePlatform)' != 'Windows' And

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -94,11 +94,11 @@
           Command="$(MonoGameContentBuilderCmd) /@:&quot;%(ContentReferences.FullPath)&quot; $(Header) /outputDir:&quot;%(ContentReferences.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReferences.ContentIntermediateOutputDir)&quot; /quiet"
           WorkingDirectory="%(ContentReferences.RootDir)%(ContentReferences.Directory)" />
 
-    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' != ''"
+    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' != '' And '%(ContentReferences.FullPath)' != ''"
             AdditionalMetadata="ContentOutputDir=$([System.String]::Copy('%(ContentReferences.Link)').Replace('%(Filename)%(Extension)', ''))">
       <Output TaskParameter="Include" ItemName="ExtraContent" />
     </CreateItem>
-    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' == '' And '%(ContentReferences.ContentPath)' == ''"
+    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' == '' And '%(ContentReferences.FullPath)' != '' And '%(ContentReferences.ContentPath)' == ''"
             AdditionalMetadata="ContentOutputDir=%(ContentReferences.RelativeDir)">
       <Output TaskParameter="Include" ItemName="ExtraContent" />
     </CreateItem>

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -26,8 +26,9 @@
       <MonoGameContentBuilderExe Condition="'$(MonoGameContentBuilderExe)' == ''">$(MSBuildThisFileDirectory)Tools\MGCB.exe</MonoGameContentBuilderExe>
       <MonoGameContentBuilderCmd>&quot;$(MonoGameContentBuilderExe)&quot;</MonoGameContentBuilderCmd>
       <MonoGameContentBuilderCmd Condition=" '$(OS)' != 'Windows_NT' ">$(MonoExe) $(MonoGameContentBuilderCmd)</MonoGameContentBuilderCmd>
-      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'">Resources\</PlatformResourcePrefix>
-      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">Assets\</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX'">$(MonoMacResourcePrefix)\</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'iOS'">$(IPhoneResourcePrefix)\</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">$(MonoAndroidAssetsPrefix)\</PlatformResourcePrefix>
       <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' == ''"></PlatformResourcePrefix>
       <Header>/platform:$(MonoGamePlatform) </Header>
     </PropertyGroup>
@@ -35,21 +36,17 @@
     <!-- Get all Mono Game Content References and store them in a list -->
     <!-- We do this here so we are compatible with xbuild -->
 
-	<Message Text="Identity= %(MonoGameContentReference.Identity)" />
-	<Message Text="FullPath= %(MonoGameContentReference.FullPath)" />
-	<Message Text="Directory= %(MonoGameContentReference.Directory)" />
-	<Message Text="RelativeDir= %(MonoGameContentReference.RelativeDir)" />
     <CreateItem Include="@(MonoGameContentReference)"
-			Condition=" '%(RelativeDir)' != '%(RootDir)%(Directory)'"
+             Condition=" '%(RelativeDir)' != '%(RootDir)%(Directory)'"
             AdditionalMetadata="ContentOutputDir=$(ProjectDir)%(RelativeDir)bin\$(MonoGamePlatform)\%(Filename);ContentIntermediateOutputDir=$(ProjectDir)%(RelativeDir)obj\$(MonoGamePlatform)\%(Filename)">
         <Output TaskParameter="Include" ItemName="ContentReferences" />
     </CreateItem>
-	<CreateItem Include="@(MonoGameContentReference)" Condition=" '%(RelativeDir)' == '%(RootDir)%(Directory)'"
+    <CreateItem Include="@(MonoGameContentReference)" Condition=" '%(RelativeDir)' == '%(RootDir)%(Directory)'"
             AdditionalMetadata="ContentPath=$([System.IO.Directory]::GetParent('%(RelativeDir)'))">
-		<Output TaskParameter="Include" ItemName="SharedProjectContentReferences" />
-	</CreateItem>
+        <Output TaskParameter="Include" ItemName="SharedProjectContentReferences" />
+    </CreateItem>
     <CreateItem Include="@(SharedProjectContentReferences)"
-			AdditionalMetadata="ContentOutputDir=%(ContentPath)\bin\$(MonoGamePlatform)\$([System.IO.Path]::GetFileName('%(ContentPath)'));ContentIntermediateOutputDir=obj\$(MonoGamePlatform)\$([System.IO.Path]::GetFileName('%(ContentPath)'))">
+            AdditionalMetadata="ContentOutputDir=%(ContentPath)\bin\$(MonoGamePlatform)\$([System.IO.Path]::GetFileName('%(ContentPath)'));ContentIntermediateOutputDir=obj\$(MonoGamePlatform)\$([System.IO.Path]::GetFileName('%(ContentPath)'))">
         <Output TaskParameter="Include" ItemName="ContentReferences" />
     </CreateItem>
 
@@ -96,28 +93,18 @@
           Command="$(MonoGameContentBuilderCmd) /@:&quot;%(ContentReferences.FullPath)&quot; $(Header) /outputDir:&quot;%(ContentReferences.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReferences.ContentIntermediateOutputDir)&quot; /quiet"
           WorkingDirectory="%(ContentReferences.RootDir)%(ContentReferences.Directory)" />
 
-	<Message Text="Identity= %(ContentReferences.Identity)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
-	<Message Text="FullPath= %(ContentReferences.FullPath)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
-	<Message Text="Directory= %(ContentReferences.Directory)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
-	<Message Text="ContentOutputDir= %(ContentReferences.ContentOutputDir)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
-	<Message Text="ContentIntermediateOutputDir= %(ContentReferences.ContentIntermediateOutputDir)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
-	<Message Text="Link= %(ContentReferences.Link)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
-	<Message Text="RelativeDir= %(ContentReferences.RelativeDir)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
-		
     <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' != ''"
-			AdditionalMetadata="ContentOutputDir=$([System.String]::Copy('%(ContentReferences.Link)').Replace('%(Filename)%(Extension)', ''))">
+            AdditionalMetadata="ContentOutputDir=$([System.String]::Copy('%(ContentReferences.Link)').Replace('%(Filename)%(Extension)', ''))">
       <Output TaskParameter="Include" ItemName="ExtraContent" />
     </CreateItem>
     <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' == '' And '%(ContentReferences.ContentPath)' == ''"
-			AdditionalMetadata="ContentOutputDir=%(ContentReferences.RelativeDir)">
+            AdditionalMetadata="ContentOutputDir=%(ContentReferences.RelativeDir)">
       <Output TaskParameter="Include" ItemName="ExtraContent" />
     </CreateItem>
     <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.ContentPath)' != ''"
-			AdditionalMetadata="ContentOutputDir=$([System.IO.Path]::GetFileName('%(ContentReferences.ContentPath)'))\">
+            AdditionalMetadata="ContentOutputDir=$([System.IO.Path]::GetFileName('%(ContentReferences.ContentPath)'))\">
       <Output TaskParameter="Include" ItemName="ExtraContent" />
     </CreateItem>
-    <Message Text="ExtraContent.FullPath = %(ExtraContent.FullPath)" />
-	 <Message Text="ExtraContent.ContentOutputDir = %(ExtraContent.ContentOutputDir)" />
   </Target>
 
   <Target Name="BuildContent" DependsOnTargets="Prepare;RunContentBuilder"

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -50,7 +50,7 @@
         <Output TaskParameter="Include" ItemName="ContentReferences" />
     </CreateItem>
 
-    <Error Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, WindowsStoreApp, WindowsPhone8, MacOSX, iOS, Linux, DesktopGL, RaspberryPi, Android, Ouya, NativeClient, PlayStation4, or PlayStationMobile."
+    <Error Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, WindowsStoreApp, WindowsPhone8, MacOSX, iOS, Linux, DesktopGL, RaspberryPi, Android, Ouya, NativeClient, PlayStation4, PSVita, XboxOne or PlayStationMobile."
        Condition="	'$(MonoGamePlatform)' != 'Windows' And
 			'$(MonoGamePlatform)' != 'iOS' And       
 			'$(MonoGamePlatform)' != 'Android' And       
@@ -59,11 +59,12 @@
 			'$(MonoGamePlatform)' != 'MacOSX' And       
 			'$(MonoGamePlatform)' != 'WindowsStoreApp' And       
 			'$(MonoGamePlatform)' != 'NativeClient' And       
-			'$(MonoGamePlatform)' != 'Ouya' And       
 			'$(MonoGamePlatform)' != 'PlayStationMobile' And       
 			'$(MonoGamePlatform)' != 'WindowsPhone8' And       
 			'$(MonoGamePlatform)' != 'RaspberryPi' And       
 			'$(MonoGamePlatform)' != 'PlayStation4' And       
+			'$(MonoGamePlatform)' != 'PSVita' And       
+			'$(MonoGamePlatform)' != 'XboxOne' And 
 			'$(MonoGamePlatform)' != 'WindowsGL'" />
 
     <Error

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -26,22 +26,34 @@
       <MonoGameContentBuilderExe Condition="'$(MonoGameContentBuilderExe)' == ''">$(MSBuildThisFileDirectory)Tools\MGCB.exe</MonoGameContentBuilderExe>
       <MonoGameContentBuilderCmd>&quot;$(MonoGameContentBuilderExe)&quot;</MonoGameContentBuilderCmd>
       <MonoGameContentBuilderCmd Condition=" '$(OS)' != 'Windows_NT' ">$(MonoExe) $(MonoGameContentBuilderCmd)</MonoGameContentBuilderCmd>
-
-      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX'">$(MonoMacResourcePrefix)\</PlatformResourcePrefix>
-      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'iOS'">$(IPhoneResourcePrefix)\</PlatformResourcePrefix>
-      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">$(MonoAndroidAssetsPrefix)\</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'">Resources\</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">Assets\</PlatformResourcePrefix>
       <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' == ''"></PlatformResourcePrefix>
       <Header>/platform:$(MonoGamePlatform) </Header>
     </PropertyGroup>
 
     <!-- Get all Mono Game Content References and store them in a list -->
     <!-- We do this here so we are compatible with xbuild -->
+
+	<Message Text="Identity= %(MonoGameContentReference.Identity)" />
+	<Message Text="FullPath= %(MonoGameContentReference.FullPath)" />
+	<Message Text="Directory= %(MonoGameContentReference.Directory)" />
+	<Message Text="RelativeDir= %(MonoGameContentReference.RelativeDir)" />
     <CreateItem Include="@(MonoGameContentReference)"
+			Condition=" '%(RelativeDir)' != '%(RootDir)%(Directory)'"
             AdditionalMetadata="ContentOutputDir=$(ProjectDir)%(RelativeDir)bin\$(MonoGamePlatform)\%(Filename);ContentIntermediateOutputDir=$(ProjectDir)%(RelativeDir)obj\$(MonoGamePlatform)\%(Filename)">
         <Output TaskParameter="Include" ItemName="ContentReferences" />
     </CreateItem>
+	<CreateItem Include="@(MonoGameContentReference)" Condition=" '%(RelativeDir)' == '%(RootDir)%(Directory)'"
+            AdditionalMetadata="ContentPath=$([System.IO.Directory]::GetParent('%(RelativeDir)'))">
+		<Output TaskParameter="Include" ItemName="SharedProjectContentReferences" />
+	</CreateItem>
+    <CreateItem Include="@(SharedProjectContentReferences)"
+			AdditionalMetadata="ContentOutputDir=%(ContentPath)\bin\$(MonoGamePlatform)\$([System.IO.Path]::GetFileName('%(ContentPath)'));ContentIntermediateOutputDir=obj\$(MonoGamePlatform)\$([System.IO.Path]::GetFileName('%(ContentPath)'))">
+        <Output TaskParameter="Include" ItemName="ContentReferences" />
+    </CreateItem>
 
-    <Error Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, WindowsStoreApp, WindowsPhone8, MacOSX, iOS, Linux, DesktopGL, RaspberryPi, Android, NativeClient, PlayStation4, or PlayStationMobile."
+    <Error Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, WindowsStoreApp, WindowsPhone8, MacOSX, iOS, Linux, DesktopGL, RaspberryPi, Android, Ouya, NativeClient, PlayStation4, or PlayStationMobile."
        Condition="	'$(MonoGamePlatform)' != 'Windows' And
 			'$(MonoGamePlatform)' != 'iOS' And       
 			'$(MonoGamePlatform)' != 'Android' And       
@@ -50,12 +62,11 @@
 			'$(MonoGamePlatform)' != 'MacOSX' And       
 			'$(MonoGamePlatform)' != 'WindowsStoreApp' And       
 			'$(MonoGamePlatform)' != 'NativeClient' And       
+			'$(MonoGamePlatform)' != 'Ouya' And       
 			'$(MonoGamePlatform)' != 'PlayStationMobile' And       
 			'$(MonoGamePlatform)' != 'WindowsPhone8' And       
 			'$(MonoGamePlatform)' != 'RaspberryPi' And       
 			'$(MonoGamePlatform)' != 'PlayStation4' And       
-			'$(MonoGamePlatform)' != 'PSVita' And       
-			'$(MonoGamePlatform)' != 'XboxOne' And       
 			'$(MonoGamePlatform)' != 'WindowsGL'" />
 
     <Error
@@ -85,14 +96,28 @@
           Command="$(MonoGameContentBuilderCmd) /@:&quot;%(ContentReferences.FullPath)&quot; $(Header) /outputDir:&quot;%(ContentReferences.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReferences.ContentIntermediateOutputDir)&quot; /quiet"
           WorkingDirectory="%(ContentReferences.RootDir)%(ContentReferences.Directory)" />
 
-
-    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' != '' And '%(ContentReferences.FullPath)' != ''" AdditionalMetadata="ContentOutputDir=$([System.String]::Copy('%(ContentReferences.Link)').Replace('%(Filename)%(Extension)', ''))">
+	<Message Text="Identity= %(ContentReferences.Identity)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
+	<Message Text="FullPath= %(ContentReferences.FullPath)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
+	<Message Text="Directory= %(ContentReferences.Directory)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
+	<Message Text="ContentOutputDir= %(ContentReferences.ContentOutputDir)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
+	<Message Text="ContentIntermediateOutputDir= %(ContentReferences.ContentIntermediateOutputDir)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
+	<Message Text="Link= %(ContentReferences.Link)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
+	<Message Text="RelativeDir= %(ContentReferences.RelativeDir)" Condition="'%(ContentReferences.RelativeDir)' == '%(ContentReferences.RootDir)%(ContentReferences.Directory)'"/>
+		
+    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' != ''"
+			AdditionalMetadata="ContentOutputDir=$([System.String]::Copy('%(ContentReferences.Link)').Replace('%(Filename)%(Extension)', ''))">
       <Output TaskParameter="Include" ItemName="ExtraContent" />
     </CreateItem>
-    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' == '' And '%(ContentReferences.FullPath)' != ''" AdditionalMetadata="ContentOutputDir=%(ContentReferences.RelativeDir)">
+    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.Link)' == '' And '%(ContentReferences.ContentPath)' == ''"
+			AdditionalMetadata="ContentOutputDir=%(ContentReferences.RelativeDir)">
       <Output TaskParameter="Include" ItemName="ExtraContent" />
-
     </CreateItem>
+    <CreateItem Include="%(ContentReferences.ContentOutputDir)\**\*.*" Condition="'%(ContentReferences.ContentPath)' != ''"
+			AdditionalMetadata="ContentOutputDir=$([System.IO.Path]::GetFileName('%(ContentReferences.ContentPath)'))\">
+      <Output TaskParameter="Include" ItemName="ExtraContent" />
+    </CreateItem>
+    <Message Text="ExtraContent.FullPath = %(ExtraContent.FullPath)" />
+	 <Message Text="ExtraContent.ContentOutputDir = %(ExtraContent.ContentOutputDir)" />
   </Target>
 
   <Target Name="BuildContent" DependsOnTargets="Prepare;RunContentBuilder"

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -42,7 +42,7 @@
         <Output TaskParameter="Include" ItemName="ContentReferences" />
     </CreateItem>
     <CreateItem Include="@(MonoGameContentReference)" Condition=" '%(RelativeDir)' == '%(RootDir)%(Directory)'"
-            AdditionalMetadata="ContentPath=$([System.IO.Directory]::GetParent('%(RelativeDir)'))">
+            AdditionalMetadata="ContentPath=$([System.String]::Copy('%(RelativeDir)').TrimEnd('\').TrimEnd('/'))">
         <Output TaskParameter="Include" ItemName="SharedProjectContentReferences" />
     </CreateItem>
     <CreateItem Include="@(SharedProjectContentReferences)"

--- a/Test/Assets/Projects/BuildSimpleProject.csproj
+++ b/Test/Assets/Projects/BuildSimpleProject.csproj
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{1A3C19CC-557D-4009-82D6-92B511EA4172}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BuildSimpleProject</RootNamespace>
+    <AssemblyName>BuildSimpleProject</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <MonoGamePlatform>DesktopGL</MonoGamePlatform>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\$(MonoGamePlatform)\$(Platform)\$(Configuration)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;LINUX</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>false</Prefer32Bit>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\$(MonoGamePlatform)\$(Platform)\$(Configuration)\</OutputPath>
+    <DefineConstants>TRACE;LINUX</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>false</Prefer32Bit>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MonoGameContentReference Include="Content\Content.mgcb" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\MonoGame.Content.Builder.targets" />
+</Project>

--- a/Test/Assets/Projects/Content/Content.mgcb
+++ b/Test/Assets/Projects/Content/Content.mgcb
@@ -1,0 +1,22 @@
+
+#----------------------------- Global Properties ----------------------------#
+
+/outputDir:bin/$(Platform)
+/intermediateDir:obj/$(Platform)
+/platform:DesktopGL
+/config:
+/profile:Reach
+/compress:False
+
+#-------------------------------- References --------------------------------#
+
+
+#---------------------------------- Content ---------------------------------#
+
+#begin ContentFont.spritefont
+/importer:FontDescriptionImporter
+/processor:FontDescriptionProcessor
+/processorParam:PremultiplyAlpha=True
+/processorParam:TextureFormat=Compressed
+/build:ContentFont.spritefont
+

--- a/Test/Assets/Projects/Content/ContentFont.spritefont
+++ b/Test/Assets/Projects/Content/ContentFont.spritefont
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file contains an xml description of a font, and will be read by the XNA
+Framework Content Pipeline. Follow the comments to customize the appearance
+of the font in your game, and to change the characters which are available to draw
+with.
+-->
+<XnaContent xmlns:Graphics="Microsoft.Xna.Framework.Content.Pipeline.Graphics">
+  <Asset Type="Graphics:FontDescription">
+
+    <!--
+    Modify this string to change the font that will be imported.
+    -->
+    <FontName>Arial</FontName>
+
+    <!--
+    Size is a float value, measured in points. Modify this value to change
+    the size of the font.
+    -->
+    <Size>12</Size>
+
+    <!--
+    Spacing is a float value, measured in pixels. Modify this value to change
+    the amount of spacing in between characters.
+    -->
+    <Spacing>0</Spacing>
+
+    <!--
+    UseKerning controls the layout of the font. If this value is true, kerning information
+    will be used when placing characters.
+    -->
+    <UseKerning>true</UseKerning>
+
+    <!--
+    Style controls the style of the font. Valid entries are "Regular", "Bold", "Italic",
+    and "Bold, Italic", and are case sensitive.
+    -->
+    <Style>Regular</Style>
+
+    <!--
+    If you uncomment this line, the default character will be substituted if you draw
+    or measure text that contains characters which were not included in the font.
+    -->
+    <!-- <DefaultCharacter>*</DefaultCharacter> -->
+
+    <!--
+    CharacterRegions control what letters are available in the font. Every
+    character from Start to End will be built and made available for drawing. The
+    default range is from 32, (ASCII space), to 126, ('~'), covering the basic Latin
+    character set. The characters are ordered according to the Unicode standard.
+    See the documentation for more information.
+    -->
+    <CharacterRegions>
+      <CharacterRegion>
+        <Start>&#32;</Start>
+        <End>&#126;</End>
+      </CharacterRegion>
+    </CharacterRegions>
+  </Asset>
+</XnaContent>

--- a/Test/ContentPipeline/BuilderTargetsTest.cs
+++ b/Test/ContentPipeline/BuilderTargetsTest.cs
@@ -8,13 +8,32 @@ namespace MonoGame.Tests.ContentPipeline
     [TestFixture]
     public class BuilderTargetsTest
     {
+        string[] msBuildFolders = new string[]
+        {
+            Path.Combine ("MSBuild", "15.0", "Bin", "MSBuild.exe"),
+            Path.Combine ("MSBuild", "14.0", "Bin", "MSBuild.exe"),
+        };
+        string FindBuildTool(string buildTool)
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT && buildTool == "msbuild")
+            {
+                var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+                foreach (var path in msBuildFolders)
+                {
+                    if (File.Exists(Path.Combine(programFiles, path)))
+                        return Path.Combine(programFiles, path);
+                }
+            }
+            return buildTool;
+        }
         bool RunBuild (string buildTool, string projectFile, params string[] parameters)
         {
             var root = Path.GetDirectoryName(typeof(BuilderTargetsTest).Assembly.Location);
-            var psi = new ProcessStartInfo(buildTool)
+            var psi = new ProcessStartInfo(FindBuildTool(buildTool))
             {
-                Arguments = projectFile + " /t:BuildContent " + string.Join(" ", parameters),
+                Arguments = projectFile + " /t:BuildContent " + string.Join(" ", parameters) + " /noconsolelogger \"/flp1:LogFile=build.log;Encoding=UTF-8;Verbosity=Diagnostic\"",
                 WorkingDirectory = root,
+                UseShellExecute = true,
             };
             using (var process = Process.Start(psi))
             {

--- a/Test/ContentPipeline/BuilderTargetsTest.cs
+++ b/Test/ContentPipeline/BuilderTargetsTest.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Diagnostics;
+using NUnit.Framework;
+namespace MonoGame.Tests.ContentPipeline
+{
+    [TestFixture]
+    public class BuilderTargetsTest
+    {
+        bool RunBuild (string buildTool, string projectFile, params string[] parameters)
+        {
+            var root = Path.GetDirectoryName(typeof(BuilderTargetsTest).Assembly.Location);
+            var psi = new ProcessStartInfo(buildTool)
+            {
+                Arguments = projectFile + " /t:BuildContent " + string.Join(" ", parameters),
+                WorkingDirectory = root,
+            };
+            using (var process = Process.Start(psi))
+            {
+                process.WaitForExit();
+                return process.ExitCode == 0;
+            }
+        }
+
+        static object[] BuilderTargetsBuildTools = new object[] {
+            "msbuild",
+            "xbuild",
+        };
+
+        [Test]
+        [TestCaseSource("BuilderTargetsBuildTools")]
+        public void BuildSimpleProject (string buildTool)
+        {
+            if (buildTool == "xbuild" && Environment.OSVersion.Platform == PlatformID.Win32NT)
+                Assert.Ignore("Skipping xbuild tests on windows");
+
+            var root = Path.GetDirectoryName(typeof(BuilderTargetsTest).Assembly.Location);
+            var outputPath = Path.Combine(root, "Assets", "Projects", "Content", "bin");
+            if (Directory.Exists(outputPath))
+                Directory.Delete(outputPath, recursive: true);
+
+            var result = RunBuild(buildTool, Path.Combine("Assets", "Projects", "BuildSimpleProject.csproj"), new string[] {
+                "/p:MonoGameContentBuilderExe=" + Path.Combine(root, "MGCB.exe")
+            });
+            Assert.AreEqual(true, result, "Content Build should have succeeded.");
+            var contentFont = Path.Combine(outputPath, "DesktopGL", "Content", "ContentFont.xnb");
+            Assert.IsTrue(File.Exists(contentFont), "'" + contentFont + "' should exist.");
+ 
+        }
+    }
+}

--- a/Test/ContentPipeline/BuilderTargetsTest.cs
+++ b/Test/ContentPipeline/BuilderTargetsTest.cs
@@ -26,7 +26,7 @@ namespace MonoGame.Tests.ContentPipeline
             }
             return buildTool;
         }
-        bool RunBuild (string buildTool, string projectFile, params string[] parameters)
+        bool RunBuild(string buildTool, string projectFile, params string[] parameters)
         {
             var root = Path.GetDirectoryName(typeof(BuilderTargetsTest).Assembly.Location);
             var psi = new ProcessStartInfo(FindBuildTool(buildTool))
@@ -49,7 +49,7 @@ namespace MonoGame.Tests.ContentPipeline
 
         [Test]
         [TestCaseSource("BuilderTargetsBuildTools")]
-        public void BuildSimpleProject (string buildTool)
+        public void BuildSimpleProject(string buildTool)
         {
             if (buildTool == "xbuild" && Environment.OSVersion.Platform == PlatformID.Win32NT)
                 Assert.Ignore("Skipping xbuild tests on windows");
@@ -65,7 +65,6 @@ namespace MonoGame.Tests.ContentPipeline
             Assert.AreEqual(true, result, "Content Build should have succeeded.");
             var contentFont = Path.Combine(outputPath, "DesktopGL", "Content", "ContentFont.xnb");
             Assert.IsTrue(File.Exists(contentFont), "'" + contentFont + "' should exist.");
- 
         }
     }
 }

--- a/Test/Framework/Graphics/Texture2DNonVisualTest.cs
+++ b/Test/Framework/Graphics/Texture2DNonVisualTest.cs
@@ -18,9 +18,9 @@ namespace MonoGame.Tests.Graphics
 
 #if !XNA
         [TestCase("Assets/Textures/LogoOnly_64px.bmp")]
-        [TestCase("Assets/Textures/LogoOnly_64px.tif")]
 #if !DESKTOPGL
         // not supported
+        [TestCase("Assets/Textures/LogoOnly_64px.tif")]
         [TestCase("Assets/Textures/LogoOnly_64px.dds")]
 #endif
 #endif
@@ -41,10 +41,10 @@ namespace MonoGame.Tests.Graphics
                 System.Drawing.GraphicsUnit gu = System.Drawing.GraphicsUnit.Pixel;
                 System.Drawing.RectangleF rf = bitmap.GetBounds(ref gu);
                 Rectangle rt = _texture.Bounds;
-                Assert.AreEqual((int) rf.Bottom, rt.Bottom);
-                Assert.AreEqual((int) rf.Left, rt.Left);
-                Assert.AreEqual((int) rf.Right, rt.Right);
-                Assert.AreEqual((int) rf.Top, rt.Top);
+                Assert.AreEqual((int)rf.Bottom, rt.Bottom);
+                Assert.AreEqual((int)rf.Left, rt.Left);
+                Assert.AreEqual((int)rf.Right, rt.Right);
+                Assert.AreEqual((int)rf.Top, rt.Top);
                 bitmap.Dispose();
             }//The dds file test case can't be checked with System.Drawing because it does not understand this format
             catch { }
@@ -57,7 +57,9 @@ namespace MonoGame.Tests.Graphics
                 [TestCase("Assets/Textures/LogoOnly_64px.dds")]
                 [TestCase("Assets/Textures/LogoOnly_64px.tif")]
 #endif
+#if !DESKTOPGL
         [TestCase("Assets/Textures/LogoOnly_64px.tga")]
+#endif
         [TestCase("Assets/Textures/SampleCube64DXT1Mips.dds")]
         public void FromStreamShouldFailTest(string filename)
         {

--- a/Tools/MonoGame.Build.Tasks/Properties/AssemblyInfo.cs
+++ b/Tools/MonoGame.Build.Tasks/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyTitle("MonoGame.Build.Tasks")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("MonoGame Team")]
+[assembly: AssemblyProduct("MonoGame.Framework")]
+[assembly: AssemblyCopyright("Copyright © 2009-2017 MonoGame Team")]
+[assembly: AssemblyTrademark("MonoGame® is a registered trademark of the MonoGame Team")]
+[assembly: AssemblyCulture("")]
+
+
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/Tools/MonoGame.Build.Tasks/Tasks/CollectContentReferences.cs
+++ b/Tools/MonoGame.Build.Tasks/Tasks/CollectContentReferences.cs
@@ -46,10 +46,13 @@ namespace MonoGame.Build.Tasks
                 {
                     contentFolder = Path.GetFileName(Path.GetDirectoryName(relative));
                 }
+                var outputPath = Path.GetFileNameWithoutExtension(fp);
+                if (!outputPath.EndsWith(contentFolder, StringComparison.OrdinalIgnoreCase))
+                    outputPath = Path.Combine(outputPath, contentFolder);
                 metaData.Add("ContentDirectory", !string.IsNullOrEmpty(contentFolder) ? contentFolder + Path.DirectorySeparatorChar : "");
                 metaData.Add("RelativeFullPath", !string.IsNullOrEmpty(relative) ? Path.GetFullPath(relative) : "");
-                metaData.Add("ContentOutputDir", Path.Combine("bin", MonoGamePlatform, Path.GetFileNameWithoutExtension(fp), contentFolder));
-                metaData.Add("ContentIntermediateOutputDir", Path.Combine("obj", MonoGamePlatform, Path.GetFileNameWithoutExtension(fp), contentFolder));
+                metaData.Add("ContentOutputDir", Path.Combine("bin", MonoGamePlatform, outputPath));
+                metaData.Add("ContentIntermediateOutputDir", Path.Combine("obj", MonoGamePlatform, outputPath));
                 output.Add(new TaskItem(fp, metaData));
             }
             Output = output.ToArray();

--- a/Tools/MonoGame.Build.Tasks/Tasks/CollectContentReferences.cs
+++ b/Tools/MonoGame.Build.Tasks/Tasks/CollectContentReferences.cs
@@ -1,0 +1,59 @@
+﻿// MIT License - Copyright (C) The Mono.Xna Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace MonoGame.Build.Tasks
+{
+    public static class StringExt
+    {
+        public static string NormalisePath(this string path)
+        {
+            return path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+        }
+    }
+
+    public class CollectContentReferences : Task
+    {
+        [Required]
+        public ITaskItem[] ContentReferences { get; set; }
+
+        [Required]
+        public string MonoGamePlatform { get; set; }
+
+        [Output]
+        public ITaskItem[] Output { get; set; }
+
+        public override bool Execute()
+        {
+            var output = new List<ITaskItem>();
+            foreach (var content in ContentReferences)
+            {
+                var relative = content.GetMetadata("RelativeDir").NormalisePath();
+                var fp = content.GetMetadata("FullPath").NormalisePath();
+                var link = content.GetMetadata("Link").NormalisePath();
+                var metaData = new Dictionary<string, string>();
+                var contentFolder = String.Empty;
+                if (!string.IsNullOrEmpty(link))
+                {
+                    contentFolder = Path.GetFileName(Path.GetDirectoryName(link));
+                }
+                else if (!string.IsNullOrEmpty(relative))
+                {
+                    contentFolder = Path.GetFileName(Path.GetDirectoryName(relative));
+                }
+                metaData.Add("ContentDirectory", !string.IsNullOrEmpty(contentFolder) ? contentFolder + Path.DirectorySeparatorChar : "");
+                metaData.Add("RelativeFullPath", !string.IsNullOrEmpty(relative) ? Path.GetFullPath(relative) : "");
+                metaData.Add("ContentOutputDir", Path.Combine("bin", MonoGamePlatform, Path.GetFileNameWithoutExtension(fp), contentFolder));
+                metaData.Add("ContentIntermediateOutputDir", Path.Combine("obj", MonoGamePlatform, Path.GetFileNameWithoutExtension(fp), contentFolder));
+                output.Add(new TaskItem(fp, metaData));
+            }
+            Output = output.ToArray();
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/default.build
+++ b/default.build
@@ -220,6 +220,10 @@
       <formatter type="Xml" usefile="true" extension=".xml" outputdir="Test\bin\Windows\AnyCPU\Debug" />
       <test assemblyname="Test\bin\Windows\AnyCPU\Debug\MonoGameTests.exe" />
     </nunit2>
+    <nunit2 if="${is == 'MacOS'}">
+      <formatter type="Xml" usefile="true" extension=".xml" outputdir="Test\bin\Linux\AnyCPU\Debug" />
+      <test assemblyname="Test\bin\Linux\AnyCPU\Debug\MonoGameTests.exe" />
+    </nunit2>
   </target>
 
 

--- a/default.build
+++ b/default.build
@@ -4,7 +4,6 @@
   <description>The MonoGame automated build script.</description>
 
   <property name="os" value="${operating-system::get-platform(environment::get-operating-system())}" />
-  <property name="mdtooldir" value="/Applications/MonoDevelop.app/Contents/MacOS"/>
   <property name="msbuild12dir" value="C:\Program Files (x86)\MSBuild\12.0\Bin" />
   <property name="msbuild14dir" value="C:\Program Files (x86)\MSBuild\14.0\Bin" />
   
@@ -23,9 +22,6 @@
     <if test="${os == 'Unix'}">
       <if test="${directory::exists('/Applications') and directory::exists('/Library')}">
         <property name="os" value="MacOS"/>
-        <if test="${not directory::exists(mdtooldir)}">
-          <property name="mdtooldir" value="${path::get-full-path('/Applications/Xamarin Studio.app/Contents/MacOS')}"/>
-        </if>
       </if>
     </if>
     <echo message="Detected : ${os}"/>
@@ -110,8 +106,8 @@
     </if>
     <if test="${os == 'MacOS'}">
       <exec program="mono" commandline="Protobuild.exe -generate Linux" />
-      <exec program="mdtool" basedir="${mdtooldir}" commandline="build -t:Clean -c:Release MonoGame.Framework.Linux.sln" />
-      <exec program="mdtool" basedir="${mdtooldir}" commandline="build -t:Build -c:Release MonoGame.Framework.Linux.sln" />
+      <exec program="xbuild" commandline="MonoGame.Framework.Linux.sln /t:Clean /p:Configuration=Release" />
+      <exec program="xbuild" commandline="MonoGame.Framework.Linux.sln /t:Build /p:Configuration=Release" />
     </if>
   </target>
 
@@ -144,13 +140,13 @@
     <if test="${os == 'MacOS'}">
       <if test="${file::exists('/Developer/MonoTouch/MSBuild/Xamarin.ObjcBinding.CSharp.targets') or file::exists('/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Xamarin.ObjcBinding.CSharp.targets')}">
         <exec program="mono" commandline="Protobuild.exe -generate iOS" />
-        <exec program="mdtool" basedir="${mdtooldir}" commandline="build -t:Clean -c:Release\|iPhoneSimulator MonoGame.Framework.iOS.sln" />
-        <exec program="mdtool" basedir="${mdtooldir}" commandline="build -t:Build -c:Release\|iPhoneSimulator MonoGame.Framework.iOS.sln" />
+        <exec program="xbuild" commandline="MonoGame.Framework.iOS.sln /t:Clean /p:Configuration=Release" />
+        <exec program="xbuild" commandline="MonoGame.Framework.iOS.sln /t:Build /p:Configuration=Release" />
       </if>
       <if test="${file::exists('/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/TVOS/Xamarin.TVOS.CSharp.targets')}" >
         <exec program="mono" commandline="Protobuild.exe -generate tvOS" />
-        <exec program="mdtool" basedir="${mdtooldir}" commandline="build -t:Clean -c:Release\|iPhoneSimulator MonoGame.Framework.tvOS.sln" />
-        <exec program="mdtool" basedir="${mdtooldir}" commandline="build -t:Build -c:Release\|iPhoneSimulator MonoGame.Framework.tvOS.sln" />
+        <exec program="xbuild" commandline="MonoGame.Framework.tvOS.sln /t:Clean /p:Configuration=Release" />
+        <exec program="xbuild" commandline="MonoGame.Framework.tvOS.sln /t:Build /p:Configuration=Release" />
       </if>
     </if>
   </target>

--- a/default.build
+++ b/default.build
@@ -220,7 +220,7 @@
       <formatter type="Xml" usefile="true" extension=".xml" outputdir="Test\bin\Windows\AnyCPU\Debug" />
       <test assemblyname="Test\bin\Windows\AnyCPU\Debug\MonoGameTests.exe" />
     </nunit2>
-    <nunit2 if="${is == 'MacOS'}">
+    <nunit2 if="${os == 'MacOS'}">
       <formatter type="Xml" usefile="true" extension=".xml" outputdir="Test\bin\Linux\AnyCPU\Debug" />
       <test assemblyname="Test\bin\Linux\AnyCPU\Debug\MonoGameTests.exe" />
     </nunit2>


### PR DESCRIPTION
PR #4997 Introduced a crash in xbuild. This is because of a bug in xbuild where `<ItemGroup>` with Metadata are not supported. Instead
you need to use `CreateItem`.

This commit fixes that issue.

There are also other issues which need to be resolved with #4997.

That said this commit also adds a new unit test for the content system.
There is a sample project which we build as part of the unit test.
We check the output to make sure it is in the right place. This test
should be expaned on to include tests for Shared Projects and other
senarios that users use. It should allow use to catch issues such as
what happened in #4997 at the point the PR is opened.