### PR TITLE
Fix a Font issue on MacOS #5900

### DIFF
--- a/Build/Projects/Framework.Content.Pipeline.References.definition
+++ b/Build/Projects/Framework.Content.Pipeline.References.definition
@@ -96,7 +96,7 @@
       Path="ThirdParty\Dependencies\NVTT\Windows\Nvidia.TextureTools.dll" />
     <Binary
       Name="SharpFont"
-      Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll" />
+      Path="ThirdParty\Dependencies\SharpFont\Windows\x64\SharpFont.dll" />
     <Binary
       Name="FreeImageNET"
       Path="ThirdParty\Dependencies\FreeImage.NET\Windows\FreeImageNET.dll" />
@@ -109,7 +109,7 @@
     <NativeBinary Path="ThirdParty\Dependencies\NVTT\Windows\x64\nvtt.dll" />
     <NativeBinary Path="ThirdParty\Dependencies\assimp\Assimp64.dll" />
     <NativeBinary Path="ThirdParty\Dependencies\MojoShader\Windows\libmojoshader_64.dll" />
-    <NativeBinary Path="ThirdParty\Dependencies\SharpFont\x64\freetype6.dll" />
+    <NativeBinary Path="ThirdParty\Dependencies\SharpFont\Windows\x64\freetype6.dll" />
     <NativeBinary Path="ThirdParty\Dependencies\FreeImage.NET\Windows\FreeImage.dll" />
     <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Windows\x64\ffmpeg.exe" />
     <NativeBinary Path="ThirdParty\Dependencies\ffmpeg\Windows\x64\ffprobe.exe" />


### PR DESCRIPTION
Bump Dependencies to bring in windows specific SharpFont assembly.

This is all down to mono now running in 64bit (we think). So the
old code we had no longer worked. The Dependencies include specific
versions of SharpFont for Mac and Linux and a seperate one for
Windows. The Mac/Linux ones support AnyCPU but the windows is
x64 specific. Since we require x64 for Windows content this
should not be a problem.