### PR TITLE
[GL] Check vbo in BufferBindingInfo

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -214,7 +214,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (!_attribsDirty &&
                     _bufferBindingInfos[slot].VertexOffset == offset &&
                     ReferenceEquals(_bufferBindingInfos[slot].AttributeInfo, attrInfo) &&
-                    _bufferBindingInfos[slot].InstanceFrequency == vertexBufferBinding.InstanceFrequency)
+                    _bufferBindingInfos[slot].InstanceFrequency == vertexBufferBinding.InstanceFrequency &&
+                    _bufferBindingInfos[slot].Vbo == vertexBufferBinding.VertexBuffer.vbo)
                     continue;
 
                 bindingsChanged = true;
@@ -247,6 +248,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 _bufferBindingInfos[slot].VertexOffset = offset;
                 _bufferBindingInfos[slot].AttributeInfo = attrInfo;
                 _bufferBindingInfos[slot].InstanceFrequency = vertexBufferBinding.InstanceFrequency;
+                _bufferBindingInfos[slot].Vbo = vertexBufferBinding.VertexBuffer.vbo;
             }
 
             _attribsDirty = false;
@@ -470,7 +472,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             _bufferBindingInfos = new BufferBindingInfo[_maxVertexBufferSlots];
             for (int i = 0; i < _bufferBindingInfos.Length; i++)
-                _bufferBindingInfos[i] = new BufferBindingInfo(null, IntPtr.Zero, 0);
+                _bufferBindingInfos[i] = new BufferBindingInfo(null, IntPtr.Zero, 0, -1);
         }
         
         private DepthStencilState clearDepthStencilState = new DepthStencilState { StencilEnable = true };
@@ -1345,12 +1347,14 @@ namespace Microsoft.Xna.Framework.Graphics
             public VertexDeclaration.VertexDeclarationAttributeInfo AttributeInfo;
             public IntPtr VertexOffset;
             public int InstanceFrequency;
+            public int Vbo;
 
-            public BufferBindingInfo(VertexDeclaration.VertexDeclarationAttributeInfo attributeInfo, IntPtr vertexOffset, int instanceFrequency)
+            public BufferBindingInfo(VertexDeclaration.VertexDeclarationAttributeInfo attributeInfo, IntPtr vertexOffset, int instanceFrequency, int vbo)
             {
                 AttributeInfo = attributeInfo;
                 VertexOffset = vertexOffset;
                 InstanceFrequency = instanceFrequency;
+                Vbo = vbo;
             }
         }
 

--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -273,6 +273,7 @@ namespace OpenGL
     }
 
     public enum GetPName : int {
+        ArrayBufferBinding = 0x8894,
         MaxTextureImageUnits = 0x8872, 
         MaxVertexAttribs = 0x8869, 
         MaxTextureSize = 0x0D33,

--- a/Test/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceTest.cs
@@ -9,6 +9,7 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Tests.ContentPipeline;
 using NUnit.Framework;
+using OpenGL;
 
 namespace MonoGame.Tests.Graphics
 {
@@ -754,5 +755,33 @@ namespace MonoGame.Tests.Graphics
             rt.Dispose();
         }
 
+#if DESKTOPGL
+        [Test]
+        public void DifferentVboGetsSet()
+        {
+            var vb1 = new VertexBuffer(gd, VertexPosition.VertexDeclaration, 6, BufferUsage.None);
+            var vb2 = new VertexBuffer(gd, VertexPosition.VertexDeclaration, 8, BufferUsage.None);
+
+            var se = new SpriteEffect(gd);
+            se.CurrentTechnique.Passes[0].Apply();
+
+            gd.SetVertexBuffer(vb1);
+            gd.DrawPrimitives(PrimitiveType.TriangleList, 0, 2);
+
+            int vbo;
+            GL.GetInteger(GetPName.ArrayBufferBinding, out vbo);
+            Assert.AreEqual(vb1.vbo, vbo);
+
+            gd.SetVertexBuffer(vb2);
+            gd.DrawPrimitives(PrimitiveType.TriangleList, 0, 2);
+
+            GL.GetInteger(GetPName.ArrayBufferBinding, out vbo);
+            Assert.AreEqual(vb2.vbo, vbo);
+
+            se.Dispose();
+            vb1.Dispose();
+            vb2.Dispose();
+        }
+#endif
     }
 }


### PR DESCRIPTION
The check in ApplyAttribs would block setting up vertex channels when the vbo changed and all other settings were the same as what was last applied.

Someone reported this issue on the forum: http://community.monogame.net/t/repeated-rendering-weird-behaviours-after-upgrading-to-3-7/9643/3 