### PR TITLE
Pool ContentManager scratch buffers

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Xna.Framework.Content
         private Dictionary<string, object> loadedAssets = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 		private List<IDisposable> disposableAssets = new List<IDisposable>();
         private bool disposed;
-        private byte[] scratchBuffer;
 
 		private static object ContentManagerLock = new object();
         private static List<WeakReference> ContentManagers = new List<WeakReference>();
+        private static ByteBufferPool _scratchBufferPool = new ByteBufferPool();
 
         private static readonly List<char> targetPlatformIdentifiers = new List<char>()
         {
@@ -191,7 +191,6 @@ namespace Microsoft.Xna.Framework.Content
                     Unload();
                 }
 
-                scratchBuffer = null;
 				disposed = true;
 			}
 		}
@@ -482,11 +481,14 @@ namespace Microsoft.Xna.Framework.Content
 		}
 
         internal byte[] GetScratchBuffer(int size)
-        {            
+        {
             size = Math.Max(size, 1024 * 1024);
-            if (scratchBuffer == null || scratchBuffer.Length < size)
-                scratchBuffer = new byte[size];
-            return scratchBuffer;
+            return _scratchBufferPool.Get(size);
         }
-	}
+
+        internal void ReturnScratchBuffer(byte[] buffer)
+        {
+            _scratchBufferPool.Return(buffer);
+        }
+    }
 }

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Xna.Framework.Content
 
 		private static object ContentManagerLock = new object();
         private static List<WeakReference> ContentManagers = new List<WeakReference>();
-        private static ByteBufferPool _scratchBufferPool = new ByteBufferPool();
+
+        internal static readonly ByteBufferPool ScratchBufferPool = new ByteBufferPool(1024 * 1024, Environment.ProcessorCount);
 
         private static readonly List<char> targetPlatformIdentifiers = new List<char>()
         {
@@ -479,16 +480,5 @@ namespace Microsoft.Xna.Framework.Content
 				return this.serviceProvider;
 			}
 		}
-
-        internal byte[] GetScratchBuffer(int size)
-        {
-            size = Math.Max(size, 1024 * 1024);
-            return _scratchBufferPool.Get(size);
-        }
-
-        internal void ReturnScratchBuffer(byte[] buffer)
-        {
-            _scratchBufferPool.Return(buffer);
-        }
     }
 }

--- a/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Xna.Framework.Content
         protected internal override Effect Read(ContentReader input, Effect existingInstance)
         {
             int dataSize = input.ReadInt32();
-            byte[] data = input.ContentManager.GetScratchBuffer(dataSize);
+            byte[] data = ContentManager.ScratchBufferPool.Get(dataSize);
             input.Read(data, 0, dataSize);
             var effect = new Effect(input.GetGraphicsDevice(), data, 0, dataSize);
-            input.ContentManager.ReturnScratchBuffer(data);
+            ContentManager.ScratchBufferPool.Return(data);
             effect.Name = input.AssetName;
             return effect;
         }

--- a/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Xna.Framework.Content
             byte[] data = input.ContentManager.GetScratchBuffer(dataSize);
             input.Read(data, 0, dataSize);
             var effect = new Effect(input.GetGraphicsDevice(), data, 0, dataSize);
+            input.ContentManager.ReturnScratchBuffer(data);
             effect.Name = input.AssetName;
             return effect;
         }

--- a/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Xna.Framework.Content
                     dataSize / (sixteenBits ? 2 : 4), BufferUsage.None);
             }
 
-            byte[] data = input.ContentManager.GetScratchBuffer(dataSize);
+            byte[] data = ContentManager.ScratchBufferPool.Get(dataSize);
             input.Read(data, 0, dataSize);
             indexBuffer.SetData(data, 0, dataSize);
-            input.ContentManager.ReturnScratchBuffer(data);
+            ContentManager.ScratchBufferPool.Return(data);
 
             return indexBuffer;
         }

--- a/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
@@ -14,9 +14,6 @@ namespace Microsoft.Xna.Framework.Content
 
             bool sixteenBits = input.ReadBoolean();
             int dataSize = input.ReadInt32();
-            byte[] data = input.ContentManager.GetScratchBuffer(dataSize);
-            input.Read(data, 0, dataSize);
-
             if (indexBuffer == null)
             {
                 indexBuffer = new IndexBuffer(input.GetGraphicsDevice(),
@@ -24,7 +21,11 @@ namespace Microsoft.Xna.Framework.Content
                     dataSize / (sixteenBits ? 2 : 4), BufferUsage.None);
             }
 
+            byte[] data = input.ContentManager.GetScratchBuffer(dataSize);
+            input.Read(data, 0, dataSize);
             indexBuffer.SetData(data, 0, dataSize);
+            input.ContentManager.ReturnScratchBuffer(data);
+
             return indexBuffer;
         }
     }

--- a/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Xna.Framework.Content
             // Store the original asset name for debugging later.
             effect.Name = input.AssetName;
 
+            input.ContentManager.ReturnScratchBuffer(data);
+
             return effect;
         }
 	}

--- a/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Xna.Framework.Content
 
             // Read the audio data buffer.
             var dataSize = input.ReadInt32();
-            var data = input.ContentManager.GetScratchBuffer(dataSize);
+            var data = ContentManager.ScratchBufferPool.Get(dataSize);
             input.Read(data, 0, dataSize);
 
             var loopStart = input.ReadInt32();
@@ -53,7 +53,7 @@ namespace Microsoft.Xna.Framework.Content
             // Store the original asset name for debugging later.
             effect.Name = input.AssetName;
 
-            input.ContentManager.ReturnScratchBuffer(data);
+            ContentManager.ScratchBufferPool.Return(data);
 
             return effect;
         }

--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Xna.Framework.Content
                 for (int level = 0; level < levelCount; level++)
 			    {
 				    var levelDataSizeInBytes = reader.ReadInt32();
-                    var levelData = reader.ContentManager.GetScratchBuffer(levelDataSizeInBytes);
+                    var levelData = ContentManager.ScratchBufferPool.Get(levelDataSizeInBytes);
                     reader.Read(levelData, 0, levelDataSizeInBytes);
                     int levelWidth = Math.Max(width >> level, 1);
                     int levelHeight = Math.Max(height >> level, 1);
@@ -170,7 +170,7 @@ namespace Microsoft.Xna.Framework.Content
 				    }
 				
                     texture.SetData(level, null, levelData, 0, levelDataSizeInBytes);
-                    reader.ContentManager.ReturnScratchBuffer(levelData);
+                    ContentManager.ScratchBufferPool.Return(levelData);
 			    }
 #if OPENGL
             });

--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Xna.Framework.Content
 				    }
 				
                     texture.SetData(level, null, levelData, 0, levelDataSizeInBytes);
+                    reader.ContentManager.ReturnScratchBuffer(levelData);
 			    }
 #if OPENGL
             });

--- a/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Xna.Framework.Content
                     width = Math.Max(width >> 1, 1);
                     height = Math.Max(height >> 1, 1);
                     depth = Math.Max(depth >> 1, 1);
+
+                    reader.ContentManager.ReturnScratchBuffer(data);
                 }
 #if OPENGL
             });

--- a/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Xna.Framework.Content
                 for (int i = 0; i < levelCount; i++)
                 {
                     int dataSize = reader.ReadInt32();
-                    byte[] data = reader.ContentManager.GetScratchBuffer(dataSize);
+                    byte[] data = ContentManager.ScratchBufferPool.Get(dataSize);
                     reader.Read(data, 0, dataSize);
                     texture.SetData(i, 0, 0, width, height, 0, depth, data, 0, dataSize);
 
@@ -40,7 +40,7 @@ namespace Microsoft.Xna.Framework.Content
                     height = Math.Max(height >> 1, 1);
                     depth = Math.Max(depth >> 1, 1);
 
-                    reader.ContentManager.ReturnScratchBuffer(data);
+                    ContentManager.ScratchBufferPool.Return(data);
                 }
 #if OPENGL
             });

--- a/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Xna.Framework.Content
                         byte[] faceData = reader.ContentManager.GetScratchBuffer(faceSize);
                         reader.Read(faceData, 0, faceSize);
                         textureCube.SetData<byte>((CubeMapFace)face, i, null, faceData, 0, faceSize);
+                        reader.ContentManager.ReturnScratchBuffer(faceData);
                     }
                 }
 #if OPENGL

--- a/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
@@ -32,10 +32,10 @@ namespace Microsoft.Xna.Framework.Content
                     for (int i = 0; i < levels; i++)
                     {
                         int faceSize = reader.ReadInt32();
-                        byte[] faceData = reader.ContentManager.GetScratchBuffer(faceSize);
+                        byte[] faceData = ContentManager.ScratchBufferPool.Get(faceSize);
                         reader.Read(faceData, 0, faceSize);
                         textureCube.SetData<byte>((CubeMapFace)face, i, null, faceData, 0, faceSize);
-                        reader.ContentManager.ReturnScratchBuffer(faceData);
+                        ContentManager.ScratchBufferPool.Return(faceData);
                     }
                 }
 #if OPENGL

--- a/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Xna.Framework.Content
             var declaration = input.ReadRawObject<VertexDeclaration>();
             var vertexCount = (int)input.ReadUInt32();
             int dataSize = vertexCount * declaration.VertexStride;
-            byte[] data = input.ContentManager.GetScratchBuffer(dataSize);
+            byte[] data = ContentManager.ScratchBufferPool.Get(dataSize);
             input.Read(data, 0, dataSize);
 
             var buffer = new VertexBuffer(input.GetGraphicsDevice(), declaration, vertexCount, BufferUsage.None);
             buffer.SetData(data, 0, dataSize);
-            input.ContentManager.ReturnScratchBuffer(data);
+            ContentManager.ScratchBufferPool.Return(data);
             return buffer;
         }
     }

--- a/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Xna.Framework.Content
 
             var buffer = new VertexBuffer(input.GetGraphicsDevice(), declaration, vertexCount, BufferUsage.None);
             buffer.SetData(data, 0, dataSize);
+            input.ContentManager.ReturnScratchBuffer(data);
             return buffer;
         }
     }

--- a/MonoGame.Framework/Utilities/ByteBufferPool.cs
+++ b/MonoGame.Framework/Utilities/ByteBufferPool.cs
@@ -36,6 +36,8 @@ namespace MonoGame.Utilities
 
                 if (index == -1)
                 {
+                    if (_freeBuffers.Count > 0)
+                        _freeBuffers.RemoveAt(0);
                     result = new byte[size];
                 }
                 else

--- a/MonoGame.Framework/Utilities/ByteBufferPool.cs
+++ b/MonoGame.Framework/Utilities/ByteBufferPool.cs
@@ -4,6 +4,9 @@ namespace MonoGame.Utilities
 {
     internal class ByteBufferPool
     {
+        private readonly int _minBufferSize;
+        private readonly int _maxBuffers;
+
         public int FreeAmount
         {
             get { return _freeBuffers.Count; }
@@ -11,8 +14,10 @@ namespace MonoGame.Utilities
 
         private readonly List<byte[]> _freeBuffers;
 
-        public ByteBufferPool()
+        public ByteBufferPool(int minBufferSize = 0, int maxBuffers = int.MaxValue)
         {
+            _minBufferSize = minBufferSize;
+            _maxBuffers = maxBuffers;
             _freeBuffers = new List<byte[]>();
         }
 
@@ -21,6 +26,9 @@ namespace MonoGame.Utilities
         /// </summary>
         public byte[] Get(int size)
         {
+            if (size < _minBufferSize)
+                size = _minBufferSize;
+
             byte[] result;
             lock (_freeBuffers)
             {
@@ -46,6 +54,8 @@ namespace MonoGame.Utilities
         {
             lock (_freeBuffers)
             {
+                if (FreeAmount >= _maxBuffers)
+                    return;
                 var index = FirstLargerThan(buffer.Length);
                 if (index == -1)
                     _freeBuffers.Add(buffer);

--- a/MonoGame.Framework/Utilities/ByteBufferPool.cs
+++ b/MonoGame.Framework/Utilities/ByteBufferPool.cs
@@ -42,7 +42,6 @@ namespace MonoGame.Utilities
         /// <summary>
         /// Return the given buffer to the pool.
         /// </summary>
-        /// <param name="buffer"></param>
         public void Return(byte[] buffer)
         {
             lock (_freeBuffers)

--- a/Tests/Framework/ByteBufferPoolTest.cs
+++ b/Tests/Framework/ByteBufferPoolTest.cs
@@ -18,7 +18,19 @@ namespace MonoGame.Tests.Framework
             pool.Return(buf2);
             Assert.AreEqual(1, pool.FreeAmount);
 
+            // ByteBufferPool removes a buffer when none of the buffers in the pool
+            // is large enough to satisfy a Get, and it has at least 1 buffer in the pool.
+            // This way the number of items in the pool does not grow beyond the number
+            // of buffers that are in use simultaneously, lowering overall memory usage.
+
+            // the following Get should remove the size 5 buffer from the pool because it is not in use
             var buf3 = pool.Get(6);
+            pool.Return(buf3);
+            Assert.AreEqual(1, pool.FreeAmount);
+            buf3 = pool.Get(6);
+
+            var buf4 = pool.Get(5);
+            pool.Return(buf4);
             pool.Return(buf3);
             Assert.AreEqual(2, pool.FreeAmount);
         }


### PR DESCRIPTION
As discussed in #5341. (edit for autoclose: fixes #5341)

I don't think this is right as is. Consider the case where a user loads incrementally larger assets. For each asset a new scratch buffer will be created and returned to the pool, staying in memory until game exit.

Maybe it would be better to use a slightly modified version of ByteBufferPool that deletes the smallest buffer from the pool whenever Get is called and there are no buffers that are large enough. That way the pool size won't grow beyond the number of threads that use a buffer from it simultaneously (most often 1).

cc @nkast 