### PR TITLE
Types in OpenGL and OpenAL namespaces now internal

### DIFF
--- a/MonoGame.Framework/Audio/AudioLoader.cs
+++ b/MonoGame.Framework/Audio/AudioLoader.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using OpenAL;
+using MonoGame.OpenAL;
 
 namespace Microsoft.Xna.Framework.Audio
 {

--- a/MonoGame.Framework/Audio/DynamicSoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/DynamicSoundEffectInstance.OpenAL.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using OpenAL;
+using MonoGame.OpenAL;
 
 namespace Microsoft.Xna.Framework.Audio
 {

--- a/MonoGame.Framework/Audio/Microphone.OpenAL.cs
+++ b/MonoGame.Framework/Audio/Microphone.OpenAL.cs
@@ -11,7 +11,7 @@ using MonoMac.AudioToolbox;
 using MonoMac.AudioUnit;
 using MonoMac.OpenAL;
 #elif OPENAL
-using OpenAL;
+using MonoGame.OpenAL;
 #if IOS || MONOMAC
 using AudioToolbox;
 using AudioUnit;

--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -3,7 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using OpenAL;
+using MonoGame.OpenAL;
 
 namespace Microsoft.Xna.Framework.Audio
 {

--- a/MonoGame.Framework/Audio/OggStream.cs
+++ b/MonoGame.Framework/Audio/OggStream.cs
@@ -13,7 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using NVorbis;
-using OpenAL;
+using MonoGame.OpenAL;
 
 namespace Microsoft.Xna.Framework.Audio
 {

--- a/MonoGame.Framework/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Audio/OpenAL.cs
@@ -6,9 +6,9 @@ using System;
 using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework.Audio;
 
-namespace OpenAL
+namespace MonoGame.OpenAL
 {
-    public enum ALFormat
+    internal enum ALFormat
     {
         Mono8 = 0x1100,
         Mono16 = 0x1101,
@@ -22,7 +22,7 @@ namespace OpenAL
         StereoFloat32 = 0x10011,
     }
 
-    public enum ALError
+    internal enum ALError
     {
         NoError = 0,
         InvalidName = 0xA001,
@@ -32,30 +32,30 @@ namespace OpenAL
         OutOfMemory = 0xA005,
     }
 
-    public enum ALGetString
+    internal enum ALGetString
     {
         Extensions = 0xB004,
     }
 
-    public enum ALBufferi
+    internal enum ALBufferi
     {
         UnpackBlockAlignmentSoft = 0x200C,
         LoopSoftPointsExt = 0x2015,
     }
 
-    public enum ALGetBufferi
+    internal enum ALGetBufferi
     {
         Bits = 0x2002,
         Channels = 0x2003,
         Size = 0x2004,
     }
 
-    public enum ALSourceb
+    internal enum ALSourceb
     {
         Looping = 0x1007,
     }
 
-    public enum ALSourcei
+    internal enum ALSourcei
     {
         SourceRelative = 0x202,
         Buffer = 0x1009,
@@ -63,14 +63,14 @@ namespace OpenAL
         EfxAuxilarySendFilter = 0x20006,
     }
 
-    public enum ALSourcef
+    internal enum ALSourcef
     {
         Pitch = 0x1003,
         Gain = 0x100A,
         ReferenceDistance = 0x1020
     }
 
-    public enum ALGetSourcei
+    internal enum ALGetSourcei
     {
         SampleOffset = 0x1025,
         SourceState = 0x1010,
@@ -78,7 +78,7 @@ namespace OpenAL
         BuffersProcessed = 0x1016,
     }
 
-    public enum ALSourceState
+    internal enum ALSourceState
     {
         Initial = 0x1011,
         Playing = 0x1012,
@@ -86,46 +86,46 @@ namespace OpenAL
         Stopped = 0x1014,
     }
 
-    public enum ALListener3f
+    internal enum ALListener3f
     {
         Position = 0x1004,
     }
 
-    public enum ALSource3f
+    internal enum ALSource3f
     {
         Position = 0x1004,
         Velocity = 0x1006,
     }
 
-    public enum ALDistanceModel
+    internal enum ALDistanceModel
     {
         None = 0,
         InverseDistanceClamped = 0xD002,
     }
 
-    public enum AlcError
+    internal enum AlcError
     {
         NoError = 0,
     }
 
-    public enum AlcGetString
+    internal enum AlcGetString
     {
         CaptureDeviceSpecifier = 0x0310,
         CaptureDefaultDeviceSpecifier = 0x0311,
         Extensions = 0x1006,
     }
 
-    public enum AlcGetInteger
+    internal enum AlcGetInteger
     {
         CaptureSamples = 0x0312,
     }
 
-    public enum EfxFilteri
+    internal enum EfxFilteri
     {
         FilterType = 0x8001,
     }
 
-    public enum EfxFilterf
+    internal enum EfxFilterf
     {
         LowpassGain = 0x0001,
         LowpassGainHF = 0x0002,
@@ -136,7 +136,7 @@ namespace OpenAL
         BandpassGainHF = 0x0003,
     }
 
-    public enum EfxFilterType
+    internal enum EfxFilterType
     {
         None = 0x0000,
         Lowpass = 0x0001,
@@ -144,18 +144,18 @@ namespace OpenAL
         Bandpass = 0x0003,
     }
 
-    public enum EfxEffecti
+    internal enum EfxEffecti
     {
         EffectType = 0x8001,
         SlotEffect = 0x0001,
     }
 
-    public enum EfxEffectSlotf
+    internal enum EfxEffectSlotf
     {
         EffectSlotGain = 0x0002,
     }
 
-    public enum EfxEffectf
+    internal enum EfxEffectf
     {
         EaxReverbDensity = 0x0001,
         EaxReverbDiffusion = 0x0002,
@@ -182,53 +182,50 @@ namespace OpenAL
         DecayHighFrequencyLimit = 0x0017,
     }
 
-    public enum EfxEffectType
+    internal enum EfxEffectType
     {
         Reverb = 0x8000,
     }
 
-    public class AL
+    internal class AL
     {
 #if ANDROID
         const string NativeLibName = "openal32.dll";
 #elif IOS
         const string NativeLibName = "/System/Library/Frameworks/OpenAL.framework/OpenAL";
 #else
-        public const string NativeLibName = "soft_oal.dll";
+        internal const string NativeLibName = "soft_oal.dll";
 #endif
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alEnable")]
-        public static extern void Enable (int cap);
+        internal static extern void Enable (int cap);
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alBufferData")]
-        public static extern void BufferData(uint bid, int format, IntPtr data, int size, int freq);
+        internal static extern void BufferData(uint bid, int format, IntPtr data, int size, int freq);
 
-        public static void BufferData(int bid, ALFormat format, byte[] data, int size, int freq)
+        internal static void BufferData(int bid, ALFormat format, byte[] data, int size, int freq)
         {
             var handle = GCHandle.Alloc(data, GCHandleType.Pinned);
             BufferData((uint)bid, (int)format, handle.AddrOfPinnedObject(), size, freq);
             handle.Free();
         }
 
-        public static void BufferData(int bid, ALFormat format, short[] data, int size, int freq)
+        internal static void BufferData(int bid, ALFormat format, short[] data, int size, int freq)
         {
             var handle = GCHandle.Alloc(data, GCHandleType.Pinned);
             BufferData((uint)bid, (int)format, handle.AddrOfPinnedObject(), size, freq);
             handle.Free();
         }
 
-        [CLSCompliant (false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alDeleteBuffers")]
-        public static unsafe extern void DeleteBuffers(int n, int* buffers);
+        internal static unsafe extern void DeleteBuffers(int n, int* buffers);
 
-        public static void DeleteBuffers(int[] buffers)
+        internal static void DeleteBuffers(int[] buffers)
         {
             DeleteBuffers (buffers.Length, ref buffers [0]);
         }
 
-        public unsafe static void DeleteBuffers(int n, ref int buffers)
+        internal unsafe static void DeleteBuffers(int n, ref int buffers)
         {
             fixed (int* pbuffers = &buffers)
             {
@@ -236,24 +233,22 @@ namespace OpenAL
             }
         }
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alBufferi")]
-        public static extern void Bufferi (int buffer, ALBufferi param, int value);
+        internal static extern void Bufferi (int buffer, ALBufferi param, int value);
 
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alGetBufferi")]
-        public static extern void GetBufferi(int bid, ALGetBufferi param, out int value);
+        internal static extern void GetBufferi(int bid, ALGetBufferi param, out int value);
 
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alBufferiv")]
-        public static extern void Bufferiv (int bid, ALBufferi param, int[] values);
+        internal static extern void Bufferiv (int bid, ALBufferi param, int[] values);
 
-        public static void GetBuffer(int bid, ALGetBufferi param, out int value)
+        internal static void GetBuffer(int bid, ALGetBufferi param, out int value)
         {
             GetBufferi(bid, param, out value);
         }
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alGenBuffers")]
-        public static unsafe extern void GenBuffers(int count, int* buffers);
+        internal static unsafe extern void GenBuffers(int count, int* buffers);
 
         internal unsafe static void GenBuffers (int count,out int[] buffers)
         {
@@ -264,26 +259,25 @@ namespace OpenAL
             }
         }
 
-        public static void GenBuffers(int count, out int buffer)
+        internal static void GenBuffers(int count, out int buffer)
         {
             int[] ret;
             GenBuffers(count, out ret);
             buffer = ret[0];
         }
 
-        public static int[] GenBuffers(int count)
+        internal static int[] GenBuffers(int count)
         {
             int[] ret;
             GenBuffers(count, out ret);
             return ret;
         }
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alGenSources")]
-        public static extern void GenSources(int n, uint[] sources);
+        internal static extern void GenSources(int n, uint[] sources);
 
 
-        public static void GenSources(int[] sources)
+        internal static void GenSources(int[] sources)
         {
             uint[] temp = new uint[sources.Length];
             GenSources(temp.Length, temp);
@@ -294,128 +288,112 @@ namespace OpenAL
         }
 
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alGetError")]
-        public static extern ALError GetError();
+        internal static extern ALError GetError();
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alIsBuffer")]
-        public static extern bool IsBuffer(uint buffer);
+        internal static extern bool IsBuffer(uint buffer);
 
-        public static bool IsBuffer(int buffer)
+        internal static bool IsBuffer(int buffer)
         {
             return IsBuffer((uint)buffer);
         }
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSourcePause")]
-        public static extern void SourcePause(uint source);
+        internal static extern void SourcePause(uint source);
 
-        public static void SourcePause(int source)
+        internal static void SourcePause(int source)
         {
             SourcePause((uint)source);
         }
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSourcePlay")]
-        public static extern void SourcePlay(uint source);
+        internal static extern void SourcePlay(uint source);
 
-        public static void SourcePlay(int source)
+        internal static void SourcePlay(int source)
         {
             SourcePlay((uint)source);
         }
 
-        public static string GetErrorString(ALError errorCode)
+        internal static string GetErrorString(ALError errorCode)
         {
             return errorCode.ToString (); 
         }
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alIsSource")]
-        public static extern bool IsSource(int source);
+        internal static extern bool IsSource(int source);
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alDeleteSources")]
-        public static extern void DeleteSources(int n, ref int sources);
+        internal static extern void DeleteSources(int n, ref int sources);
 
-        public static void DeleteSource(int source)
+        internal static void DeleteSource(int source)
         {
             DeleteSources (1, ref source);
         }
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSourceStop")]
-        public static extern void SourceStop (int sourceId);
+        internal static extern void SourceStop (int sourceId);
 
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSourcei")]
         internal static extern void Source (int sourceId, int i, int a);
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSource3i")]
-        public static extern void Source (int sourceId, ALSourcei i, int a, int b, int c);
+        internal static extern void Source (int sourceId, ALSourcei i, int a, int b, int c);
 
-        public static void Source (int sourceId, ALSourcei i, int a)
+        internal static void Source (int sourceId, ALSourcei i, int a)
         {
             Source (sourceId, (int)i, a);
         }
 
-        public static void Source (int sourceId, ALSourceb i, bool a) {
+        internal static void Source (int sourceId, ALSourceb i, bool a) {
             Source (sourceId, (int)i, a ? 1 : 0);
         }
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSourcef")]
-        public static extern void Source (int sourceId, ALSourcef i, float a);
+        internal static extern void Source (int sourceId, ALSourcef i, float a);
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSource3f")]
-        public static extern void Source (int sourceId, ALSource3f i, float x, float y, float z);
+        internal static extern void Source (int sourceId, ALSource3f i, float x, float y, float z);
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alGetSourcei")]
-        public static extern void GetSource (int sourceId, ALGetSourcei i, out int state);
+        internal static extern void GetSource (int sourceId, ALGetSourcei i, out int state);
 
-        public static ALSourceState GetSourceState(int sourceId) {
+        internal static ALSourceState GetSourceState(int sourceId) {
             int state;
             GetSource (sourceId, ALGetSourcei.SourceState, out state);
             return (ALSourceState)state;
         }
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alGetListener3f")]
-        public static extern void GetListener (ALListener3f param, out float value1, out float value2, out float value3);
+        internal static extern void GetListener (ALListener3f param, out float value1, out float value2, out float value3);
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alDistanceModel")]
-        public static extern void DistanceModel (ALDistanceModel model);
+        internal static extern void DistanceModel (ALDistanceModel model);
 
-        [CLSCompliant(false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alDopplerFactor")]
-        public static extern void DopplerFactor (float value);
+        internal static extern void DopplerFactor (float value);
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSourceQueueBuffers")]
-        public unsafe static extern void SourceQueueBuffers (int sourceId, int numEntries, [In] int* buffers);
+        internal unsafe static extern void SourceQueueBuffers (int sourceId, int numEntries, [In] int* buffers);
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSourceUnqueueBuffers")]
-        public unsafe static extern void SourceUnqueueBuffers (int sourceId, int numEntries, [In] int* salvaged);
+        internal unsafe static extern void SourceUnqueueBuffers (int sourceId, int numEntries, [In] int* salvaged);
 
-        [CLSCompliant (false)]
-        public unsafe static void SourceQueueBuffers (int sourceId, int numEntries, int [] buffers)
+        internal unsafe static void SourceQueueBuffers (int sourceId, int numEntries, int [] buffers)
         {
             fixed (int* ptr = &buffers[0]) {
                 AL.SourceQueueBuffers (sourceId, numEntries, ptr);
             }
         }
 
-        public unsafe static void SourceQueueBuffer (int sourceId, int buffer)
+        internal unsafe static void SourceQueueBuffer (int sourceId, int buffer)
         {
             AL.SourceQueueBuffers (sourceId, 1, &buffer);
         }
 
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alSourceUnqueueBuffers")]
-        public static extern void SourceUnqueueBuffers (int sid, int numEntries, [Out] int [] bids);
+        internal static extern void SourceUnqueueBuffers (int sid, int numEntries, [Out] int [] bids);
 
-        public static unsafe int [] SourceUnqueueBuffers (int sourceId, int numEntries)
+        internal static unsafe int [] SourceUnqueueBuffers (int sourceId, int numEntries)
         {
             if (numEntries <= 0) {
                 throw new ArgumentOutOfRangeException ("numEntries", "Must be greater than zero.");
@@ -429,141 +407,127 @@ namespace OpenAL
         }
 
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alGetEnumValue")]
-        public static extern int GetEnumValue (string enumName);
+        internal static extern int GetEnumValue (string enumName);
 
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alIsExtensionPresent")]
-        public static extern bool IsExtensionPresent (string extensionName);
+        internal static extern bool IsExtensionPresent (string extensionName);
 
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alGetProcAddress")]
-        public static extern IntPtr GetProcAddress (string functionName);
+        internal static extern IntPtr GetProcAddress (string functionName);
 
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alGetString")]
         private static extern IntPtr alGetString (int p);
 
-        public static string GetString (int p)
+        internal static string GetString (int p)
         {
             return Marshal.PtrToStringAnsi (alGetString (p));
         }
 
-        public static string Get (ALGetString p)
+        internal static string Get (ALGetString p)
         {
             return GetString ((int)p);
         }
     }
 
-    public partial class Alc
+    internal partial class Alc
     {
 #if ANDROID
         const string NativeLibName = "openal32.dll";
 #elif IOS
         const string NativeLibName = "/System/Library/Frameworks/OpenAL.framework/OpenAL";
 #else
-        public const string NativeLibName = "soft_oal.dll";
+        internal const string NativeLibName = "soft_oal.dll";
 #endif
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCreateContext")]
-        public static extern IntPtr CreateContext (IntPtr device, int [] attributes);
+        internal static extern IntPtr CreateContext (IntPtr device, int [] attributes);
 
-        public static AlcError GetError()
+        internal static AlcError GetError()
         {
             return GetError (IntPtr.Zero);
         }
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcGetError")]
-        public static extern AlcError GetError (IntPtr device);
+        internal static extern AlcError GetError (IntPtr device);
 
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcGetIntegerv")]
         internal static extern void alcGetIntegerv(IntPtr device, int param, int size, int[] values);
 
-        public static void GetInteger(IntPtr device, AlcGetInteger param, int size, int[] values)
+        internal static void GetInteger(IntPtr device, AlcGetInteger param, int size, int[] values)
         {
             alcGetIntegerv(device, (int)param, size, values);
         }
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcGetCurrentContext")]
-        public static extern IntPtr GetCurrentContext ();
+        internal static extern IntPtr GetCurrentContext ();
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcMakeContextCurrent")]
-        public static extern void MakeContextCurrent (IntPtr context);
+        internal static extern void MakeContextCurrent (IntPtr context);
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcDestroyContext")]
-        public static extern void DestroyContext (IntPtr context);
+        internal static extern void DestroyContext (IntPtr context);
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCloseDevice")]
-        public static extern void CloseDevice (IntPtr device);
+        internal static extern void CloseDevice (IntPtr device);
 
-        [CLSCompliant (false)]
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcOpenDevice")]
-        public static extern IntPtr OpenDevice ([In] [MarshalAs(UnmanagedType.LPStr)] string device);
+        internal static extern IntPtr OpenDevice ([In] [MarshalAs(UnmanagedType.LPStr)] string device);
 
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureOpenDevice")]
         internal static extern IntPtr alcCaptureOpenDevice([In()] [MarshalAs(UnmanagedType.LPStr)] string device, uint sampleRate, int format, int sampleSize);
 
-        [CLSCompliant(false)]
-        public static IntPtr CaptureOpenDevice(string device, uint sampleRate, ALFormat format, int sampleSize)
+        internal static IntPtr CaptureOpenDevice(string device, uint sampleRate, ALFormat format, int sampleSize)
         {
             return alcCaptureOpenDevice(device, sampleRate, (int)format, sampleSize);
         }
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureStart")]
-        public static extern IntPtr CaptureStart(IntPtr device);
+        internal static extern IntPtr CaptureStart(IntPtr device);
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureSamples")]
-        public static extern void CaptureSamples(IntPtr device, IntPtr buffer, int samples);
+        internal static extern void CaptureSamples(IntPtr device, IntPtr buffer, int samples);
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureStop")]
-        public static extern IntPtr CaptureStop(IntPtr device);
+        internal static extern IntPtr CaptureStop(IntPtr device);
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcCaptureCloseDevice")]
-        public static extern IntPtr CaptureCloseDevice(IntPtr device);
+        internal static extern IntPtr CaptureCloseDevice(IntPtr device);
 
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcIsExtensionPresent")]
-        public static extern bool IsExtensionPresent (IntPtr device, [MarshalAs (UnmanagedType.LPStr)] string extensionName);
+        internal static extern bool IsExtensionPresent (IntPtr device, [MarshalAs (UnmanagedType.LPStr)] string extensionName);
 
         [DllImport (NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcGetString")]
         internal static extern IntPtr alGetString (IntPtr device, int p);
 
-        public static string GetString (IntPtr device, int p)
+        internal static string GetString (IntPtr device, int p)
         {
             return Marshal.PtrToStringAnsi (alGetString (device, p));
         }
 
-        public static string GetString (IntPtr device, AlcGetString p)
+        internal static string GetString (IntPtr device, AlcGetString p)
         {
             return GetString (device, (int)p);
         }
 #if IOS
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcSuspendContext")]
-        public static extern void SuspendContext(IntPtr context);
+        internal static extern void SuspendContext(IntPtr context);
 
-        [CLSCompliant(false)]
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcProcessContext")]
-        public static extern void ProcessContext(IntPtr context);
+        internal static extern void ProcessContext(IntPtr context);
 #endif
 
 #if ANDROID
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcDevicePauseSOFT")]
-        public static extern void DevicePause(IntPtr device);
+        internal static extern void DevicePause(IntPtr device);
 
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "alcDeviceResumeSOFT")]
-        public static extern void DeviceResume(IntPtr device);
+        internal static extern void DeviceResume(IntPtr device);
 #endif
     }
 
-    public class XRamExtension
+    internal class XRamExtension
     {
-        public enum XRamStorage
+        internal enum XRamStorage
         {
             Automatic,
             Hardware,
@@ -581,7 +545,7 @@ namespace OpenAL
 
         private SetBufferModeDelegate setBufferMode;
 
-        public XRamExtension ()
+        internal XRamExtension ()
         {
             IsInitialized = false;
             if (!AL.IsExtensionPresent ("EAX-RAM")) {
@@ -603,9 +567,9 @@ namespace OpenAL
             IsInitialized = true;
         }
 
-        public bool IsInitialized { get; private set; }
+        internal bool IsInitialized { get; private set; }
 
-        public bool SetBufferMode(int i, ref int id, XRamStorage storage) {
+        internal bool SetBufferMode(int i, ref int id, XRamStorage storage) {
             if (storage == XRamExtension.XRamStorage.Accessible) {
                 return setBufferMode (i, ref id, StorageAccessible);
             }
@@ -616,8 +580,7 @@ namespace OpenAL
         }
     }
 
-    [CLSCompliant (false)]
-    public class EffectsExtension
+    internal class EffectsExtension
     {
         /* Effect API */
 
@@ -667,7 +630,7 @@ namespace OpenAL
 
         internal static IntPtr device;
         static EffectsExtension _instance;
-        public static EffectsExtension Instance {
+        internal static EffectsExtension Instance {
             get {
                 if (_instance == null)
                     _instance = new EffectsExtension ();
@@ -675,7 +638,7 @@ namespace OpenAL
             }
         }
 
-        public EffectsExtension ()
+        internal EffectsExtension ()
         {
             IsInitialized = false;
             if (!Alc.IsExtensionPresent (device, "ALC_EXT_EFX")) {
@@ -699,7 +662,7 @@ namespace OpenAL
             IsInitialized = true;
         }
 
-        public bool IsInitialized { get; private set; }
+        internal bool IsInitialized { get; private set; }
 
         /*
             
@@ -709,72 +672,72 @@ alEffecti (effect, EfxEffecti.FilterType, (int)EfxEffectType.Reverb);
             
         */
 
-        public void GenAuxiliaryEffectSlots (int count, out uint slot)
+        internal void GenAuxiliaryEffectSlots (int count, out uint slot)
         {
             this.alGenAuxiliaryEffectSlots (count, out slot);
             ALHelper.CheckError ("Failed to Genereate Aux slot");
         }
 
-        public void GenEffect (out uint effect)
+        internal void GenEffect (out uint effect)
         {
             this.alGenEffects (1, out effect);
             ALHelper.CheckError ("Failed to Generate Effect.");
         }
 
-		public void DeleteAuxiliaryEffectSlot (int slot)
+		internal void DeleteAuxiliaryEffectSlot (int slot)
 		{
             alDeleteAuxiliaryEffectSlots (1, ref slot);
 		}
 
-        public void DeleteEffect (int effect)
+        internal void DeleteEffect (int effect)
         {
             alDeleteEffects (1, ref effect);
         }
 
-        public void BindEffectToAuxiliarySlot (uint slot, uint effect)
+        internal void BindEffectToAuxiliarySlot (uint slot, uint effect)
         {
             alAuxiliaryEffectSloti (slot,EfxEffecti.SlotEffect, effect);
             ALHelper.CheckError ("Failed to bind Effect");
         }
 
-        public void AuxiliaryEffectSlot (uint slot, EfxEffectSlotf param, float value)
+        internal void AuxiliaryEffectSlot (uint slot, EfxEffectSlotf param, float value)
         {
             alAuxiliaryEffectSlotf (slot, param, value);
             ALHelper.CheckError ("Failes to set " + param + " " + value);
         }
 
-        public void BindSourceToAuxiliarySlot (int SourceId, int slot, int slotnumber, int filter)
+        internal void BindSourceToAuxiliarySlot (int SourceId, int slot, int slotnumber, int filter)
 		{
             AL.Source (SourceId, ALSourcei.EfxAuxilarySendFilter, slot, slotnumber, filter);
 		}
 
-        public void Effect (uint effect, EfxEffectf param, float value)
+        internal void Effect (uint effect, EfxEffectf param, float value)
         {
             alEffectf (effect, param, value);
             ALHelper.CheckError ("Failed to set " + param + " " + value);
         }
 
-        public void Effect (uint effect, EfxEffecti param, int value)
+        internal void Effect (uint effect, EfxEffecti param, int value)
         {
             alEffecti (effect, param, value);
             ALHelper.CheckError ("Failed to set " + param + " " + value);
         }
 
-        public unsafe int GenFilter() {
+        internal unsafe int GenFilter() {
             uint filter = 0;
             this.alGenFilters (1, &filter);
             return (int)filter;
         }
-        public void Filter(int sourceId, EfxFilteri filter, int EfxFilterType) {
+        internal void Filter(int sourceId, EfxFilteri filter, int EfxFilterType) {
             this.alFilteri ((uint)sourceId, filter, EfxFilterType);
         }
-        public void Filter(int sourceId, EfxFilterf filter, float EfxFilterType) {
+        internal void Filter(int sourceId, EfxFilterf filter, float EfxFilterType) {
             this.alFilterf ((uint)sourceId, filter, EfxFilterType);
         }
-        public void BindFilterToSource(int sourceId, int filterId) {
+        internal void BindFilterToSource(int sourceId, int filterId) {
             AL.Source (sourceId, ALSourcei.EfxDirectFilter, filterId);
         }
-        public unsafe void DeleteFilter (int filterId)
+        internal unsafe void DeleteFilter (int filterId)
         {
             alDeleteFilters (1, (uint*)&filterId);
         }

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 using MonoGame.Utilities;
 #endif
 
-using OpenAL;
+using MonoGame.OpenAL;
 
 #if ANDROID
 using System.Globalization;

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -10,7 +10,7 @@ using MonoMac.AudioToolbox;
 using MonoMac.AudioUnit;
 using MonoMac.OpenAL;
 #elif OPENAL
-using OpenAL;
+using MonoGame.OpenAL;
 #if IOS || MONOMAC
 using AudioToolbox;
 using AudioUnit;

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -3,7 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using OpenAL;
+using MonoGame.OpenAL;
 
 namespace Microsoft.Xna.Framework.Audio
 {

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.OpenGL.cs
@@ -18,8 +18,8 @@ using OpenTK.Graphics.ES20;
 using GetParamName = OpenTK.Graphics.ES20.All;
 using GetPName = OpenTK.Graphics.ES20.GetPName;
 #else
-using OpenGL;
-using GetParamName = OpenGL.GetPName;
+using MonoGame.OpenGL;
+using GetParamName = MonoGame.OpenGL.GetPName;
 #endif
 #endif
 

--- a/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
@@ -5,9 +5,9 @@
 using System;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace OpenGL
+namespace MonoGame.OpenGL
 {
-    public class GraphicsContext : IGraphicsContext, IDisposable
+    internal class GraphicsContext : IGraphicsContext, IDisposable
     {
         private IntPtr _context;
         private IntPtr _winHandle;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
@@ -20,7 +20,7 @@ using OpenTK.Graphics.OpenGL;
 #endif
 
 #if (WINDOWS || DESKTOPGL) && !GLES
-using OpenGL;
+using MonoGame.OpenGL;
 
 #endif
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -18,7 +18,7 @@ using GLPrimitiveType = OpenTK.Graphics.OpenGL.BeginMode;
 #endif
 
 #if DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #endif
 
 #if ANGLE

--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -17,9 +17,9 @@ using GLPixelFormat = OpenTK.Graphics.OpenGL.All;
 using PixelFormat = OpenTK.Graphics.OpenGL.PixelFormat;
 #endif
 #elif DESKTOPGL
-using OpenGL;
-using GLPixelFormat = OpenGL.PixelFormat;
-using PixelFormat = OpenGL.PixelFormat;
+using MonoGame.OpenGL;
+using GLPixelFormat = MonoGame.OpenGL.PixelFormat;
+using PixelFormat = MonoGame.OpenGL.PixelFormat;
 #elif GLES
 #if ANGLE
 using OpenTK.Graphics;

--- a/MonoGame.Framework/Graphics/IGraphicsContext.cs
+++ b/MonoGame.Framework/Graphics/IGraphicsContext.cs
@@ -4,9 +4,9 @@
 
 using System;
 
-namespace OpenGL
+namespace MonoGame.OpenGL
 {
-    public interface IGraphicsContext : IDisposable
+    internal interface IGraphicsContext : IDisposable
     {
         int SwapInterval { get; set; }
         bool IsDisposed { get; }

--- a/MonoGame.Framework/Graphics/IRenderTarget.cs
+++ b/MonoGame.Framework/Graphics/IRenderTarget.cs
@@ -50,7 +50,7 @@ using OpenTK.Graphics.OpenGL;
 #if GLES
 using OpenTK.Graphics.ES20;
 #else
-using OpenGL;
+using MonoGame.OpenGL;
 #endif
 #endif
 

--- a/MonoGame.Framework/Graphics/IWindowInfo.cs
+++ b/MonoGame.Framework/Graphics/IWindowInfo.cs
@@ -4,9 +4,9 @@
 
 using System;
 
-namespace OpenGL
+namespace MonoGame.OpenGL
 {
-    public interface IWindowInfo
+    internal interface IWindowInfo
     {
         IntPtr Handle { get; }
     }

--- a/MonoGame.Framework/Graphics/OcclusionQuery.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OcclusionQuery.OpenGL.cs
@@ -10,7 +10,7 @@ using MonoMac.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES30;
 #endif

--- a/MonoGame.Framework/Graphics/OpenGL.Common.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.Common.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 
-namespace OpenGL
+namespace MonoGame.OpenGL
 {
     // Required to allow platforms other than iOS use the same code.
     // just don't include this on iOS
     [AttributeUsage (AttributeTargets.Delegate)]
-    public sealed class MonoNativeFunctionWrapper : Attribute {
+    internal sealed class MonoNativeFunctionWrapper : Attribute
+    {
     }
 }
 

--- a/MonoGame.Framework/Graphics/OpenGL.SDL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.SDL.cs
@@ -6,9 +6,9 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security;
 
-namespace OpenGL
+namespace MonoGame.OpenGL
 {
-    public partial class GL
+    internal partial class GL
     {
         static partial void LoadPlatformEntryPoints()
         {
@@ -21,13 +21,13 @@ namespace OpenGL
         }
     }
 
-    internal class EntryPointHelper {
-
+    internal class EntryPointHelper
+    {
         [SuppressUnmanagedCodeSecurity]
         [DllImport(Sdl.NativeLibName, CallingConvention = CallingConvention.Cdecl,
             EntryPoint = "SDL_GL_GetProcAddress", ExactSpelling = true)]
-        public static extern IntPtr GetProcAddress(IntPtr proc);
-        public static IntPtr GetAddress(string proc)
+        internal static extern IntPtr GetProcAddress(IntPtr proc);
+        internal static IntPtr GetAddress(string proc)
         {
             IntPtr p = Marshal.StringToHGlobalAnsi(proc);
             try

--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -12,57 +12,57 @@ using System.Runtime.CompilerServices;
 using ObjCRuntime;
 #endif
 
-namespace OpenGL
+namespace MonoGame.OpenGL
 {
-    public enum BufferAccess {
+    internal enum BufferAccess {
         ReadOnly = 0x88B8,
     }
 
-    public enum BufferUsageHint {
+    internal enum BufferUsageHint {
         StreamDraw = 0x88E0,
         StaticDraw = 0x88E4,
     }
 
-    public enum StencilFace {
+    internal enum StencilFace {
         Front = 0x0404, 
         Back = 0x0405,
     }
-    public enum DrawBuffersEnum {
+    internal enum DrawBuffersEnum {
         UnsignedShort,
         UnsignedInt,
     }
 
-    public enum ShaderType {
+    internal enum ShaderType {
         VertexShader = 0x8B31,
         FragmentShader = 0x8B30,
     }
 
-    public enum ShaderParameter {
+    internal enum ShaderParameter {
         LogLength = 0x8B84,
         CompileStatus = 0x8B81,
         SourceLength = 0x8B88,
     }
 
-    public enum GetProgramParameterName {
+    internal enum GetProgramParameterName {
         LogLength = 0x8B84,
         LinkStatus = 0x8B82,
     }
 
-    public enum DrawElementsType {
+    internal enum DrawElementsType {
         UnsignedShort = 0x1403,
         UnsignedInt = 0x1405,
     }
 
-    public enum QueryTarget {
+    internal enum QueryTarget {
         SamplesPassed = 0x8914,
     }
 
-    public enum GetQueryObjectParam {
+    internal enum GetQueryObjectParam {
         QueryResultAvailable = 0x8867,
         QueryResult = 0x8866,
     }
 
-    public enum GenerateMipmapTarget {
+    internal enum GenerateMipmapTarget {
         Texture1D = 0x0DE0,
         Texture2D = 0x0DE1,
         Texture3D = 0x806F,
@@ -73,19 +73,19 @@ namespace OpenGL
         Texture2DMultisampleArray = 0x9102, 
     }
 
-    public enum BlitFramebufferFilter {
+    internal enum BlitFramebufferFilter {
         Nearest = 0x2600,
     }
 
-    public enum ReadBufferMode {
+    internal enum ReadBufferMode {
         ColorAttachment0 = 0x8CE0,
     }
 
-    public enum DrawBufferMode {
+    internal enum DrawBufferMode {
         ColorAttachment0 = 0x8CE0,
     }
 
-    public enum FramebufferErrorCode {
+    internal enum FramebufferErrorCode {
         FramebufferUndefined = 0x8219,
         FramebufferComplete = 0x8CD5,
         FramebufferCompleteExt = 0x8CD5,
@@ -106,30 +106,30 @@ namespace OpenGL
         FramebufferIncompleteLayerCount = 0x8DA9,
     }
 
-    public enum BufferTarget {
+    internal enum BufferTarget {
         ArrayBuffer = 0x8892,
         ElementArrayBuffer = 0x8893,
     }
 
-    public enum RenderbufferTarget {
+    internal enum RenderbufferTarget {
         Renderbuffer = 0x8D41,
         RenderbufferExt = 0x8D41,
     }
 
-    public enum FramebufferTarget {
+    internal enum FramebufferTarget {
         Framebuffer = 0x8D40,
         FramebufferExt = 0x8D40,
         ReadFramebuffer = 0x8CA8,
     }
 
-    public enum RenderbufferStorage {
+    internal enum RenderbufferStorage {
         Rgba8 = 0x8058,
         DepthComponent16 = 0x81a5,
         DepthComponent24 = 0x81a6,
         Depth24Stencil8 = 0x88F0,
     }
 
-    public enum EnableCap : int
+    internal enum EnableCap : int
     {
         PointSmooth = 0x0B10,
         LineSmooth = 0x0B20,
@@ -160,38 +160,38 @@ namespace OpenGL
         DebugOutput = 0x92E0,
     }
 
-    public enum VertexPointerType {
+    internal enum VertexPointerType {
         Float = 0x1406,
         Short = 0x1402,
     }
 
-    public enum VertexAttribPointerType {
+    internal enum VertexAttribPointerType {
         Float = 0x1406,
         Short = 0x1402,
         UnsignedByte = 0x1401,
         HalfFloat = 0x140B,
     }
 
-    public enum CullFaceMode {
+    internal enum CullFaceMode {
         Back = 0x0405, 
         Front = 0x0404,
     }
 
-    public enum FrontFaceDirection {
+    internal enum FrontFaceDirection {
         Cw = 0x0900,
         Ccw = 0x0901,
     }
 
-    public enum MaterialFace {
+    internal enum MaterialFace {
         FrontAndBack = 0x0408,
     }
 
-    public enum PolygonMode {
+    internal enum PolygonMode {
         Fill = 0x1B02,
         Line = 0x1B01,
     }
 
-    public enum ColorPointerType {
+    internal enum ColorPointerType {
         Float = 0x1406,
         Short = 0x1402,
         UnsignedShort = 0x1403,
@@ -199,7 +199,7 @@ namespace OpenGL
         HalfFloat = 0x140B,
     }
 
-    public enum NormalPointerType {
+    internal enum NormalPointerType {
         Byte = 0x1400,
         Float = 0x1406,
         Short = 0x1402,
@@ -208,7 +208,7 @@ namespace OpenGL
         HalfFloat = 0x140B,
     }
 
-    public enum TexCoordPointerType {
+    internal enum TexCoordPointerType {
         Byte = 0x1400,
         Float = 0x1406,
         Short = 0x1402,
@@ -217,7 +217,7 @@ namespace OpenGL
         HalfFloat = 0x140B,
     }
 
-    public enum BlendEquationMode {
+    internal enum BlendEquationMode {
         FuncAdd = 0x8006,
         Max = 0x8008,  // ios MaxExt
         Min = 0x8007,  // ios MinExt
@@ -225,7 +225,7 @@ namespace OpenGL
         FuncSubtract = 0x800A,
     }
 
-    public enum BlendingFactorSrc {
+    internal enum BlendingFactorSrc {
         Zero = 0,
         SrcColor = 0x0300,
         OneMinusSrcColor = 0x0301,
@@ -243,7 +243,7 @@ namespace OpenGL
         One = 1,
     }
 
-    public enum BlendingFactorDest {
+    internal enum BlendingFactorDest {
         Zero = 0,
         SrcColor = 0x0300,
         OneMinusSrcColor = 0x0301,
@@ -261,7 +261,7 @@ namespace OpenGL
         One = 1,
     }
 
-    public enum DepthFunction {
+    internal enum DepthFunction {
         Always = 0x0207,
         Equal = 0x0202,
         Greater = 0x0204,
@@ -272,7 +272,7 @@ namespace OpenGL
         Notequal = 0x0205,
     }
 
-    public enum GetPName : int {
+    internal enum GetPName : int {
         ArrayBufferBinding = 0x8894,
         MaxTextureImageUnits = 0x8872, 
         MaxVertexAttribs = 0x8869, 
@@ -283,19 +283,19 @@ namespace OpenGL
         MaxSamples = 0x8D57,
     }
 
-    public enum StringName { 
+    internal enum StringName { 
         Extensions = 0x1F03, 
         Version = 0x1F02,
     }
 
-    public enum FramebufferAttachment {
+    internal enum FramebufferAttachment {
         ColorAttachment0 = 0x8CE0,
         ColorAttachment0Ext = 0x8CE0,
         DepthAttachment = 0x8D00,
         StencilAttachment = 0x8D20,
     }
 
-    public enum GLPrimitiveType {
+    internal enum GLPrimitiveType {
         Lines = 0x0001,
         LineStrip = 0x0003,
         Triangles = 0x0004,
@@ -303,22 +303,22 @@ namespace OpenGL
     }
 
     [Flags]
-    public enum ClearBufferMask
+    internal enum ClearBufferMask
     {
         DepthBufferBit = 0x00000100,
         StencilBufferBit = 0x00000400,
         ColorBufferBit = 0x00004000,
     }
 
-    public enum ErrorCode {
+    internal enum ErrorCode {
         NoError = 0,
     }
 
-    public enum TextureUnit {
+    internal enum TextureUnit {
         Texture0 = 0x84C0,
     }
 
-    public enum TextureTarget {
+    internal enum TextureTarget {
         Texture2D = 0x0DE1,
         Texture3D = 0x806F,
         TextureCubeMap = 0x8513,
@@ -330,7 +330,7 @@ namespace OpenGL
         TextureCubeMapNegativeZ = 0x851A,
     }
 
-    public enum PixelInternalFormat {
+    internal enum PixelInternalFormat {
         Rgba = 0x1908,
         Rgb = 0x1907,
         Rgba4 = 0x8056,
@@ -365,7 +365,7 @@ namespace OpenGL
 
     }
 
-    public enum PixelFormat {
+    internal enum PixelFormat {
         Rgba = 0x1908,
         Rgb = 0x1907,
         Luminance = 0x1909,
@@ -374,7 +374,7 @@ namespace OpenGL
         Rg = 0x8227,
     }
 
-    public enum PixelType {
+    internal enum PixelType {
         UnsignedByte = 0x1401,
         UnsignedShort565 = 0x8363,
         UnsignedShort4444 = 0x8033,
@@ -386,12 +386,12 @@ namespace OpenGL
         UnsignedInt1010102 = 0x8036,
     }
 
-    public enum PixelStoreParameter {
+    internal enum PixelStoreParameter {
         UnpackAlignment = 0x0CF5,
         PackAlignment = 0x0D05,
     }
 
-    public enum GLStencilFunction {
+    internal enum GLStencilFunction {
         Always = 0x0207,
         Equal = 0x0202,
         Greater = 0x0204,
@@ -402,7 +402,7 @@ namespace OpenGL
         Notequal = 0x0205,
     }
 
-    public enum StencilOp {
+    internal enum StencilOp {
         Keep = 0x1E00,
         DecrWrap = 0x8508,
         Decr = 0x1E03,
@@ -413,7 +413,7 @@ namespace OpenGL
         Zero = 0,
     }
 
-    public enum TextureParameterName {
+    internal enum TextureParameterName {
         TextureMaxAnisotropyExt = 0x84FE,
         TextureBaseLevel = 0x813C,
         TextureMaxLevel = 0x813D,
@@ -428,12 +428,12 @@ namespace OpenGL
         GenerateMipmap = 0x8191,
     }
 
-    public enum Bool {
+    internal enum Bool {
         True = 1,
         False = 0,
     }
 
-    public enum TextureMinFilter {
+    internal enum TextureMinFilter {
         LinearMipmapNearest = 0x2701,
         NearestMipmapLinear = 0x2702,
         LinearMipmapLinear = 0x2703,
@@ -442,17 +442,17 @@ namespace OpenGL
         Nearest = 0x2600,
     }
 
-    public enum TextureMagFilter {
+    internal enum TextureMagFilter {
         Linear = 0x2601,
         Nearest = 0x2600,
     }
 
-    public enum TextureCompareMode {
+    internal enum TextureCompareMode {
         CompareRefToTexture = 0x884E,
         None = 0,
     }
 
-    public enum TextureWrapMode {
+    internal enum TextureWrapMode {
         ClampToEdge = 0x812F,
         Repeat = 0x2901,
         MirroredRepeat = 0x8370,
@@ -460,8 +460,8 @@ namespace OpenGL
         ClampToBorder = 0x812D,
     }
 
-    public partial class ColorFormat {
-        public ColorFormat(int r, int g, int b, int a)
+    internal partial class ColorFormat {
+        internal ColorFormat(int r, int g, int b, int a)
         {
             R = r;
             G = g;
@@ -469,81 +469,80 @@ namespace OpenGL
             A = a;
         }
 
-        public int R { get; private set; }
-        public int G { get; private set; }
-        public int B { get; private set; }
-        public int A { get; private set; }
+        internal int R { get; private set; }
+        internal int G { get; private set; }
+        internal int B { get; private set; }
+        internal int A { get; private set; }
     }
 
-    [CLSCompliant (false)]
-    public partial class GL
+    internal partial class GL
     {
-        public enum RenderApi
+        internal enum RenderApi
         {
             ES = 12448,
             GL = 12450,
         }
 
-        public static RenderApi BoundApi = RenderApi.GL;
+        internal static RenderApi BoundApi = RenderApi.GL;
 
-        public partial class Ext
+        internal partial class Ext
         {
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate void GenRenderbuffersDelegate (int count, out int buffer);
-            public static GenRenderbuffersDelegate GenRenderbuffers;
+            internal delegate void GenRenderbuffersDelegate (int count, out int buffer);
+            internal static GenRenderbuffersDelegate GenRenderbuffers;
 
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate void BindRenderbufferDelegate (RenderbufferTarget target, int buffer);
-            public static BindRenderbufferDelegate BindRenderbuffer;
+            internal delegate void BindRenderbufferDelegate (RenderbufferTarget target, int buffer);
+            internal static BindRenderbufferDelegate BindRenderbuffer;
 
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate void DeleteRenderbuffersDelegate (int count, ref int buffer);
-            public static DeleteRenderbuffersDelegate DeleteRenderbuffers;
+            internal delegate void DeleteRenderbuffersDelegate (int count, ref int buffer);
+            internal static DeleteRenderbuffersDelegate DeleteRenderbuffers;
 
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate void RenderbufferStorageMultisampleDelegate (RenderbufferTarget target, int sampleCount,
+            internal delegate void RenderbufferStorageMultisampleDelegate (RenderbufferTarget target, int sampleCount,
                 RenderbufferStorage storage, int width, int height);
-            public static RenderbufferStorageMultisampleDelegate RenderbufferStorageMultisample;
+            internal static RenderbufferStorageMultisampleDelegate RenderbufferStorageMultisample;
 
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate void GenFramebuffersDelegate (int count, out int buffer);
-            public static GenFramebuffersDelegate GenFramebuffers;
+            internal delegate void GenFramebuffersDelegate (int count, out int buffer);
+            internal static GenFramebuffersDelegate GenFramebuffers;
 
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate void BindFramebufferDelegate (FramebufferTarget target, int buffer);
-            public static BindFramebufferDelegate BindFramebuffer;
+            internal delegate void BindFramebufferDelegate (FramebufferTarget target, int buffer);
+            internal static BindFramebufferDelegate BindFramebuffer;
 
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate void DeleteFramebuffersDelegate (int count, ref int buffer);
-            public static DeleteFramebuffersDelegate DeleteFramebuffers;
+            internal delegate void DeleteFramebuffersDelegate (int count, ref int buffer);
+            internal static DeleteFramebuffersDelegate DeleteFramebuffers;
 
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate void FramebufferTexture2DDelegate (FramebufferTarget target, FramebufferAttachment attachement,
+            internal delegate void FramebufferTexture2DDelegate (FramebufferTarget target, FramebufferAttachment attachement,
                 TextureTarget textureTarget, int texture, int level);
-            public static FramebufferTexture2DDelegate FramebufferTexture2D;
+            internal static FramebufferTexture2DDelegate FramebufferTexture2D;
 
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate void FramebufferRenderbufferDelegate (FramebufferTarget target, FramebufferAttachment attachement,
+            internal delegate void FramebufferRenderbufferDelegate (FramebufferTarget target, FramebufferAttachment attachement,
                 RenderbufferTarget renderBufferTarget, int buffer);
-            public static FramebufferRenderbufferDelegate FramebufferRenderbuffer;
+            internal static FramebufferRenderbufferDelegate FramebufferRenderbuffer;
 
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate void GenerateMipmapDelegate (GenerateMipmapTarget target);
-            public static GenerateMipmapDelegate GenerateMipmap;
+            internal delegate void GenerateMipmapDelegate (GenerateMipmapTarget target);
+            internal static GenerateMipmapDelegate GenerateMipmap;
 
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate void BlitFramebufferDelegate (int srcX0,
+            internal delegate void BlitFramebufferDelegate (int srcX0,
                 int srcY0,
                 int srcX1,
                 int srcY1,
@@ -553,33 +552,33 @@ namespace OpenGL
                 int dstY1,
                 ClearBufferMask mask,
                 BlitFramebufferFilter filter);
-            public static BlitFramebufferDelegate BlitFramebuffer;
+            internal static BlitFramebufferDelegate BlitFramebuffer;
 
             [System.Security.SuppressUnmanagedCodeSecurity ()]
             [MonoNativeFunctionWrapper]           
-            public delegate FramebufferErrorCode CheckFramebufferStatusDelegate (FramebufferTarget target);
-            public static CheckFramebufferStatusDelegate CheckFramebufferStatus;
+            internal delegate FramebufferErrorCode CheckFramebufferStatusDelegate (FramebufferTarget target);
+            internal static CheckFramebufferStatusDelegate CheckFramebufferStatus;
         }
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void EnableVertexAttribArrayDelegate (int attrib);
-        public static EnableVertexAttribArrayDelegate EnableVertexAttribArray;
+        internal delegate void EnableVertexAttribArrayDelegate (int attrib);
+        internal static EnableVertexAttribArrayDelegate EnableVertexAttribArray;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]
-        public delegate void DisableVertexAttribArrayDelegate (int attrib);
-        public static DisableVertexAttribArrayDelegate DisableVertexAttribArray;
+        internal delegate void DisableVertexAttribArrayDelegate (int attrib);
+        internal static DisableVertexAttribArrayDelegate DisableVertexAttribArray;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void MakeCurrentDelegate(IntPtr window);
-        public static MakeCurrentDelegate MakeCurrent;
+        internal delegate void MakeCurrentDelegate(IntPtr window);
+        internal static MakeCurrentDelegate MakeCurrent;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public unsafe delegate void GetIntegerDelegate(int param, [Out] int* data);
-        public static GetIntegerDelegate GetIntegerv;
+        internal unsafe delegate void GetIntegerDelegate(int param, [Out] int* data);
+        internal static GetIntegerDelegate GetIntegerv;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
@@ -588,190 +587,190 @@ namespace OpenGL
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void ClearDepthDelegate (float depth);
-        public static ClearDepthDelegate ClearDepth;
+        internal delegate void ClearDepthDelegate (float depth);
+        internal static ClearDepthDelegate ClearDepth;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DepthRangeDelegate (double min, double max);
-        public static DepthRangeDelegate DepthRange;
+        internal delegate void DepthRangeDelegate (double min, double max);
+        internal static DepthRangeDelegate DepthRange;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void ClearDelegate(ClearBufferMask mask);
-        public static ClearDelegate Clear;
+        internal delegate void ClearDelegate(ClearBufferMask mask);
+        internal static ClearDelegate Clear;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void ClearColorDelegate(float red,float green,float blue,float alpha);
-        public static ClearColorDelegate ClearColor;
+        internal delegate void ClearColorDelegate(float red,float green,float blue,float alpha);
+        internal static ClearColorDelegate ClearColor;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void ClearStencilDelegate(int stencil);
-        public static ClearStencilDelegate ClearStencil;
+        internal delegate void ClearStencilDelegate(int stencil);
+        internal static ClearStencilDelegate ClearStencil;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void ViewportDelegate(int x, int y, int w, int h);
-        public static ViewportDelegate Viewport;
+        internal delegate void ViewportDelegate(int x, int y, int w, int h);
+        internal static ViewportDelegate Viewport;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate ErrorCode GetErrorDelegate();
-        public static GetErrorDelegate GetError;
+        internal delegate ErrorCode GetErrorDelegate();
+        internal static GetErrorDelegate GetError;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void FlushDelegate();
-        public static FlushDelegate Flush;
+        internal delegate void FlushDelegate();
+        internal static FlushDelegate Flush;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GenTexturesDelegte (int count, [Out] out int id);
-        public static GenTexturesDelegte GenTextures;
+        internal delegate void GenTexturesDelegte (int count, [Out] out int id);
+        internal static GenTexturesDelegte GenTextures;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BindTextureDelegate(TextureTarget target, int id);
-        public static BindTextureDelegate BindTexture;
+        internal delegate void BindTextureDelegate(TextureTarget target, int id);
+        internal static BindTextureDelegate BindTexture;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate int EnableDelegate (EnableCap cap);
-        public static EnableDelegate Enable;
+        internal delegate int EnableDelegate (EnableCap cap);
+        internal static EnableDelegate Enable;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate int DisableDelegate (EnableCap cap);
-        public static DisableDelegate Disable;
+        internal delegate int DisableDelegate (EnableCap cap);
+        internal static DisableDelegate Disable;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void CullFaceDelegate(CullFaceMode mode);
-        public static CullFaceDelegate CullFace;
+        internal delegate void CullFaceDelegate(CullFaceMode mode);
+        internal static CullFaceDelegate CullFace;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void FrontFaceDelegate(FrontFaceDirection direction);
-        public static FrontFaceDelegate FrontFace;
+        internal delegate void FrontFaceDelegate(FrontFaceDirection direction);
+        internal static FrontFaceDelegate FrontFace;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void PolygonModeDelegate (MaterialFace face, PolygonMode mode);
-        public static PolygonModeDelegate PolygonMode;
+        internal delegate void PolygonModeDelegate (MaterialFace face, PolygonMode mode);
+        internal static PolygonModeDelegate PolygonMode;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void PolygonOffsetDelegate (float slopeScaleDepthBias, float depthbias);
-        public static PolygonOffsetDelegate PolygonOffset;
+        internal delegate void PolygonOffsetDelegate (float slopeScaleDepthBias, float depthbias);
+        internal static PolygonOffsetDelegate PolygonOffset;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DrawBuffersDelegate (int count, DrawBuffersEnum[] buffers);
-        public static DrawBuffersDelegate DrawBuffers;
+        internal delegate void DrawBuffersDelegate (int count, DrawBuffersEnum[] buffers);
+        internal static DrawBuffersDelegate DrawBuffers;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void UseProgramDelegate(int program);
-        public static UseProgramDelegate UseProgram;
+        internal delegate void UseProgramDelegate(int program);
+        internal static UseProgramDelegate UseProgram;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public unsafe delegate void Uniform4fvDelegate (int location, int size, float* values);
-        public static Uniform4fvDelegate Uniform4fv;
+        internal unsafe delegate void Uniform4fvDelegate (int location, int size, float* values);
+        internal static Uniform4fvDelegate Uniform4fv;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void Uniform1iDelegate (int location, int value);
-        public static Uniform1iDelegate Uniform1i;
+        internal delegate void Uniform1iDelegate (int location, int value);
+        internal static Uniform1iDelegate Uniform1i;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void ScissorDelegate(int x, int y, int width, int height);
-        public static ScissorDelegate Scissor;
+        internal delegate void ScissorDelegate(int x, int y, int width, int height);
+        internal static ScissorDelegate Scissor;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BindBufferDelegate(BufferTarget target, int buffer);
-        public static BindBufferDelegate BindBuffer;
+        internal delegate void BindBufferDelegate(BufferTarget target, int buffer);
+        internal static BindBufferDelegate BindBuffer;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DrawElementsDelegate (GLPrimitiveType primitiveType, int count, DrawElementsType elementType, IntPtr offset);
-        public static DrawElementsDelegate DrawElements;
+        internal delegate void DrawElementsDelegate (GLPrimitiveType primitiveType, int count, DrawElementsType elementType, IntPtr offset);
+        internal static DrawElementsDelegate DrawElements;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DrawArraysDelegate (GLPrimitiveType primitiveType, int offset, int count);
-        public static DrawArraysDelegate DrawArrays;
+        internal delegate void DrawArraysDelegate (GLPrimitiveType primitiveType, int offset, int count);
+        internal static DrawArraysDelegate DrawArrays;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GenRenderbuffersDelegate(int count, [Out] out int buffer);
-        public static GenRenderbuffersDelegate GenRenderbuffers;
+        internal delegate void GenRenderbuffersDelegate(int count, [Out] out int buffer);
+        internal static GenRenderbuffersDelegate GenRenderbuffers;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BindRenderbufferDelegate (RenderbufferTarget target, int buffer);
-        public static BindRenderbufferDelegate BindRenderbuffer;
+        internal delegate void BindRenderbufferDelegate (RenderbufferTarget target, int buffer);
+        internal static BindRenderbufferDelegate BindRenderbuffer;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DeleteRenderbuffersDelegate(int count, [In] [Out] ref int buffer);
-        public static DeleteRenderbuffersDelegate DeleteRenderbuffers;
+        internal delegate void DeleteRenderbuffersDelegate(int count, [In] [Out] ref int buffer);
+        internal static DeleteRenderbuffersDelegate DeleteRenderbuffers;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void RenderbufferStorageMultisampleDelegate(RenderbufferTarget target, int sampleCount, 
+        internal delegate void RenderbufferStorageMultisampleDelegate(RenderbufferTarget target, int sampleCount, 
             RenderbufferStorage storage, int width, int height);
-        public static RenderbufferStorageMultisampleDelegate RenderbufferStorageMultisample;
+        internal static RenderbufferStorageMultisampleDelegate RenderbufferStorageMultisample;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GenFramebuffersDelegate(int count, out int buffer);
-        public static GenFramebuffersDelegate GenFramebuffers;
+        internal delegate void GenFramebuffersDelegate(int count, out int buffer);
+        internal static GenFramebuffersDelegate GenFramebuffers;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BindFramebufferDelegate (FramebufferTarget target, int buffer);
-        public static BindFramebufferDelegate BindFramebuffer;
+        internal delegate void BindFramebufferDelegate (FramebufferTarget target, int buffer);
+        internal static BindFramebufferDelegate BindFramebuffer;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DeleteFramebuffersDelegate(int count, ref int buffer);
-        public static DeleteFramebuffersDelegate DeleteFramebuffers;
+        internal delegate void DeleteFramebuffersDelegate(int count, ref int buffer);
+        internal static DeleteFramebuffersDelegate DeleteFramebuffers;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void FramebufferTexture2DDelegate(FramebufferTarget target, FramebufferAttachment attachement,
+        internal delegate void FramebufferTexture2DDelegate(FramebufferTarget target, FramebufferAttachment attachement,
             TextureTarget textureTarget, int texture, int level );
-        public static FramebufferTexture2DDelegate FramebufferTexture2D;
+        internal static FramebufferTexture2DDelegate FramebufferTexture2D;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void FramebufferRenderbufferDelegate (FramebufferTarget target, FramebufferAttachment attachement,
+        internal delegate void FramebufferRenderbufferDelegate (FramebufferTarget target, FramebufferAttachment attachement,
             RenderbufferTarget renderBufferTarget, int buffer);
-        public static FramebufferRenderbufferDelegate FramebufferRenderbuffer;
+        internal static FramebufferRenderbufferDelegate FramebufferRenderbuffer;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GenerateMipmapDelegate (GenerateMipmapTarget target);
-        public static GenerateMipmapDelegate GenerateMipmap;
+        internal delegate void GenerateMipmapDelegate (GenerateMipmapTarget target);
+        internal static GenerateMipmapDelegate GenerateMipmap;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void ReadBufferDelegate (ReadBufferMode buffer);
-        public static ReadBufferDelegate ReadBuffer;
+        internal delegate void ReadBufferDelegate (ReadBufferMode buffer);
+        internal static ReadBufferDelegate ReadBuffer;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DrawBufferDelegate (DrawBufferMode buffer);
-        public static DrawBufferDelegate DrawBuffer;
+        internal delegate void DrawBufferDelegate (DrawBufferMode buffer);
+        internal static DrawBufferDelegate DrawBuffer;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BlitFramebufferDelegate (int srcX0,
+        internal delegate void BlitFramebufferDelegate (int srcX0,
             int srcY0,
             int srcX1,
             int srcY1,
@@ -781,232 +780,232 @@ namespace OpenGL
             int dstY1,
             ClearBufferMask mask,
             BlitFramebufferFilter filter);
-        public static BlitFramebufferDelegate BlitFramebuffer;
+        internal static BlitFramebufferDelegate BlitFramebuffer;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate FramebufferErrorCode CheckFramebufferStatusDelegate (FramebufferTarget target);
-        public static CheckFramebufferStatusDelegate CheckFramebufferStatus;
+        internal delegate FramebufferErrorCode CheckFramebufferStatusDelegate (FramebufferTarget target);
+        internal static CheckFramebufferStatusDelegate CheckFramebufferStatus;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void TexParameterFloatDelegate (TextureTarget target, TextureParameterName name, float value);
-        public static TexParameterFloatDelegate TexParameterf;
+        internal delegate void TexParameterFloatDelegate (TextureTarget target, TextureParameterName name, float value);
+        internal static TexParameterFloatDelegate TexParameterf;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public unsafe delegate void TexParameterFloatArrayDelegate (TextureTarget target, TextureParameterName name, float* values);
-        public static TexParameterFloatArrayDelegate TexParameterfv;
+        internal unsafe delegate void TexParameterFloatArrayDelegate (TextureTarget target, TextureParameterName name, float* values);
+        internal static TexParameterFloatArrayDelegate TexParameterfv;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void TexParameterIntDelegate (TextureTarget target, TextureParameterName name, int value);
-        public static TexParameterIntDelegate TexParameteri;
+        internal delegate void TexParameterIntDelegate (TextureTarget target, TextureParameterName name, int value);
+        internal static TexParameterIntDelegate TexParameteri;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GenQueriesDelegate (int count, [Out] out int queryId);
-        public static GenQueriesDelegate GenQueries;
+        internal delegate void GenQueriesDelegate (int count, [Out] out int queryId);
+        internal static GenQueriesDelegate GenQueries;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BeginQueryDelegate (QueryTarget target, int queryId);
-        public static BeginQueryDelegate BeginQuery;
+        internal delegate void BeginQueryDelegate (QueryTarget target, int queryId);
+        internal static BeginQueryDelegate BeginQuery;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void EndQueryDelegate (QueryTarget target);
-        public static EndQueryDelegate EndQuery;
+        internal delegate void EndQueryDelegate (QueryTarget target);
+        internal static EndQueryDelegate EndQuery;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GetQueryObjectDelegate(int queryId, GetQueryObjectParam getparam, [Out] out int ready);
-        public static GetQueryObjectDelegate GetQueryObject;
+        internal delegate void GetQueryObjectDelegate(int queryId, GetQueryObjectParam getparam, [Out] out int ready);
+        internal static GetQueryObjectDelegate GetQueryObject;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DeleteQueriesDelegate(int count, [In] [Out] ref int queryId);
-        public static DeleteQueriesDelegate DeleteQueries;
+        internal delegate void DeleteQueriesDelegate(int count, [In] [Out] ref int queryId);
+        internal static DeleteQueriesDelegate DeleteQueries;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void ActiveTextureDelegate (TextureUnit textureUnit);
-        public static ActiveTextureDelegate ActiveTexture;
+        internal delegate void ActiveTextureDelegate (TextureUnit textureUnit);
+        internal static ActiveTextureDelegate ActiveTexture;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate int CreateShaderDelegate (ShaderType type);
-        public static CreateShaderDelegate CreateShader;
+        internal delegate int CreateShaderDelegate (ShaderType type);
+        internal static CreateShaderDelegate CreateShader;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public unsafe delegate void ShaderSourceDelegate(int shaderId, int count, IntPtr code, int* length);
-        public static ShaderSourceDelegate ShaderSourceInternal;
+        internal unsafe delegate void ShaderSourceDelegate(int shaderId, int count, IntPtr code, int* length);
+        internal static ShaderSourceDelegate ShaderSourceInternal;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void CompileShaderDelegate (int shaderId);
-        public static CompileShaderDelegate CompileShader;
+        internal delegate void CompileShaderDelegate (int shaderId);
+        internal static CompileShaderDelegate CompileShader;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public unsafe delegate void GetShaderDelegate(int shaderId, int parameter, int* value);
-        public static GetShaderDelegate GetShaderiv;
+        internal unsafe delegate void GetShaderDelegate(int shaderId, int parameter, int* value);
+        internal static GetShaderDelegate GetShaderiv;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GetShaderInfoLogDelegate(int shader, int bufSize, IntPtr length, StringBuilder infoLog);
-        public static GetShaderInfoLogDelegate GetShaderInfoLogInternal;
+        internal delegate void GetShaderInfoLogDelegate(int shader, int bufSize, IntPtr length, StringBuilder infoLog);
+        internal static GetShaderInfoLogDelegate GetShaderInfoLogInternal;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate bool IsShaderDelegate(int shaderId);
-        public static IsShaderDelegate IsShader;
+        internal delegate bool IsShaderDelegate(int shaderId);
+        internal static IsShaderDelegate IsShader;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DeleteShaderDelegate (int shaderId);
-        public static DeleteShaderDelegate DeleteShader;
+        internal delegate void DeleteShaderDelegate (int shaderId);
+        internal static DeleteShaderDelegate DeleteShader;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate int GetAttribLocationDelegate(int programId, string name);
-        public static GetAttribLocationDelegate GetAttribLocation;
+        internal delegate int GetAttribLocationDelegate(int programId, string name);
+        internal static GetAttribLocationDelegate GetAttribLocation;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate int GetUniformLocationDelegate(int programId, string name);
-        public static GetUniformLocationDelegate GetUniformLocation;
+        internal delegate int GetUniformLocationDelegate(int programId, string name);
+        internal static GetUniformLocationDelegate GetUniformLocation;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate bool IsProgramDelegate (int programId);
-        public static IsProgramDelegate IsProgram;
+        internal delegate bool IsProgramDelegate (int programId);
+        internal static IsProgramDelegate IsProgram;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DeleteProgramDelegate (int programId);
-        public static DeleteProgramDelegate DeleteProgram;
+        internal delegate void DeleteProgramDelegate (int programId);
+        internal static DeleteProgramDelegate DeleteProgram;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate int CreateProgramDelegate();
-        public static CreateProgramDelegate CreateProgram;
+        internal delegate int CreateProgramDelegate();
+        internal static CreateProgramDelegate CreateProgram;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void AttachShaderDelegate (int programId, int shaderId);
-        public static AttachShaderDelegate AttachShader;
+        internal delegate void AttachShaderDelegate (int programId, int shaderId);
+        internal static AttachShaderDelegate AttachShader;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void LinkProgramDelegate(int programId);
-        public static LinkProgramDelegate LinkProgram;
+        internal delegate void LinkProgramDelegate(int programId);
+        internal static LinkProgramDelegate LinkProgram;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public unsafe delegate void GetProgramDelegate(int programId, int name, int* linked);
-        public static GetProgramDelegate GetProgramiv;
+        internal unsafe delegate void GetProgramDelegate(int programId, int name, int* linked);
+        internal static GetProgramDelegate GetProgramiv;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GetProgramInfoLogDelegate(int program, int bufSize, IntPtr length, StringBuilder infoLog);
-        public static GetProgramInfoLogDelegate GetProgramInfoLogInternal;
+        internal delegate void GetProgramInfoLogDelegate(int program, int bufSize, IntPtr length, StringBuilder infoLog);
+        internal static GetProgramInfoLogDelegate GetProgramInfoLogInternal;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DetachShaderDelegate(int programId, int shaderId);
-        public static DetachShaderDelegate DetachShader;
+        internal delegate void DetachShaderDelegate(int programId, int shaderId);
+        internal static DetachShaderDelegate DetachShader;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BlendColorDelegate(float r, float g, float b, float a);
-        public static BlendColorDelegate BlendColor;
+        internal delegate void BlendColorDelegate(float r, float g, float b, float a);
+        internal static BlendColorDelegate BlendColor;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BlendEquationSeparateDelegate(BlendEquationMode colorMode, BlendEquationMode alphaMode);
-        public static BlendEquationSeparateDelegate BlendEquationSeparate;
+        internal delegate void BlendEquationSeparateDelegate(BlendEquationMode colorMode, BlendEquationMode alphaMode);
+        internal static BlendEquationSeparateDelegate BlendEquationSeparate;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BlendFuncSeparateDelegate(BlendingFactorSrc colorSrc, BlendingFactorDest colorDst,
+        internal delegate void BlendFuncSeparateDelegate(BlendingFactorSrc colorSrc, BlendingFactorDest colorDst,
             BlendingFactorSrc alphaSrc, BlendingFactorDest alphaDst);
-        public static BlendFuncSeparateDelegate BlendFuncSeparate;
+        internal static BlendFuncSeparateDelegate BlendFuncSeparate;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void ColorMaskDelegate(bool r, bool g, bool b, bool a);
-        public static ColorMaskDelegate ColorMask;
+        internal delegate void ColorMaskDelegate(bool r, bool g, bool b, bool a);
+        internal static ColorMaskDelegate ColorMask;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DepthFuncDelegate(DepthFunction function);
-        public static DepthFuncDelegate DepthFunc;
+        internal delegate void DepthFuncDelegate(DepthFunction function);
+        internal static DepthFuncDelegate DepthFunc;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DepthMaskDelegate (bool enabled);
-        public static DepthMaskDelegate DepthMask;
+        internal delegate void DepthMaskDelegate (bool enabled);
+        internal static DepthMaskDelegate DepthMask;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void StencilFuncSeparateDelegate (StencilFace face, GLStencilFunction function, int referenceStencil, int mask);
-        public static StencilFuncSeparateDelegate StencilFuncSeparate;
+        internal delegate void StencilFuncSeparateDelegate (StencilFace face, GLStencilFunction function, int referenceStencil, int mask);
+        internal static StencilFuncSeparateDelegate StencilFuncSeparate;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void StencilOpSeparateDelegate(StencilFace face, StencilOp stencilfail, StencilOp depthFail, StencilOp pass);
-        public static StencilOpSeparateDelegate StencilOpSeparate;
+        internal delegate void StencilOpSeparateDelegate(StencilFace face, StencilOp stencilfail, StencilOp depthFail, StencilOp pass);
+        internal static StencilOpSeparateDelegate StencilOpSeparate;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void StencilFuncDelegate(GLStencilFunction function, int referenceStencil, int mask);
-        public static StencilFuncDelegate StencilFunc;
+        internal delegate void StencilFuncDelegate(GLStencilFunction function, int referenceStencil, int mask);
+        internal static StencilFuncDelegate StencilFunc;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void StencilOpDelegate (StencilOp stencilfail, StencilOp depthFail, StencilOp pass);
-        public static StencilOpDelegate StencilOp;
+        internal delegate void StencilOpDelegate (StencilOp stencilfail, StencilOp depthFail, StencilOp pass);
+        internal static StencilOpDelegate StencilOp;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void StencilMaskDelegate(int mask);
-        public static StencilMaskDelegate StencilMask;
+        internal delegate void StencilMaskDelegate(int mask);
+        internal static StencilMaskDelegate StencilMask;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void CompressedTexImage2DDelegate(TextureTarget target, int level, PixelInternalFormat internalFormat,
+        internal delegate void CompressedTexImage2DDelegate(TextureTarget target, int level, PixelInternalFormat internalFormat,
             int width, int height, int border, int size, IntPtr data);
-        public static CompressedTexImage2DDelegate CompressedTexImage2D;
+        internal static CompressedTexImage2DDelegate CompressedTexImage2D;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void TexImage2DDelegate(TextureTarget target,int level, PixelInternalFormat internalFormat,
+        internal delegate void TexImage2DDelegate(TextureTarget target,int level, PixelInternalFormat internalFormat,
             int width, int height, int border,PixelFormat format, PixelType pixelType, IntPtr data);
-        public static TexImage2DDelegate TexImage2D;
+        internal static TexImage2DDelegate TexImage2D;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void CompressedTexSubImage2DDelegate (TextureTarget target, int level,
+        internal delegate void CompressedTexSubImage2DDelegate (TextureTarget target, int level,
             int x, int y, int width, int height, PixelInternalFormat format, int size, IntPtr data);
-        public static CompressedTexSubImage2DDelegate CompressedTexSubImage2D;
+        internal static CompressedTexSubImage2DDelegate CompressedTexSubImage2D;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void TexSubImage2DDelegate (TextureTarget target, int level,
+        internal delegate void TexSubImage2DDelegate (TextureTarget target, int level,
             int x, int y, int width, int height, PixelFormat format, PixelType pixelType, IntPtr data);
-        public static TexSubImage2DDelegate TexSubImage2D;
+        internal static TexSubImage2DDelegate TexSubImage2D;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void PixelStoreDelegate (PixelStoreParameter parameter, int size);
-        public static PixelStoreDelegate PixelStore;
+        internal delegate void PixelStoreDelegate (PixelStoreParameter parameter, int size);
+        internal static PixelStoreDelegate PixelStore;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void FinishDelegate();
-        public static FinishDelegate Finish;
+        internal delegate void FinishDelegate();
+        internal static FinishDelegate Finish;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
@@ -1020,69 +1019,67 @@ namespace OpenGL
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void TexImage3DDelegate(TextureTarget target,int level, PixelInternalFormat internalFormat,
+        internal delegate void TexImage3DDelegate(TextureTarget target,int level, PixelInternalFormat internalFormat,
             int width, int height, int depth, int border,PixelFormat format, PixelType pixelType, IntPtr data);
-        public static TexImage3DDelegate TexImage3D;
+        internal static TexImage3DDelegate TexImage3D;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void TexSubImage3DDelegate (TextureTarget target, int level,
+        internal delegate void TexSubImage3DDelegate (TextureTarget target, int level,
             int x, int y, int z, int width, int height, int depth, PixelFormat format, PixelType pixelType, IntPtr data);
-        public static TexSubImage3DDelegate TexSubImage3D;
+        internal static TexSubImage3DDelegate TexSubImage3D;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void DeleteTexturesDelegate(int count, ref int id);
-        public static DeleteTexturesDelegate DeleteTextures;
+        internal delegate void DeleteTexturesDelegate(int count, ref int id);
+        internal static DeleteTexturesDelegate DeleteTextures;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void GenBuffersDelegate(int count, out int buffer);
-        public static GenBuffersDelegate GenBuffers;
+        internal delegate void GenBuffersDelegate(int count, out int buffer);
+        internal static GenBuffersDelegate GenBuffers;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BufferDataDelegate(BufferTarget target, IntPtr size, IntPtr n, BufferUsageHint usage);
-        public static BufferDataDelegate BufferData;
+        internal delegate void BufferDataDelegate(BufferTarget target, IntPtr size, IntPtr n, BufferUsageHint usage);
+        internal static BufferDataDelegate BufferData;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate IntPtr MapBufferDelegate(BufferTarget target, BufferAccess access);
-        public static MapBufferDelegate MapBuffer;
+        internal delegate IntPtr MapBufferDelegate(BufferTarget target, BufferAccess access);
+        internal static MapBufferDelegate MapBuffer;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void UnmapBufferDelegate(BufferTarget target);
-        public static UnmapBufferDelegate UnmapBuffer;
+        internal delegate void UnmapBufferDelegate(BufferTarget target);
+        internal static UnmapBufferDelegate UnmapBuffer;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void BufferSubDataDelegate (BufferTarget target, IntPtr offset, IntPtr size, IntPtr data);
-        public static BufferSubDataDelegate BufferSubData;
-
-        [CLSCompliant (false)]
-        [System.Security.SuppressUnmanagedCodeSecurity()]
-        [MonoNativeFunctionWrapper]       
-        public delegate void DeleteBuffersDelegate (int count, [In] [Out] ref int buffer);
-        [CLSCompliant (false)]
-        public static DeleteBuffersDelegate DeleteBuffers;
+        internal delegate void BufferSubDataDelegate (BufferTarget target, IntPtr offset, IntPtr size, IntPtr data);
+        internal static BufferSubDataDelegate BufferSubData;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]       
-        public delegate void VertexAttribPointerDelegate(int location, int elementCount, VertexAttribPointerType type, bool normalize,
+        internal delegate void DeleteBuffersDelegate (int count, [In] [Out] ref int buffer);
+        internal static DeleteBuffersDelegate DeleteBuffers;
+
+        [System.Security.SuppressUnmanagedCodeSecurity()]
+        [MonoNativeFunctionWrapper]       
+        internal delegate void VertexAttribPointerDelegate(int location, int elementCount, VertexAttribPointerType type, bool normalize,
             int stride, IntPtr data);
-        public static VertexAttribPointerDelegate VertexAttribPointer;
+        internal static VertexAttribPointerDelegate VertexAttribPointer;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]
-        public delegate void DrawElementsInstancedDelegate(GLPrimitiveType primitiveType, int count, DrawElementsType elementType, 
+        internal delegate void DrawElementsInstancedDelegate(GLPrimitiveType primitiveType, int count, DrawElementsType elementType, 
             IntPtr offset, int instanceCount);
-        public static DrawElementsInstancedDelegate DrawElementsInstanced;
+        internal static DrawElementsInstancedDelegate DrawElementsInstanced;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]
-        public delegate void VertexAttribDivisorDelegate(int location, int frequency);
-        public static VertexAttribDivisorDelegate VertexAttribDivisor;
+        internal delegate void VertexAttribDivisorDelegate(int location, int frequency);
+        internal static VertexAttribDivisorDelegate VertexAttribDivisor;
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         delegate void DebugMessageCallbackProc(int source, int type, int id, int severity, int length, IntPtr message, IntPtr userParam);
@@ -1091,8 +1088,8 @@ namespace OpenGL
         delegate void DebugMessageCallbackDelegate(DebugMessageCallbackProc callback, IntPtr userParam);
         static DebugMessageCallbackDelegate DebugMessageCallback;
 
-        public delegate void ErrorDelegate(string message);
-        public static event ErrorDelegate OnError;
+        internal delegate void ErrorDelegate(string message);
+        internal static event ErrorDelegate OnError;
 
 #if DEBUG
         static void DebugMessageCallbackHandler(int source, int type, int id, int severity, int length, IntPtr message, IntPtr userParam)
@@ -1104,9 +1101,9 @@ namespace OpenGL
         }
 #endif
 
-        public static int SwapInterval { get; set; }
+        internal static int SwapInterval { get; set; }
 
-        public static void LoadEntryPoints()
+        internal static void LoadEntryPoints()
         {
             LoadPlatformEntryPoints ();
 
@@ -1271,29 +1268,29 @@ namespace OpenGL
 #endif
         }
 
-        public static System.Delegate LoadEntryPoint<T>(string proc)
+        internal static System.Delegate LoadEntryPoint<T>(string proc)
         {
             return Marshal.GetDelegateForFunctionPointer(EntryPointHelper.GetAddress(proc), typeof(T));
         }
 
         static partial void LoadPlatformEntryPoints();
 
-        public static IGraphicsContext CreateContext(IWindowInfo info)
+        internal static IGraphicsContext CreateContext(IWindowInfo info)
         {
             return PlatformCreateContext(info);
         }
 
         /* Helper Functions */
 
-        public static void Uniform1 (int location, int value) {
+        internal static void Uniform1 (int location, int value) {
             Uniform1i(location, value);
         }
 
-        public static unsafe void Uniform4 (int location, int size, float* value) {
+        internal static unsafe void Uniform4 (int location, int size, float* value) {
             Uniform4fv(location, size, value);
         }
 
-        public unsafe static string GetString (StringName name)
+        internal unsafe static string GetString (StringName name)
         {
             return Marshal.PtrToStringAnsi (GetStringInternal (name));
         }
@@ -1349,7 +1346,7 @@ namespace OpenGL
             Marshal.FreeHGlobal (ptr);
         }
 
-        public static string GetProgramInfoLog (int programId)
+        internal static string GetProgramInfoLog (int programId)
         {
             int length = 0;
             GetProgram(programId, GetProgramParameterName.LogLength, out length);
@@ -1358,7 +1355,7 @@ namespace OpenGL
             return sb.ToString();
         }
             
-        public static string GetShaderInfoLog (int shaderId) {
+        internal static string GetShaderInfoLog (int shaderId) {
             int length = 0;
             GetShader(shaderId, ShaderParameter.LogLength, out length);
             var sb = new StringBuilder();
@@ -1366,7 +1363,7 @@ namespace OpenGL
             return sb.ToString();
         }
             
-        public unsafe static void ShaderSource(int shaderId, string code)
+        internal unsafe static void ShaderSource(int shaderId, string code)
         {
             int length = code.Length;
             IntPtr intPtr = MarshalStringArrayToPtr (new string[] { code });
@@ -1374,7 +1371,7 @@ namespace OpenGL
             FreeStringArrayPtr(intPtr, 1);
         }
 
-        public unsafe static void GetShader (int shaderId, ShaderParameter name, out int result)
+        internal unsafe static void GetShader (int shaderId, ShaderParameter name, out int result)
         {
             fixed (int* ptr = &result)
             {
@@ -1382,7 +1379,7 @@ namespace OpenGL
             }
         }
 
-        public unsafe static void GetProgram(int programId, GetProgramParameterName name, out int result)
+        internal unsafe static void GetProgram(int programId, GetProgramParameterName name, out int result)
         {
             fixed (int* ptr = &result)
             {
@@ -1390,14 +1387,14 @@ namespace OpenGL
             }
         }
 
-        public unsafe static void GetInteger (GetPName name, out int value)
+        internal unsafe static void GetInteger (GetPName name, out int value)
         {
             fixed (int* ptr = &value) {
                 GetIntegerv ((int)name, ptr);
             }
         }
 
-        public unsafe static void GetInteger (int name, out int value)
+        internal unsafe static void GetInteger (int name, out int value)
         {
             fixed (int* ptr = &value)
             {
@@ -1405,12 +1402,12 @@ namespace OpenGL
             }
         }
 
-        public static void TexParameter(TextureTarget target, TextureParameterName name, float value)
+        internal static void TexParameter(TextureTarget target, TextureParameterName name, float value)
         {
             TexParameterf(target, name, value);
         }
 
-        public unsafe static void TexParameter(TextureTarget target, TextureParameterName name, float[] values)
+        internal unsafe static void TexParameter(TextureTarget target, TextureParameterName name, float[] values)
         {
             fixed (float* ptr = &values[0])
             {
@@ -1418,12 +1415,12 @@ namespace OpenGL
             }
         }
 
-        public static void TexParameter(TextureTarget target, TextureParameterName name, int value)
+        internal static void TexParameter(TextureTarget target, TextureParameterName name, int value)
         {
             TexParameteri(target, name, value);
         }
 
-        public static void GetTexImage<T>(TextureTarget target, int level, PixelFormat format, PixelType type, T[] pixels) where T : struct
+        internal static void GetTexImage<T>(TextureTarget target, int level, PixelFormat format, PixelType type, T[] pixels) where T : struct
         {
             var pixelsPtr = GCHandle.Alloc(pixels, GCHandleType.Pinned);
             try
@@ -1436,7 +1433,7 @@ namespace OpenGL
             }
         }
 
-        public static void GetCompressedTexImage<T>(TextureTarget target, int level, T[] pixels) where T : struct
+        internal static void GetCompressedTexImage<T>(TextureTarget target, int level, T[] pixels) where T : struct
         {
             var pixelsPtr = GCHandle.Alloc(pixels, GCHandleType.Pinned);
             try

--- a/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
@@ -6,11 +6,11 @@
 #if PLATFORM_MACOS_LEGACY
 using MonoMac.OpenGL;
 #else
-using OpenGL;
+using MonoGame.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 using System;
 using System.Collections.Generic;
 #elif GLES

--- a/MonoGame.Framework/Graphics/RenderTargetCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.OpenGL.cs
@@ -12,7 +12,7 @@ using OpenTK.Graphics.OpenGL;
 using OpenTK.Graphics.ES20;
 #endif
 #if DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
@@ -11,7 +11,7 @@ using MonoMac.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;
 #endif

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
@@ -11,7 +11,7 @@ using MonoMac.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;
 #endif

--- a/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
@@ -15,7 +15,7 @@ using OpenTK.Graphics.OpenGL;
 using Bool = OpenTK.Graphics.OpenGL.Boolean;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;
 using Bool = OpenTK.Graphics.ES20.All;

--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -14,7 +14,7 @@ using GetProgramParameterName = OpenTK.Graphics.OpenGL.ProgramParameter;
 using Bool = OpenTK.Graphics.OpenGL.Boolean;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #elif WINRT
 
 #else

--- a/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
@@ -9,7 +9,7 @@ using MonoMac.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;
 #endif

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
@@ -11,7 +11,7 @@ using OpenTK.Graphics.OpenGL;
 using GLStencilFunction = OpenTK.Graphics.OpenGL.StencilFunction;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;
 using GLStencilFunction = OpenTK.Graphics.ES20.StencilFunction;

--- a/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
@@ -11,7 +11,7 @@ using MonoMac.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;
 #endif

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -12,7 +12,7 @@ using MonoMac.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;
 #endif

--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -9,7 +9,7 @@ using MonoMac.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #if DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #endif
 #if GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -42,9 +42,9 @@ using PixelInternalFormat = OpenTK.Graphics.OpenGL.PixelFormat;
 #endif
 
 #if DESKTOPGL
-using OpenGL;
-using GLPixelFormat = OpenGL.PixelFormat;
-using PixelFormat = OpenGL.PixelFormat;
+using MonoGame.OpenGL;
+using GLPixelFormat = MonoGame.OpenGL.PixelFormat;
+using PixelFormat = MonoGame.OpenGL.PixelFormat;
 #endif
 
 #if GLES

--- a/MonoGame.Framework/Graphics/Texture3D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.OpenGL.cs
@@ -13,7 +13,7 @@ using MonoMac.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
@@ -9,7 +9,7 @@ using MonoMac.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #elif DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;
 #endif

--- a/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
@@ -17,9 +17,9 @@ using PixelInternalFormat = OpenTK.Graphics.OpenGL.PixelFormat;
 using Bool = OpenTK.Graphics.OpenGL.Boolean;
 #endif
 #if DESKTOPGL
-using OpenGL;
-using GLPixelFormat = OpenGL.PixelFormat;
-using PixelFormat = OpenGL.PixelFormat;
+using MonoGame.OpenGL;
+using GLPixelFormat = MonoGame.OpenGL.PixelFormat;
+using PixelFormat = MonoGame.OpenGL.PixelFormat;
 #endif
 #if GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -19,7 +19,7 @@ using OpenTK.Graphics.ES20;
 using BufferUsageHint = OpenTK.Graphics.ES20.BufferUsage;
 #endif
 #if DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -15,7 +15,7 @@ using MonoMac.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #if DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #endif
 #if GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
@@ -12,7 +12,7 @@ using MonoMac.OpenGL;
 using OpenTK.Graphics.OpenGL;
 #endif
 #if DESKTOPGL
-using OpenGL;
+using MonoGame.OpenGL;
 #endif
 #if GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/WindowInfo.SDL.cs
+++ b/MonoGame.Framework/Graphics/WindowInfo.SDL.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 
-namespace OpenGL
+namespace MonoGame.OpenGL
 {
-    public class WindowInfo : IWindowInfo
+    internal class WindowInfo : IWindowInfo
     {
         public IntPtr Handle { get; private set; }
 

--- a/MonoGame.Framework/Media/Song.NVorbis.cs
+++ b/MonoGame.Framework/Media/Song.NVorbis.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 using Microsoft.Xna.Framework.Audio;
-using OpenAL;
+using MonoGame.OpenAL;
 
 namespace Microsoft.Xna.Framework.Media
 {

--- a/MonoGame.Framework/Threading.cs
+++ b/MonoGame.Framework/Threading.cs
@@ -16,7 +16,7 @@ using OpenTK.Graphics.ES11;
 using OpenTK.Graphics.ES20;
 #endif
 #elif DESKTOPGL || ANGLE
-using OpenGL;
+using MonoGame.OpenGL;
 #endif
 #if WINDOWS_PHONE
 using System.Windows;

--- a/Test/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceTest.cs
@@ -9,7 +9,9 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Tests.ContentPipeline;
 using NUnit.Framework;
-using OpenGL;
+#if DESKTOPGL
+using MonoGame.OpenGL;
+#endif
 
 namespace MonoGame.Tests.Graphics
 {


### PR DESCRIPTION
OpenGL namespace renamed to MonoGame.OpenGL. All symbols within changed from public to internal.
OpenAL namespace renamed to MonoGame.OpenAL. All symbols within changed from public to internal.