### PR TITLE
Add new build task projects to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ MonoGame.Framework/*.csproj
 Tools/2MGFX/*.csproj
 Tools/MGCB/*.csproj
 Tools/Pipeline/*.csproj
+Tools/MonoGame.Build.Tasks/MonoGame.Build.Tasks.*.csproj
 ThirdParty/Lidgren.Network/*.csproj
 Test/*.csproj
 !Test/MonoGame.Test.XNA.csproj


### PR DESCRIPTION
They are generated by Protobuild and I noticed they weren't ignored yet.
Projects where added in #5897.