### PR TITLE
Fix #5939. Install MonoGame.Build.Tasks in the right folder

### DIFF
--- a/Installers/Windows/MonoGame.nsi
+++ b/Installers/Windows/MonoGame.nsi
@@ -80,6 +80,7 @@ Section "MonoGame Core Components" CoreComponents ;No components page, name is n
   SetOutPath ${MSBuildInstallDir}
   File '..\..\MonoGame.Framework.Content.Pipeline\MonoGame.Content.Builder.targets'
   File '..\..\MonoGame.Framework.Content.Pipeline\MonoGame.Common.props'
+  File '..\..\Tools\Pipeline\bin\Windows\AnyCPU\Release\MonoGame.Build.Tasks.dll'
 
   ; Install the MonoGame tools to a single shared folder.
   SetOutPath ${MSBuildInstallDir}\Tools

--- a/Installers/default.build
+++ b/Installers/default.build
@@ -94,6 +94,11 @@
                 <include name="MonoGame.Common.props"/>
          </fileset>
       </copy>
+      <copy todir="root/Library/Frameworks/MonoGame.framework/v${buildNumber}">
+         <fileset basedir="../Tools/Pipeline/bin/MacOS/AnyCPU/Release">
+                <include name="MonoGame.Build.Tasks.dll"/>
+         </fileset>
+      </copy>
       <copy todir="root/Library/Frameworks/MonoGame.framework/v${buildNumber}/Assemblies/iOS">
          <fileset basedir="../MonoGame.Framework/bin/iOS/iPhoneSimulator/Release">
                 <include name="*.*"/>
@@ -177,6 +182,7 @@ fi
       <copy file="../IDE/MonoDevelop/MonoDevelop.MonoGame_${buildNumber}.mpack" tofile="Linux/tmp_run/Main/MonoDevelop.MonoGame.mpack" overwrite="true"/>
       <copy file="../MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets" tofile="Linux/tmp_run/MonoGameSDK/MonoGame.Content.Builder.targets"/>
       <copy file="../MonoGame.Framework.Content.Pipeline/MonoGame.Common.props" tofile="Linux/tmp_run/MonoGameSDK/MonoGame.Common.props"/>
+      <copy file="../Tools/Pipeline/bin/Linux/AnyCPU/Release/MonoGame.Build.Tasks.dll" tofile="Linux/tmp_run/MonoGameSDK/MonoGame.Build.Tasks.dll"/>
       <copy todir="Linux/tmp_run/MonoGameSDK/Tools">
         <fileset basedir="../Tools/Pipeline/bin/Linux/AnyCPU/Release"/>
       </copy>


### PR DESCRIPTION
Fixes #5939 