### PR TITLE
Dont run the BuildContent target if we do not have any Content.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -98,6 +98,7 @@
   </Target>
 
   <Target Name="BuildContent" DependsOnTargets="Prepare;RunContentBuilder"
+          Condition=" '@(MonoGameContentReference)' != '' "
           Outputs="%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension)">
 
     <CreateItem Include="%(ExtraContent.FullPath)"


### PR DESCRIPTION
If the `@(MonoGameContentReference)` ItemGroup is Empty we
do not need to even attempt to build content.