### PR TITLE
Fix for reading 24-bit DDS files

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/DdsLoader.cs
+++ b/MonoGame.Framework.Content.Pipeline/DdsLoader.cs
@@ -334,6 +334,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                     {
                         var content = CreateBitmapContent(format, w, h);
                         var byteCount = GetBitmapSize(format, w, h);
+                        // A 24-bit format is slightly different
+                        if (header.ddspf.dwRgbBitCount == 24)
+                            byteCount = 3 * w * h;
                         var bytes = reader.ReadBytes(byteCount);
                         if (rbSwap)
                         {


### PR DESCRIPTION
It was trying to read 32-bits per pixel rather than 24-bits from the file. The expansion to 32-bits happens later.