### PR TITLE
Upgrade to SharpDX 4.0.1

### DIFF
--- a/Build/Projects/2MGFXReferences.definition
+++ b/Build/Projects/2MGFXReferences.definition
@@ -4,10 +4,10 @@
   <Platform Type="Windows">
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
     <Binary
       Name="SharpDX.D3DCompiler"
-      Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.D3DCompiler.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.D3DCompiler.dll" />
     <Binary
       Name="CppNet"
       Path="ThirdParty/Dependencies/CppNet/CppNet.dll" />

--- a/Build/Projects/Framework.Content.Pipeline.References.definition
+++ b/Build/Projects/Framework.Content.Pipeline.References.definition
@@ -81,10 +81,10 @@
   <Platform Type="Windows">
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
     <Binary
       Name="SharpDX.D3DCompiler"
-      Path="ThirdParty\Dependencies\SharpDX\Desktop\SharpDX.D3DCompiler.dll" />
+      Path="ThirdParty\Dependencies\SharpDX\SharpDX.D3DCompiler.dll" />
     <Binary
       Name="CppNet"
       Path="ThirdParty\Dependencies\CppNet\CppNet.dll" />

--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -46,25 +46,25 @@
       <Reference Include="System.Xml" />
       <Binary
         Name="SharpDX"
-        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
       <Binary
         Name="SharpDX.Direct2D1"
-        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.Direct2D1.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/SharpDX.Direct2D1.dll" />
       <Binary
         Name="SharpDX.Direct3D11"
-        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.Direct3D11.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/SharpDX.Direct3D11.dll" />
       <Binary
         Name="SharpDX.DXGI"
-        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.DXGI.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/SharpDX.DXGI.dll" />
       <Binary
         Name="SharpDX.MediaFoundation"
-        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.MediaFoundation.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/net45/SharpDX.MediaFoundation.dll" />
       <Binary
         Name="SharpDX.XAudio2"
-        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.XAudio2.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/SharpDX.XAudio2.dll" />
       <Binary
         Name="SharpDX.XInput"
-        Path="ThirdParty/Dependencies/SharpDX/Desktop/SharpDX.XInput.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/SharpDX.XInput.dll" />
     </Service>
 
     <Service Name="MonoGame.Framework/OpenGLGraphics">
@@ -92,22 +92,22 @@
   <Platform Type="WindowsUniversal">
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
     <Binary
       Name="SharpDX.Direct2D1"
-      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.Direct2D1.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.Direct2D1.dll" />
     <Binary
       Name="SharpDX.Direct3D11"
-      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.Direct3D11.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.Direct3D11.dll" />
     <Binary
       Name="SharpDX.DXGI"
-      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.DXGI.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.DXGI.dll" />
     <Binary
       Name="SharpDX.MediaFoundation"
-      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.MediaFoundation.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.MediaFoundation.dll" />
     <Binary
       Name="SharpDX.XAudio2"
-      Path="ThirdParty/Dependencies/SharpDX/StoreApp/SharpDX.XAudio2.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/SharpDX.XAudio2.dll" />
   </Platform>
 	
   <Platform Type="Web">


### PR DESCRIPTION
Not much to do here apart from upgrading the references and dependencies. The dll's are the ones that target .NET Standard 1.1 so we can use them for both DX and UWP. I did need the .NET 4.5 dll for MediaFoundation because `CreateSampleGrabberSinkActivate` is only available on Desktop and thus not in the .NET Standard assembly. 