### PR TITLE
[ANDROID] Implement GraphicsAdapter.IsProfileSupported()

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
@@ -12,6 +12,9 @@ using UIKit;
 using Android.Views;
 using Android.Runtime;
 #endif
+#if DESKTOPGL || ANGLE || GLES
+using MonoGame.OpenGL;
+#endif
 
 // NOTE: This is the legacy graphics adapter implementation
 // which should no longer be updated.  All new development
@@ -362,6 +365,12 @@ namespace Microsoft.Xna.Framework.Graphics
                 case GraphicsProfile.HiDef:
                     bool result = true;
                     // TODO: check adapter capabilities...
+#if ANDROID
+                    int maxTextureSize;
+                    GL.GetInteger(GetPName.MaxTextureSize, out maxTextureSize);                    
+                    if (maxTextureSize < 4096)
+                        result = false;
+#endif
                     return result;
                 default:
                     throw new InvalidOperationException();


### PR DESCRIPTION
I test this on a device (maxTextureSize = 4096) and the emulator (maxTextureSize = 16384).

It would be nice if someone can test this on an older Android to verify that maxTextureSize = 2048 and also on iOS.

With a compination of MaxTextureSize & MaxTextureImageUnits we should be able to identify the entire range of Feature Levels if we choose to expand the set of graphic profiles.

This works because android allready has an active Context. Usually  the method is called before the graphicsdevice is initialize. 

On DesktopGL we need to check if there is an active context and create a temp context for the adapter. (is this possible? I think you can have only one default adapter under openGL).

