### PR TITLE
Support DDS cubemaps that don't follow the rules

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/DdsLoader.cs
+++ b/MonoGame.Framework.Content.Pipeline/DdsLoader.cs
@@ -303,19 +303,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 
                 int faceCount = 1;
                 int mipMapCount = (int)(header.dwCaps.HasFlag(DdsCaps.MipMap) ? header.dwMipMapCount : 1);
-                if (header.dwCaps.HasFlag(DdsCaps.Complex))
+                if (header.dwCaps2.HasFlag(DdsCaps2.Cubemap))
                 {
-                    if (header.dwCaps2.HasFlag(DdsCaps2.Cubemap))
-                    {
-                        if (!header.dwCaps2.HasFlag(DdsCaps2.CubemapAllFaces))
-                            throw new ContentLoadException("Incomplete cubemap in DDS file");
-                        faceCount = 6;
-                        output = new TextureCubeContent() { Identity = identity };
-                    }
-                    else
-                    {
-                        output = new Texture2DContent() { Identity = identity };
-                    }
+                    if (!header.dwCaps2.HasFlag(DdsCaps2.CubemapAllFaces))
+                        throw new ContentLoadException("Incomplete cubemap in DDS file");
+                    faceCount = 6;
+                    output = new TextureCubeContent() { Identity = identity };
                 }
                 else
                 {


### PR DESCRIPTION
DDS cubemaps should have the DDSCAPS_COMPLEX flag set, but not all DDS writers do this. NormalizeCubeMap.dds from the XNA Racer sample is one of those non-compliant DDS files.