### PR TITLE
Reset framebuffer after Texture2D.GetData on GL ES

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -212,6 +212,9 @@ namespace Microsoft.Xna.Framework.Graphics
             GL.ReadPixels(rect.X, rect.Y, rect.Width, rect.Height, this.glFormat, this.glType, data);
             GraphicsExtensions.CheckGLError();
             GraphicsDevice.DisposeFramebuffer(framebufferId);
+
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, GraphicsDevice.glFramebuffer);
+            GraphicsExtensions.CheckGLError();
 #else
             var tSizeInByte = ReflectionHelpers.SizeOf<T>.Get();
             GL.BindTexture(TextureTarget.Texture2D, this.glTexture);


### PR DESCRIPTION
GetData left the framebuffer bound to the texture.

Although it is rather unlikely to happen, I think there can still be a problem if a rendertarget was bound before, but I don't know how to fix that.