### PR TITLE
Fixed GamePad.SetVibration crash

### DIFF
--- a/MonoGame.Framework/Input/GamePad.XInput.cs
+++ b/MonoGame.Framework/Input/GamePad.XInput.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             // If the device was disconneced then wait for 
             // the timeout to elapsed before we test it again.
-            if (!_connected[index] && _timeout[index] > DateTime.UtcNow.Ticks)
+            if (!_connected[index] && !HasDisconnectedTimeoutElapsed(index))
                 return new GamePadCapabilities();
       
             // Check to see if the device is connected.
@@ -44,7 +44,7 @@ namespace Microsoft.Xna.Framework.Input
             // timeout period has elapsed to avoid the overhead.
             if (!_connected[index])
             {
-                _timeout[index] = DateTime.UtcNow.Ticks + TimeoutTicks;
+                SetDisconnectedTimeout(index);
                 return new GamePadCapabilities();
             }
 
@@ -154,7 +154,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             // If the device was disconneced then wait for 
             // the timeout to elapsed before we test it again.
-            if (!_connected[index] && _timeout[index] > DateTime.UtcNow.Ticks)
+            if (!_connected[index] && !HasDisconnectedTimeoutElapsed(index))
                 return GetDefaultState();
 
             int packetNumber = 0;
@@ -177,7 +177,7 @@ namespace Microsoft.Xna.Framework.Input
             // timeout period has elapsed to avoid the overhead.
             if (!_connected[index])
             {
-                _timeout[index] = DateTime.UtcNow.Ticks + TimeoutTicks;
+                SetDisconnectedTimeout(index);
                 return GetDefaultState();
             }
 
@@ -264,16 +264,50 @@ namespace Microsoft.Xna.Framework.Input
         private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)
         {
             if (!_connected[index])
-                return false;
-
-            var controller = _controllers[index];
-            var result = controller.SetVibration(new SharpDX.XInput.Vibration
             {
-                LeftMotorSpeed = (ushort)(leftMotor * ushort.MaxValue),
-                RightMotorSpeed = (ushort)(rightMotor * ushort.MaxValue),
-            });
+                if (!HasDisconnectedTimeoutElapsed(index))
+                    return false;
+                if (!_controllers[index].IsConnected)
+                {
+                    SetDisconnectedTimeout(index);
+                    return false;
+                }
+                _connected[index] = true;
+            }
+
+            SharpDX.Result result;
+            try
+            {
+                var vibration = new SharpDX.XInput.Vibration
+                    {
+                        LeftMotorSpeed = (ushort)(leftMotor * ushort.MaxValue),
+                        RightMotorSpeed = (ushort)(rightMotor * ushort.MaxValue),
+                    };
+                result = _controllers[index].SetVibration(vibration);
+            }
+            catch (SharpDX.SharpDXException ex)
+            {
+                const int deviceNotConnectedHResult = unchecked((int)0x8007048f);
+                if (ex.HResult == deviceNotConnectedHResult)
+                {
+                    _connected[index] = false;
+                    SetDisconnectedTimeout(index);
+                    return false;
+                }
+                throw;
+            }
 
             return result == SharpDX.Result.Ok;
+        }
+
+        private static bool HasDisconnectedTimeoutElapsed(int index)
+        {
+            return _timeout[index] <= DateTime.UtcNow.Ticks;
+        }
+
+        private static void SetDisconnectedTimeout(int index)
+        {
+            _timeout[index] = DateTime.UtcNow.Ticks + TimeoutTicks;
         }
     }
 }


### PR DESCRIPTION
In the Windows DirectX build, it's possible for `GamePad.SetVibration` to throw a SharpDX "device not connected" exception if the gamepad was disconnected when `SetVibration` was called.

To reproduce:

1. Create a test app which calls `SetVibration` in every update
2. Plug in a gamepad and run the app
3. Unplug the gamepad
4. Most times the app should throw the exception. If not, try plugging/unplugging the gamepad a few more times.

This was mainly because the `_connected` variable was only being updated by the `GetCapabilities` and `GetState` methods. Because of this, it was also possible for `SetVibration` to do nothing if a gamepad was connected after startup without these methods being called first.

This PR fixes these issues by using the same disconnect timeout logic that the `GetCapabilities` and `GetState` methods use. It also specifically catches the "device not connected" exception as it's still possible for it to happen (just much less often).

I have tested this first in an experimental branch of [my game](http://store.steampowered.com/app/459830/Final_Days/) for 1 week and now in the public branch for the last 3 weeks without any further issues being reported.