### PR TITLE
[Pipeline Tool] Linux Headerbar improvements

### DIFF
--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -102,6 +102,11 @@
       <LogicalName>MainWindow.glade</LogicalName>
       <Platforms>Linux</Platforms>
     </EmbeddedResource>
+    <EmbeddedResource Include="MainWindow.AppMenu.glade">
+      <DependentUpon>MainWindow.cs</DependentUpon>
+      <LogicalName>MainWindow.AppMenu.glade</LogicalName>
+      <Platforms>Linux</Platforms>
+    </EmbeddedResource>
 	<Compile Include="Global.Linux.cs">
       <DependentUpon>Global.cs</DependentUpon>
       <Platforms>Linux</Platforms>

--- a/Tools/Pipeline/Global.Linux.cs
+++ b/Tools/Pipeline/Global.Linux.cs
@@ -28,6 +28,8 @@ namespace MonoGame.Tools.Pipeline
 
     static partial class Global
     {
+        public static IntPtr ApplicationHandle;
+        
         private static IconTheme _theme;
 
         private static void PlatformInit()

--- a/Tools/Pipeline/MainWindow.AppMenu.glade
+++ b/Tools/Pipeline/MainWindow.AppMenu.glade
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.1 -->
+<interface>
+  <requires lib="gtk+" version="3.16"/>
+  <menu id="appmenu">
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">_Help</attribute>
+        <attribute name="action">app.help</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">_About</attribute>
+        <attribute name="action">app.about</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">_Quit</attribute>
+        <attribute name="action">app.quit</attribute>
+      </item>
+    </section>
+  </menu>
+</interface>
+  

--- a/Tools/Pipeline/MainWindow.glade
+++ b/Tools/Pipeline/MainWindow.glade
@@ -1,257 +1,137 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.1 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
-  <menu id="appmenu">
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">_Help</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">_About</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">_Quit</attribute>
-      </item>
-    </section>
-  </menu>
   <object class="GtkImage" id="build_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="icon_name">applications-system-symbolic</property>
-  </object>
-  <object class="GtkImage" id="rebuild_image">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">system-run-symbolic</property>
   </object>
   <object class="GtkImage" id="cancel_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="icon_name">process-stop-symbolic</property>
   </object>
-  <object class="GtkImage" id="new_image">
+  <object class="GtkImage" id="clean_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">document-new-symbolic</property>
+    <property name="icon_name">edit-clear-all-symbolic</property>
   </object>
   <object class="GtkImage" id="menu_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="icon_name">open-menu-symbolic</property>
   </object>
-  <object class="GtkHeaderBar" id="headerbar">
+  <object class="GtkImage" id="new_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="show_close_button">True</property>
-    <child>
-      <object class="GtkButton" id="build_button">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="can_default">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Build</property>
-        <property name="valign">center</property>
-        <property name="image">build_image</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkButton" id="rebuild_button">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="can_default">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Rebuild</property>
-        <property name="valign">center</property>
-        <property name="image">rebuild_image</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkButton" id="cancel_button">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="can_default">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Cancel</property>
-        <property name="valign">center</property>
-        <property name="image">cancel_image</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkSeparator" id="separator1">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkButton" id="new_button">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="can_default">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">New</property>
-        <property name="valign">center</property>
-        <property name="image">new_image</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuButton" id="open_button">
-        <property name="label" translatable="yes">Open</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="can_default">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Open</property>
-        <property name="valign">center</property>
-        <property name="popover">popovermenu2</property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuButton" id="gear_button">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Menu</property>
-        <property name="valign">center</property>
-        <property name="image">menu_image</property>
-        <property name="popover">popovermenu1</property>
-      </object>
-      <packing>
-        <property name="pack_type">end</property>
-        <property name="position">2</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkButton" id="save_button">
-        <property name="label" translatable="yes">Save</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="receives_default">True</property>
-        <property name="tooltip_text" translatable="yes">Save</property>
-      </object>
-      <packing>
-        <property name="pack_type">end</property>
-        <property name="position">4</property>
-      </packing>
-    </child>
-    <style>
-      <class name="titlebar"/>
-    </style>
+    <property name="icon_name">document-new-symbolic</property>
   </object>
   <object class="GtkPopoverMenu" id="popovermenu1">
+    <property name="can_focus">False</property>
     <child>
       <object class="GtkBox">
         <property name="width_request">130</property>
         <property name="visible">True</property>
-        <property name="margin">10</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">10</property>
+        <property name="margin_right">10</property>
+        <property name="margin_top">10</property>
+        <property name="margin_bottom">10</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkModelButton" id="saveas_button">
+          <object class="GtkModelButton">
             <property name="visible">True</property>
-            <property name="text" translatable="yes">Save As</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
+            <property name="action_name">app.saveas</property>
+            <property name="text" translatable="yes">Save As...</property>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
         </child>
         <child>
           <object class="GtkSeparator">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
             <property name="margin_top">3</property>
             <property name="margin_bottom">3</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="undo_button">
-            <property name="visible">True</property>
-            <property name="text" translatable="yes">Undo</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="redo_button">
-            <property name="visible">True</property>
-            <property name="text" translatable="yes">Redo</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSeparator">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
-            <property name="margin_top">3</property>
-            <property name="margin_bottom">3</property>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
         </child>
         <child>
           <object class="GtkModelButton">
             <property name="visible">True</property>
-            <property name="menu-name">build</property>
-            <property name="text" translatable="yes">Build</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
+            <property name="action_name">app.undo</property>
+            <property name="text" translatable="yes">Undo</property>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
         </child>
         <child>
-          <object class="GtkModelButton" id="close_button">
+          <object class="GtkModelButton">
             <property name="visible">True</property>
-            <property name="text" translatable="yes">Close</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
+            <property name="action_name">app.redo</property>
+            <property name="text" translatable="yes">Redo</property>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
         </child>
         <child>
           <object class="GtkSeparator">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
             <property name="margin_top">3</property>
             <property name="margin_bottom">3</property>
+            <property name="orientation">vertical</property>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
         </child>
         <child>
-          <object class="GtkModelButton" id="help_button">
+          <object class="GtkModelButton">
             <property name="visible">True</property>
-            <property name="text" translatable="yes">Help</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
+            <property name="action_name">app.close</property>
+            <property name="text" translatable="yes">Close Project</property>
           </object>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="about_button">
-            <property name="visible">True</property>
-            <property name="text" translatable="yes">About</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="exit_button">
-            <property name="visible">True</property>
-            <property name="text" translatable="yes">Quit</property>
-          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">6</property>
+          </packing>
         </child>
       </object>
       <packing>
         <property name="submenu">main</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="margin">10</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="menu-name">main</property>
-            <property name="inverted">True</property>
-            <property name="text" translatable="yes">Build</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkModelButton" id="clean_button">
-            <property name="visible">True</property>
-            <property name="text" translatable="yes">Clean</property>
-          </object>
-        </child>
-      </object>
-      <packing>
-        <property name="submenu">build</property>
+        <property name="position">1</property>
       </packing>
     </child>
   </object>
   <object class="GtkPopoverMenu" id="popovermenu2">
+    <property name="can_focus">False</property>
     <child>
       <object class="GtkBox">
         <property name="width_request">280</property>
@@ -295,11 +175,12 @@
             <property name="can_focus">False</property>
             <property name="spacing">5</property>
             <child>
-              <object class="GtkButton" id="open_other_button">
+              <object class="GtkButton">
                 <property name="label" translatable="yes">Open Other...</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="action_name">app.open</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -308,11 +189,12 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="import_button">
+              <object class="GtkButton">
                 <property name="label" translatable="yes">Import</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="action_name">app.import</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -328,6 +210,175 @@
           </packing>
         </child>
       </object>
+      <packing>
+        <property name="submenu">main</property>
+        <property name="position">1</property>
+      </packing>
     </child>
+  </object>
+  <object class="GtkImage" id="rebuild_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">system-run-symbolic</property>
+  </object>
+  <object class="GtkHeaderBar" id="headerbar">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="show_close_button">True</property>
+    <child>
+      <object class="GtkBox" id="build_buttonbox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="homogeneous">True</property>
+        <child>
+          <object class="GtkRadioButton" id="build_button">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="can_default">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Build</property>
+            <property name="valign">center</property>
+            <property name="image">build_image</property>
+            <property name="draw_indicator">False</property>
+            <property name="action_name">app.build</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkRadioButton" id="rebuild_button">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="can_default">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Rebuild</property>
+            <property name="valign">center</property>
+            <property name="image">rebuild_image</property>
+            <property name="draw_indicator">False</property>
+            <property name="action_name">app.rebuild</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkRadioButton" id="clean_button">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="can_default">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Clean</property>
+            <property name="valign">center</property>
+            <property name="image">clean_image</property>
+            <property name="draw_indicator">False</property>
+            <property name="action_name">app.clean</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <style>
+          <class name="linked"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="cancel_button">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="can_default">True</property>
+        <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes">Cancel</property>
+        <property name="valign">center</property>
+        <property name="image">cancel_image</property>
+        <property name="action_name">app.cancel</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSeparator" id="separator1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+      </object>
+      <packing>
+        <property name="position">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkButton" id="new_button">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="can_default">True</property>
+        <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes">New</property>
+        <property name="valign">center</property>
+        <property name="image">new_image</property>
+        <property name="action_name">app.new</property>
+      </object>
+      <packing>
+        <property name="position">4</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkMenuButton" id="open_button">
+        <property name="label" translatable="yes">Open</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="can_default">True</property>
+        <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes">Open</property>
+        <property name="valign">center</property>
+        <property name="popover">popovermenu2</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="position">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkMenuButton" id="gear_button">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes">Menu</property>
+        <property name="valign">center</property>
+        <property name="image">menu_image</property>
+        <property name="popover">popovermenu1</property>
+      </object>
+      <packing>
+        <property name="pack_type">end</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkButton" id="save_button">
+        <property name="label" translatable="yes">Save</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="receives_default">True</property>
+        <property name="tooltip_text" translatable="yes">Save</property>
+        <property name="action_name">app.save</property>
+      </object>
+      <packing>
+        <property name="pack_type">end</property>
+        <property name="position">4</property>
+      </packing>
+    </child>
+    <style>
+      <class name="titlebar"/>
+    </style>
   </object>
 </interface>

--- a/Tools/Pipeline/Program.cs
+++ b/Tools/Pipeline/Program.cs
@@ -29,6 +29,10 @@ namespace MonoGame.Tools.Pipeline
             var win = new MainWindow();
             var controller = PipelineController.Create(win);
 
+#if LINUX
+            Gtk3Wrapper.gtk_application_add_window(Global.ApplicationHandle, win.NativeHandle);
+#endif
+
             string project = null;
 
             if (Global.Unix && !Global.Linux)

--- a/Tools/Pipeline/Styles.Linux.cs
+++ b/Tools/Pipeline/Styles.Linux.cs
@@ -36,6 +36,54 @@ namespace MonoGame.Tools.Pipeline
 
         [DllImport(gtklibpath, CallingConvention = CallingConvention.Cdecl)]
         public static extern void gtk_header_bar_set_subtitle(IntPtr handle, string text);
+
+        [DllImport(gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void gtk_application_set_app_menu (IntPtr application, IntPtr app_menu);
+
+        [DllImport(gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void gtk_application_add_window (IntPtr application, IntPtr window);
+
+        [DllImport(gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr g_simple_action_new (string name, IntPtr parameter_type);
+
+        [DllImport(gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void g_action_map_add_action (IntPtr action_map, IntPtr action);
+
+        [DllImport(gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void g_simple_action_set_enabled (IntPtr simple, bool enabled);
+
+        [DllImport(gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr gtk_accel_group_new();
+
+        [DllImport(gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr gtk_accel_group_connect (IntPtr accel_group, Gdk.Key accel_key, Gdk.ModifierType accel_mods, Gtk.AccelFlags accel_flags, IntPtr closure);
+    
+        [DllImport(gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr g_cclosure_new (IntPtr callback_func, IntPtr user_data, IntPtr destroy_data);
+
+        [DllImport(gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void gtk_window_add_accel_group (IntPtr window, IntPtr accel_group);
+    }
+
+    public class SimpleAction : GLib.Object
+    {
+        public delegate void ActivateHandler(object o, EventArgs args);
+        public event ActivateHandler Activate
+        {
+            add { AddSignalHandler("activate", value, typeof(EventArgs)); }
+            remove { RemoveSignalHandler("activate", value); }
+        }
+
+        public bool Enabled
+        {
+            get { return false; }
+            set { Gtk3Wrapper.g_simple_action_set_enabled(Handle, value); }
+        }
+
+        public SimpleAction(string name) : base(Gtk3Wrapper.g_simple_action_new(name, IntPtr.Zero))
+        {
+            
+        }
     }
 
     public class ModalButton : Gtk.Button
@@ -54,38 +102,10 @@ namespace MonoGame.Tools.Pipeline
 
     public static class Styles
     {
-        private static Gtk.Widget popovermenu1, popovermenu2;
-
-        private static void Connect(IntPtr handle, Command com, bool sensitivity = true)
-        {
-            var b = new Gtk.Button(handle);
-            b.Clicked += delegate
-            {
-                popovermenu1.Hide();
-                popovermenu2.Hide();
-                com.Execute();
-            };
-
-            com.EnabledChanged += delegate
-            {
-                if (sensitivity)
-                    b.Sensitive = com.Enabled;
-                else
-                    b.Visible = com.Enabled;
-            };
-        }
-
-        private static void Connect(IntPtr handle, CheckCommand com)
-        {
-            var widget = new ModalButton(handle);
-            widget.Active = com.Checked;
-
-            widget.Clicked += delegate
-            {
-                com.Checked = !com.Checked;
-                widget.Active = com.Checked;
-            };
-        }
+        private static IntPtr _actionGroup;
+        private static Gtk.Widget _popovermenu1, _popovermenu2;
+        private static Gtk.RadioButton _mainbutton;
+        private static Gtk.Widget _buttonbox, _cancelbox, _separator;
 
         [GLib.ConnectBefore]
         public static void TreeView_ButtonPressEvent(object o, Gtk.ButtonPressEventArgs args)
@@ -107,52 +127,125 @@ namespace MonoGame.Tools.Pipeline
             }
         }
 
+        public static void Connect(string action, Command cmd)
+        {
+            var a = new SimpleAction(action);
+            a.Activate += (o, args) => 
+            {
+                _popovermenu1.Hide();
+                _popovermenu2.Hide();
+                cmd.Execute();
+            };
+
+            cmd.EnabledChanged += (sender, e) => a.Enabled = cmd.Enabled;
+
+            Gtk3Wrapper.g_action_map_add_action(Global.ApplicationHandle, a.Handle);
+        }
+
+        private static void Connect(Command cmd, Gdk.Key key, Gdk.ModifierType modifier = Gdk.ModifierType.None)
+        {
+            var cclosure = Gtk3Wrapper.g_cclosure_new(Marshal.GetFunctionPointerForDelegate(
+                (Action<IntPtr, IntPtr, IntPtr, IntPtr, IntPtr>)((IntPtr a, IntPtr b, IntPtr c, IntPtr d, IntPtr data) =>
+            {
+                var command = ((GCHandle)data).Target as Command;
+
+                if (command.Enabled)
+                    command.Execute();
+            })), (IntPtr)GCHandle.Alloc(cmd), IntPtr.Zero);
+
+            Gtk3Wrapper.gtk_accel_group_connect(_actionGroup, key, modifier, Gtk.AccelFlags.Mask, cclosure);
+        }
+
+        private static void RejectActive(IntPtr handle)
+        {
+            var rb = new Gtk.RadioButton(handle);
+            rb.JoinGroup(_mainbutton);
+            rb.Toggled += (sender, e) => 
+            {
+                if (rb.Active)
+                    _mainbutton.Active = true;
+            };
+        }
+
+        private static void ReloadBuildbox()
+        {
+            var b = MainWindow.Instance.cmdBuild.Enabled;
+            var c = MainWindow.Instance.cmdCancelBuild.Enabled;
+
+            _buttonbox.Visible = b;
+            _cancelbox.Visible = c;
+            _separator.Visible = b || c;
+        }
+
         public static void Load()
         {
             Style.Add<ApplicationHandler>("PipelineTool", h =>
             {
+                Global.ApplicationHandle = h.Control.Handle;
+
                 if (Gtk.Global.MajorVersion >= 3 && Gtk.Global.MinorVersion >= 16)
                     Global.UseHeaderBar = Gtk3Wrapper.gtk_application_prefers_app_menu(h.Control.Handle);
+                
+                if (Global.UseHeaderBar)
+                    Gtk3Wrapper.gtk_application_set_app_menu(h.Control.Handle, (new Gtk.Builder("MainWindow.AppMenu.glade")).GetObject("appmenu").Handle);
             });
 
             Style.Add<FormHandler>("MainWindow", h =>
             {
                 if (!Global.UseHeaderBar)
                     return;
+                
+                var builder = new Gtk.Builder("MainWindow.glade");
+                var headerBar = new Gtk.Widget(builder.GetObject("headerbar").Handle);
 
                 h.Menu = null;
                 h.ToolBar = null;
 
-                var builder = new Gtk.Builder(null, "MainWindow.glade", null);
-                var headerBar = new Gtk.Widget(builder.GetObject("headerbar").Handle);
-                var separator = new Gtk.Widget(builder.GetObject("separator1").Handle);
+                Connect("new", MainWindow.Instance.cmdNew);
+                Connect("open", MainWindow.Instance.cmdOpen);
+                Connect("save", MainWindow.Instance.cmdSave);
+                Connect("saveas", MainWindow.Instance.cmdSaveAs);
+                Connect("import", MainWindow.Instance.cmdImport);
+                Connect("close", MainWindow.Instance.cmdClose);
+                Connect("help", MainWindow.Instance.cmdHelp);
+                Connect("about", MainWindow.Instance.cmdAbout);
+                Connect("quit", MainWindow.Instance.cmdExit);
+                Connect("undo", MainWindow.Instance.cmdUndo);
+                Connect("redo", MainWindow.Instance.cmdRedo);
+                Connect("build", MainWindow.Instance.cmdBuild);
+                Connect("rebuild", MainWindow.Instance.cmdRebuild);
+                Connect("clean", MainWindow.Instance.cmdClean);
+                Connect("cancel", MainWindow.Instance.cmdCancelBuild);
 
-                popovermenu1 = new Gtk.Widget(builder.GetObject("popovermenu1").Handle);
-                popovermenu2 = new Gtk.Widget(builder.GetObject("popovermenu2").Handle);
+                _actionGroup = Gtk3Wrapper.gtk_accel_group_new();
+
+                Connect(MainWindow.Instance.cmdNew, Gdk.Key.N, Gdk.ModifierType.ControlMask);
+                Connect(MainWindow.Instance.cmdOpen, Gdk.Key.O, Gdk.ModifierType.ControlMask);
+                Connect(MainWindow.Instance.cmdSave, Gdk.Key.S, Gdk.ModifierType.ControlMask);
+                Connect(MainWindow.Instance.cmdExit, Gdk.Key.Q, Gdk.ModifierType.ControlMask);
+                Connect(MainWindow.Instance.cmdUndo, Gdk.Key.Z, Gdk.ModifierType.ControlMask);
+                Connect(MainWindow.Instance.cmdRedo, Gdk.Key.Y, Gdk.ModifierType.ControlMask);
+                Connect(MainWindow.Instance.cmdBuild, Gdk.Key.F6);
+                Connect(MainWindow.Instance.cmdHelp, Gdk.Key.F1);
+
+                Gtk3Wrapper.gtk_window_add_accel_group(h.Control.Handle, _actionGroup);
+
+                _popovermenu1 = new Gtk.Widget(builder.GetObject("popovermenu1").Handle);
+                _popovermenu2 = new Gtk.Widget(builder.GetObject("popovermenu2").Handle);
 
                 Gtk3Wrapper.gtk_window_set_titlebar(h.Control.Handle, headerBar.Handle);
                 Gtk3Wrapper.gtk_header_bar_set_show_close_button(headerBar.Handle, true);
 
-                Connect(builder.GetObject("new_button").Handle, MainWindow.Instance.cmdNew);
-                Connect(builder.GetObject("save_button").Handle, MainWindow.Instance.cmdSave);
-                Connect(builder.GetObject("build_button").Handle, MainWindow.Instance.cmdBuild, false);
-                Connect(builder.GetObject("rebuild_button").Handle, MainWindow.Instance.cmdRebuild, false);
-                Connect(builder.GetObject("cancel_button").Handle, MainWindow.Instance.cmdCancelBuild, false);
-                Connect(builder.GetObject("open_other_button").Handle, MainWindow.Instance.cmdOpen);
-                Connect(builder.GetObject("import_button").Handle, MainWindow.Instance.cmdImport);
-                Connect(builder.GetObject("saveas_button").Handle, MainWindow.Instance.cmdSaveAs);
-                Connect(builder.GetObject("undo_button").Handle, MainWindow.Instance.cmdUndo);
-                Connect(builder.GetObject("redo_button").Handle, MainWindow.Instance.cmdRedo);
-                Connect(builder.GetObject("close_button").Handle, MainWindow.Instance.cmdClose);
-                Connect(builder.GetObject("clean_button").Handle, MainWindow.Instance.cmdClean);
-                Connect(builder.GetObject("help_button").Handle, MainWindow.Instance.cmdHelp);
-                Connect(builder.GetObject("about_button").Handle, MainWindow.Instance.cmdAbout);
-                Connect(builder.GetObject("exit_button").Handle, MainWindow.Instance.cmdExit);
+                _mainbutton = new Gtk.RadioButton("");
+                RejectActive(builder.GetObject("build_button").Handle);
+                RejectActive(builder.GetObject("rebuild_button").Handle);
+                RejectActive(builder.GetObject("clean_button").Handle);
 
-                MainWindow.Instance.cmdBuild.EnabledChanged += (sender, e) =>
-                    separator.Visible = MainWindow.Instance.cmdBuild.Enabled || MainWindow.Instance.cmdCancelBuild.Enabled;
-                MainWindow.Instance.cmdCancelBuild.EnabledChanged += (sender, e) => 
-                    separator.Visible = MainWindow.Instance.cmdBuild.Enabled || MainWindow.Instance.cmdCancelBuild.Enabled;
+                _buttonbox = new Gtk.Widget(builder.GetObject("build_buttonbox").Handle);
+                _cancelbox = new Gtk.Widget(builder.GetObject("cancel_button").Handle);
+                _separator = new Gtk.Widget(builder.GetObject("separator1").Handle);
+                MainWindow.Instance.cmdBuild.EnabledChanged += (sender, e) => ReloadBuildbox();
+                MainWindow.Instance.cmdCancelBuild.EnabledChanged += (sender, e) => ReloadBuildbox();
 
                 MainWindow.Instance.TitleChanged += delegate
                 {
@@ -195,7 +288,7 @@ namespace MonoGame.Tools.Pipeline
 
                 treeview1.RowActivated += (o, args) =>
                 {
-                    popovermenu2.Hide();
+                    _popovermenu2.Hide();
 
                     Gtk.TreeIter iter;
                     if (!store.GetIter(out iter, args.Path))
@@ -205,7 +298,7 @@ namespace MonoGame.Tools.Pipeline
                     PipelineController.Instance.OpenProject(project);
                 };
 
-                h.Control.ShowAll();
+                headerBar.Show();
             });
 
             Style.Add<ButtonHandler>("Destuctive", h => h.Control.StyleContext.AddClass("destructive-action"));


### PR DESCRIPTION
Stuff done:
 - Fixed shortcuts not working in headerbar mode
 - Moved "Help", "About" and "Quit" to the global app menu
 - Added clean button to the headerbar
 - Grouped together "Build", "Rebuild" and "Clean" buttons
 - Split out MainWindow.glade into 2 files and made it editable from Glade application
 - Fixed popups not closing after an action