### PR TITLE
Throw a ContentLoadError on the UI thread if we hit one.

### DIFF
--- a/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
@@ -660,9 +660,17 @@ namespace Microsoft.Xna.Framework
             {
                 UpdateFrameInternal(updateEventArgs);
             }
-            catch (Content.ContentLoadException)
+            catch (Content.ContentLoadException ex)
             {
-                // ignore it..
+                if (RenderOnUIThread)
+                    throw ex;
+                else
+                {
+                    Game.Activity.RunOnUiThread (() =>
+                    {
+                        throw ex;
+                    });
+                }
             }
 
             prevUpdateTime = curUpdateTime;


### PR DESCRIPTION
Currently if we hit a content problem on android the error
is swallowed. We need to throw it on the UI thread so that
it will get caught by the app exception handler.