### PR TITLE
MGCB Improvements

### DIFF
--- a/Tools/MGCB/BuildContent.cs
+++ b/Tools/MGCB/BuildContent.cs
@@ -17,16 +17,19 @@ namespace MGCB
     {
         [CommandLineParameter(
             Name = "launchdebugger",
+            Flag = "d",
             Description = "Wait for debugger to attach before building content.")]
         public bool LaunchDebugger = false;
 
         [CommandLineParameter(
             Name = "quiet",
+            Flag = "q",
             Description = "Only output content build errors.")]
         public bool Quiet = false;
 
         [CommandLineParameter(
             Name = "@",
+            Flag = "@",
             ValueName = "responseFile",
             Description = "Read a text response file with additional command line options and switches.")]
         // This property only exists for documentation.
@@ -39,6 +42,7 @@ namespace MGCB
 
         [CommandLineParameter(
             Name = "workingDir",
+            Flag = "w",
             ValueName = "directoryPath",
             Description = "The working directory where all source content is located.")]
         public void SetWorkingDir(string path)
@@ -48,45 +52,53 @@ namespace MGCB
 
         [CommandLineParameter(
             Name = "outputDir",
-            ValueName = "directoryPath",
+            Flag = "o",
+            ValueName = "path",
             Description = "The directory where all content is written.")]
         public string OutputDir = string.Empty;
 
         [CommandLineParameter(
             Name = "intermediateDir",
-            ValueName = "directoryPath",
+            Flag = "n",
+            ValueName = "path",
             Description = "The directory where all intermediate files are written.")]
         public string IntermediateDir = string.Empty;
 
         [CommandLineParameter(
             Name = "rebuild",
+            Flag = "r",
             Description = "Forces a full rebuild of all content.")]
         public bool Rebuild = false;
 
         [CommandLineParameter(
-            Name = "clean",            
+            Name = "clean",
+            Flag = "c",
             Description = "Delete all previously built content and intermediate files.")]
         public bool Clean = false;
 
         [CommandLineParameter(
             Name = "incremental",
+            Flag = "I",
             Description = "Skip cleaning files not included in the current build.")]
         public bool Incremental = false;
 
         [CommandLineParameter(
             Name = "reference",
-            ValueName = "assemblyNameOrFile",
+            Flag = "f",
+            ValueName = "assembly",
             Description = "Adds an assembly reference for resolving content importers, processors, and writers.")]
         public readonly List<string> References = new List<string>();
 
         [CommandLineParameter(
             Name = "platform",
+            Flag = "t",
             ValueName = "targetPlatform",
             Description = "Set the target platform for this build.  Defaults to Windows desktop DirectX.")]
         public TargetPlatform Platform = TargetPlatform.Windows;
 
         [CommandLineParameter(
             Name = "profile",
+            Flag = "g",
             ValueName = "graphicsProfile",
             Description = "Set the target graphics profile for this build.  Defaults to HiDef.")]
         public GraphicsProfile Profile = GraphicsProfile.HiDef;
@@ -99,12 +111,14 @@ namespace MGCB
 
         [CommandLineParameter(
             Name = "importer",
+            Flag = "i",
             ValueName = "className",
             Description = "Defines the class name of the content importer for reading source content.")]
         public string Importer = null;
 
         [CommandLineParameter(
             Name = "processor",
+            Flag = "p",
             ValueName = "className",
             Description = "Defines the class name of the content processor for processing imported content.")]
         public void SetProcessor(string processor)
@@ -121,11 +135,12 @@ namespace MGCB
 
         [CommandLineParameter(
             Name = "processorParam",
+            Flag = "P",
             ValueName = "name=value",
             Description = "Defines a parameter name and value to set on a content processor.")]
         public void AddProcessorParam(string nameAndValue)
         {
-            var keyAndValue = nameAndValue.Split('=');
+            var keyAndValue = nameAndValue.Split('=', ':');
             if (keyAndValue.Length != 2)
             {
                 // Do we error out or something?
@@ -138,6 +153,7 @@ namespace MGCB
 
         [CommandLineParameter(
             Name = "build",
+            Flag = "b",
             ValueName = "sourceFile",
             Description = "Build the content source file using the previously set switches and options.")]
         public void OnBuild(string sourceFile)
@@ -404,6 +420,15 @@ namespace MGCB
                     ++errorCount;
                 }
             }
+        }
+
+        [CommandLineParameter(
+            Name = "help",
+            Flag = "h",
+            Description = "Displays this help.")]
+        public void Help()
+        {
+            MGBuildParser.Instance.ShowError(null);
         }
     }
 }

--- a/Tools/MGCB/CommandLineParser.cs
+++ b/Tools/MGCB/CommandLineParser.cs
@@ -11,18 +11,16 @@ using System.Diagnostics;
 using System.Reflection;
 using System.ComponentModel;
 
-
 namespace MGCB
-{    
-    
-    
-
+{
     /// <summary>
     /// Adapted from this generic command line argument parser:
     /// http://blogs.msdn.com/b/shawnhar/archive/2012/04/20/a-reusable-reflection-based-command-line-parser.aspx     
     /// </summary>
     public class MGBuildParser
     {
+        public static MGBuildParser Instance;
+
         #region Supporting Types
 
         public class PreprocessorProperty
@@ -85,6 +83,7 @@ namespace MGCB
         private readonly object _optionsObject;
         private readonly Queue<MemberInfo> _requiredOptions;
         private readonly Dictionary<string, MemberInfo> _optionalOptions;
+        private readonly Dictionary<string, string> _flags;
         private readonly List<string> _requiredUsageHelp;
 
         public readonly PreprocessorPropertyCollection _properties;
@@ -94,6 +93,8 @@ namespace MGCB
 
         public MGBuildParser(object optionsObject)
         {
+            Instance = this;
+
             _optionsObject = optionsObject;
             _requiredOptions = new Queue<MemberInfo>();
             _optionalOptions = new Dictionary<string, MemberInfo>();
@@ -175,6 +176,14 @@ namespace MGCB
                     _optionalOptions.Add(param.Name.ToLowerInvariant(), method);
                 }
             }
+
+            _flags = new Dictionary<string, string>();
+            foreach(var pair in _optionalOptions)
+            {
+                var fi = GetAttribute<CommandLineParameterAttribute>(pair.Value);
+                if(!string.IsNullOrEmpty(fi.Flag))
+                    _flags.Add(fi.Flag, fi.Name);
+            }
         }        
 
         public bool Parse(IEnumerable<string> args)
@@ -182,12 +191,12 @@ namespace MGCB
             args = Preprocess(args);
 
             var showUsage = true;
-            var success = true;            
+            var success = true;
             foreach (var arg in args)
             {
                 showUsage = false;
 
-                if (!ParseArgument(arg))
+                if (!ParseFlags(arg))
                 {
                     success = false;
                     break;
@@ -281,7 +290,7 @@ namespace MGCB
                     continue;
                 }
 
-                if (arg.StartsWith("/define:") || arg.StartsWith("-define:"))
+                if (arg.StartsWith("/define:") || arg.StartsWith("--define:"))
                 {
                     var words = arg.Substring(8).Split('=');
                     var name = words[0];
@@ -293,7 +302,7 @@ namespace MGCB
 
                 }
 
-                if (arg.StartsWith("/@:") || arg.StartsWith("-@:"))
+                if (arg.StartsWith("/@:") || arg.StartsWith("--@:") || arg.StartsWith("-@:"))
                 {
                     var file = arg.Substring(3);
                     var commands = File.ReadAllLines(file);
@@ -324,9 +333,48 @@ namespace MGCB
             return output.ToArray();
         }
 
+        private bool ParseFlags(string arg)
+        {
+            // Only one flag
+            if (arg.Length >= 3 &&
+                (arg[0] == '-' || arg[0] == '/') &&
+                (arg[2] == '=' || arg[2] == ':'))
+            {
+                string name;
+                if (!_flags.TryGetValue(arg[1].ToString(), out name))
+                {
+                    ShowError("Unknown option '{0}'", arg[1].ToString());
+                    return false;
+                }
+
+                ParseArgument("/" + name + arg.Substring(2));
+                return true;
+            }
+
+            // Multiple flags
+            if (arg.Length >= 2 &&
+               ((arg[0] == '-' && arg[1] != '-') || arg[0] == '/') &&
+               !arg.Contains(":") && !arg.Contains("=") &&
+               !_optionalOptions.ContainsKey(arg.Substring(1)))
+            {
+                for (int i = 1; i < arg.Length; i++)
+                {
+                    string name;
+                    if (!_flags.TryGetValue(arg[i].ToString(), out name))
+                    {
+                        ShowError("Unknown option '{0}'", arg[i].ToString());
+                        break;
+                    }
+                }
+            }
+
+            // Not a flag, parse argument
+            return ParseArgument(arg);
+        }
+
         private bool ParseArgument(string arg)
         {
-            if (arg.StartsWith("/") || arg.StartsWith("-"))
+            if (arg.StartsWith("/") || arg.StartsWith("--"))
             {
                 // After the first escaped argument we can no
                 // longer read non-escaped arguments.
@@ -334,9 +382,9 @@ namespace MGCB
                     return false;
 
                 // Parse an optional argument.
-                char[] separators = {':'};
+                char[] separators = { ':', '=' };
 
-                var split = arg.Substring(1).Split(separators, 2, StringSplitOptions.None);
+                var split = arg.Substring(arg.StartsWith("/") ? 1 : 2).Split(separators, 2, StringSplitOptions.None);
 
                 var name = split[0];
                 var value = (split.Length > 1) ? split[1] : "true";
@@ -415,7 +463,8 @@ namespace MGCB
                 "$",
                 "/",                
                 "#",
-                "-",
+                "--",
+                "-"
             };
 
         static void CheckReservedPrefixes(string str)
@@ -486,9 +535,9 @@ namespace MGCB
 
         public string Title { get; set; }
 
-        bool IsWindows(PlatformID platform)
+        bool IsWindows()
         {
-            switch (platform)
+            switch (Environment.OSVersion.Platform)
             {
                 case PlatformID.Win32NT:
                 case PlatformID.Win32S:
@@ -521,24 +570,31 @@ namespace MGCB
                 Console.Error.WriteLine();
             }
 
-            var defaultParamPrefix = IsWindows(Environment.OSVersion.Platform) ? "  /" : "  -";
+            var defaultParamPrefix = IsWindows() ? "/" : "--";
             Console.Error.WriteLine("Usage: {0} {1}{2}", 
                 name, 
-                string.Join(" ", _requiredUsageHelp), 
-                _optionalOptions.Count > 0 ? " <Options>" : string.Empty);
+                _requiredUsageHelp.Count > 0 ? string.Join(" ", _requiredUsageHelp) + " " : string.Empty, 
+                _optionalOptions.Count > 0 ? "<Options>" : string.Empty);
 
             if (_optionalOptions.Count > 0)
             {
                 Console.Error.WriteLine();
-                Console.Error.WriteLine("Options:\n");
+                Console.Error.WriteLine("Options:");
 
-                foreach (var pair in _optionalOptions)
+                var data = _optionalOptions.Values.ToList();
+                data.Sort((x, y) => {
+                    var px = GetAttribute<CommandLineParameterAttribute>(x);
+                    var py = GetAttribute<CommandLineParameterAttribute>(y);
+
+                    return px.Name.CompareTo(py.Name);
+                });
+
+                foreach(var d in data)
                 {
-                    var field = pair.Value as FieldInfo;
-                    var prop = pair.Value as PropertyInfo;
-                    var method = pair.Value as MethodInfo;
-                    var param = GetAttribute<CommandLineParameterAttribute>(pair.Value);
-
+                    var attr = GetAttribute<CommandLineParameterAttribute>(d);
+                    var field = d as FieldInfo;
+                    var prop = d as PropertyInfo;
+                    var method = d as MethodInfo;
                     var hasValue = false;
 
                     if (field != null && field.FieldType != typeof (bool))
@@ -547,11 +603,38 @@ namespace MGCB
                         hasValue = true;
                     if (method != null && method.GetParameters().Length != 0)
                         hasValue = true;
+                    
+                    var s = "  ";
+
+                    s += (!string.IsNullOrEmpty(attr.Flag)) ? (IsWindows() ? "/" : "-") + attr.Flag + "," : "   ";
+                    s += " " + defaultParamPrefix + attr.Name;
 
                     if (hasValue)
-                        Console.Error.WriteLine(defaultParamPrefix + "{0}:<{1}>\n    {2}\n", param.Name, param.ValueName, param.Description);
-                    else
-                        Console.Error.WriteLine(defaultParamPrefix + "{0}\n    {1}\n", param.Name, param.Description);
+                    {
+                        if (IsWindows())
+                            s += ":<" + attr.ValueName + ">";
+                        else
+                            s += "=" + attr.ValueName.Replace("=", ":").ToUpper();
+                    }
+
+                    s = s.PadRight(35, ' ');
+
+                    // Wrap text description
+                    var bw = Math.Max(60, Console.BufferWidth);
+                    var desc = attr.Description.Split(' ');
+
+                    foreach(var dw in desc)
+                    {
+                        if (s.Length + dw.Length >= bw)
+                        {
+                            Console.WriteLine(s);
+                            s = string.Empty.PadRight(37, ' ');
+                        }
+
+                        s += " " + dw;
+                    }
+
+                    Console.WriteLine(s);
                 }
             }
         }
@@ -574,10 +657,12 @@ namespace MGCB
 
         public string Name { get; set; }
 
+        public string Flag { get; set; }
+
         public bool Required { get; set; }
 
         public string ValueName { get; set; }
 
-        public string Description { get; set; }        
+        public string Description { get; set; }
     }
 }

--- a/Tools/MGCB/Program.cs
+++ b/Tools/MGCB/Program.cs
@@ -45,24 +45,29 @@ namespace MGCB
                 }
             }
 
-            // Print a startup message.            
-            var buildStarted = DateTime.Now;
-            if (!content.Quiet)
-                Console.WriteLine("Build started {0}\n", buildStarted);
-
-            // Let the content build.
-            int successCount, errorCount;
-            content.Build(out successCount, out errorCount);
-
-            // Print the finishing info.
-            if (!content.Quiet)
+            if (content.HasWork)
             {
-                Console.WriteLine("\nBuild {0} succeeded, {1} failed.\n", successCount, errorCount);
-                Console.WriteLine("Time elapsed {0:hh\\:mm\\:ss\\.ff}.", DateTime.Now - buildStarted);
+                // Print a startup message.            
+                var buildStarted = DateTime.Now;
+                if (!content.Quiet)
+                    Console.WriteLine("Build started {0}\n", buildStarted);
+
+                // Let the content build.
+                int successCount, errorCount;
+                content.Build(out successCount, out errorCount);
+
+                // Print the finishing info.
+                if (!content.Quiet)
+                {
+                    Console.WriteLine("\nBuild {0} succeeded, {1} failed.\n", successCount, errorCount);
+                    Console.WriteLine("Time elapsed {0:hh\\:mm\\:ss\\.ff}.", DateTime.Now - buildStarted);
+                }
+
+                // Return the error count.
+                return errorCount;
             }
 
-            // Return the error count.
-            return errorCount;
+            return 0;
         }
     }
 }


### PR DESCRIPTION
All the existing commands still work, these are just some qol changes for us Unix users.

Stuff done:
 - Adds flags
   - do tell me if you want some flags changed / added
 - Fixes Unix param argument to be "--" instead of "-"
 - Makes it so separators for arguments can both be ":" and "="
 - Improves help display (mostly mimicking Unix style here)
   - If the command description is too long there is extra text warping code added
 - Includes help command

Help menu on Windows:
```
MonoGame Content Builder
Builds optimized game content for MonoGame projects.

Usage: MGCB <Options>

Options:
  /@, /@:<responseFile>             Read a text response file with additional command line options and switches.
  /b, /build:<sourceFile>           Build the content source file using the previously set switches and options.
  /c, /clean                        Delete all previously built content and intermediate files.
      /compress                     Compress the XNB files for smaller file sizes.
      /config:<string>              The optional build config string from the build system.
      /copy:<sourceFile>            Copy the content source file verbatim to the output directory.
  /h, /help                         Displays this help.
  /i, /importer:<className>         Defines the class name of the content importer for reading source content.
  /I, /incremental                  Skip cleaning files not included in the current build.
  /n, /intermediateDir:<path>       The directory where all intermediate files are written.
  /d, /launchdebugger               Wait for debugger to attach before building content.
  /o, /outputDir:<path>             The directory where all content is written.
  /t, /platform:<targetPlatform>    Set the target platform for this build.  Defaults to Windows desktop DirectX.
  /p, /processor:<className>        Defines the class name of the content processor for processing imported content.
  /P, /processorParam:<name=value>  Defines a parameter name and value to set on a content processor.
  /g, /profile:<graphicsProfile>    Set the target graphics profile for this build.  Defaults to HiDef.
  /q, /quiet                        Only output content build errors.
  /r, /rebuild                      Forces a full rebuild of all content.
  /f, /reference:<assembly>         Adds an assembly reference for resolving content importers, processors, and writers.
  /w, /workingDir:<directoryPath>   The working directory where all source content is located.
```

Help menu on Unix:
```
MonoGame Content Builder
Builds optimized game content for MonoGame projects.

Usage: MGCB <Options>

Options:
  -@, --@=RESPONSEFILE              Read a text response file with additional command line options and switches.
  -b, --build=SOURCEFILE            Build the content source file using the previously set switches and options.
  -c, --clean                       Delete all previously built content and intermediate files.
      --compress                    Compress the XNB files for smaller file sizes.
      --config=STRING               The optional build config string from the build system.
      --copy=SOURCEFILE             Copy the content source file verbatim to the output directory.
  -h, --help                        Displays this help.
  -i, --importer=CLASSNAME          Defines the class name of the content importer for reading source content.
  -I, --incremental                 Skip cleaning files not included in the current build.
  -n, --intermediateDir=PATH        The directory where all intermediate files are written.
  -d, --launchdebugger              Wait for debugger to attach before building content.
  -o, --outputDir=PATH              The directory where all content is written.
  -t, --platform=TARGETPLATFORM     Set the target platform for this build.  Defaults to Windows desktop DirectX.
  -p, --processor=CLASSNAME         Defines the class name of the content processor for processing imported content.
  -P, --processorParam=NAME:VALUE   Defines a parameter name and value to set on a content processor.
  -g, --profile=GRAPHICSPROFILE     Set the target graphics profile for this build.  Defaults to HiDef.
  -q, --quiet                       Only output content build errors.
  -r, --rebuild                     Forces a full rebuild of all content.
  -f, --reference=ASSEMBLY          Adds an assembly reference for resolving content importers, processors, and writers.
  -w, --workingDir=DIRECTORYPATH    The working directory where all source content is located.
```

CC. @dellis1972 I think you are the only one who will appreciate this work here ༼ ༎ຶ ෴ ༎ຶ༽