### PR TITLE
Included mgcb autocomplete for bash

### DIFF
--- a/Installers/Linux/Main/mgcb
+++ b/Installers/Linux/Main/mgcb
@@ -1,0 +1,83 @@
+# MGCB autocomplete for bash
+
+function _mgcbcomplete()
+{
+  local cur prev
+  _get_comp_words_by_ref -n = cur prev
+  
+  case "$cur" in
+    "--platform="* | "-t="* | "/platform="* | "/t="*)
+      COMPREPLY=($(compgen -W "Windows Xbox360 iOS Android DesktopGL \
+                               MacOSX WindowsStoreApp NativeClient \
+                               PlayStationMobile WindowsPhone8 RaspberryPi \
+                               PlayStation4 PSVita XboxOne Switch" -- ${cur#*=}))
+      return 0;
+      ;;
+    "--profile="* | "-p="* | "/profile="* | "/p="*)
+      COMPREPLY=($(compgen -W "Reach HiDef" -- ${cur#*=}))
+      return 0;
+      ;;
+    "--build="* | "--outputDir="* | "--intermediateDir="* | \
+    "--workingDir="* | "--copy="* | "--reference"* | "--@="* | \
+    "-b="* | "-o="* | "-n="* | "-w="* | "-f="* | "-@="* | \
+    "/build="* | "/outputDir="* | "/intermediateDir="* | \
+    "/workingDir="* | "/copy="* | "/reference"* | \
+    "/b="* | "/o="* | "/n="* | "/w="* | "/f="* | "/@="*)
+      COMPREPLY=()
+      return 0
+      ;;
+    "--config=" | "/config=")
+      return 0;
+      ;;
+    "--processor=" | "--importer=" | "--processorParam=" | \
+    "/processor=" | "/importer=" | "/processorParam=")
+      # TODO
+      return 0;
+      ;;
+    "-b" | "-o" | "-n" | "-w" | "-f" | "-@" | \
+    "-q" | "-t" | "-p" | "-P" | "-i" | \
+    "/b" | "/o" | "/n" | "/w" | "/f" | "/@" | \
+    "/q" | "/t" | "/p" | "/P" | "/i")
+      COMPREPLY=("$cur=")
+      return 0;
+      ;;
+    "-c" | "-h" | "-I" | "-d" | "-q" | "-r" | \
+    "/c" | "/h" | "/I" | "/d" | "/q" | "/r")
+      COMPREPLY=("$cur")
+      compopt +o nospace
+      return 0;
+      ;;
+  esac
+  
+  if [[ "$cur" == "--"* ]]
+  then
+    COMPREPLY=($(compgen -W "--@= --build= --clean --compress --config= --copy= \
+                             --help --importer= --incremental --intermediateDir= \
+                             --launchdebugger --outputDir= --platform= --processor= \
+                             --processorParam= --profile= --quiet --rebuild \
+                             --reference= --workingDir=" -- $cur))
+    if [[ ${COMPREPLY[0]} != *"=" ]]
+    then
+      compopt +o nospace
+    fi
+    
+    return 0;
+  fi
+  
+  if [[ "$cur" == "/"* ]]
+  then
+    COMPREPLY=($(compgen -W "/@= /build= /clean /compress /config= /copy= \
+                             /help /importer= /incremental /intermediateDir= \
+                             /launchdebugger /outputDir= /platform= /processor= \
+                             /processorParam= /profile= /quiet /rebuild \
+                             /reference= /workingDir=" -- $cur))
+    if [[ ${COMPREPLY[0]} != *"=" ]]
+    then
+      compopt +o nospace
+    fi
+    
+    return 0;
+  fi
+}
+
+complete -o nospace -o default -F _mgcbcomplete mgcb

--- a/Installers/Linux/Main/mgcbcomplete
+++ b/Installers/Linux/Main/mgcbcomplete
@@ -11,10 +11,12 @@ function _mgcbcomplete()
                                MacOSX WindowsStoreApp NativeClient \
                                PlayStationMobile WindowsPhone8 RaspberryPi \
                                PlayStation4 PSVita XboxOne Switch" -- ${cur#*=}))
+      compopt +o nospace
       return 0;
       ;;
     "--profile="* | "-p="* | "/profile="* | "/p="*)
       COMPREPLY=($(compgen -W "Reach HiDef" -- ${cur#*=}))
+      compopt +o nospace
       return 0;
       ;;
     "--build="* | "--outputDir="* | "--intermediateDir="* | \

--- a/Installers/Linux/RUN/postinstall.sh
+++ b/Installers/Linux/RUN/postinstall.sh
@@ -117,7 +117,7 @@ cat > /usr/bin/mgcb <<'endmsg'
 mono /usr/lib/mono/xbuild/MonoGame/v3.0/Tools/MGCB.exe "$@"
 endmsg
 chmod +x /usr/bin/mgcb
-cp "$DIR/Main/mgcb" "/etc/bash_completion.d/mgcb"
+cp "$DIR/Main/mgcbcomplete" "/etc/bash_completion.d/mgcb"
 
 # MonoGame icon
 mkdir -p /usr/share/icons/hicolor/scalable/mimetypes

--- a/Installers/Linux/RUN/postinstall.sh
+++ b/Installers/Linux/RUN/postinstall.sh
@@ -117,6 +117,7 @@ cat > /usr/bin/mgcb <<'endmsg'
 mono /usr/lib/mono/xbuild/MonoGame/v3.0/Tools/MGCB.exe "$@"
 endmsg
 chmod +x /usr/bin/mgcb
+cp "$DIR/Main/mgcb" "/etc/bash_completion.d/mgcb"
 
 # MonoGame icon
 mkdir -p /usr/share/icons/hicolor/scalable/mimetypes

--- a/Installers/Linux/RUN/uninstall.sh
+++ b/Installers/Linux/RUN/uninstall.sh
@@ -10,6 +10,7 @@ fi
 rm -f /usr/bin/monogame-pipeline-tool
 rm -f /usr/bin/monogame-uninstall
 rm -f /usr/bin/mgcb
+rm -f /etc/bash_completion.d/mgcb
 
 #remove application icon
 rm -rf /usr/share/icons/gnome/scalable/mimetypes/monogame.svg


### PR DESCRIPTION
Most of the autocomplete stuff done, the only thing left is to setup a bridge between bash and MGCB so that processors/importers/processorParams can also get autocompleted, but I'll leave that for a future PR.

Preview:
![autocomplete](https://user-images.githubusercontent.com/6773302/31153441-819ef200-a8a1-11e7-905d-80bc52f48527.png)

CC. @dellis1972 (pssss, I think the file should work on Mac as well)