### PR TITLE
Use desktop assembly of XAudio for DX projects

### DIFF
--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -61,7 +61,7 @@
         Path="ThirdParty/Dependencies/SharpDX/net45/SharpDX.MediaFoundation.dll" />
       <Binary
         Name="SharpDX.XAudio2"
-        Path="ThirdParty/Dependencies/SharpDX/SharpDX.XAudio2.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/net45/SharpDX.XAudio2.dll" />
       <Binary
         Name="SharpDX.XInput"
         Path="ThirdParty/Dependencies/SharpDX/SharpDX.XInput.dll" />


### PR DESCRIPTION
Fixes #5986. This PR makes Windows DX projects use the net45 XAudio2 assembly.

Depends on MonoGame/MonoGame.Dependencies#113. 