### PR TITLE
Compressed texture fallback formats

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
@@ -118,23 +118,23 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             switch (format)
             {
                 case TextureProcessorOutputFormat.AtcCompressed:
-                    GraphicsUtil.CompressAti(content);
+                    GraphicsUtil.CompressAti(context, content, isSpriteFont);
                     break;
 
                 case TextureProcessorOutputFormat.Color16Bit:
-                    GraphicsUtil.CompressColor16Bit(content);
+                    GraphicsUtil.CompressColor16Bit(context, content);
                     break;
 
                 case TextureProcessorOutputFormat.DxtCompressed:
-                    GraphicsUtil.CompressDxt(context.TargetProfile, content, isSpriteFont);
+                    GraphicsUtil.CompressDxt(context, content, isSpriteFont);
                     break;
 
                 case TextureProcessorOutputFormat.Etc1Compressed:
-                    GraphicsUtil.CompressEtc1(content);
+                    GraphicsUtil.CompressEtc1(context, content, isSpriteFont);
                     break;
 
                 case TextureProcessorOutputFormat.PvrCompressed:
-                    GraphicsUtil.CompressPvrtc(content, isSpriteFont);
+                    GraphicsUtil.CompressPvrtc(context, content, isSpriteFont);
                     break;
             }
         }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/TextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/TextureProfile.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             // Handle this common compression format.
             if (format == TextureProcessorOutputFormat.Color16Bit)
             {
-                GraphicsUtil.CompressColor16Bit(content);
+                GraphicsUtil.CompressColor16Bit(context, content);
                 return;
             }
 

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				return new Rectangle(0, 0, this.width, this.height);
             }
         }
+
         /// <summary>
         /// Creates a new texture of the given size
         /// </summary>
@@ -45,6 +46,7 @@ namespace Microsoft.Xna.Framework.Graphics
             : this(graphicsDevice, width, height, false, SurfaceFormat.Color, SurfaceType.Texture, false, 1)
         {
         }
+
         /// <summary>
         /// Creates a new texture of a given size with a surface format and optional mipmaps 
         /// </summary>
@@ -57,6 +59,7 @@ namespace Microsoft.Xna.Framework.Graphics
             : this(graphicsDevice, width, height, mipmap, format, SurfaceType.Texture, false, 1)
         {
         }
+
         /// <summary>
         /// Creates a new texture array of a given size with a surface format and optional mipmaps.
         /// Throws ArgumentException if the current GraphicsDevice can't work with texture arrays
@@ -115,6 +118,9 @@ namespace Microsoft.Xna.Framework.Graphics
             PlatformConstruct(width, height, mipmap, format, type, shared);
         }
 
+        /// <summary>
+        /// Gets the width of the texture in pixels.
+        /// </summary>
         public int Width
         {
             get
@@ -123,6 +129,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets the height of the texture in pixels.
+        /// </summary>
         public int Height
         {
             get
@@ -130,6 +139,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 return height;
             }
         }
+
         /// <summary>
         /// Changes the pixels of the texture
         /// Throws ArgumentNullException if data is null
@@ -148,6 +158,7 @@ namespace Microsoft.Xna.Framework.Graphics
             ValidateParams(level, arraySlice, rect, data, startIndex, elementCount, out checkedRect);
             PlatformSetData(level, arraySlice, checkedRect, data, startIndex, elementCount);
         }
+
         /// <summary>
         /// Changes the pixels of the texture
         /// </summary>
@@ -161,8 +172,12 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             Rectangle checkedRect;
             ValidateParams(level, 0, rect, data, startIndex, elementCount, out checkedRect);
-            PlatformSetData(level, 0, checkedRect, data, startIndex, elementCount);
+            if (rect.HasValue)
+                PlatformSetData(level, 0, checkedRect, data, startIndex, elementCount);
+            else
+                PlatformSetData(level, data, startIndex, elementCount);
         }
+
         /// <summary>
         /// Changes the texture's pixels
         /// </summary>
@@ -176,6 +191,7 @@ namespace Microsoft.Xna.Framework.Graphics
             ValidateParams(0, 0, null, data, startIndex, elementCount, out checkedRect);
             PlatformSetData(0, data, startIndex, elementCount);
         }
+
 		/// <summary>
         /// Changes the texture's pixels
         /// </summary>
@@ -187,6 +203,7 @@ namespace Microsoft.Xna.Framework.Graphics
             ValidateParams(0, 0, null, data, 0, data.Length, out checkedRect);
             PlatformSetData(0, data, 0, data.Length);
         }
+
         /// <summary>
         /// Retrieves the contents of the texture
         /// Throws ArgumentException if data is null, data.length is too short or
@@ -205,6 +222,7 @@ namespace Microsoft.Xna.Framework.Graphics
             ValidateParams(level, arraySlice, rect, data, startIndex, elementCount, out checkedRect);
             PlatformGetData(level, arraySlice, checkedRect, data, startIndex, elementCount);
         }
+
         /// <summary>
         /// Retrieves the contents of the texture
         /// Throws ArgumentException if data is null, data.length is too short or
@@ -220,6 +238,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             this.GetData(level, 0, rect, data, startIndex, elementCount);
         }
+
         /// <summary>
         /// Retrieves the contents of the texture
         /// Throws ArgumentException if data is null, data.length is too short or
@@ -233,6 +252,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			this.GetData(0, null, data, startIndex, elementCount);
 		}
+
         /// <summary>
         /// Retrieves the contents of the texture
         /// Throws ArgumentException if data is null, data.length is too short or
@@ -273,6 +293,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new InvalidOperationException("This image format is not supported", e);
             }
         }
+
         /// <summary>
         /// Converts the texture to a JPG image
         /// </summary>
@@ -283,6 +304,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             PlatformSaveAsJpeg(stream, width, height);
         }
+
         /// <summary>
         /// Converts the texture to a PNG image
         /// </summary>

--- a/Test/ContentPipeline/TextureProcessorTests.cs
+++ b/Test/ContentPipeline/TextureProcessorTests.cs
@@ -244,7 +244,7 @@ namespace MonoGame.Tests.ContentPipeline
         }
 
 #if !XNA
-        void CompressDefault<T>(TargetPlatform platform, Color color)
+        void CompressDefault<T>(TargetPlatform platform, Color color, int width = 16, int height = 16)
         {
             var context = new TestProcessorContext(platform, "dummy.xnb");
 
@@ -257,7 +257,7 @@ namespace MonoGame.Tests.ContentPipeline
                 TextureFormat = TextureProcessorOutputFormat.Compressed
             };
 
-            var face = new PixelBitmapContent<Color>(16, 16);
+            var face = new PixelBitmapContent<Color>(width, height);
             Fill(face, color);
             var input = new Texture2DContent();
             input.Faces[0] = face;
@@ -265,10 +265,10 @@ namespace MonoGame.Tests.ContentPipeline
             var output = processor.Process(input, context);
 
             Assert.NotNull(output);
-            Assert.AreEqual(1, output.Faces.Count);
-            Assert.AreEqual(5, output.Faces[0].Count);
+            Assert.AreEqual(1, output.Faces.Count, "Expected number of faces");
+            Assert.AreEqual(5, output.Faces[0].Count, "Expected number of mipmaps");
 
-            Assert.IsAssignableFrom<T>(output.Faces[0][0]);
+            Assert.IsAssignableFrom<T>(output.Faces[0][0], "Incorrect pixel format");
         }
 
         [Test]
@@ -290,27 +290,99 @@ namespace MonoGame.Tests.ContentPipeline
         }
 
         [Test]
-        public void CompressDefaultiOSOpaque()
+        public void CompressDefaultiOSOpaqueSquarePOT()
         {
-            CompressDefault<PvrtcRgb4BitmapContent>(TargetPlatform.iOS, Color.Red);
+            CompressDefault<PvrtcRgb4BitmapContent>(TargetPlatform.iOS, Color.Red, 16, 16);
         }
 
         [Test]
-        public void CompressDefaultiOSAlpha()
+        public void CompressDefaultiOSOpaqueSquareNPOT()
+        {
+            CompressDefault<PixelBitmapContent<Bgr565>>(TargetPlatform.iOS, Color.Red, 24, 24);
+        }
+
+        [Test]
+        public void CompressDefaultiOSOpaqueNonSquarePOT()
+        {
+            CompressDefault<PixelBitmapContent<Bgr565>>(TargetPlatform.iOS, Color.Red, 8, 16);
+        }
+
+        [Test]
+        public void CompressDefaultiOSOpaqueNonSquareNPOT()
+        {
+            CompressDefault<PixelBitmapContent<Bgr565>>(TargetPlatform.iOS, Color.Red, 24, 16);
+        }
+
+        [Test]
+        public void CompressDefaultiOSAlphaSquarePOT()
         {
             CompressDefault<PvrtcRgba4BitmapContent>(TargetPlatform.iOS, Color.Red * 0.5f);
         }
 
         [Test]
-        public void CompressDefaultAndroidOpaque()
+        public void CompressDefaultiOSAlphaSquareNPOT()
         {
-            CompressDefault<Etc1BitmapContent>(TargetPlatform.Android, Color.Red);
+            CompressDefault<PixelBitmapContent<Bgra4444>>(TargetPlatform.iOS, Color.Red * 0.5f, 24, 24);
         }
 
         [Test]
-        public void CompressDefaultAndroidAlpha()
+        public void CompressDefaultiOSAlphaNonSquarePOT()
+        {
+            CompressDefault<PixelBitmapContent<Bgra4444>>(TargetPlatform.iOS, Color.Red * 0.5f, 8, 16);
+        }
+
+        [Test]
+        public void CompressDefaultiOSAlphaNonSquareNPOT()
+        {
+            CompressDefault<PixelBitmapContent<Bgra4444>>(TargetPlatform.iOS, Color.Red * 0.5f, 24, 16);
+        }
+
+        [Test]
+        public void CompressDefaultAndroidOpaqueSquarePOT()
+        {
+            CompressDefault<Etc1BitmapContent>(TargetPlatform.Android, Color.Red, 16, 16);
+        }
+
+        [Test]
+        public void CompressDefaultAndroidOpaqueSquareNPOT()
+        {
+            CompressDefault<PixelBitmapContent<Bgr565>>(TargetPlatform.Android, Color.Red, 24, 24);
+        }
+
+        [Test]
+        public void CompressDefaultAndroidOpaqueNonSquarePOT()
+        {
+            CompressDefault<Etc1BitmapContent>(TargetPlatform.Android, Color.Red, 8, 16);
+        }
+
+        [Test]
+        public void CompressDefaultAndroidOpaqueNonSquareNPOT()
+        {
+            CompressDefault<PixelBitmapContent<Bgr565>>(TargetPlatform.Android, Color.Red, 24, 16);
+        }
+
+        [Test]
+        public void CompressDefaultAndroidAlphaSquarePOT()
         {
             CompressDefault<PixelBitmapContent<Bgra4444>>(TargetPlatform.Android, Color.Red * 0.5f);
+        }
+
+        [Test]
+        public void CompressDefaultAndroidAlphaSquareNPOT()
+        {
+            CompressDefault<PixelBitmapContent<Bgra4444>>(TargetPlatform.Android, Color.Red * 0.5f, 24, 24);
+        }
+
+        [Test]
+        public void CompressDefaultAndroidAlphaNonSquarePOT()
+        {
+            CompressDefault<PixelBitmapContent<Bgra4444>>(TargetPlatform.Android, Color.Red * 0.5f, 8, 16);
+        }
+
+        [Test]
+        public void CompressDefaultAndroidAlphaNonSquareNPOT()
+        {
+            CompressDefault<PixelBitmapContent<Bgra4444>>(TargetPlatform.Android, Color.Red * 0.5f, 24, 16);
         }
 #endif
     }


### PR DESCRIPTION
This PR fixes some cases where ETC1 fallback wasn't working as expected, and expands the fallback support to allow NPOT and non-square textures to fall back to 16-bit formats instead of failing.

More unit tests added for texture compression.

If no rect is passed to Texture2D.SetData() that takes an optional rect, it passes the call to the full texture PlatformSetData instead for performance reasons.

~~Remove a try..catch on Android that was hiding ContentLoadException thrown during content load.~~

Fixes #5983