### PR TITLE
Use desktop and UWP specific assemblies where necessary

### DIFF
--- a/Build/Projects/2MGFXReferences.definition
+++ b/Build/Projects/2MGFXReferences.definition
@@ -4,7 +4,7 @@
   <Platform Type="Windows">
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/net40/SharpDX.dll" />
     <Binary
       Name="SharpDX.D3DCompiler"
       Path="ThirdParty/Dependencies/SharpDX/SharpDX.D3DCompiler.dll" />

--- a/Build/Projects/Framework.Content.Pipeline.References.definition
+++ b/Build/Projects/Framework.Content.Pipeline.References.definition
@@ -81,7 +81,7 @@
   <Platform Type="Windows">
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
+      Path="ThirdParty\Dependencies\SharpDX\net40\SharpDX.dll" />
     <Binary
       Name="SharpDX.D3DCompiler"
       Path="ThirdParty\Dependencies\SharpDX\SharpDX.D3DCompiler.dll" />

--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -46,7 +46,7 @@
       <Reference Include="System.Xml" />
       <Binary
         Name="SharpDX"
-        Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/net45/SharpDX.dll" />
       <Binary
         Name="SharpDX.Direct2D1"
         Path="ThirdParty/Dependencies/SharpDX/SharpDX.Direct2D1.dll" />
@@ -92,7 +92,7 @@
   <Platform Type="WindowsUniversal">
     <Binary
       Name="SharpDX"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/uap10.0/SharpDX.dll" />
     <Binary
       Name="SharpDX.Direct2D1"
       Path="ThirdParty/Dependencies/SharpDX/SharpDX.Direct2D1.dll" />
@@ -104,10 +104,10 @@
       Path="ThirdParty/Dependencies/SharpDX/SharpDX.DXGI.dll" />
     <Binary
       Name="SharpDX.MediaFoundation"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.MediaFoundation.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/uap10.0/SharpDX.MediaFoundation.dll" />
     <Binary
       Name="SharpDX.XAudio2"
-      Path="ThirdParty/Dependencies/SharpDX/SharpDX.XAudio2.dll" />
+      Path="ThirdParty/Dependencies/SharpDX/uap10.0/SharpDX.XAudio2.dll" />
   </Platform>
 	
   <Platform Type="Web">

--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -46,7 +46,7 @@
       <Reference Include="System.Xml" />
       <Binary
         Name="SharpDX"
-        Path="ThirdParty/Dependencies/SharpDX/net45/SharpDX.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/net40/SharpDX.dll" />
       <Binary
         Name="SharpDX.Direct2D1"
         Path="ThirdParty/Dependencies/SharpDX/SharpDX.Direct2D1.dll" />
@@ -58,13 +58,13 @@
         Path="ThirdParty/Dependencies/SharpDX/SharpDX.DXGI.dll" />
       <Binary
         Name="SharpDX.MediaFoundation"
-        Path="ThirdParty/Dependencies/SharpDX/net45/SharpDX.MediaFoundation.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/net40/SharpDX.MediaFoundation.dll" />
       <Binary
         Name="SharpDX.XAudio2"
-        Path="ThirdParty/Dependencies/SharpDX/net45/SharpDX.XAudio2.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/net40/SharpDX.XAudio2.dll" />
       <Binary
         Name="SharpDX.XInput"
-        Path="ThirdParty/Dependencies/SharpDX/SharpDX.XInput.dll" />
+        Path="ThirdParty/Dependencies/SharpDX/net40/SharpDX.XInput.dll" />
     </Service>
 
     <Service Name="MonoGame.Framework/OpenGLGraphics">


### PR DESCRIPTION
Depends on MonoGame/MonoGame.Dependencies#115. 

Because we used the .NET Standard assemblies, some conditionally compiled code that we need was not included (see the issue in .Dependencies for details). This makes MG use the assemblies compiled specifically for either UWP or desktop where needed.

This should fix issue #5998 