### PR TITLE
Expose ContentIdentity of the source asset inside ContentProcessorContext.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineProcessorContext.cs
@@ -34,6 +34,8 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
         public override ContentBuildLogger Logger { get { return _manager.Logger; } }
 
+        public override ContentIdentity SourceIdentity { get { return new ContentIdentity(_pipelineEvent.SourceFile); } }
+
         public override void AddDependency(string filename)
         {
             _pipelineEvent.Dependencies.AddUnique(filename);

--- a/MonoGame.Framework.Content.Pipeline/ContentProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentProcessorContext.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         public abstract ContentBuildLogger Logger { get; }
 
         /// <summary>
+        /// Gets the ContentIdentity representing the source asset imported.
+        /// </summary>
+        public abstract ContentIdentity SourceIdentity { get; }
+
+        /// <summary>
         /// Gets the output path of the content processor.
         /// </summary>
         public abstract string OutputDirectory { get; }

--- a/Test/ContentPipeline/TestProcessorContext.cs
+++ b/Test/ContentPipeline/TestProcessorContext.cs
@@ -49,6 +49,11 @@ namespace MonoGame.Tests.ContentPipeline
             get { throw new NotImplementedException(); }
         }
 
+        public override ContentIdentity SourceIdentity
+        {
+            get { throw new NotImplementedException(); }
+        }
+
         public override TargetPlatform TargetPlatform
         {
             get { return _targetPlatform; }


### PR DESCRIPTION
Exposes the ContentIdentity of the imported asset-file to reduce the need for special types in importers. The information was already available in the ProcessorContext, this just brings it up to the surface so extension authors can benefit. The main usecase is when adding external references or building dependencies during content processing. Resolves #6014