### PR TITLE
Added buffered KeyDown & KeyUp events

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -280,6 +280,9 @@
     <Compile Include="IDrawable.cs" />
     <Compile Include="IGameComponent.cs" />
     <Compile Include="IGraphicsDeviceManager.cs" />
+    <Compile Include="InputKeyEventArgs.cs">
+      <Platforms>Angle,Linux,MacOS,Windows,WindowsGL,WindowsUniversal</Platforms>
+    </Compile>
     <Compile Include="IUpdateable.cs" />
     <Compile Include="LaunchParameters.cs" />
     <Compile Include="MathHelper.cs" />
@@ -991,6 +994,9 @@
     </Compile>
     <Compile Include="Input\KeyboardState.cs" />
     <Compile Include="Input\Keys.cs" />
+    <Compile Include="Input\KeysHelper.cs">
+      <Platforms>Angle,Linux,MacOS,Windows,WindowsGL,WindowsUniversal</Platforms>
+    </Compile>
     <Compile Include="Input\KeyState.cs" />
     <Compile Include="Input\MessageBox.cs">
       <Platforms>Android,iOS,WindowsUniversal</Platforms>

--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -102,6 +102,14 @@ namespace Microsoft.Xna.Framework {
 		/// This event is only supported on the Windows DirectX, Windows OpenGL and Linux platforms.
 		/// </remarks>
 		public event EventHandler<TextInputEventArgs> TextInput;
+        /// <summary>
+        /// Buffered keyboard KeyDown event.
+        /// </summary>
+		public event EventHandler<InputKeyEventArgs> KeyDown;
+	    /// <summary>
+	    /// Buffered keyboard KeyUp event.
+	    /// </summary>
+		public event EventHandler<InputKeyEventArgs> KeyUp;
 #endif
 
 		#endregion Events
@@ -148,9 +156,17 @@ namespace Microsoft.Xna.Framework {
 		{
             EventHelpers.Raise(this, TextInput, e);
 		}
+	    protected void OnKeyDown(object sender, InputKeyEventArgs e)
+	    {
+	        EventHelpers.Raise(this, KeyDown, e);
+	    }
+	    protected void OnKeyUp(object sender, InputKeyEventArgs e)
+	    {
+	        EventHelpers.Raise(this, KeyUp, e);
+	    }
 #endif
 
-		protected internal abstract void SetSupportedOrientations (DisplayOrientation orientations);
+        protected internal abstract void SetSupportedOrientations (DisplayOrientation orientations);
 		protected abstract void SetTitle (string title);
 
 #if DIRECTX && WINDOWS

--- a/MonoGame.Framework/Input/KeyboardUtil.SDL.cs
+++ b/MonoGame.Framework/Input/KeyboardUtil.SDL.cs
@@ -155,8 +155,9 @@ namespace Microsoft.Xna.Framework.Input
 
         public static Keys ToXna(int key)
         {
-            if (_map.ContainsKey(key))
-                return _map[key];
+            Keys xnaKey;
+            if (_map.TryGetValue(key, out xnaKey))
+                return xnaKey;
 
             return Keys.None;
         }

--- a/MonoGame.Framework/Input/KeysHelper.cs
+++ b/MonoGame.Framework/Input/KeysHelper.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Input

--- a/MonoGame.Framework/Input/KeysHelper.cs
+++ b/MonoGame.Framework/Input/KeysHelper.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    internal static class KeysHelper
+    {
+        static Dictionary<int, Keys> _map;
+
+        static KeysHelper()
+        {
+            _map = new Dictionary<int, Keys>();
+            var allKeys = (Keys[])Enum.GetValues(typeof(Keys));
+            foreach (var key in allKeys)
+            {
+                _map.Add((int)key, (key));
+            }
+        }
+
+        /// <summary>
+        /// Checks if specified value is valid Key.
+        /// </summary>
+        /// <param name="value">Keys base value</param>
+        /// <returns>Returns true if value is valid Key, false otherwise</returns>
+        public static bool IsKey(int value)
+        {
+            return _map.ContainsKey(value);
+        }
+    }
+}

--- a/MonoGame.Framework/InputKeyEventArgs.cs
+++ b/MonoGame.Framework/InputKeyEventArgs.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Microsoft.Xna.Framework.Input;
+
+namespace Microsoft.Xna.Framework
+{
+    public class InputKeyEventArgs : EventArgs
+    {
+        public Keys Key { get; private set; }
+
+        public InputKeyEventArgs(Keys key)
+        {
+            Key = key;
+        }
+    }
+}

--- a/MonoGame.Framework/InputKeyEventArgs.cs
+++ b/MonoGame.Framework/InputKeyEventArgs.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
 using Microsoft.Xna.Framework.Input;
 
 namespace Microsoft.Xna.Framework

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -138,6 +138,8 @@ namespace Microsoft.Xna.Framework
                     if (!_keys.Contains (key))
                         _keys.Add (key);
                     char character = (char)ev.Key.Keysym.Sym;
+                    if (KeysHelper.IsKey((int)key))
+                        _view.CallKeyDown(key);
                     if (char.IsControl (character))
                         _view.CallTextInput (character, key);
                 }
@@ -145,6 +147,8 @@ namespace Microsoft.Xna.Framework
                 {
                     var key = KeyboardUtil.ToXna(ev.Key.Keysym.Sym);
                     _keys.Remove(key);
+                    if (KeysHelper.IsKey((int)key))
+                        _view.CallKeyUp(key);
                 }
                 else if (ev.Type == Sdl.EventType.TextInput)
                 {

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -299,6 +299,16 @@ namespace Microsoft.Xna.Framework
             OnTextInput(this, new TextInputEventArgs(c, key));
         }
 
+        public void CallKeyDown(Keys key)
+        {
+            OnKeyDown(this, new InputKeyEventArgs(key));
+        }
+
+        public void CallKeyUp(Keys key)
+        {
+            OnKeyUp(this, new InputKeyEventArgs(key));
+        }
+
         protected internal override void SetSupportedOrientations(DisplayOrientation orientations)
         {
             // Nothing to do here

--- a/MonoGame.Framework/Windows/WinFormsGameForm.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameForm.cs
@@ -39,6 +39,9 @@ namespace Microsoft.Xna.Framework.Windows
         public const int WM_POINTERDOWN = 0x0246;
         public const int WM_POINTERUPDATE = 0x0245;
         public const int WM_KEYDOWN = 0x0100;
+        public const int WM_KEYUP = 0x0101;
+        public const int WM_SYSKEYDOWN = 0x0104;
+        public const int WM_SYSKEYUP = 0x0105;
         public const int WM_TABLET_QUERYSYSTEMGESTURESTA = (0x02C0 + 12);
 
         public const int WM_ENTERSIZEMOVE = 0x0231;
@@ -93,6 +96,7 @@ namespace Microsoft.Xna.Framework.Windows
                     }
 #if (WINDOWS && DIRECTX)
                 case WM_KEYDOWN:
+                    HandleKeyMessage(ref m);
                     switch (m.WParam.ToInt32())
                     {
                         case 0x5B:  // Left Windows Key
@@ -100,9 +104,16 @@ namespace Microsoft.Xna.Framework.Windows
 
                             if (_window.IsFullScreen && _window.HardwareModeSwitch)
                                 this.WindowState = FormWindowState.Minimized;
- 		 
+
                             break;
                     }
+                    break;
+                case WM_SYSKEYDOWN:
+                    HandleKeyMessage(ref m);
+                    break;
+                case WM_KEYUP:
+                case WM_SYSKEYUP:
+                    HandleKeyMessage(ref m);
                     break;
 #endif
                 case WM_SYSCOMMAND:
@@ -160,6 +171,62 @@ namespace Microsoft.Xna.Framework.Windows
             }
 
             base.WndProc(ref m);
+        }
+
+        void HandleKeyMessage(ref Message m)
+        {
+            long virtualKeyCode = m.WParam.ToInt64();
+            bool extended = (m.LParam.ToInt64() & 0x01000000) != 0;
+            long scancode = (m.LParam.ToInt64() & 0x00ff0000) >> 16;
+            var key = KeyCodeTranslate(
+                (System.Windows.Forms.Keys)virtualKeyCode,
+                extended,
+                scancode);
+            if (Input.KeysHelper.IsKey((int)key))
+            {
+                switch (m.Msg)
+                {
+                    case WM_KEYDOWN:
+                    case WM_SYSKEYDOWN:
+                        _window.CallOnKeyDown(key);
+                        break;
+                    case WM_KEYUP:
+                    case WM_SYSKEYUP:
+                        _window.CallOnKeyUp(key);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+        }
+
+        private static Microsoft.Xna.Framework.Input.Keys KeyCodeTranslate(
+            System.Windows.Forms.Keys keyCode, bool extended, long scancode)
+        {
+            switch (keyCode)
+            {
+                // WinForms does not distinguish between left/right keys
+                // We have to check for special keys such as control/shift/alt/ etc
+                case System.Windows.Forms.Keys.ControlKey:
+                    return extended
+                        ? Microsoft.Xna.Framework.Input.Keys.RightControl
+                        : Microsoft.Xna.Framework.Input.Keys.LeftControl;
+                case System.Windows.Forms.Keys.ShiftKey:
+                    // left shift is 0x2A, right shift is 0x36. IsExtendedKey is always false.
+                    return ((scancode & 0x1FF) == 0x36)
+                               ? Microsoft.Xna.Framework.Input.Keys.RightShift
+                                : Microsoft.Xna.Framework.Input.Keys.LeftShift;
+                // Note that the Alt key is now refered to as Menu.
+                case System.Windows.Forms.Keys.Menu:
+                case System.Windows.Forms.Keys.Alt:
+                    return extended
+                        ? Microsoft.Xna.Framework.Input.Keys.RightAlt
+                        : Microsoft.Xna.Framework.Input.Keys.LeftAlt;
+
+                default:
+                    return (Microsoft.Xna.Framework.Input.Keys)keyCode;
+            }
         }
     }
 }

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -310,6 +310,36 @@ namespace MonoGame.Framework
             OnTextInput(sender, new TextInputEventArgs(e.KeyChar));
         }
 
+        internal void CallOnKeyDown(Microsoft.Xna.Framework.Input.Keys key)
+        {
+            OnKeyDown(this, new InputKeyEventArgs(key));
+        }
+
+        internal void CallOnKeyUp(Microsoft.Xna.Framework.Input.Keys key)
+        {
+            OnKeyUp(this, new InputKeyEventArgs(key));
+        }
+
+        internal static Microsoft.Xna.Framework.Input.Keys KeyEventTranslate(KeyEventArgs e)
+        {
+            switch (e.KeyCode)
+            {
+                // WinForms does not distinguish between left/right keys
+                // We have to check for special keys such as control/shift/alt/ etc
+                case System.Windows.Forms.Keys.ControlKey:
+                    return Microsoft.Xna.Framework.Input.Keys.LeftControl;
+                case System.Windows.Forms.Keys.ShiftKey:
+                    return Microsoft.Xna.Framework.Input.Keys.LeftShift;
+                // Note that the Alt key is now refered to as Menu.
+                case System.Windows.Forms.Keys.Menu:
+                case System.Windows.Forms.Keys.Alt:
+                    return Microsoft.Xna.Framework.Input.Keys.LeftAlt;
+
+                default:
+                    return (Microsoft.Xna.Framework.Input.Keys)e.KeyCode;
+            }
+        }
+
         internal void Initialize(int width, int height)
         {
             Form.ClientSize = new Size(width, height);

--- a/MonoGame.Framework/WindowsUniversal/InputEvents.cs
+++ b/MonoGame.Framework/WindowsUniversal/InputEvents.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Xna.Framework
             Keyboard.UpdateState();
         }
 
-        private static Keys KeyTranslate(Windows.System.VirtualKey inkey, CorePhysicalKeyStatus keyStatus)
+        internal static Keys KeyTranslate(Windows.System.VirtualKey inkey, CorePhysicalKeyStatus keyStatus)
         {
             switch (inkey)
             {

--- a/MonoGame.Framework/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPGameWindow.cs
@@ -131,6 +131,7 @@ namespace Microsoft.Xna.Framework
             _coreWindow.Closed += Window_Closed;
             _coreWindow.Activated += Window_FocusChanged;
             _coreWindow.CharacterReceived += Window_CharacterReceived;
+            _coreWindow.Dispatcher.AcceleratorKeyActivated += Dispatcher_AcceleratorKeyActivated;
 
             SystemNavigationManager.GetForCurrentView().BackRequested += BackRequested;
 
@@ -214,6 +215,27 @@ namespace Microsoft.Xna.Framework
         private void Window_CharacterReceived(CoreWindow sender, CharacterReceivedEventArgs args)
         {
             _textQueue.Enqueue((char)args.KeyCode);
+        }
+
+        private void Dispatcher_AcceleratorKeyActivated(CoreDispatcher sender, AcceleratorKeyEventArgs args)
+        {
+            // NOTE: Dispatcher event is used becuase KeyDown event doesn't handle Alt key
+            var key = InputEvents.KeyTranslate(args.VirtualKey, args.KeyStatus);
+            switch (args.EventType)
+            {
+                case CoreAcceleratorKeyEventType.KeyDown:
+                case CoreAcceleratorKeyEventType.SystemKeyDown:
+                    if (KeysHelper.IsKey((int)key))
+                        OnKeyDown(sender, new InputKeyEventArgs(key));
+                    break;
+                case CoreAcceleratorKeyEventType.KeyUp:
+                case CoreAcceleratorKeyEventType.SystemKeyUp:
+                    if (KeysHelper.IsKey((int)key))
+                        OnKeyUp(sender, new InputKeyEventArgs(key));
+                    break;
+                default:
+                    break;
+            }
         }
 
         private void UpdateTextInput()


### PR DESCRIPTION
I know this is not par of XNA's API, but since we already have TextInput I also added KeyDown & KeyUp events. Like TextInput they are buffered (no missed keys if framerate is low). This two events can be for example used to move cursor inside text box with arrow keys or with 'Home' and 'End' keys.