### PR TITLE
[UWP] Force enable V-Sync to prevent crashes

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -239,6 +239,12 @@ namespace Microsoft.Xna.Framework.Graphics
             PresentationParameters.MultiSampleCount =
                 GetClampedMultisampleCount(PresentationParameters.MultiSampleCount);
 
+            // Force V-Sync On for UAP
+#if WINDOWS_UAP
+            // TODO: Add V-Sync off support for UWP https://msdn.microsoft.com/en-us/library/windows/desktop/mt742104.aspx
+            PresentationParameters.PresentationInterval = PresentInterval.One;
+#endif
+
             _d3dContext.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView)null, 
                                                 (SharpDX.Direct3D11.RenderTargetView)null);  
 


### PR DESCRIPTION
Fixes #6020

Unfortunately I wasn't able to add proper support for disabling V-Sync in UWP. This PR just forces V-Sync to be always on in order to prevent crashing.

Here is some info on how to properly add this feature, if anyone has time:
https://stackoverflow.com/questions/45071415/how-can-i-disable-vsync-in-uwp
https://blogs.msdn.microsoft.com/directx/2016/05/10/unlocked-frame-rate-and-more-now-enabled-for-uwp/