### PR TITLE
Fix error when reading none square textures using mipmaps.

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -74,8 +74,8 @@ namespace Microsoft.Xna.Framework.Content
 				    var levelDataSizeInBytes = reader.ReadInt32();
                     var levelData = reader.ContentManager.GetScratchBuffer(levelDataSizeInBytes);
                     reader.Read(levelData, 0, levelDataSizeInBytes);
-                    int levelWidth = width >> level;
-                    int levelHeight = height >> level;
+                    int levelWidth = Math.Max(width >> level, 1);
+                    int levelHeight = Math.Max(height >> level, 1);
 
                     if (level >= levelCountOutput)
                         continue;


### PR DESCRIPTION
Commit https://github.com/MonoGame/MonoGame/commit/8b5bc3ac93960cd88b60bec9917956209f025d99
changed how mipmaps generation is handled. Part of that fix includes validation logic executed when setting texture data Texture2D.SetData.

I have a none square texture 256x128 that correctly loaded in the past, but after commit above I get the following exception on load:

Texture2D.cs:357

throw new ArgumentException("startIndex must be at least zero and smaller than data.Length.", "startIndex");

Turns out that when reading back mipmaps we hit a scenario for none square textures that set width/height to 1x0 instead of 1x1 for smallest mipmap and that cause allocation of 0 length data buffer that in turn trigger ValidateParams to throw an exception.

Problem is the implementation of Texture2DReader.cs line 78,79:

int levelWidth = width >> level;
int levelHeight = height >> level;

Since that will transform to 1x0 for smallest mipmap of none square textures instead of 1x1.

Fix is to make sure we never get smaller than 1x1 in above statements.