### PR TITLE
Windows 10 CoreWindow service registry

### DIFF
--- a/MonoGame.Framework/WindowsUniversal/UAPFrameworkView.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPFrameworkView.cs
@@ -82,6 +82,9 @@ namespace Microsoft.Xna.Framework
         {
             // Initialize the singleton window.
             UAPGameWindow.Instance.Initialize(window, null, UAPGamePlatform.TouchQueue);
+
+			// Register the CoreWindow with the services registry
+			_game.Services.AddService (typeof(CoreWindow), window);
         }
 
         public void Uninitialize()

--- a/MonoGame.Framework/WindowsUniversal/XamlGame.cs
+++ b/MonoGame.Framework/WindowsUniversal/XamlGame.cs
@@ -48,6 +48,9 @@ namespace MonoGame.Framework
                 throw new NullReferenceException("You must create the GraphicsDeviceManager in the Game constructor!");
             game.graphicsDeviceManager.SwapChainPanel = swapChainPanel;
 
+            // Register the CoreWindow with the services registry
+            game.Services.AddService(typeof(CoreWindow), window);
+
             // Start running the game.
             game.Run(GameRunBehavior.Asynchronous);
 


### PR DESCRIPTION
Small PR to add the reference to the CoreWindow to the service library.  Replicating behaviour used in iOS/Android

Needed for MR/HL support

In Windows HoloGraphic, this is used to define the holographic space needed for the environment.  The constructor requires access to the CoreWindow to define bounds.