### PR TITLE
[MGCB] Parse filenames as arguments

### DIFF
--- a/Installers/Linux/Main/mgcb.1
+++ b/Installers/Linux/Main/mgcb.1
@@ -15,6 +15,10 @@ is a command line tool for building XNB content on Windows, Mac, and Linux deskt
 Typically it is executed by the Pipeline GUI tool when editing content or indirectly from Visual Studio or MonoDevelop during the build process of a MonoGame project. Alternatively you can use it yourself from the command line for specialized build pipelines or for debugging content processing.
 
 .TP
+.BR \fIFILENAME\fR
+Automatically selects either build or response file option for the selected file, see below for more detail on what these options are.
+
+.TP
 .BR \-@ ", " \-\-@ =\fIRESPONSEFILE\fR
 Read a text response file with additional command line options and switches.
 

--- a/Tools/MGCB/CommandLineParser.cs
+++ b/Tools/MGCB/CommandLineParser.cs
@@ -302,9 +302,13 @@ namespace MGCB
 
                 }
 
-                if (arg.StartsWith("/@:") || arg.StartsWith("--@:") || arg.StartsWith("-@:"))
+                if (arg.StartsWith("/@") || arg.StartsWith("--@") || arg.StartsWith("-@")
+                    || (arg.EndsWith(".mgcb") && File.Exists(arg)))
                 {
-                    var file = arg.Substring(3);
+                    var file = arg;
+                    if (!File.Exists(arg))
+                        file = arg.Substring(arg.StartsWith("--@") ? 4 : 3);
+
                     var commands = File.ReadAllLines(file);
                     var offset = 0;
                     lines.Insert(0, string.Format("# Begin:{0} ", file));
@@ -335,6 +339,10 @@ namespace MGCB
 
         private bool ParseFlags(string arg)
         {
+            // Filename detected, redo with a build command
+            if (File.Exists(arg))
+                return ParseFlags("/build=" + arg);
+
             // Only one flag
             if (arg.Length >= 3 &&
                 (arg[0] == '-' || arg[0] == '/') &&


### PR DESCRIPTION
Allows parsing of filenames (and depending if its a .mgcb file it will either treat it like a response file or build it) like so:

**Build single content file:**
```
mgcb test.png
```

**Build response file:**
```
mgcb Content.mgcb
```

PS. Also fixes the error of trying to process response file with "--@:", and the fact that "=" was not a valid separator for them.