### PR TITLE
[ContentManager] Turned some private fields to protected for external extensibility

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -24,11 +24,11 @@ namespace Microsoft.Xna.Framework.Content
         const byte ContentCompressedLz4 = 0x40;
 
 		private string _rootDirectory = string.Empty;
-		private IServiceProvider serviceProvider;
-		private IGraphicsDeviceService graphicsDeviceService;
-        private Dictionary<string, object> loadedAssets = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+		protected IServiceProvider serviceProvider;
+		protected IGraphicsDeviceService graphicsDeviceService;
+        protected Dictionary<string, object> loadedAssets = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 		private List<IDisposable> disposableAssets = new List<IDisposable>();
-        private bool disposed;
+        protected bool disposed;
         private byte[] scratchBuffer;
 
 		private static object ContentManagerLock = new object();
@@ -341,7 +341,7 @@ namespace Microsoft.Xna.Framework.Content
 			return (T)result;
 		}
 
-        private ContentReader GetContentReaderFromXnb(string originalAssetName, Stream stream, BinaryReader xnbReader, Action<IDisposable> recordDisposableObject)
+        protected ContentReader GetContentReaderFromXnb(string originalAssetName, Stream stream, BinaryReader xnbReader, Action<IDisposable> recordDisposableObject)
         {
             // The first 4 bytes should be the "XNB" header. i use that to detect an invalid file
             byte x = xnbReader.ReadByte();

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Xna.Framework.Content
 		protected IServiceProvider serviceProvider;
 		protected IGraphicsDeviceService graphicsDeviceService;
         protected Dictionary<string, object> loadedAssets = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-		private List<IDisposable> disposableAssets = new List<IDisposable>();
+		protected List<IDisposable> disposableAssets = new List<IDisposable>();
         protected bool disposed;
         private byte[] scratchBuffer;
 

--- a/MonoGame.Framework/Content/ContentReader.cs
+++ b/MonoGame.Framework/Content/ContentReader.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Xna.Framework.Content
             }
         }
 
-        internal object ReadAsset<T>()
+        public object ReadAsset<T>()
         {
             InitializeTypeReaders();
 
@@ -77,7 +77,7 @@ namespace Microsoft.Xna.Framework.Content
             return result;
         }
 
-        internal object ReadAsset<T>(T existingInstance)
+        public object ReadAsset<T>(T existingInstance)
         {
             InitializeTypeReaders();
 


### PR DESCRIPTION
Currently it is not really possible to extend ContentManager without changing the Monogame sources themselves, there are a number of private members that are needed in order to bring real customization.