### PR TITLE
[WindowsDX] fix NullReferenceException in Mouse.WindowHandle

### DIFF
--- a/MonoGame.Framework/Input/Mouse.Windows.cs
+++ b/MonoGame.Framework/Input/Mouse.Windows.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Xna.Framework.Input
 
         private static IntPtr PlatformGetWindowHandle()
         {
-            return _window.Handle;
+            return (_window == null) ? IntPtr.Zero : _window.Handle;
         }
 
         private static void PlatformSetWindowHandle(IntPtr windowHandle)


### PR DESCRIPTION
When WindowHandle/_window is not set it should return `IntPtr.Zero`.
Currently  it throws a NullReferenceException.

Related to #5816