### PR TITLE
[DesktopDX] Handle Mouse input/state inside Mouse class

### DIFF
--- a/MonoGame.Framework/Input/Mouse.Default.cs
+++ b/MonoGame.Framework/Input/Mouse.Default.cs
@@ -22,6 +22,14 @@ namespace Microsoft.Xna.Framework.Input
             return window.MouseState;
         }
 
+        private static MouseState PlatformGetState()
+        {
+            if (PrimaryWindow != null)
+                return PlatformGetState(PrimaryWindow);
+
+            return _defaultState;
+        }
+
         private static void PlatformSetPosition(int x, int y)
         {
             PrimaryWindow.MouseState.X = x;

--- a/MonoGame.Framework/Input/Mouse.MacOS.cs
+++ b/MonoGame.Framework/Input/Mouse.MacOS.cs
@@ -55,6 +55,14 @@ namespace Microsoft.Xna.Framework.Input
             return window.MouseState;
         }
 
+        private static MouseState PlatformGetState()
+        {
+            if (PrimaryWindow != null)
+                return PlatformGetState(PrimaryWindow);
+
+            return _defaultState;
+        }
+
         private static void PlatformSetPosition(int x, int y)
         {
             PrimaryWindow.MouseState.X = x;

--- a/MonoGame.Framework/Input/Mouse.SDL.cs
+++ b/MonoGame.Framework/Input/Mouse.SDL.cs
@@ -49,6 +49,14 @@ namespace Microsoft.Xna.Framework.Input
             return window.MouseState;
         }
 
+        private static MouseState PlatformGetState()
+        {
+            if (PrimaryWindow != null)
+                return PlatformGetState(PrimaryWindow);
+
+            return _defaultState;
+        }
+
         private static void PlatformSetPosition(int x, int y)
         {
             PrimaryWindow.MouseState.X = x;

--- a/MonoGame.Framework/Input/Mouse.Windows.cs
+++ b/MonoGame.Framework/Input/Mouse.Windows.cs
@@ -31,6 +31,14 @@ namespace Microsoft.Xna.Framework.Input
             return window.MouseState;
         }
 
+        private static MouseState PlatformGetState()
+        {
+            if (PrimaryWindow != null)
+                return PlatformGetState(PrimaryWindow);
+
+            return _defaultState;
+        }
+
         private static void PlatformSetPosition(int x, int y)
         {
             PrimaryWindow.MouseState.X = x;

--- a/MonoGame.Framework/Input/Mouse.Windows.cs
+++ b/MonoGame.Framework/Input/Mouse.Windows.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Xna.Framework.Input
 
         private static IntPtr PlatformGetWindowHandle()
         {
-            return _window.Handle;
+            return (_window == null) ? IntPtr.Zero : _window.Handle;
         }
 
         private static void PlatformSetWindowHandle(IntPtr windowHandle)

--- a/MonoGame.Framework/Input/Mouse.Windows.cs
+++ b/MonoGame.Framework/Input/Mouse.Windows.cs
@@ -10,9 +10,23 @@ namespace Microsoft.Xna.Framework.Input
 {
     public static partial class Mouse
     {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct POINTSTRUCT
+        {
+            public int X;
+            public int Y;
+        }
+
         [DllImportAttribute("user32.dll", EntryPoint = "SetCursorPos")]
         [return: MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.Bool)]
         private static extern bool SetCursorPos(int X, int Y);
+
+        [DllImport("user32.dll", ExactSpelling=true, CharSet=CharSet.Auto)]
+        [return: MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.Bool)]
+        internal static extern bool GetCursorPos(out POINTSTRUCT pt);
+        
+        [DllImport("user32.dll", ExactSpelling=true, CharSet=CharSet.Auto)]
+        internal static extern int MapWindowPoints(HandleRef hWndFrom, HandleRef hWndTo, out POINTSTRUCT pt, int cPoints);
 
         private static Control _window;
         private static MouseInputWnd _mouseInputWnd = new MouseInputWnd();
@@ -41,8 +55,10 @@ namespace Microsoft.Xna.Framework.Input
         {
             if (_window != null)
             {
-                var screenPos = Control.MousePosition;
-                var clientPos = _window.PointToClient(screenPos);
+                POINTSTRUCT pos;
+                GetCursorPos(out pos);
+                MapWindowPoints(new HandleRef(null, IntPtr.Zero), new HandleRef(_window, WindowHandle), out pos, 1);
+                var clientPos = new System.Drawing.Point(pos.X, pos.Y);
                 var buttons = Control.MouseButtons;
                 
                 return new MouseState(

--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -42,10 +42,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <returns>Current state of the mouse.</returns>
         public static MouseState GetState()
         {
-            if (PrimaryWindow != null)
-                return GetState(PrimaryWindow);
-
-            return _defaultState;
+            return PlatformGetState();
         }
 
         /// <summary>


### PR DESCRIPTION
fixes #6009 

Breaking change:
Mouse.Position will be updated on every call of GetState(). 
Previously on DesktopDX the mouse state was updated once per Update().
The new behavior is similar to XNA and some other MG platforms (WindowsUniversal & OpenGL I think).
