### PR TITLE
Fix GL PInvoke calling convention

### DIFF
--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -759,7 +759,6 @@ namespace MonoGame.OpenGL
 
         [System.Security.SuppressUnmanagedCodeSecurity ()]
         [MonoNativeFunctionWrapper]
-        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         internal delegate void ReadPixelsDelegate (int x, int y, int width, int height, PixelFormat format, PixelType type, IntPtr data);
         internal static ReadPixelsDelegate ReadPixelsInternal;
 
@@ -839,7 +838,6 @@ namespace MonoGame.OpenGL
 
         [System.Security.SuppressUnmanagedCodeSecurity ()]
         [MonoNativeFunctionWrapper]
-        [UnmanagedFunctionPointer (CallingConvention.Cdecl)]
         public delegate void RenderbufferStorageDelegate (RenderbufferTarget target, RenderbufferStorage storage, int width, int hegiht);
         public static RenderbufferStorageDelegate RenderbufferStorage;
 


### PR DESCRIPTION
Calling conventions were wrong for these two methods. We should just use the default (StdCall), so removing the lines that specify the custom calling convention fixes the issue. 

fixes #6084 
cc @dellis1972 