### PR TITLE
Binary search for curve evaluation

### DIFF
--- a/MonoGame.Framework/Curve.cs
+++ b/MonoGame.Framework/Curve.cs
@@ -303,7 +303,10 @@ namespace Microsoft.Xna.Framework
         private float GetCurvePosition(float position)
         {
             //only for position in curve
-            int nextIndex = Math.Max(this._keys.IndexAtPosition(position), 1);
+            int nextIndex = this._keys.IndexAtPosition(position);
+            if (nextIndex < 0)
+                nextIndex = ~nextIndex;
+            nextIndex = Math.Max(nextIndex, 1);
             CurveKey prev = _keys[nextIndex - 1];
             CurveKey next = _keys[nextIndex];
             if (prev.Continuity == CurveContinuity.Step)

--- a/MonoGame.Framework/Curve.cs
+++ b/MonoGame.Framework/Curve.cs
@@ -303,36 +303,29 @@ namespace Microsoft.Xna.Framework
         private float GetCurvePosition(float position)
         {
             //only for position in curve
-            CurveKey prev = this._keys[0];
-            CurveKey next;
-            for (int i = 1; i < this._keys.Count; ++i)
+            int nextIndex = Math.Max(this._keys.IndexAtPosition(position), 1);
+            CurveKey prev = _keys[nextIndex - 1];
+            CurveKey next = _keys[nextIndex];
+            if (prev.Continuity == CurveContinuity.Step)
             {
-                next = this.Keys[i];
-                if (next.Position >= position)
+                if (position >= 1f)
                 {
-                    if (prev.Continuity == CurveContinuity.Step)
-                    {
-                        if (position >= 1f)
-                        {
-                            return next.Value;
-                        }
-                        return prev.Value;
-                    }
-                    float t = (position - prev.Position) / (next.Position - prev.Position);//to have t in [0,1]
-                    float ts = t * t;
-                    float tss = ts * t;
-                    //After a lot of search on internet I have found all about spline function
-                    // and bezier (phi'sss ancien) but finaly use hermite curve 
-                    //http://en.wikipedia.org/wiki/Cubic_Hermite_spline
-                    //P(t) = (2*t^3 - 3t^2 + 1)*P0 + (t^3 - 2t^2 + t)m0 + (-2t^3 + 3t^2)P1 + (t^3-t^2)m1
-                    //with P0.value = prev.value , m0 = prev.tangentOut, P1= next.value, m1 = next.TangentIn
-                    return (2 * tss - 3 * ts + 1f) * prev.Value + (tss - 2 * ts + t) * prev.TangentOut + (3 * ts - 2 * tss) * next.Value + (tss - ts) * next.TangentIn;
+                    return next.Value;
                 }
-                prev = next;
+                return prev.Value;
             }
-            return 0f;
+            float t = (position - prev.Position) / (next.Position - prev.Position);//to have t in [0,1]
+            float ts = t * t;
+            float tss = ts * t;
+            //After a lot of search on internet I have found all about spline function
+            // and bezier (phi'sss ancien) but finaly use hermite curve 
+            //http://en.wikipedia.org/wiki/Cubic_Hermite_spline
+            //P(t) = (2*t^3 - 3t^2 + 1)*P0 + (t^3 - 2t^2 + t)m0 + (-2t^3 + 3t^2)P1 + (t^3-t^2)m1
+            //with P0.value = prev.value , m0 = prev.tangentOut, P1= next.value, m1 = next.TangentIn
+            return (2 * tss - 3 * ts + 1f) * prev.Value + (tss - 2 * ts + t) * prev.TangentOut + (3 * ts - 2 * tss) * next.Value + (tss - ts) * next.TangentIn;
         }
 
         #endregion
     }
+
 }

--- a/MonoGame.Framework/CurveKeyCollection.cs
+++ b/MonoGame.Framework/CurveKeyCollection.cs
@@ -182,15 +182,14 @@ namespace Microsoft.Xna.Framework
         /// Searches for the key with the lowest position greater than or equal to the specified position.
         /// </summary>
         /// <param name="position">Position to search for.</param>
-        /// <returns>The lowest index of the matching keys or, if the last element's position is less than the specified position, <c>Count</c>. </returns>
+        /// <returns>The zero-based index of the first matching position if there is a match; otherwise, a negative number that is the bitwise complement of the index of the next element that is larger than <c>position</c> or, if there is no larger element, the bitwise complement of <c>Count</c>.</returns>
         public int IndexAtPosition(float position)
         {
             int index = _keys.BinarySearch(new CurveKey(position, 0));
-            
-            //If position doesn't exist in list, return the key with the closest larger position
+
             if (index < 0)
-                return ~index;
-            
+                return index;
+
             //If several matching keys exist, return the first one
             while (index - 1 >= 0 && _keys[index - 1].Position == position)
                 index--;

--- a/MonoGame.Framework/CurveKeyCollection.cs
+++ b/MonoGame.Framework/CurveKeyCollection.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Xna.Framework
         #region Private Fields
 
         private readonly List<CurveKey> _keys;
-        private readonly IComparer<CurveKey> _keyPositionComparer = Comparer<CurveKey>.Create((x, y) => x.Position.CompareTo(y.Position));
 
         #endregion
 
@@ -186,7 +185,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>The lowest index of the matching keys or, if the last element's position is less than the specified position, <c>Count</c>. </returns>
         public int IndexAtPosition(float position)
         {
-            int index = _keys.BinarySearch(new CurveKey(position, 0), _keyPositionComparer);
+            int index = _keys.BinarySearch(new CurveKey(position, 0));
             
             //If position doesn't exist in list, return the key with the closest larger position
             if (index < 0)

--- a/MonoGame.Framework/CurveKeyCollection.cs
+++ b/MonoGame.Framework/CurveKeyCollection.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Xna.Framework
         #region Private Fields
 
         private readonly List<CurveKey> _keys;
+        private readonly IComparer<CurveKey> _keyPositionComparer = Comparer<CurveKey>.Create((x, y) => x.Position.CompareTo(y.Position));
 
         #endregion
 
@@ -176,6 +177,25 @@ namespace Microsoft.Xna.Framework
         public int IndexOf(CurveKey item)
         {
             return _keys.IndexOf(item);
+        }
+
+        /// <summary>
+        /// Searches for the key with the lowest position greater than or equal to the specified position.
+        /// </summary>
+        /// <param name="position">Position to search for.</param>
+        /// <returns>The lowest index of the matching keys or, if the last element's position is less than the specified position, <c>Count</c>. </returns>
+        public int IndexAtPosition(float position)
+        {
+            int index = _keys.BinarySearch(new CurveKey(position, 0), _keyPositionComparer);
+            
+            //If position doesn't exist in list, return the key with the closest larger position
+            if (index < 0)
+                return ~index;
+            
+            //If several matching keys exist, return the first one
+            while (index - 1 >= 0 && _keys[index - 1].Position == position)
+                index--;
+            return index;
         }
 
         /// <summary>


### PR DESCRIPTION
In `Curve.Evaluate`, instead of looping through the keys to find those surrounding the evaluation point, I tried a binary search. It reduced the vertex buffer creation time for a large scene from a few seconds to around one second. For debug builds it went from minutes to a few seconds.

Since the underlying List container `Curve._keys._keys` (ie. `CurveKeyCollection._keys`) is private I had to make a public method `CurveKeyCollection.IndexAtPosition` in which I do the search.