### PR TITLE
[SDL] Optimize mouse position tracking (fixes #6045)

### DIFF
--- a/MonoGame.Framework/Input/Mouse.SDL.cs
+++ b/MonoGame.Framework/Input/Mouse.SDL.cs
@@ -23,14 +23,12 @@ namespace Microsoft.Xna.Framework.Input
         private static MouseState PlatformGetState(GameWindow window)
         {
             int x, y;
-
             var winFlags = Sdl.Window.GetWindowFlags(window.Handle);
-            var state = (Sdl.Patch > 4) ? // SDL 2.0.4 has a bug with Global Mouse
-                    Sdl.Mouse.GetGlobalState(out x, out y) :
-                    Sdl.Mouse.GetState(out x, out y);
-            
+            var state = Sdl.Mouse.GetGlobalState(out x, out y);
+
             if ((winFlags & Sdl.Window.State.MouseFocus) != 0)
             {
+                // Window has mouse focus, position will be set from the motion event
                 window.MouseState.LeftButton = (state & Sdl.Mouse.Button.Left) != 0 ? ButtonState.Pressed : ButtonState.Released;
                 window.MouseState.MiddleButton = (state & Sdl.Mouse.Button.Middle) != 0 ? ButtonState.Pressed : ButtonState.Released;
                 window.MouseState.RightButton = (state & Sdl.Mouse.Button.Right) != 0 ? ButtonState.Pressed : ButtonState.Released;
@@ -40,17 +38,12 @@ namespace Microsoft.Xna.Framework.Input
                 window.MouseState.HorizontalScrollWheelValue = ScrollX;
                 window.MouseState.ScrollWheelValue = ScrollY;
             }
-
-            if (Sdl.Patch > 4)
+            else
             {
+                // Window does not have mouse focus, we need to manually get the position
                 var clientBounds = window.ClientBounds;
                 window.MouseState.X = x - clientBounds.X;
                 window.MouseState.Y = y - clientBounds.Y;
-            }
-            else
-            {
-                window.MouseState.X = x;
-                window.MouseState.Y = y;
             }
 
             return window.MouseState;

--- a/MonoGame.Framework/SDL/SDL2.cs
+++ b/MonoGame.Framework/SDL/SDL2.cs
@@ -113,6 +113,8 @@ internal static class Sdl
         [FieldOffset(0)]
         public Keyboard.Event Key;
         [FieldOffset(0)]
+        public Mouse.MotionEvent Motion;
+        [FieldOffset(0)]
         public Keyboard.TextEditingEvent Edit;
         [FieldOffset(0)]
         public Keyboard.TextInputEvent Text;
@@ -558,6 +560,23 @@ internal static class Sdl
             SizeAll,
             No,
             Hand
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MotionEvent
+        {
+            public EventType Type;
+            public uint Timestamp;
+            public uint WindowID;
+            public uint Which;
+            public byte State;
+            private byte _padding1;
+            private byte _padding2;
+            private byte _padding3;
+            public int X;
+            public int Y;
+            public int Xrel;
+            public int Yrel;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -128,18 +128,25 @@ namespace Microsoft.Xna.Framework
                     GamePad.RemoveDevice(ev.ControllerDevice.Which);
                 else if (ev.Type == Sdl.EventType.JoyDeviceRemoved)
                     Joystick.RemoveDevice(ev.JoystickDevice.Which);
-                else if (ev.Type == Sdl.EventType.MouseWheel) {
+                else if (ev.Type == Sdl.EventType.MouseWheel)
+                {
                     const int wheelDelta = 120;
                     Mouse.ScrollY += ev.Wheel.Y * wheelDelta;
                     Mouse.ScrollX += ev.Wheel.X * wheelDelta;
                 }
-                else if (ev.Type == Sdl.EventType.KeyDown) {
-                    var key = KeyboardUtil.ToXna (ev.Key.Keysym.Sym);
-                    if (!_keys.Contains (key))
-                        _keys.Add (key);
+                else if (ev.Type == Sdl.EventType.MouseMotion)
+                {
+                    Window.MouseState.X = ev.Motion.X;
+                    Window.MouseState.Y = ev.Motion.Y;
+                }
+                else if (ev.Type == Sdl.EventType.KeyDown)
+                {
+                    var key = KeyboardUtil.ToXna(ev.Key.Keysym.Sym);
+                    if (!_keys.Contains(key))
+                        _keys.Add(key);
                     char character = (char)ev.Key.Keysym.Sym;
-                    if (char.IsControl (character))
-                        _view.CallTextInput (character, key);
+                    if (char.IsControl(character))
+                        _view.CallTextInput(character, key);
                 }
                 else if (ev.Type == Sdl.EventType.KeyUp)
                 {


### PR DESCRIPTION
Notes:
 - We are providing our own SDL, and are not supporting anything below SDL 2.0.5 (been like that for a while, some if code has just been left behind)
 - If we have mouse focus, mouse position is now tracked separately by the mouse motion event
   - This fixes #6045 where if you were to call SetPosition and GetState().Position on the same frame it would return the old position (since no sdl pull event had occurred to that point)