### PR TITLE
fix crash in build output view toggle

### DIFF
--- a/Tools/Pipeline/Controls/BuildOutput.cs
+++ b/Tools/Pipeline/Controls/BuildOutput.cs
@@ -21,6 +21,7 @@ namespace MonoGame.Tools.Pipeline
         private CheckCommand _cmdFilterOutput, _cmdAutoScroll, _cmdShowSkipped, _cmdShowSuccessful, _cmdShowCleaned;
         private Image _iconInformation, _iconFail, _iconProcessing, _iconSkip, _iconSucceed, _iconSucceedWithWarnings, _iconStart, _iconEndSucceed, _iconEndFailed;
         private BuildItem _selectedItem;
+        Eto.Drawing.Point _scrollPosition;
 
         public BuildOutput()
         {
@@ -251,6 +252,7 @@ namespace MonoGame.Tools.Pipeline
 
         private void Scrollable1_Scroll(object sender, EventArgs e)
         {
+            _scrollPosition = scrollable.ScrollPosition;
             drawable.Invalidate();
         }
 
@@ -279,7 +281,7 @@ namespace MonoGame.Tools.Pipeline
                     continue;
 
                 // Check if the item is in the visible rectangle
-                if (y + item.Height >= scrollPosition.Y && y < scrollPosition.Y + scrollable.Height)
+                if (y + item.Height >= _scrollPosition.Y && y < _scrollPosition.Y + scrollable.Height)
                 {
                     // Check if the item is selected
                     if (MouseLocation.Y > y && MouseLocation.Y < y + item.Height)

--- a/Tools/Pipeline/Controls/BuildOutput.cs
+++ b/Tools/Pipeline/Controls/BuildOutput.cs
@@ -21,7 +21,7 @@ namespace MonoGame.Tools.Pipeline
         private CheckCommand _cmdFilterOutput, _cmdAutoScroll, _cmdShowSkipped, _cmdShowSuccessful, _cmdShowCleaned;
         private Image _iconInformation, _iconFail, _iconProcessing, _iconSkip, _iconSucceed, _iconSucceedWithWarnings, _iconStart, _iconEndSucceed, _iconEndFailed;
         private BuildItem _selectedItem;
-        Eto.Drawing.Point _scrollPosition;
+        private Eto.Drawing.Point _scrollPosition;
 
         public BuildOutput()
         {

--- a/Tools/Pipeline/Controls/BuildOutput.cs
+++ b/Tools/Pipeline/Controls/BuildOutput.cs
@@ -82,7 +82,7 @@ namespace MonoGame.Tools.Pipeline
             if (_cmdFilterOutput.Checked)
                 drawable.Paint -= Drawable_Paint;
 
-            panel.Content = _cmdFilterOutput.Checked ? (Control)scrollable1 : textArea;
+            panel.Content = _cmdFilterOutput.Checked ? (Control)scrollable : textArea;
             PipelineSettings.Default.FilterOutput = _cmdFilterOutput.Checked;
 
             if (_cmdFilterOutput.Checked)
@@ -117,7 +117,7 @@ namespace MonoGame.Tools.Pipeline
         public void ClearOutput()
         {
             drawable.Width = _reqWidth = 0;
-            scrollable1.ScrollPosition = new Point(0, 0);
+            scrollable.ScrollPosition = new Point(0, 0);
             textArea.Text = "";
             _items.Clear();
             drawable.Invalidate();
@@ -240,7 +240,7 @@ namespace MonoGame.Tools.Pipeline
                 _tryScroll = false;
 
                 if (PipelineSettings.Default.AutoScrollBuildOutput)
-                    scrollable1.ScrollPosition = new Point(0, drawable.Height + 10 - scrollable1.Height);
+                    scrollable.ScrollPosition = new Point(0, drawable.Height + 10 - scrollable.Height);
             }
         }
 
@@ -279,7 +279,7 @@ namespace MonoGame.Tools.Pipeline
                     continue;
 
                 // Check if the item is in the visible rectangle
-                if (y + item.Height >= scrollable1.ScrollPosition.Y && y < scrollable1.ScrollPosition.Y + scrollable1.Height)
+                if (y + item.Height >= scrollPosition.Y && y < scrollPosition.Y + scrollable.Height)
                 {
                     // Check if the item is selected
                     if (MouseLocation.Y > y && MouseLocation.Y < y + item.Height)

--- a/Tools/Pipeline/Controls/BuildOutput.eto.cs
+++ b/Tools/Pipeline/Controls/BuildOutput.eto.cs
@@ -13,7 +13,6 @@ namespace MonoGame.Tools.Pipeline
         TextArea textArea;
         Scrollable scrollable;
         Drawable drawable;
-        Eto.Drawing.Point scrollPosition;
 
         private void InitializeComponent()
         {
@@ -32,8 +31,6 @@ namespace MonoGame.Tools.Pipeline
             drawable = new Drawable();
             scrollable.Content = drawable;
 
-            scrollable.Scroll += Scrollable1_Scroll1;
-
             panel.Content = textArea;
             CreateContent(panel);
 
@@ -44,11 +41,6 @@ namespace MonoGame.Tools.Pipeline
             drawable.Paint += Drawable_Paint;
             scrollable.SizeChanged += Scrollable1_SizeChanged;
             scrollable.Scroll += Scrollable1_Scroll;
-        }
-
-        private void Scrollable1_Scroll1(object sender, ScrollEventArgs e)
-        {
-            scrollPosition = scrollable.ScrollPosition;
         }
     }
 }

--- a/Tools/Pipeline/Controls/BuildOutput.eto.cs
+++ b/Tools/Pipeline/Controls/BuildOutput.eto.cs
@@ -11,8 +11,9 @@ namespace MonoGame.Tools.Pipeline
     {
         Panel panel;
         TextArea textArea;
-        Scrollable scrollable1;
+        Scrollable scrollable;
         Drawable drawable;
+        Eto.Drawing.Point scrollPosition;
 
         private void InitializeComponent()
         {
@@ -24,12 +25,14 @@ namespace MonoGame.Tools.Pipeline
             textArea.Wrap = false;
             textArea.ReadOnly = true;
 
-            scrollable1 = new Scrollable();
-            scrollable1.BackgroundColor = DrawInfo.BackColor;
-            scrollable1.ExpandContentWidth = true;
-            scrollable1.ExpandContentHeight = true;
+            scrollable = new Scrollable();
+            scrollable.BackgroundColor = DrawInfo.BackColor;
+            scrollable.ExpandContentWidth = true;
+            scrollable.ExpandContentHeight = true;
             drawable = new Drawable();
-            scrollable1.Content = drawable;
+            scrollable.Content = drawable;
+
+            scrollable.Scroll += Scrollable1_Scroll1;
 
             panel.Content = textArea;
             CreateContent(panel);
@@ -39,8 +42,13 @@ namespace MonoGame.Tools.Pipeline
             drawable.MouseLeave += Drawable_MouseLeave;
             drawable.SizeChanged += Drawable_SizeChanged;
             drawable.Paint += Drawable_Paint;
-            scrollable1.SizeChanged += Scrollable1_SizeChanged;
-            scrollable1.Scroll += Scrollable1_Scroll;
+            scrollable.SizeChanged += Scrollable1_SizeChanged;
+            scrollable.Scroll += Scrollable1_Scroll;
+        }
+
+        private void Scrollable1_Scroll1(object sender, ScrollEventArgs e)
+        {
+            scrollPosition = scrollable.ScrollPosition;
         }
     }
 }


### PR DESCRIPTION
fix crash in build output when toggling between fancy and text view if any items in fancy view were opened. Also fix a typo in a scrollable member name.