### PR TITLE
Added missing constructor to GamePadState (fixes #6027)

### DIFF
--- a/MonoGame.Framework/Input/GamePadState.cs
+++ b/MonoGame.Framework/Input/GamePadState.cs
@@ -88,6 +88,20 @@ namespace Microsoft.Xna.Framework.Input
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="T:Microsoft.Xna.Framework.Input.GamePadState"/> struct.
+        /// using the specified stick, trigger, and button values.
+        /// </summary>
+        /// <param name="leftThumbStick">Left stick value. Each axis is clamped between −1.0 and 1.0.</param>
+        /// <param name="rightThumbStick">Right stick value. Each axis is clamped between −1.0 and 1.0.</param>
+        /// <param name="leftTrigger">Left trigger value. This value is clamped between 0.0 and 1.0.</param>
+        /// <param name="rightTrigger">Right trigger value. This value is clamped between 0.0 and 1.0.</param>
+        /// <param name="buttons"> Array or parameter list of Buttons to initialize as pressed.</param>
+        public GamePadState(Vector2 leftThumbStick, Vector2 rightThumbStick, float leftTrigger, float rightTrigger, params Buttons[] buttons)
+            : this(new GamePadThumbSticks(leftThumbStick, rightThumbStick), new GamePadTriggers(leftTrigger, rightTrigger), new GamePadButtons(buttons), new GamePadDPad(buttons[0]))
+        {
+        }
+
+        /// <summary>
         /// Define this method in platform partial classes to initialize default
         /// values for platform-specific fields.
         /// </summary>


### PR DESCRIPTION
Brings back 
<code>public GamePadState(Vector2, Vector2 , float , float , params Buttons[])</code>
as GamePadState ctor.