### PR TITLE
Made SpriteFont constructor public

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -28,8 +28,11 @@ namespace Microsoft.Xna.Framework.Graphics
         private int _defaultGlyphIndex = -1;
 		
 		private readonly Texture2D _texture;
-        
-		internal Glyph[] Glyphs { get { return _glyphs; } }
+
+		/// <summary>
+		/// All the glyphs in this SpriteFont.
+		/// </summary>
+		public Glyph[] Glyphs { get { return _glyphs; } }
 
 		class CharComparer: IEqualityComparer<char>
 		{
@@ -46,7 +49,18 @@ namespace Microsoft.Xna.Framework.Graphics
 			static public readonly CharComparer Default = new CharComparer();
 		}
 
-		internal SpriteFont (
+		/// <summary>
+		/// Initializes a new instance of the <see cref="SpriteFont" /> class.
+		/// </summary>
+		/// <param name="texture">The font texture.</param>
+		/// <param name="glyphBounds">The rectangles in the font texture containing letters.</param>
+		/// <param name="cropping">The cropping rectangles, which are applied to the corresponding glyphBounds to calculate the bounds of the actual character.</param>
+		/// <param name="characters">The characters.</param>
+		/// <param name="lineSpacing">The line spacing (the distance from baseline to baseline) of the font.</param>
+		/// <param name="spacing">The spacing (tracking) between characters in the font.</param>
+		/// <param name="kerning">The letters kernings(X - left side bearing, Y - width and Z - right side bearing).</param>
+		/// <param name="defaultCharacter">The character that will be substituted when a given character is not included in the font.</param>
+		public SpriteFont (
 			Texture2D texture, List<Rectangle> glyphBounds, List<Rectangle> cropping, List<char> characters,
 			int lineSpacing, float spacing, List<Vector3> kerning, char? defaultCharacter)
 		{


### PR DESCRIPTION
Please, consider making the SpriteFont constructor public. So it could be created in the run-time, ignoring Content Pipeline.