### PR TITLE
Issue-6123: Guide functions were not preserving state

### DIFF
--- a/MonoGame.Framework/Android/GamerServices/Guide.cs
+++ b/MonoGame.Framework/Android/GamerServices/Guide.cs
@@ -62,6 +62,8 @@ namespace Microsoft.Xna.Framework.GamerServices
 		private static bool isTrialMode;
 		private static bool isVisible;
 		private static bool simulateTrialMode;
+        private static ShowKeyboardInputDelegate ski = ShowKeyboardInput;
+        private static ShowMessageBoxDelegate smb = ShowMessageBox;
 
         internal static void Initialise(Game game)
         {
@@ -153,16 +155,14 @@ namespace Microsoft.Xna.Framework.GamerServices
 
 			IsVisible = true;
 
-			ShowKeyboardInputDelegate ski = ShowKeyboardInput; 
-
-			return ski.BeginInvoke(player, title, description, defaultText, usePasswordMode, callback, ski);
+			return ski.BeginInvoke(player, title, description, defaultText, usePasswordMode, callback, state);
 		}
 
 		public static string EndShowKeyboardInput (IAsyncResult result)
 		{
 			try 
 			{
-				return (result.AsyncState as ShowKeyboardInputDelegate).EndInvoke(result);
+				return ski.EndInvoke(result);
 			} 
 			finally 
 			{
@@ -233,9 +233,7 @@ namespace Microsoft.Xna.Framework.GamerServices
 			
 			IsVisible = true;
 			
-			ShowMessageBoxDelegate smb = ShowMessageBox; 
-
-			return smb.BeginInvoke(title, text, buttons, focusButton, icon, callback, smb);			
+			return smb.BeginInvoke(title, text, buttons, focusButton, icon, callback, state);			
 		}
 
 		public static IAsyncResult BeginShowMessageBox (
@@ -255,7 +253,7 @@ namespace Microsoft.Xna.Framework.GamerServices
 		{
 			try
 			{
-				return (result.AsyncState as ShowMessageBoxDelegate).EndInvoke(result);
+				return smb.EndInvoke(result);
 			} 
 			finally 
 			{

--- a/MonoGame.Framework/iOS/GamerServices/Guide.cs
+++ b/MonoGame.Framework/iOS/GamerServices/Guide.cs
@@ -160,6 +160,9 @@ namespace Microsoft.Xna.Framework.GamerServices
         private static UIWindow _window;
         private static UIViewController _gameViewController;
 
+        private static ShowKeyboardInputDelegate ski = ShowKeyboardInput;
+        private static ShowMessageBoxDelegate smb = ShowMessageBox;
+
         [CLSCompliant(false)]
         public static GKMatch Match { get; private set; }
 
@@ -282,15 +285,13 @@ namespace Microsoft.Xna.Framework.GamerServices
             if (IsVisible)
                 throw new GuideAlreadyVisibleException("The function cannot be completed at this time: the Guide UI is already active. Wait until Guide.IsVisible is false before issuing this call.");
 
-            ShowKeyboardInputDelegate ski = ShowKeyboardInput;
-
-            return ski.BeginInvoke(title, description, defaultText, state, usePasswordMode, callback, ski);
+            return ski.BeginInvoke(title, description, defaultText, state, usePasswordMode, callback, state);
         }
 
         public static string EndShowKeyboardInput(IAsyncResult result)
         {
             keyboardViewController = null;
-            return (result.AsyncState as ShowKeyboardInputDelegate).EndInvoke(result);
+            return ski.EndInvoke(result);
         }
 
         delegate Nullable<nint> ShowMessageBoxDelegate(
@@ -335,9 +336,7 @@ namespace Microsoft.Xna.Framework.GamerServices
 
             IsVisible = true;
 
-            ShowMessageBoxDelegate smb = ShowMessageBox; 
-
-            return smb.BeginInvoke(title, text, buttons, focusButton, icon, callback, smb);         
+            return smb.BeginInvoke(title, text, buttons, focusButton, icon, callback, state);         
         }
 
         public static IAsyncResult BeginShowMessageBox(
@@ -350,7 +349,7 @@ namespace Microsoft.Xna.Framework.GamerServices
 
         public static Nullable<nint> EndShowMessageBox(IAsyncResult result)
         {
-            return (result.AsyncState as ShowMessageBoxDelegate).EndInvoke(result);
+            return smb.EndInvoke(result);
         }
 
         public static void ShowMarketplace(PlayerIndex player)


### PR DESCRIPTION
Documentation for XNA 4.0 mentions that the `BeginShowKeyboardInput` and `BeginShowMessageBox` functions take a state variable that is passed to `EndShowKeyboardInput` and `EndShowMessageBox` respectively.

MonoGame implementation violated this as it used the state variable internally, thus preventing the user from using the state variable if he wanted to do so. This PR fixes the iOS and Android implementations (ie. the ones that I was able to test on my phones).