### PR TITLE
Android crash fix: unsafe fixed statement string->char* causes crash on Android

### DIFF
--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -1522,9 +1522,13 @@ namespace MonoGame.OpenGL
             if (intPtr == IntPtr.Zero) {
                 throw new OutOfMemoryException ();
             }
-            fixed (char* chars = str + RuntimeHelpers.OffsetToStringData / 2) {
-                int bytes = Encoding.ASCII.GetBytes (chars, str.Length, (byte*)((void*)intPtr), num);
-                Marshal.WriteByte (intPtr, bytes, 0);
+
+            // Must NOT use fixed(char* c = str) because it crashes on some device for some unknown reason!
+            byte[] strSafeBytes = Encoding.Unicode.GetBytes(str);
+            fixed (byte* strRawBytes = strSafeBytes)
+            {
+                int bytes = Encoding.ASCII.GetBytes((char*)strRawBytes, str.Length, (byte*)((void*)intPtr), num);
+                Marshal.WriteByte(intPtr, bytes, 0);
                 return intPtr;
             }
         }


### PR DESCRIPTION
**DO NOT MERGE IN YET, NEEDS MORE TESTS!!!**
**DO NOT MERGE IN YET, NEEDS MORE TESTS!!!**

Issue:  the app crashes if a function is called which contains a statement like this:
string str = ...
fixed(char* c = str) 

If we convert the string to unicode bytes and use fixed(byte* b=strBytes) it works.

EDIT: **this issue appeared when OpenTK was removed,** an older version of monogame which still has OpenTK (3.7.0.512) works fine.
OpenTK code seemed to have used some native OpenGL calls to do this.

EDIT 2: I get a crash also if I executed fixed(char* c = str) in our game code (so outside of the MonoGame lib).

**Potential issue**: this RuntimeHelpers.OffsetToStringData is not applied now: 
char* c = str + RuntimeHelpers.OffsetToStringData / 2
Any idea about this? It works for a quick test game (stuff renders, will need to test more).

@dellis1972 If I remember correctly you were the one who did the OpenTK removal and rewrite? Do you have any idea about this?

I'm using the latest development branch.

The issue is very strange because the app crashes not when this 'fixed' statement is encountered, but when the function which contains this 'fixed' statement is called:

```
unsafe void DoUnsafe()
{
  // neither code nor debugger gets to here! 
   System.Diagnostics.Debug.WriteLine("testy"); // this does not print!
    string str="bla";
   fixed(char* c = str)
   {
   }
}

void Issue()
{
  DoUnsafe(); // crash happens here!
}
```


Some observations: 
- sometimes I get a "index out of range" exception, but does not happen always. I assume its a side effect of the strange crash, because most of the time the app shuts down hard, no c# exception is thrown most of the time.

I have confirmed this crash on 2 phones: Huawie G620S-L01 and Nexus 5X.

The fix works on both phones.

Can anyone else reproduce this?

Top of stack trace:

```
01-06 22:41:26.830 9578-9578/com.game E/mono-rt: Stacktrace:
01-06 22:41:26.830 9578-9578/com.game E/mono-rt:   at <unknown> <0xffffffff>
01-06 22:41:26.830 9578-9578/com.game E/mono-rt:   at MonoGame.OpenGL.GL.MarshalStringArrayToPtr (string[]) [0x00052] in <aac7c7476e4b413091b00e98f9c80047>:0
01-06 22:41:26.830 9578-9578/com.game E/mono-rt:   at MonoGame.OpenGL.GL.ShaderSource (int,string) [0x00008] in <aac7c7476e4b413091b00e98f9c80047>:0
01-06 22:41:26.830 9578-9578/com.game E/mono-rt:   at Microsoft.Xna.Framework.Graphics.Shader.GetShaderHandle () [0x00047] in <aac7c7476e4b413091b00e98f9c80047>:0
```


Android project compilation:
Compiling with Android 7.1
Min Android version: 4.4
Target Android version: 4.4

Phone 1: Huawei G620S-L01
OS: Custom rom LineageOS 14.1
Android OS version: 7.1.2

Phone 2: Nexus 5X
Stock rom.
Android 8.0.0
  
  
  