### PR TITLE
Fixed VertexContent.RemoveRange

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannel.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannel.cs
@@ -221,5 +221,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         {
             Items.RemoveAt(index);
         }
+
+        /// <summary>
+        /// Removes a range of values from the channel.
+        /// </summary>
+        /// <param name="index">The zero-based starting index of the range of elements to remove.</param>
+        /// <param name="count"> The number of elements to remove.</param>
+        internal abstract void RemoveRange(int index, int count);
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannelGeneric.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannelGeneric.cs
@@ -227,5 +227,15 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         {
             Items.RemoveAt(index);
         }
+
+        /// <summary>
+        /// Removes a range of values from the channel.
+        /// </summary>
+        /// <param name="index">The zero-based starting index of the range of elements to remove.</param>
+        /// <param name="count"> The number of elements to remove.</param>
+        internal override void RemoveRange(int index, int count)
+        {
+            items.RemoveRange(index, count);
+        }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/VertexContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/VertexContent.cs
@@ -200,6 +200,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         /// <param name="index">Index of the vertex to be removed.</param>
         public void RemoveAt(int index)
         {
+            if (index < 0 || index >= VertexCount)
+                throw new ArgumentOutOfRangeException("index");
+
             positionIndices.Items.RemoveAt(index);
 
             foreach (var channel in channels)
@@ -213,8 +216,15 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         /// <param name="count">Number of indices to remove.</param>
         public void RemoveRange(int index, int count)
         {
-            for (var i = index; i < index + count; i++)
-                RemoveAt(i);
+            if (index < 0 || index >= VertexCount)
+                throw new ArgumentOutOfRangeException("index");
+            if (count < 0 || (index+count) > VertexCount)
+                throw new ArgumentOutOfRangeException("count");
+
+            positionIndices.RemoveRange(index, count);
+
+            foreach (var channel in channels)
+                channel.RemoveRange(index, count);
         }
     }
 }

--- a/Test/ContentPipeline/MeshBuilderTests.cs
+++ b/Test/ContentPipeline/MeshBuilderTests.cs
@@ -439,5 +439,90 @@ namespace MonoGame.Tests.ContentPipeline
             Assert.AreEqual(3 * iterations, geom.Indices.Count);
             Assert.AreEqual(6, geom.Vertices.VertexCount);
         }
+
+        [Test]
+        public void RemoveVertices()
+        {
+            MeshContent output;
+            
+            output = CreateBasicMesh(material1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Geometry[0].Vertices.RemoveAt(-1));
+            Assert.AreEqual(3, output.Geometry[0].Vertices.VertexCount);
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Geometry[0].Vertices.RemoveAt(3));
+            Assert.AreEqual(3, output.Geometry[0].Vertices.VertexCount);
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Geometry[0].Vertices.RemoveRange(-1,1));
+            Assert.AreEqual(3, output.Geometry[0].Vertices.VertexCount);
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Geometry[0].Vertices.RemoveRange(0,-1));
+            Assert.AreEqual(3, output.Geometry[0].Vertices.VertexCount);
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Geometry[0].Vertices.RemoveRange(0,4));
+            Assert.AreEqual(3, output.Geometry[0].Vertices.VertexCount);
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Geometry[0].Vertices.RemoveRange(3, 1));
+            Assert.AreEqual(3, output.Geometry[0].Vertices.VertexCount);
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Geometry[0].Vertices.RemoveRange(4, 0));
+            Assert.AreEqual(3, output.Geometry[0].Vertices.VertexCount);
+
+            // NOTE: XNA seems to have a bug where you can specifiy one pased
+            // the last index when removing a range of zero.  We fixed this in MG.
+#if !XNA
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Geometry[0].Vertices.RemoveRange(3, 0));
+            Assert.AreEqual(3, output.Geometry[0].Vertices.VertexCount);
+#endif
+
+            // RemoveAt(1)
+            output = CreateBasicMesh(material1);
+            output.Geometry[0].Vertices.RemoveAt(1);
+            Assert.AreEqual(2, output.Geometry[0].Vertices.VertexCount);
+            Assert.AreEqual(2, output.Geometry[0].Vertices.Positions.Count);
+            Assert.AreEqual(2, output.Geometry[0].Vertices.PositionIndices.Count);
+            Assert.AreEqual(2, output.Geometry[0].Vertices.Channels[0].Count);
+            Assert.AreEqual(new Vector3(0, 0, 0), output.Geometry[0].Vertices.Positions[0]);
+            Assert.AreEqual(new Vector3(1, 1, 1), output.Geometry[0].Vertices.Positions[1]);
+            Assert.AreEqual(0, output.Geometry[0].Vertices.PositionIndices[0]);
+            Assert.AreEqual(2, output.Geometry[0].Vertices.PositionIndices[1]);
+
+            // RemoveRange(0, 0)
+            output = CreateBasicMesh(material1);
+            output.Geometry[0].Vertices.RemoveRange(0, 0);
+            Assert.AreEqual(3, output.Geometry[0].Vertices.VertexCount);
+            Assert.AreEqual(3, output.Geometry[0].Vertices.Positions.Count);
+            Assert.AreEqual(3, output.Geometry[0].Vertices.PositionIndices.Count);
+            Assert.AreEqual(3, output.Geometry[0].Vertices.Channels[0].Count);
+            Assert.AreEqual(new Vector3(0, 0, 0), output.Geometry[0].Vertices.Positions[0]);
+            Assert.AreEqual(new Vector3(1, 0, 0), output.Geometry[0].Vertices.Positions[1]);
+            Assert.AreEqual(new Vector3(1, 1, 1), output.Geometry[0].Vertices.Positions[2]);
+            Assert.AreEqual(0, output.Geometry[0].Vertices.PositionIndices[0]);
+            Assert.AreEqual(1, output.Geometry[0].Vertices.PositionIndices[1]);
+            Assert.AreEqual(2, output.Geometry[0].Vertices.PositionIndices[2]);
+
+            // RemoveRange(0, 1)
+            output = CreateBasicMesh(material1);
+            output.Geometry[0].Vertices.RemoveRange(0, 1);
+            Assert.AreEqual(2, output.Geometry[0].Vertices.VertexCount);
+            Assert.AreEqual(2, output.Geometry[0].Vertices.Positions.Count);
+            Assert.AreEqual(2, output.Geometry[0].Vertices.PositionIndices.Count);
+            Assert.AreEqual(2, output.Geometry[0].Vertices.Channels[0].Count);
+            Assert.AreEqual(new Vector3(1, 0, 0), output.Geometry[0].Vertices.Positions[0]);
+            Assert.AreEqual(new Vector3(1, 1, 1), output.Geometry[0].Vertices.Positions[1]);
+            Assert.AreEqual(1, output.Geometry[0].Vertices.PositionIndices[0]);
+            Assert.AreEqual(2, output.Geometry[0].Vertices.PositionIndices[1]);
+
+            // RemoveRange(1, 2)
+            output = CreateBasicMesh(material1);
+            output.Geometry[0].Vertices.RemoveRange(1, 2);
+            Assert.AreEqual(1, output.Geometry[0].Vertices.VertexCount);
+            Assert.AreEqual(1, output.Geometry[0].Vertices.Positions.Count);
+            Assert.AreEqual(1, output.Geometry[0].Vertices.PositionIndices.Count);
+            Assert.AreEqual(1, output.Geometry[0].Vertices.Channels[0].Count);
+            Assert.AreEqual(new Vector3(0, 0, 0), output.Geometry[0].Vertices.Positions[0]);
+            Assert.AreEqual(0, output.Geometry[0].Vertices.PositionIndices[0]);
+
+            // RemoveRange(0, 3)
+            output = CreateBasicMesh(material1);
+            output.Geometry[0].Vertices.RemoveRange(0, 3);
+            Assert.AreEqual(0, output.Geometry[0].Vertices.VertexCount);
+            Assert.AreEqual(0, output.Geometry[0].Vertices.Positions.Count);
+            Assert.AreEqual(0, output.Geometry[0].Vertices.PositionIndices.Count);
+            Assert.AreEqual(0, output.Geometry[0].Vertices.Channels[0].Count);
+        }
     }
 }

--- a/Test/ContentPipeline/TestProcessorContext.cs
+++ b/Test/ContentPipeline/TestProcessorContext.cs
@@ -49,10 +49,12 @@ namespace MonoGame.Tests.ContentPipeline
             get { throw new NotImplementedException(); }
         }
 
+#if !XNA
         public override ContentIdentity SourceIdentity
         {
             get { throw new NotImplementedException(); }
         }
+#endif
 
         public override TargetPlatform TargetPlatform
         {

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MonoGame.Tests</RootNamespace>
     <AssemblyName>MonoGame.Tests.XNA</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This fixes a bug in `VertexContent.RemoveRange()` and adds some unit tests verifying it works.

Also fixed the XNA Test project which wasn't building.