### PR TITLE
add SingleReader and EffectReader to auto-spidered reader list

### DIFF
--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Xna.Framework.Content
                 var hMatrixReader = new MatrixReader();
                 var hBasicEffectReader = new BasicEffectReader();
                 var hVertexBufferReader = new VertexBufferReader();
+                var hEffectReader = new EffectReader();
                 var hAlphaTestEffectReader = new AlphaTestEffectReader();
                 var hEnumSpriteEffectsReader = new EnumReader<Graphics.SpriteEffects>();
                 var hArrayFloatReader = new ArrayReader<float>();
@@ -113,6 +114,7 @@ namespace Microsoft.Xna.Framework.Content
                 var hSongReader = new SongReader();
                 var hModelReader = new ModelReader();
                 var hInt32Reader = new Int32Reader();
+                var hSingleReader = new SingleReader();
 
                 // At the moment the Video class doesn't exist
                 // on all platforms... Allow it to compile anyway.


### PR DESCRIPTION
Why don't we incorporate EffectReader by default? I know a lot of games don't need effects, but every single one that doesnt not need effects, does.
SingleReader is tiny, and an obvious counterpart to ArrayReader<float> (I needed it for loading movie files)

NOTE: I made this edit on github. So I don't know whyfor the huge amount of noise. But it should be safe.