### PR TITLE
Implement GraphicsAdapter.QueryRenderTargetFormat()

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
@@ -146,7 +146,17 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </remarks>
         public static DriverType UseDriverType { get; set; }
 
-        /*
+        /// <summary>
+        /// Queries for support of the requested render target format on the adaptor.
+        /// </summary>
+        /// <param name="graphicsProfile">The graphics profile.</param>
+        /// <param name="format">The requested surface format.</param>
+        /// <param name="depthFormat">The requested depth stencil format.</param>
+        /// <param name="multiSampleCount">The requested multisample count.</param>
+        /// <param name="selectedFormat">Set to the best format supported by the adaptor for the requested surface format.</param>
+        /// <param name="selectedDepthFormat">Set to the best format supported by the adaptor for the requested depth stencil format.</param>
+        /// <param name="selectedMultiSampleCount">Set to the best count supported by the adaptor for the requested multisample count.</param>
+        /// <returns>True if the requested format is supported by the adaptor. False if one or more of the values was changed.</returns>
 		public bool QueryRenderTargetFormat(
 			GraphicsProfile graphicsProfile,
 			SurfaceFormat format,
@@ -156,9 +166,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			out DepthFormat selectedDepthFormat,
 			out int selectedMultiSampleCount)
 		{
-			throw new NotImplementedException();
+			selectedFormat = format;
+            selectedDepthFormat = depthFormat;
+            selectedMultiSampleCount = multiSampleCount;
+
+            return (format == selectedFormat) && (depthFormat == selectedDepthFormat) && (multiSampleCount == selectedMultiSampleCount);
 		}
 
+        /*
         public string Description
         {
             get

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
@@ -169,6 +169,35 @@ namespace Microsoft.Xna.Framework.Graphics
 			selectedFormat = format;
             selectedDepthFormat = depthFormat;
             selectedMultiSampleCount = multiSampleCount;
+            
+            // fallback for unsupported renderTarget surface formats.
+            if (selectedFormat == SurfaceFormat.Alpha8 ||
+                selectedFormat == SurfaceFormat.NormalizedByte2 ||
+                selectedFormat == SurfaceFormat.NormalizedByte4 ||
+                selectedFormat == SurfaceFormat.Dxt1 ||
+                selectedFormat == SurfaceFormat.Dxt3 ||
+                selectedFormat == SurfaceFormat.Dxt5 ||
+                selectedFormat == SurfaceFormat.Dxt1a ||
+                selectedFormat == SurfaceFormat.Dxt1SRgb ||
+                selectedFormat == SurfaceFormat.Dxt3SRgb ||
+                selectedFormat == SurfaceFormat.Dxt5SRgb)
+                selectedFormat = SurfaceFormat.Color;
+
+            // fallback for unsupported renderTarget surface formats on Reach profile.
+            if (graphicsProfile == GraphicsProfile.Reach)
+            {
+                if (selectedFormat == SurfaceFormat.HalfSingle ||
+                   selectedFormat == SurfaceFormat.HalfVector2 ||
+                   selectedFormat == SurfaceFormat.HalfVector4 ||
+                   selectedFormat == SurfaceFormat.HdrBlendable ||
+                   selectedFormat == SurfaceFormat.Rg32 ||
+                   selectedFormat == SurfaceFormat.Rgba1010102 ||
+                   selectedFormat == SurfaceFormat.Rgba64 ||
+                   selectedFormat == SurfaceFormat.Single ||
+                   selectedFormat == SurfaceFormat.Vector2 ||
+                   selectedFormat == SurfaceFormat.Vector4)
+                    selectedFormat = SurfaceFormat.Color;
+            }
 
             return (format == selectedFormat) && (depthFormat == selectedDepthFormat) && (multiSampleCount == selectedMultiSampleCount);
 		}

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -150,6 +150,35 @@ namespace Microsoft.Xna.Framework.Graphics
             selectedDepthFormat = depthFormat;
             selectedMultiSampleCount = multiSampleCount;
 
+            // fallback for unsupported renderTarget surface formats.
+            if (selectedFormat == SurfaceFormat.Alpha8 ||
+                selectedFormat == SurfaceFormat.NormalizedByte2 ||
+                selectedFormat == SurfaceFormat.NormalizedByte4 ||
+                selectedFormat == SurfaceFormat.Dxt1 ||
+                selectedFormat == SurfaceFormat.Dxt3 ||
+                selectedFormat == SurfaceFormat.Dxt5 ||
+                selectedFormat == SurfaceFormat.Dxt1a ||
+                selectedFormat == SurfaceFormat.Dxt1SRgb ||
+                selectedFormat == SurfaceFormat.Dxt3SRgb ||
+                selectedFormat == SurfaceFormat.Dxt5SRgb)
+                selectedFormat = SurfaceFormat.Color;
+
+            // fallback for unsupported renderTarget surface formats on Reach profile.
+            if (graphicsProfile == GraphicsProfile.Reach)
+            {
+                if (selectedFormat == SurfaceFormat.HalfSingle ||
+                   selectedFormat == SurfaceFormat.HalfVector2 ||
+                   selectedFormat == SurfaceFormat.HalfVector4 ||
+                   selectedFormat == SurfaceFormat.HdrBlendable ||
+                   selectedFormat == SurfaceFormat.Rg32 ||
+                   selectedFormat == SurfaceFormat.Rgba1010102 ||
+                   selectedFormat == SurfaceFormat.Rgba64 ||
+                   selectedFormat == SurfaceFormat.Single ||
+                   selectedFormat == SurfaceFormat.Vector2 ||
+                   selectedFormat == SurfaceFormat.Vector4)
+                    selectedFormat = SurfaceFormat.Color;
+            }
+            
             return (format == selectedFormat) && (depthFormat == selectedDepthFormat) && (multiSampleCount == selectedMultiSampleCount);
 		}
 

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -126,8 +126,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        /*
-		public bool QueryRenderTargetFormat(
+        /// <summary>
+        /// Queries for support of the requested render target format on the adaptor.
+        /// </summary>
+        /// <param name="graphicsProfile">The graphics profile.</param>
+        /// <param name="format">The requested surface format.</param>
+        /// <param name="depthFormat">The requested depth stencil format.</param>
+        /// <param name="multiSampleCount">The requested multisample count.</param>
+        /// <param name="selectedFormat">Set to the best format supported by the adaptor for the requested surface format.</param>
+        /// <param name="selectedDepthFormat">Set to the best format supported by the adaptor for the requested depth stencil format.</param>
+        /// <param name="selectedMultiSampleCount">Set to the best count supported by the adaptor for the requested multisample count.</param>
+        /// <returns>True if the requested format is supported by the adaptor. False if one or more of the values was changed.</returns>
+ 		public bool QueryRenderTargetFormat(
 			GraphicsProfile graphicsProfile,
 			SurfaceFormat format,
 			DepthFormat depthFormat,
@@ -136,9 +146,12 @@ namespace Microsoft.Xna.Framework.Graphics
 			out DepthFormat selectedDepthFormat,
 			out int selectedMultiSampleCount)
 		{
-			throw new NotImplementedException();
+			selectedFormat = format;
+            selectedDepthFormat = depthFormat;
+            selectedMultiSampleCount = multiSampleCount;
+
+            return (format == selectedFormat) && (depthFormat == selectedDepthFormat) && (multiSampleCount == selectedMultiSampleCount);
 		}
-        */
 
         public bool IsProfileSupported(GraphicsProfile graphicsProfile)
         {

--- a/Test/Framework/Graphics/GraphicsAdapterTest.cs
+++ b/Test/Framework/Graphics/GraphicsAdapterTest.cs
@@ -95,6 +95,58 @@ namespace MonoGame.Tests.Graphics
             Assert.IsTrue(adapter.IsDefaultAdapter);
             Assert.Contains(adapter, GraphicsAdapter.Adapters);
         }
+
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Color, SurfaceFormat.Color, true)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Color, SurfaceFormat.Color, true)]
+        // unsupported formats
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Alpha8, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Dxt1, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Dxt3, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Dxt5, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.NormalizedByte2, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.NormalizedByte4, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Alpha8, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Dxt1, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Dxt3, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Dxt5, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.NormalizedByte2, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.NormalizedByte4, SurfaceFormat.Color, false)]
+        // non-Reach formats
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.HalfSingle, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.HalfVector2, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.HalfVector4, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.HdrBlendable, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Rg32, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Rgba1010102, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Rgba64, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Single, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Vector2, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Vector4, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.HalfSingle, SurfaceFormat.HalfSingle, true)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.HalfVector2, SurfaceFormat.HalfVector2, true)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.HalfVector4, SurfaceFormat.HalfVector4, true)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.HdrBlendable, SurfaceFormat.HdrBlendable, true)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Rg32, SurfaceFormat.Rg32, true)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Rgba1010102, SurfaceFormat.Rgba1010102, true)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Rgba64, SurfaceFormat.Rgba64, true)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Single, SurfaceFormat.Single, true)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Vector2, SurfaceFormat.Vector2, true)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Vector4, SurfaceFormat.Vector4, true)]
+        public static void QueryRenderTargetFormat_preferredSurface(GraphicsProfile graphicsProfile, SurfaceFormat preferredSurfaceFormat, SurfaceFormat expectedSurfaceFormat, bool expectedIsSupported)
+        {
+            var adapter = GraphicsAdapter.DefaultAdapter;
+
+            SurfaceFormat selectedFormat;
+            DepthFormat selectedDepthFormat;
+            int selectedMultiSampleCount;
+            bool isSupported = adapter.QueryRenderTargetFormat(graphicsProfile, preferredSurfaceFormat, DepthFormat.None, 0,
+                out selectedFormat, out selectedDepthFormat, out selectedMultiSampleCount);
+
+            Assert.AreEqual(isSupported, expectedIsSupported);
+            Assert.AreEqual(selectedFormat, expectedSurfaceFormat);
+            Assert.AreEqual(selectedDepthFormat, DepthFormat.None);
+            Assert.AreEqual(selectedMultiSampleCount, 0);
+        }
     }
 }
 


### PR DESCRIPTION
Fallback of unsuported and profile depended SurfaceFormat. (Dxt, Single, drBlendable, ...)

Not implemeneted: 
Optional/Device depended formats. (566, 4444, ...)
Depth Formats.
MultiSampleCount.