### PR TITLE
Reduce MouseState garbage in Desktop DirectX

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -164,8 +164,22 @@ namespace MonoGame.Framework
             RegisterToAllWindows();
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct POINTSTRUCT
+        {
+            public int X;
+            public int Y;
+        }
+
         [DllImport("shell32.dll", CharSet = CharSet.Auto, BestFitMapping = false)]
         private static extern IntPtr ExtractIcon(IntPtr hInst, string exeFileName, int iconIndex);
+        
+        [DllImport("user32.dll", ExactSpelling=true, CharSet=CharSet.Auto)]
+        [return: MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.Bool)]
+        internal static extern bool GetCursorPos(out POINTSTRUCT pt);
+        
+        [DllImport("user32.dll", ExactSpelling=true, CharSet=CharSet.Auto)]
+        internal static extern int MapWindowPoints(HandleRef hWndFrom, HandleRef hWndTo, out POINTSTRUCT pt, int cPoints);
 
         private void SetIcon()
         {
@@ -244,7 +258,10 @@ namespace MonoGame.Framework
             if (!Form.Visible)
                 return;
 
-            var clientPos = Form.PointToClient(Control.MousePosition);
+            POINTSTRUCT pos;
+            GetCursorPos(out pos);
+            MapWindowPoints(new HandleRef(null, IntPtr.Zero), new HandleRef(Form, Form.Handle), out pos, 1);
+            var clientPos = new System.Drawing.Point(pos.X, pos.Y);
             var withinClient = Form.ClientRectangle.Contains(clientPos);
             var buttons = Control.MouseButtons;
 


### PR DESCRIPTION
Replace Control.MousePosition and Control.PointToClient() with native methods.
WinForms uses NativeMethods.POINT instead of NativeMethods.POINTSTRUCT which generates garbage on every frame.

https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/NativeMethods.cs,6adeb4095f8d1cb9,references
https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/NativeMethods.cs,66722dafd2d3fae2,references
https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/Control.cs,5e4c0ba768a38d00,references
https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/Control.cs,87b2e50fe264ffef,references

http://community.monogame.net/t/how-do-i-get-around-mouse-getstate-generating-garbage/8494/11
http://community.monogame.net/t/reducing-dynamic-memory-allocation-when-rendering/10184
MonoGame#3662
MonoGame#2717