### PR TITLE
Fallback SurfaceFormat for RenderTargets

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
@@ -170,6 +170,19 @@ namespace Microsoft.Xna.Framework.Graphics
             selectedDepthFormat = depthFormat;
             selectedMultiSampleCount = multiSampleCount;
 
+            // fallback for unsupported renderTarget surface formats.
+            if (selectedFormat == SurfaceFormat.Alpha8 ||
+                selectedFormat == SurfaceFormat.NormalizedByte2 ||
+                selectedFormat == SurfaceFormat.NormalizedByte4 ||
+                selectedFormat == SurfaceFormat.Dxt1 ||
+                selectedFormat == SurfaceFormat.Dxt3 ||
+                selectedFormat == SurfaceFormat.Dxt5 ||
+                selectedFormat == SurfaceFormat.Dxt1a ||
+                selectedFormat == SurfaceFormat.Dxt1SRgb ||
+                selectedFormat == SurfaceFormat.Dxt3SRgb ||
+                selectedFormat == SurfaceFormat.Dxt5SRgb)
+                selectedFormat = SurfaceFormat.Color;
+
 
             return (format == selectedFormat) && (depthFormat == selectedDepthFormat) && (multiSampleCount == selectedMultiSampleCount);
 		}

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
@@ -146,7 +146,17 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </remarks>
         public static DriverType UseDriverType { get; set; }
 
-        /*
+        /// <summary>
+        /// Queries for support of the requested render target format on the adaptor.
+        /// </summary>
+        /// <param name="graphicsProfile">The graphics profile.</param>
+        /// <param name="format">The requested surface format.</param>
+        /// <param name="depthFormat">The requested depth stencil format.</param>
+        /// <param name="multiSampleCount">The requested multisample count.</param>
+        /// <param name="selectedFormat">Set to the best format supported by the adaptor for the requested surface format.</param>
+        /// <param name="selectedDepthFormat">Set to the best format supported by the adaptor for the requested depth stencil format.</param>
+        /// <param name="selectedMultiSampleCount">Set to the best count supported by the adaptor for the requested multisample count.</param>
+        /// <returns>True if the requested format is supported by the adaptor. False if one or more of the values was changed.</returns>
 		public bool QueryRenderTargetFormat(
 			GraphicsProfile graphicsProfile,
 			SurfaceFormat format,
@@ -156,9 +166,15 @@ namespace Microsoft.Xna.Framework.Graphics
 			out DepthFormat selectedDepthFormat,
 			out int selectedMultiSampleCount)
 		{
-			throw new NotImplementedException();
+			selectedFormat = format;
+            selectedDepthFormat = depthFormat;
+            selectedMultiSampleCount = multiSampleCount;
+
+
+            return (format == selectedFormat) && (depthFormat == selectedDepthFormat) && (multiSampleCount == selectedMultiSampleCount);
 		}
 
+        /*
         public string Description
         {
             get

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -126,7 +126,17 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        /*
+        /// <summary>
+        /// Queries for support of the requested render target format on the adaptor.
+        /// </summary>
+        /// <param name="graphicsProfile">The graphics profile.</param>
+        /// <param name="format">The requested surface format.</param>
+        /// <param name="depthFormat">The requested depth stencil format.</param>
+        /// <param name="multiSampleCount">The requested multisample count.</param>
+        /// <param name="selectedFormat">Set to the best format supported by the adaptor for the requested surface format.</param>
+        /// <param name="selectedDepthFormat">Set to the best format supported by the adaptor for the requested depth stencil format.</param>
+        /// <param name="selectedMultiSampleCount">Set to the best count supported by the adaptor for the requested multisample count.</param>
+        /// <returns>True if the requested format is supported by the adaptor. False if one or more of the values was changed.</returns>
 		public bool QueryRenderTargetFormat(
 			GraphicsProfile graphicsProfile,
 			SurfaceFormat format,
@@ -136,9 +146,12 @@ namespace Microsoft.Xna.Framework.Graphics
 			out DepthFormat selectedDepthFormat,
 			out int selectedMultiSampleCount)
 		{
-			throw new NotImplementedException();
+            selectedFormat = format;
+            selectedDepthFormat = depthFormat;
+            selectedMultiSampleCount = multiSampleCount;
+			
+            return (format == selectedFormat) && (depthFormat == selectedDepthFormat) && (multiSampleCount == selectedMultiSampleCount);
 		}
-        */
 
         public bool IsProfileSupported(GraphicsProfile graphicsProfile)
         {

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -150,6 +150,19 @@ namespace Microsoft.Xna.Framework.Graphics
             selectedDepthFormat = depthFormat;
             selectedMultiSampleCount = multiSampleCount;
 			
+            // fallback for unsupported renderTarget surface formats.
+            if (selectedFormat == SurfaceFormat.Alpha8 ||
+                selectedFormat == SurfaceFormat.NormalizedByte2 ||
+                selectedFormat == SurfaceFormat.NormalizedByte4 ||
+                selectedFormat == SurfaceFormat.Dxt1 ||
+                selectedFormat == SurfaceFormat.Dxt3 ||
+                selectedFormat == SurfaceFormat.Dxt5 ||
+                selectedFormat == SurfaceFormat.Dxt1a ||
+                selectedFormat == SurfaceFormat.Dxt1SRgb ||
+                selectedFormat == SurfaceFormat.Dxt3SRgb ||
+                selectedFormat == SurfaceFormat.Dxt5SRgb)
+                selectedFormat = SurfaceFormat.Color;
+
             return (format == selectedFormat) && (depthFormat == selectedDepthFormat) && (multiSampleCount == selectedMultiSampleCount);
 		}
 

--- a/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private RenderTarget2D _resolvedTexture;
 
         private void PlatformConstruct(GraphicsDevice graphicsDevice, int width, int height, bool mipMap,
-            SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared)
+            DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared)
         {
             GenerateIfRequired();
         }

--- a/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         private void PlatformConstruct(GraphicsDevice graphicsDevice, int width, int height, bool mipMap,
-            SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared)
+            DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared)
         {
             Threading.BlockOnUIThread(() =>
             {
-                graphicsDevice.PlatformCreateRenderTarget(this, width, height, mipMap, preferredFormat, preferredDepthFormat, preferredMultiSampleCount, usage);
+                graphicsDevice.PlatformCreateRenderTarget(this, width, height, mipMap, this.Format, preferredDepthFormat, preferredMultiSampleCount, usage);
             });
             
             

--- a/MonoGame.Framework/Graphics/RenderTarget2D.Web.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.Web.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Xna.Framework.Graphics
             int width, 
             int height, 
             bool mipMap,
-            SurfaceFormat preferredFormat, 
             DepthFormat preferredDepthFormat,
             int preferredMultiSampleCount,
             RenderTargetUsage usage, 

--- a/MonoGame.Framework/Graphics/RenderTarget2D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
             MultiSampleCount = graphicsDevice.GetClampedMultisampleCount(preferredMultiSampleCount);
             RenderTargetUsage = usage;
 
-            PlatformConstruct(graphicsDevice, width, height, mipMap, preferredFormat, preferredDepthFormat, preferredMultiSampleCount, usage, shared);
+            PlatformConstruct(graphicsDevice, width, height, mipMap, preferredDepthFormat, preferredMultiSampleCount, usage, shared);
 	    }
 
         public RenderTarget2D (GraphicsDevice graphicsDevice, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared)

--- a/MonoGame.Framework/Graphics/RenderTarget2D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
 	    public RenderTarget2D(GraphicsDevice graphicsDevice, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared, int arraySize)
-	        : base(graphicsDevice, width, height, mipMap, preferredFormat, SurfaceType.RenderTarget, shared, arraySize)
+	        : base(graphicsDevice, width, height, mipMap, QuerySelectedFormat(graphicsDevice, preferredFormat), SurfaceType.RenderTarget, shared, arraySize)
 	    {
             DepthStencilFormat = preferredDepthFormat;
             MultiSampleCount = graphicsDevice.GetClampedMultisampleCount(preferredMultiSampleCount);
@@ -32,6 +32,18 @@ namespace Microsoft.Xna.Framework.Graphics
 
             PlatformConstruct(graphicsDevice, width, height, mipMap, preferredDepthFormat, preferredMultiSampleCount, usage, shared);
 	    }
+        
+        protected static SurfaceFormat QuerySelectedFormat(GraphicsDevice graphicsDevice, SurfaceFormat preferredFormat)
+        {
+			SurfaceFormat selectedFormat;
+			DepthFormat selectedDepthFormat;
+			int selectedMultiSampleCount;
+
+            graphicsDevice.Adapter.QueryRenderTargetFormat(graphicsDevice.GraphicsProfile, preferredFormat, DepthFormat.None, 0, 
+                out selectedFormat, out selectedDepthFormat, out selectedMultiSampleCount);
+            
+            return selectedFormat;
+        }
 
         public RenderTarget2D (GraphicsDevice graphicsDevice, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared)
 			: this(graphicsDevice, width, height, mipMap, preferredFormat, preferredDepthFormat, preferredMultiSampleCount, usage, shared, 1)
@@ -74,6 +86,6 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             PlatformGraphicsDeviceResetting();
             base.GraphicsDeviceResetting();
-        }
+        }        
 	}
 }

--- a/MonoGame.Framework/Graphics/RenderTarget3D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget3D.DirectX.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private DepthStencilView _depthStencilView;
 
         private void PlatformConstruct(GraphicsDevice graphicsDevice, int width, int height, bool mipMap,
-            SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
+            DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
         {
             // Setup the multisampling description.
             var multisampleDesc = new SharpDX.DXGI.SampleDescription(1, 0);

--- a/MonoGame.Framework/Graphics/RenderTarget3D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget3D.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (preferredDepthFormat == DepthFormat.None)
                 return;
 
-            PlatformConstruct(graphicsDevice, width, height, mipMap, preferredFormat, preferredDepthFormat, preferredMultiSampleCount, usage);
+            PlatformConstruct(graphicsDevice, width, height, mipMap, preferredDepthFormat, preferredMultiSampleCount, usage);
         }
 
 		public RenderTarget3D(GraphicsDevice graphicsDevice, int width, int height, int depth, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat)

--- a/MonoGame.Framework/Graphics/RenderTarget3D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget3D.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
 		public RenderTarget3D(GraphicsDevice graphicsDevice, int width, int height, int depth, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
-			:base (graphicsDevice, width, height, depth, mipMap, preferredFormat, true)
+			:base (graphicsDevice, width, height, depth, mipMap, QuerySelectedFormat(graphicsDevice, preferredFormat), true)
 		{
 			DepthStencilFormat = preferredDepthFormat;
 			MultiSampleCount = preferredMultiSampleCount;
@@ -35,6 +35,18 @@ namespace Microsoft.Xna.Framework.Graphics
                 return;
 
             PlatformConstruct(graphicsDevice, width, height, mipMap, preferredDepthFormat, preferredMultiSampleCount, usage);
+        }
+
+        protected static SurfaceFormat QuerySelectedFormat(GraphicsDevice graphicsDevice, SurfaceFormat preferredFormat)
+        {
+			SurfaceFormat selectedFormat;
+			DepthFormat selectedDepthFormat;
+			int selectedMultiSampleCount;
+
+            graphicsDevice.Adapter.QueryRenderTargetFormat(graphicsDevice.GraphicsProfile, preferredFormat, DepthFormat.None, 0, 
+                out selectedFormat, out selectedDepthFormat, out selectedMultiSampleCount);
+            
+            return selectedFormat;
         }
 
 		public RenderTarget3D(GraphicsDevice graphicsDevice, int width, int height, int depth, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat)

--- a/MonoGame.Framework/Graphics/RenderTargetCube.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.DirectX.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private RenderTargetView[] _renderTargetViews;
         private DepthStencilView _depthStencilView;
 
-        private void PlatformConstruct(GraphicsDevice graphicsDevice, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
+        private void PlatformConstruct(GraphicsDevice graphicsDevice, bool mipMap, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
         {
             // Create one render target view per cube map face.
             _renderTargetViews = new RenderTargetView[6];
@@ -22,7 +22,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 var renderTargetViewDescription = new RenderTargetViewDescription
                 {
                     Dimension = RenderTargetViewDimension.Texture2DArray,
-                    Format = SharpDXHelper.ToFormat(preferredFormat),
+                    Format = SharpDXHelper.ToFormat(this.Format),
                     Texture2DArray =
                     {
                         ArraySize = 1,

--- a/MonoGame.Framework/Graphics/RenderTargetCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.OpenGL.cs
@@ -27,11 +27,11 @@ namespace Microsoft.Xna.Framework.Graphics
             return TextureTarget.TextureCubeMapPositiveX + renderTargetBinding.ArraySlice;
         }
 
-        private void PlatformConstruct(GraphicsDevice graphicsDevice, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
+        private void PlatformConstruct(GraphicsDevice graphicsDevice, bool mipMap, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
         {
             Threading.BlockOnUIThread(() =>
             {
-                graphicsDevice.PlatformCreateRenderTarget(this, size, size, mipMap, preferredFormat, preferredDepthFormat, preferredMultiSampleCount, usage);
+                graphicsDevice.PlatformCreateRenderTarget(this, size, size, mipMap, this.Format, preferredDepthFormat, preferredMultiSampleCount, usage);
             });
         }
 

--- a/MonoGame.Framework/Graphics/RenderTargetCube.Web.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.Web.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class RenderTargetCube
     {
-        private void PlatformConstruct(GraphicsDevice graphicsDevice, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
+        private void PlatformConstruct(GraphicsDevice graphicsDevice, bool mipMap, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
         {
             throw new NotImplementedException();
         }

--- a/MonoGame.Framework/Graphics/RenderTargetCube.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.cs
@@ -68,13 +68,25 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="preferredMultiSampleCount">The preferred number of multisample locations.</param>
         /// <param name="usage">The usage mode of the render target.</param>
         public RenderTargetCube(GraphicsDevice graphicsDevice, int size, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
-            : base(graphicsDevice, size, mipMap, preferredFormat, true)
+            : base(graphicsDevice, size, mipMap, QuerySelectedFormat(graphicsDevice, preferredFormat), true)
         {
             DepthStencilFormat = preferredDepthFormat;
             MultiSampleCount = preferredMultiSampleCount;
             RenderTargetUsage = usage;
 
             PlatformConstruct(graphicsDevice, mipMap, preferredDepthFormat, preferredMultiSampleCount, usage);
+        }
+        
+        protected static SurfaceFormat QuerySelectedFormat(GraphicsDevice graphicsDevice, SurfaceFormat preferredFormat)
+        {
+			SurfaceFormat selectedFormat;
+			DepthFormat selectedDepthFormat;
+			int selectedMultiSampleCount;
+
+            graphicsDevice.Adapter.QueryRenderTargetFormat(graphicsDevice.GraphicsProfile, preferredFormat, DepthFormat.None, 0, 
+                out selectedFormat, out selectedDepthFormat, out selectedMultiSampleCount);
+            
+            return selectedFormat;
         }
     }
 }

--- a/MonoGame.Framework/Graphics/RenderTargetCube.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Xna.Framework.Graphics
             MultiSampleCount = preferredMultiSampleCount;
             RenderTargetUsage = usage;
 
-            PlatformConstruct(graphicsDevice, mipMap, preferredFormat, preferredDepthFormat, preferredMultiSampleCount, usage);
+            PlatformConstruct(graphicsDevice, mipMap, preferredDepthFormat, preferredMultiSampleCount, usage);
         }
     }
 }

--- a/Test/Framework/Graphics/GraphicsAdapterTest.cs
+++ b/Test/Framework/Graphics/GraphicsAdapterTest.cs
@@ -95,6 +95,47 @@ namespace MonoGame.Tests.Graphics
             Assert.IsTrue(adapter.IsDefaultAdapter);
             Assert.Contains(adapter, GraphicsAdapter.Adapters);
         }
+
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Color, SurfaceFormat.Color, true)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Color, SurfaceFormat.Color, true)]
+        // unsupported renderTarget formats
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Alpha8, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Alpha8, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Dxt1, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Dxt1, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Dxt3, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Dxt3, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Dxt5, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Dxt5, SurfaceFormat.Color, false)]
+#if !XNA        
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Dxt1a, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Dxt1a, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Dxt1SRgb, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Dxt1SRgb, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Dxt3SRgb, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Dxt3SRgb, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.Dxt5SRgb, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.Dxt5SRgb, SurfaceFormat.Color, false)]
+#endif
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.NormalizedByte2, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.NormalizedByte2, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.Reach, SurfaceFormat.NormalizedByte4, SurfaceFormat.Color, false)]
+        [TestCase(GraphicsProfile.HiDef, SurfaceFormat.NormalizedByte4, SurfaceFormat.Color, false)]
+        public static void QueryRenderTargetFormat_preferredSurface(GraphicsProfile graphicsProfile, SurfaceFormat preferredSurfaceFormat, SurfaceFormat expectedSurfaceFormat, bool expectedIsSupported)
+        {
+            var adapter = GraphicsAdapter.DefaultAdapter;
+
+            SurfaceFormat selectedFormat;
+            DepthFormat selectedDepthFormat;
+            int selectedMultiSampleCount;
+            bool isSupported = adapter.QueryRenderTargetFormat(graphicsProfile, preferredSurfaceFormat, DepthFormat.None, 0,
+                out selectedFormat, out selectedDepthFormat, out selectedMultiSampleCount);
+
+            Assert.AreEqual(isSupported, expectedIsSupported);
+            Assert.AreEqual(selectedFormat, expectedSurfaceFormat);
+            Assert.AreEqual(selectedDepthFormat, DepthFormat.None);
+            Assert.AreEqual(selectedMultiSampleCount, 0);
+        }
     }
 }
 

--- a/Test/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Test/Framework/Graphics/RenderTarget2DTest.cs
@@ -104,5 +104,26 @@ namespace MonoGame.Tests.Graphics
             spriteBatch.Dispose();
             renderTarget.Dispose();
         }
+        
+        [TestCase(SurfaceFormat.Color, SurfaceFormat.Color)]
+        // unsupported renderTarget formats
+        [TestCase(SurfaceFormat.Alpha8, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt1, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt3, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt5, SurfaceFormat.Color)]
+#if !XNA        
+        [TestCase(SurfaceFormat.Dxt1a, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt1SRgb, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt3SRgb, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt5SRgb, SurfaceFormat.Color)]
+#endif
+        [TestCase(SurfaceFormat.NormalizedByte2, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.NormalizedByte4, SurfaceFormat.Color)]
+        public void PreferredSurfaceFormatTest(SurfaceFormat preferredSurfaceFormat, SurfaceFormat expectedSurfaceFormat)
+        {                    
+            var renderTarget = new RenderTarget2D(gd, 16, 16, false, preferredSurfaceFormat, DepthFormat.None);
+                    
+            Assert.AreEqual(renderTarget.Format, expectedSurfaceFormat);
+        }
     }
 }

--- a/Test/Framework/Graphics/RenderTargetCubeTest.cs
+++ b/Test/Framework/Graphics/RenderTargetCubeTest.cs
@@ -55,5 +55,26 @@ namespace MonoGame.Tests.Graphics
 
             renderTargetCube.Dispose();
         }
+                
+        [TestCase(SurfaceFormat.Color, SurfaceFormat.Color)]
+        // unsupported renderTarget formats
+        [TestCase(SurfaceFormat.Alpha8, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt1, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt3, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt5, SurfaceFormat.Color)]
+#if !XNA        
+        [TestCase(SurfaceFormat.Dxt1a, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt1SRgb, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt3SRgb, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.Dxt5SRgb, SurfaceFormat.Color)]
+#endif
+        [TestCase(SurfaceFormat.NormalizedByte2, SurfaceFormat.Color)]
+        [TestCase(SurfaceFormat.NormalizedByte4, SurfaceFormat.Color)]
+        public void PreferredSurfaceFormatTest(SurfaceFormat preferredSurfaceFormat, SurfaceFormat expectedSurfaceFormat)
+        {                    
+            var renderTarget = new RenderTargetCube(gd, 16, false, preferredSurfaceFormat, DepthFormat.None);
+                    
+            Assert.AreEqual(renderTarget.Format, expectedSurfaceFormat);
+        }
     }
 }


### PR DESCRIPTION
fixes #6036

This PR partially implements Adapter.QueryRenderTargetFormat().

The use of QuerySelectedFormat() is not perfect. We need to rethink how RenderTargets call the base Texture constructor.