### PR TITLE
FIX: SpriteFont.TryGetGlyphIndex could return an unavailable glyph

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -260,12 +260,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
                     else if (pRegions[m].Start > c)
                     {
-                        r = m;
-                        if (l == r)
-                        {
-                            regionIdx = l;
-                            break;
-                        }
+                        r = m - 1;
                     }
                     else
                     {

--- a/Test/Framework/Graphics/SpriteFontTest.cs
+++ b/Test/Framework/Graphics/SpriteFontTest.cs
@@ -569,21 +569,32 @@ But the answer was still '42'.
             CheckFrames();
 		}
 
-		[Test]
-		public void Throws_when_drawing_unavailable_characters ()
+        [TestCase("The rain in España stays mainly in the plain - now in français")]
+        [TestCase("\x1f")]
+        [TestCase("\x7f")]
+        public void Throws_when_drawing_unavailable_characters(string text)
 		{
-			const string text = "The rain in España stays mainly in the plain - now in français";
             _spriteBatch.Begin ();
             Assert.Throws<ArgumentException> (() =>
                 _spriteBatch.DrawString (_defaultFont, text, Vector2.Zero, Color.Violet));
             _spriteBatch.End ();
 		}
 
-        [Test]
-		public void Throws_when_setting_unavailable_DefaultCharacter ()
+        [TestCase('ñ')]
+        [TestCase((char)127)]
+        [TestCase((char)31)]
+        public void Throws_when_setting_unavailable_DefaultCharacter(char character)
 		{
             Assert.Throws<ArgumentException> (() =>
-                _defaultFont.DefaultCharacter = 'ñ');
+                _defaultFont.DefaultCharacter = character);
 		}
+
+        [TestCase((char)32)]
+        [TestCase((char)63)]
+        [TestCase((char)126)]
+        public void Does_not_throw_when_setting_available_DefaultCharacter(char character)
+        {
+            Assert.DoesNotThrow(() => _defaultFont.DefaultCharacter = character);
+        }
 	}
 }


### PR DESCRIPTION
`SpriteFont.TryGetGlyphIndex` had a bug in it which meant it could mistakenly succeed for an unavailable glyph and give an invalid index. This could result in unexpected behaviour when drawing a string which contained unavailable glyphs. Because other dependant code then uses pointers to reference the glyph, it could potentially have some nasty side effects.

This PR fixes this bug, as well as adding some test cases which expose it (the test cases which include characters before 0x20 / 32 fail with the previous code).

(this issue was originally introduced in PR #5874, cc @nkast)