### PR TITLE
Android | Added more key maps and stopped claiming to handle unhandled keys.

### DIFF
--- a/MonoGame.Framework/Android/Input/Keyboard.cs
+++ b/MonoGame.Framework/Android/Input/Keyboard.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Xna.Framework.Input
             maps[Keycode.DpadRight] = Keys.Right;
             maps[Keycode.DpadUp] = Keys.Up;
             maps[Keycode.DpadDown] = Keys.Down;
-			maps[Keycode.DpadCenter] = Keys.Enter;
+            maps[Keycode.DpadCenter] = Keys.Enter;
             maps[Keycode.Num0] = Keys.D0;
             maps[Keycode.Num1] = Keys.D1;
             maps[Keycode.Num2] = Keys.D2;
@@ -99,7 +99,7 @@ namespace Microsoft.Xna.Framework.Input
             maps[Keycode.Num7] = Keys.D7;
             maps[Keycode.Num8] = Keys.D8;
             maps[Keycode.Num9] = Keys.D9;
-			maps[Keycode.A] = Keys.A;
+            maps[Keycode.A] = Keys.A;
             maps[Keycode.B] = Keys.B;
             maps[Keycode.C] = Keys.C;
             maps[Keycode.D] = Keys.D;
@@ -121,12 +121,12 @@ namespace Microsoft.Xna.Framework.Input
             maps[Keycode.T] = Keys.T;
             maps[Keycode.U] = Keys.U;
             maps[Keycode.V] = Keys.V;
-			maps[Keycode.W] = Keys.W;
-			maps[Keycode.X] = Keys.X;
+            maps[Keycode.W] = Keys.W;
+            maps[Keycode.X] = Keys.X;
             maps[Keycode.Y] = Keys.Y;
             maps[Keycode.Z] = Keys.Z;
             maps[Keycode.Space] = Keys.Space;
-			maps[Keycode.Escape] = Keys.Escape;
+            maps[Keycode.Escape] = Keys.Escape;
             maps[Keycode.Back] = Keys.Back;
             maps[Keycode.Home] = Keys.Home;
             maps[Keycode.Enter] = Keys.Enter;

--- a/MonoGame.Framework/Android/Input/Keyboard.cs
+++ b/MonoGame.Framework/Android/Input/Keyboard.cs
@@ -52,24 +52,28 @@ namespace Microsoft.Xna.Framework.Input
 
         private static readonly IDictionary<Keycode, Keys> KeyMap = LoadKeyMap();
 
-        internal static void KeyDown(Keycode keyCode)
+        internal static bool KeyDown(Keycode keyCode)
         {
             Keys key;
-            if (KeyMap.TryGetValue(keyCode, out key))
+            if (KeyMap.TryGetValue(keyCode, out key) && key != Keys.None)
             {
                 if (!keys.Contains(key))
                     keys.Add(key);
+                return true;
             }
+            return false;
         }
 
-        internal static void KeyUp(Keycode keyCode)
+        internal static bool KeyUp(Keycode keyCode)
         {
             Keys key;
-            if (KeyMap.TryGetValue(keyCode, out key))
+            if (KeyMap.TryGetValue(keyCode, out key) && key != Keys.None)
             {
                 if (keys.Contains(key))
                     keys.Remove(key);
+                return true;
             }
+            return false;
         }
 
         private static IDictionary<Keycode, Keys> LoadKeyMap()
@@ -120,18 +124,60 @@ namespace Microsoft.Xna.Framework.Input
 			maps[Keycode.W] = Keys.W;
 			maps[Keycode.X] = Keys.X;
             maps[Keycode.Y] = Keys.Y;
-            maps[Keycode.C] = Keys.Z;
-			maps[Keycode.Back] = Keys.Escape;
+            maps[Keycode.Z] = Keys.Z;
+            maps[Keycode.Space] = Keys.Space;
+			maps[Keycode.Escape] = Keys.Escape;
             maps[Keycode.Back] = Keys.Back;
             maps[Keycode.Home] = Keys.Home;
             maps[Keycode.Enter] = Keys.Enter;
             maps[Keycode.Period] = Keys.OemPeriod;
             maps[Keycode.Comma] = Keys.OemComma;
-            // TODO: put in all the other mappings
             maps[Keycode.Menu] = Keys.Help;
             maps[Keycode.Search] = Keys.BrowserSearch;
             maps[Keycode.VolumeUp] = Keys.VolumeUp;
             maps[Keycode.VolumeDown] = Keys.VolumeDown;
+            maps[Keycode.MediaPause] = Keys.Pause;
+            maps[Keycode.MediaPlayPause] = Keys.MediaPlayPause;
+            maps[Keycode.MediaStop] = Keys.MediaStop;
+            maps[Keycode.MediaNext] = Keys.MediaNextTrack;
+            maps[Keycode.MediaPrevious] = Keys.MediaPreviousTrack;
+            maps[Keycode.Mute] = Keys.VolumeMute;
+            maps[Keycode.AltLeft] = Keys.LeftAlt;
+            maps[Keycode.AltRight] = Keys.RightAlt;
+            maps[Keycode.ShiftLeft] = Keys.LeftShift;
+            maps[Keycode.ShiftRight] = Keys.RightShift;
+            maps[Keycode.Tab] = Keys.Tab;
+            maps[Keycode.Del] = Keys.Delete;
+            maps[Keycode.Minus] = Keys.OemMinus;
+            maps[Keycode.LeftBracket] = Keys.OemOpenBrackets;
+            maps[Keycode.RightBracket] = Keys.OemCloseBrackets;
+            maps[Keycode.Backslash] = Keys.OemBackslash;
+            maps[Keycode.Semicolon] = Keys.OemSemicolon;
+            maps[Keycode.PageUp] = Keys.PageUp;
+            maps[Keycode.PageDown] = Keys.PageDown;
+            maps[Keycode.CtrlLeft] = Keys.LeftControl;
+            maps[Keycode.CtrlRight] = Keys.RightControl;
+            maps[Keycode.CapsLock] = Keys.CapsLock;
+            maps[Keycode.ScrollLock] = Keys.Scroll;
+            maps[Keycode.NumLock] = Keys.NumLock;
+            maps[Keycode.Insert] = Keys.Insert;
+            maps[Keycode.F1] = Keys.F1;
+            maps[Keycode.F2] = Keys.F2;
+            maps[Keycode.F3] = Keys.F3;
+            maps[Keycode.F4] = Keys.F4;
+            maps[Keycode.F5] = Keys.F5;
+            maps[Keycode.F6] = Keys.F6;
+            maps[Keycode.F7] = Keys.F7;
+            maps[Keycode.F8] = Keys.F8;
+            maps[Keycode.F9] = Keys.F9;
+            maps[Keycode.F10] = Keys.F10;
+            maps[Keycode.F11] = Keys.F11;
+            maps[Keycode.F12] = Keys.F12;
+            maps[Keycode.NumpadDivide] = Keys.Divide;
+            maps[Keycode.NumpadMultiply] = Keys.Multiply;
+            maps[Keycode.NumpadSubtract] = Keys.Subtract;
+            maps[Keycode.NumpadAdd] = Keys.Add;
+
             return maps;
         }
 

--- a/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Android/MonoGameAndroidGameView.cs
@@ -1113,14 +1113,18 @@ namespace Microsoft.Xna.Framework
 
         public override bool OnKeyDown(Keycode keyCode, KeyEvent e)
         {
+            bool handled = false;
             if (GamePad.OnKeyDown(keyCode, e))
                 return true;
 
-            Keyboard.KeyDown(keyCode);
+            handled = Keyboard.KeyDown(keyCode);
 #if !OUYA
             // we need to handle the Back key here because it doesnt work any other way
             if (keyCode == Keycode.Back)
+            {
                 GamePad.Back = true;
+                handled = true;
+            }
 #endif
             if (keyCode == Keycode.VolumeUp)
             {
@@ -1136,15 +1140,14 @@ namespace Microsoft.Xna.Framework
                 return true;
             }
 
-            return true;
+            return handled;
         }
 
         public override bool OnKeyUp(Keycode keyCode, KeyEvent e)
         {
             if (GamePad.OnKeyUp(keyCode, e))
                 return true;
-            Keyboard.KeyUp(keyCode);
-            return true;
+            return Keyboard.KeyUp(keyCode);
         }
 
         public override bool OnGenericMotionEvent(MotionEvent e)


### PR DESCRIPTION
Unhandled keys were being claimed has having been handled. This made it
impossible to catch the key inputs elsewhere (via the Xamarin OnKey*
override methods)

Also added some more standard key mappings.