### PR TITLE
Fix Pipeline tool to work regardless of Mono changes.[DONT MERGE]

### DIFF
--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -358,6 +358,16 @@
       <Platforms>MacOS</Platforms>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\ThirdParty\Dependencies\FreeImage.NET\MacOS\libfreeimage.dylib">
+      <Platforms>MacOS</Platforms>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>libfreeimage.dylib</Link>
+    </Content>
+    <Content Include="/Library/Frameworks/Mono.framework/Commands/mono">
+      <Platforms>MacOS</Platforms>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>mono</Link>
+    </Content>
   </Files>
 
 </Project>

--- a/Tools/MGCB/Info.plist
+++ b/Tools/MGCB/Info.plist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.monogame.mgcb</string>
+</dict>
 </plist>

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -515,6 +515,8 @@ namespace MonoGame.Tools.Pipeline
                 _buildProcess.StartInfo.StandardOutputEncoding = encoding;
                 _buildProcess.OutputDataReceived += (sender, args) => View.OutputAppend(args.Data);
 
+                View.OutputAppend(string.Format("Working Directory: {0} ", _buildProcess.StartInfo.WorkingDirectory));
+                View.OutputAppend(string.Format("Running: {0} {1}", _buildProcess.StartInfo.FileName, _buildProcess.StartInfo.Arguments));
                 // Fire off the process.
                 _buildProcess.Start();
                 _buildProcess.BeginOutputReadLine();

--- a/Tools/Pipeline/Info.plist
+++ b/Tools/Pipeline/Info.plist
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>	
+<dict>
 	<key>LSEnvironment</key>
-    	<dict>
-        	<key>MONO_MANAGED_WATCHER</key>
-        	<string>false</string>
-    	</dict>
+	<dict>
+		<key>MONO_MANAGED_WATCHER</key>
+		<string>false</string>
+	</dict>
 	<key>CFBundleName</key>
 	<string>Pipeline.MacOS</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.6</string>
+	<string>10.7</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>LSApplicationCategoryType</key>

--- a/Tools/Pipeline/MainWindow.cs
+++ b/Tools/Pipeline/MainWindow.cs
@@ -26,6 +26,7 @@ namespace MonoGame.Tools.Pipeline
         private ContextMenu _contextMenu;
         private FileFilter _mgcbFileFilter, _allFileFilter, _xnaFileFilter;
         private string[] monoLocations = {
+            Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "mono"),
             "/usr/bin/mono",
             "/usr/local/bin/mono",
             "/Library/Frameworks/Mono.framework/Versions/Current/bin/mono"
@@ -322,7 +323,10 @@ namespace MonoGame.Tools.Pipeline
                 foreach (var path in monoLocations)
                 {
                     if (File.Exists(path))
+                    {
                         monoLoc = path;
+                        break;
+                    }
                 }
 
                 if (string.IsNullOrEmpty(monoLoc))
@@ -330,6 +334,8 @@ namespace MonoGame.Tools.Pipeline
                     monoLoc = "mono";
                     OutputAppend("Cound not find mono. Please install the latest version from http://www.mono-project.com");
                 }
+
+                OutputAppend("Found mono at " + monoLoc);
 
                 proc.StartInfo.FileName = monoLoc;
 


### PR DESCRIPTION
One of the problems we have with the Pipeline tool
at the moment on Mac is this. When running the MGCB.exe
using system `mono` we can end up in a situation where
the wrong versions of the system assemblies and mscorlib
are loaded. As a result some calls to the system will
fail because entry points are missing or are invalid.

This is an attempt to fix that by bundling the `mono`
we are built against inside the Pipeline.app package.
In theory this should help.

I tried setting `MONO_PATH` and various other mono related
flags but nothing worked.