### PR TITLE
 Fix Pipeline tool to work regardless of Mono changes

### DIFF
--- a/Build/AdditionalProjectTransforms.xslt
+++ b/Build/AdditionalProjectTransforms.xslt
@@ -3,3 +3,6 @@
     <DefineConstants Condition=" '$(TargetFrameworkVersion)' != 'v4.0' And '$(TargetFrameworkVersion)' != 'v3.5' And '$(TargetFrameworkVersion)' != 'v3.0' And '$(TargetFrameworkVersion)' != 'v2.0' ">$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
 </xsl:if>
+<xsl:if test="/Input/Properties/ImportPipelineTargets = 'True'">
+  <Import Project="Pipeline.targets" />
+</xsl:if>

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -33,6 +33,7 @@
       <Platform Name="MacOS"><Version>v4.6.1</Version></Platform>
     </FrameworkVersions>
     <IncludeMonoRuntimeOnMac>True</IncludeMonoRuntimeOnMac>
+    <ImportPipelineTargets>True</ImportPipelineTargets>
   </Properties>
 
   <Files>
@@ -359,5 +360,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </Files>
-
 </Project>

--- a/Installers/MacOS/Scripts/Pipeline/postinstall
+++ b/Installers/MacOS/Scripts/Pipeline/postinstall
@@ -4,6 +4,7 @@
 chmod +x /Applications/Pipeline.app/Contents/MacOS/Pipeline   
 chmod +x /Applications/Pipeline.app/Contents/MonoBundle/ffmpeg
 chmod +x /Applications/Pipeline.app/Contents/MonoBundle/ffprobe
+chmod +x /Applications/Pipeline.app/Contents/MonoBundle/mono
 /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -v -f /Applications/Pipeline.app
 
 #mgcb terminal command

--- a/Tools/MGCB/Info.plist
+++ b/Tools/MGCB/Info.plist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.monogame.mgcb</string>
+</dict>
 </plist>

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -30,7 +30,7 @@ namespace MonoGame.Tools.Pipeline
 
         private static readonly string [] _mgcbSearchPaths = new []       
         {
-            "",
+            "/Library/Frameworks/MonoGame.framework/Current/Tools",
 #if DEBUG
             "../../../../../MGCB/bin/Windows/AnyCPU/Debug",
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../../../MGCB/bin/Windows/AnyCPU/Debug"),
@@ -41,6 +41,7 @@ namespace MonoGame.Tools.Pipeline
             "../MGCB",
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../MGCB"),
             Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+            "",
         };
 
         public IEnumerable<ContentItemTemplate> Templates
@@ -509,6 +510,7 @@ namespace MonoGame.Tools.Pipeline
             } catch (NotSupportedException) {
                 encoding = Encoding.UTF8;
             }
+            var currentDir = Environment.CurrentDirectory;
             try
             {
                 // Prepare the process.
@@ -522,6 +524,7 @@ namespace MonoGame.Tools.Pipeline
                 _buildProcess.OutputDataReceived += (sender, args) => View.OutputAppend(args.Data);
 
                 // Fire off the process.
+                Environment.CurrentDirectory = _buildProcess.StartInfo.WorkingDirectory;
                 _buildProcess.Start();
                 _buildProcess.BeginOutputReadLine();
                 _buildProcess.WaitForExit();
@@ -537,6 +540,9 @@ namespace MonoGame.Tools.Pipeline
                     View.OutputAppend("Build failed:" + Environment.NewLine);
                     View.OutputAppend(ex.ToString());
                 }
+            }
+            finally {
+                Environment.CurrentDirectory = currentDir;
             }
 
             // Clear the process pointer, so that cancel

--- a/Tools/Pipeline/MainWindow.cs
+++ b/Tools/Pipeline/MainWindow.cs
@@ -28,7 +28,8 @@ namespace MonoGame.Tools.Pipeline
         private string[] monoLocations = {
             "/usr/bin/mono",
             "/usr/local/bin/mono",
-            "/Library/Frameworks/Mono.framework/Versions/Current/bin/mono"
+            "/Library/Frameworks/Mono.framework/Versions/Current/bin/mono",
+            Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "mono"),
         };
 
         int setw = 0;
@@ -323,7 +324,10 @@ namespace MonoGame.Tools.Pipeline
                 foreach (var path in monoLocations)
                 {
                     if (File.Exists(path))
+                    {
                         monoLoc = path;
+                        break;
+                    }
                 }
 
                 if (string.IsNullOrEmpty(monoLoc))

--- a/Tools/Pipeline/Pipeline.targets
+++ b/Tools/Pipeline/Pipeline.targets
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_IncludeMono" AfterTargets="_CompileToNative">
+    <Copy SourceFiles="/Library/Frameworks/Mono.framework/Commands/mono;..\..\ThirdParty\Dependencies\FreeImage.NET\MacOS\libfreeimage.dylib"
+      DestinationFolder="$(_AppBundlePath)Contents\MonoBundle" />
+  </Target>
+</Project>


### PR DESCRIPTION
One of the problems we have with the Pipeline tool
at the moment on Mac is this. When running the MGCB.exe
using system `mono` we can end up in a situation where
the wrong versions of the system assemblies and mscorlib
are loaded. As a result some calls to the system will
fail because entry points are missing or are invalid.

This is an attempt to fix that by bundling the `mono`
we are built against inside the Pipeline.app package.
In theory this should help. We also look for the system
`mono` (on a Mac) before anything else. 
We also change the CurrentDirectory when we start MGCB to
ensure that we don't try to load any assemblies from the
Pipeline.app/Contents/MonoBundle directory. This was based
on advice from the Xamarin.Mac team.