### PR TITLE
Switch order of parameters in Ray.Deconstruct

### DIFF
--- a/MonoGame.Framework/Ray.cs
+++ b/MonoGame.Framework/Ray.cs
@@ -259,12 +259,12 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Deconstruction method for <see cref="Ray"/>.
         /// </summary>
-        /// <param name="direction"></param>
-        /// <param name="position"></param>
-        public void Deconstruct(out Vector3 direction, out Vector3 position)
+        /// <param name="position">Receives the start position of the ray.</param>
+        /// <param name="direction">Receives the direction of the ray.</param>
+        public void Deconstruct(out Vector3 position, out Vector3 direction)
         {
-            direction = Direction;
             position = Position;
+            direction = Direction;
         }
 
         #endregion

--- a/Test/Framework/RayTest.cs
+++ b/Test/Framework/RayTest.cs
@@ -52,12 +52,12 @@ namespace MonoGame.Tests.Framework
         {
             Ray ray = new Ray(Vector3.Backward, Vector3.Right);
 
-            Vector3 direction, position;
+            Vector3 position, direction;
 
-            ray.Deconstruct(out direction, out position);
+            ray.Deconstruct(out position, out direction);
 
-            Assert.AreEqual(direction, ray.Direction);
             Assert.AreEqual(position, ray.Position);
+            Assert.AreEqual(direction, ray.Direction);
         }
     }
 }


### PR DESCRIPTION
The parameters in the type deconstructors should match the order of the parameters in the constructors.

Completes #6096