### PR TITLE
Added ability to load images(png/jpg/bmp/gif/tga) into the memory

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/Image2DArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Image2DArrayReader.cs
@@ -1,0 +1,73 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Framework.Graphics;
+
+namespace Microsoft.Xna.Framework.Content
+{
+    internal class Image2DArrayReader : ContentTypeReader<Image2DArray>
+    {
+        public Image2DArrayReader()
+        {
+        }
+
+        protected internal override Image2DArray Read(ContentReader reader, Image2DArray existingInstance)
+        {
+            return Read(reader, existingInstance, int.MaxValue);
+        }
+
+        internal Image2DArray Read(ContentReader reader, Image2DArray existingInstance, int maxCount)
+        {
+            SurfaceFormat surfaceFormat = (SurfaceFormat)reader.ReadInt32();
+            SurfaceFormat convertedFormat = Texture2DReader.GetConvertedFormat(surfaceFormat, false, false);
+
+            int width = reader.ReadInt32();
+            int height = reader.ReadInt32();
+            int levelCount = reader.ReadInt32();
+            int actualLevelCount = Math.Min(levelCount, maxCount);
+
+            Image2DArray images = existingInstance ?? new Image2DArray(width, height, new Image2D[actualLevelCount]);
+
+            for (int level = 0; level < actualLevelCount; level++)
+            {
+                int levelDataSizeInBytes = reader.ReadInt32();
+                byte[] levelData = ContentManager.ScratchBufferPool.Get(levelDataSizeInBytes);
+                reader.Read(levelData, 0, levelDataSizeInBytes);
+                int levelWidth = Math.Max(width >> level, 1);
+                int levelHeight = Math.Max(height >> level, 1);
+
+                // Convert the image data if required
+                byte[] actualLevelData = Texture2DReader.ConvertLevelData(
+                    surfaceFormat, convertedFormat, false, false, false,
+                    levelData, levelWidth, levelHeight, ref levelDataSizeInBytes);
+
+                Image2D image = images[level];
+                bool needsCopy = true;
+
+                if (image == null)
+                {
+                    if (actualLevelData == levelData)
+                    {
+                        image = new Image2D(levelWidth, levelHeight);
+                    }
+                    else
+                    {
+                        image = new Image2D(actualLevelData, levelWidth, levelHeight);
+                        needsCopy = false;
+                    }
+                    images[level] = image;
+                }
+
+                if (needsCopy)
+                    Buffer.BlockCopy(actualLevelData, 0, image.PixelData, 0, levelDataSizeInBytes);
+
+                ContentManager.ScratchBufferPool.Return(levelData);
+            }
+
+            return images;
+        }
+    }
+}

--- a/MonoGame.Framework/Content/ContentReaders/Image2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Image2DReader.cs
@@ -1,0 +1,25 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using MonoGame.Framework.Graphics;
+
+namespace Microsoft.Xna.Framework.Content
+{
+    internal class Image2DReader : ContentTypeReader<Image2D>
+    {
+        private Image2DArrayReader _arrayReader;
+        private Image2DArray _existingArray;
+
+        public Image2DReader()
+        {
+            _arrayReader = new Image2DArrayReader();
+        }
+
+        protected internal override Image2D Read(ContentReader reader, Image2D existingInstance)
+        {
+            _existingArray = _arrayReader.Read(reader, _existingArray);
+            return _existingArray[0];
+        }
+    }
+}

--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -3,33 +3,29 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using Microsoft.Xna;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
     internal class Texture2DReader : ContentTypeReader<Texture2D>
     {
-		public Texture2DReader()
-		{
-			// Do nothing
-		}
+        public Texture2DReader()
+        {
+            // Do nothing
+        }
 
         protected internal override Texture2D Read(ContentReader reader, Texture2D existingInstance)
-		{
-			Texture2D texture = null;
-
+        {
             var surfaceFormat = (SurfaceFormat)reader.ReadInt32();
             int width = reader.ReadInt32();
             int height = reader.ReadInt32();
             int levelCount = reader.ReadInt32();
             int levelCountOutput = levelCount;
+            var graphicsDevice = reader.GetGraphicsDevice();
 
             // If the system does not fully support Power of Two textures,
             // skip any mip maps supplied with any non PoT textures.
-            if (levelCount > 1 && !reader.GetGraphicsDevice().GraphicsCapabilities.SupportsNonPowerOfTwo &&
+            if (levelCount > 1 && !graphicsDevice.GraphicsCapabilities.SupportsNonPowerOfTwo &&
                 (!MathHelper.IsPowerOfTwo(width) || !MathHelper.IsPowerOfTwo(height)))
             {
                 levelCountOutput = 1;
@@ -37,146 +33,172 @@ namespace Microsoft.Xna.Framework.Content
                     "Device does not support non Power of Two textures. Skipping mipmaps.");
             }
 
-			SurfaceFormat convertedFormat = surfaceFormat;
-			switch (surfaceFormat)
-			{
-				case SurfaceFormat.Dxt1:
-				case SurfaceFormat.Dxt1a:
-					if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsDxt1)
-						convertedFormat = SurfaceFormat.Color;
-					break;
-				case SurfaceFormat.Dxt1SRgb:
-					if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsDxt1)
-						convertedFormat = SurfaceFormat.ColorSRgb;
-					break;
-				case SurfaceFormat.Dxt3:
-				case SurfaceFormat.Dxt5:
-					if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc)
-						convertedFormat = SurfaceFormat.Color;
-					break;
-				case SurfaceFormat.Dxt3SRgb:
-				case SurfaceFormat.Dxt5SRgb:
-					if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc)
-						convertedFormat = SurfaceFormat.ColorSRgb;
-					break;
-				case SurfaceFormat.NormalizedByte4:
-					convertedFormat = SurfaceFormat.Color;
-					break;
-			}
-			
-            texture = existingInstance ?? new Texture2D(reader.GetGraphicsDevice(), width, height, levelCountOutput > 1, convertedFormat);
-#if OPENGL
-            Threading.BlockOnUIThread(() =>
+            bool supportsDxt1 = graphicsDevice.GraphicsCapabilities.SupportsDxt1;
+            bool supportsS3tc = graphicsDevice.GraphicsCapabilities.SupportsS3tc;
+
+            SurfaceFormat convertedFormat = GetConvertedFormat(surfaceFormat, supportsDxt1, supportsS3tc);
+
+            Texture2D texture = existingInstance ?? new Texture2D(graphicsDevice, width, height, levelCountOutput > 1, convertedFormat);
+
+            for (int level = 0; level < levelCount; level++)
             {
-#endif
-                for (int level = 0; level < levelCount; level++)
-			    {
-				    var levelDataSizeInBytes = reader.ReadInt32();
-                    var levelData = ContentManager.ScratchBufferPool.Get(levelDataSizeInBytes);
-                    reader.Read(levelData, 0, levelDataSizeInBytes);
-                    int levelWidth = Math.Max(width >> level, 1);
-                    int levelHeight = Math.Max(height >> level, 1);
+                int levelDataSizeInBytes = reader.ReadInt32();
+                byte[] levelData = ContentManager.ScratchBufferPool.Get(levelDataSizeInBytes);
+                reader.Read(levelData, 0, levelDataSizeInBytes);
+                int levelWidth = Math.Max(width >> level, 1);
+                int levelHeight = Math.Max(height >> level, 1);
 
-                    if (level >= levelCountOutput)
-                        continue;
+                if (level >= levelCountOutput)
+                    continue;
 
-				    //Convert the image data if required
-				    switch (surfaceFormat)
-				    {
-					    case SurfaceFormat.Dxt1:
-                        case SurfaceFormat.Dxt1SRgb:
-                        case SurfaceFormat.Dxt1a:
-				            if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsDxt1 && convertedFormat == SurfaceFormat.Color)
-				            {
-				                levelData = DxtUtil.DecompressDxt1(levelData, levelWidth, levelHeight);
-				                levelDataSizeInBytes = levelData.Length;
-				            }
-				            break;
-					    case SurfaceFormat.Dxt3:
-					    case SurfaceFormat.Dxt3SRgb:
-                            if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc)
-				                if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc &&
-				                    convertedFormat == SurfaceFormat.Color)
-				                {
-				                    levelData = DxtUtil.DecompressDxt3(levelData, levelWidth, levelHeight);
-                                    levelDataSizeInBytes = levelData.Length;
-                                }
-				            break;
-					    case SurfaceFormat.Dxt5:
-					    case SurfaceFormat.Dxt5SRgb:
-                            if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc)
-				                if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc &&
-				                    convertedFormat == SurfaceFormat.Color)
-				                {
-				                    levelData = DxtUtil.DecompressDxt5(levelData, levelWidth, levelHeight);
-                                    levelDataSizeInBytes = levelData.Length;
-                                }
-				            break;
-                        case SurfaceFormat.Bgra5551:
-                            {
+                bool forOpenGL = false;
 #if OPENGL
-                                // Shift the channels to suit OpenGL
-                                int offset = 0;
-                                for (int y = 0; y < levelHeight; y++)
-                                {
-                                    for (int x = 0; x < levelWidth; x++)
-                                    {
-                                        ushort pixel = BitConverter.ToUInt16(levelData, offset);
-                                        pixel = (ushort)(((pixel & 0x7FFF) << 1) | ((pixel & 0x8000) >> 15));
-                                        levelData[offset] = (byte)(pixel);
-                                        levelData[offset + 1] = (byte)(pixel >> 8);
-                                        offset += 2;
-                                    }
-                                }
+                forOpenGL = true;
 #endif
-                            }
-                            break;
-					    case SurfaceFormat.Bgra4444:
-						    {
-#if OPENGL
-                                // Shift the channels to suit OpenGL
-							    int offset = 0;
-							    for (int y = 0; y < levelHeight; y++)
-							    {
-								    for (int x = 0; x < levelWidth; x++)
-								    {
-									    ushort pixel = BitConverter.ToUInt16(levelData, offset);
-									    pixel = (ushort)(((pixel & 0x0FFF) << 4) | ((pixel & 0xF000) >> 12));
-									    levelData[offset] = (byte)(pixel);
-									    levelData[offset + 1] = (byte)(pixel >> 8);
-									    offset += 2;
-								    }
-							    }
-#endif
-						    }
-						    break;
-					    case SurfaceFormat.NormalizedByte4:
-						    {
-							    int bytesPerPixel = surfaceFormat.GetSize();
-							    int pitch = levelWidth * bytesPerPixel;
-							    for (int y = 0; y < levelHeight; y++)
-							    {
-								    for (int x = 0; x < levelWidth; x++)
-								    {
-									    int color = BitConverter.ToInt32(levelData, y * pitch + x * bytesPerPixel);
-									    levelData[y * pitch + x * 4] = (byte)(((color >> 16) & 0xff)); //R:=W
-									    levelData[y * pitch + x * 4 + 1] = (byte)(((color >> 8) & 0xff)); //G:=V
-									    levelData[y * pitch + x * 4 + 2] = (byte)(((color) & 0xff)); //B:=U
-									    levelData[y * pitch + x * 4 + 3] = (byte)(((color >> 24) & 0xff)); //A:=Q
-								    }
-							    }
-						    }
-						    break;
-				    }
-				
-                    texture.SetData(level, null, levelData, 0, levelDataSizeInBytes);
-                    ContentManager.ScratchBufferPool.Return(levelData);
-			    }
-#if OPENGL
-            });
-#endif
-        			
-			return texture;
-		}
+
+                // Convert the image data if required
+                byte[] actualLevelData = ConvertLevelData(
+                    surfaceFormat, convertedFormat, supportsDxt1, supportsS3tc, forOpenGL,
+                    levelData, levelWidth, levelHeight, ref levelDataSizeInBytes);
+
+                texture.SetData(level, null, actualLevelData, 0, levelDataSizeInBytes);
+                ContentManager.ScratchBufferPool.Return(levelData);
+            }
+
+            return texture;
+        }
+
+        public static SurfaceFormat GetConvertedFormat(
+            SurfaceFormat surfaceFormat, bool supportsDxt1, bool supportsS3tc)
+        {
+            SurfaceFormat convertedFormat = surfaceFormat;
+            switch (surfaceFormat)
+            {
+                case SurfaceFormat.Dxt1:
+                case SurfaceFormat.Dxt1a:
+                    if (!supportsDxt1)
+                        convertedFormat = SurfaceFormat.Color;
+                    break;
+
+                case SurfaceFormat.Dxt1SRgb:
+                    if (!supportsDxt1)
+                        convertedFormat = SurfaceFormat.ColorSRgb;
+                    break;
+
+                case SurfaceFormat.Dxt3:
+                case SurfaceFormat.Dxt5:
+                    if (!supportsS3tc)
+                        convertedFormat = SurfaceFormat.Color;
+                    break;
+
+                case SurfaceFormat.Dxt3SRgb:
+                case SurfaceFormat.Dxt5SRgb:
+                    if (!supportsS3tc)
+                        convertedFormat = SurfaceFormat.ColorSRgb;
+                    break;
+
+                case SurfaceFormat.NormalizedByte4:
+                    convertedFormat = SurfaceFormat.Color;
+                    break;
+            }
+            return convertedFormat;
+        }
+
+        public static byte[] ConvertLevelData(
+            SurfaceFormat surfaceFormat, SurfaceFormat convertedFormat, bool supportsDxt1, bool supportsS3tc, bool forOpenGL,
+            byte[] levelData, int levelWidth, int levelHeight, ref int levelDataSizeInBytes)
+        {
+            switch (surfaceFormat)
+            {
+                case SurfaceFormat.Dxt1:
+                case SurfaceFormat.Dxt1SRgb:
+                case SurfaceFormat.Dxt1a:
+                    if (!supportsDxt1 && convertedFormat == SurfaceFormat.Color)
+                    {
+                        levelData = DxtUtil.DecompressDxt1(levelData, levelWidth, levelHeight);
+                        levelDataSizeInBytes = levelData.Length;
+                    }
+                    break;
+
+                case SurfaceFormat.Dxt3:
+                case SurfaceFormat.Dxt3SRgb:
+                    if (!supportsS3tc && convertedFormat == SurfaceFormat.Color)
+                    {
+                        levelData = DxtUtil.DecompressDxt3(levelData, levelWidth, levelHeight);
+                        levelDataSizeInBytes = levelData.Length;
+                    }
+                    break;
+
+                case SurfaceFormat.Dxt5:
+                case SurfaceFormat.Dxt5SRgb:
+                    if (!supportsS3tc && convertedFormat == SurfaceFormat.Color)
+                    {
+                        levelData = DxtUtil.DecompressDxt5(levelData, levelWidth, levelHeight);
+                        levelDataSizeInBytes = levelData.Length;
+                    }
+                    break;
+
+                case SurfaceFormat.Bgra5551:
+                {
+                    if (!forOpenGL)
+                        break;
+
+                    // Shift the channels to suit OpenGL
+                    int offset = 0;
+                    for (int y = 0; y < levelHeight; y++)
+                    {
+                        for (int x = 0; x < levelWidth; x++)
+                        {
+                            ushort pixel = BitConverter.ToUInt16(levelData, offset);
+                            pixel = (ushort)(((pixel & 0x7FFF) << 1) | ((pixel & 0x8000) >> 15));
+                            levelData[offset] = (byte)(pixel);
+                            levelData[offset + 1] = (byte)(pixel >> 8);
+                            offset += 2;
+                        }
+                    }
+                }
+                break;
+
+                case SurfaceFormat.Bgra4444:
+                {
+                    if (!forOpenGL)
+                        break;
+
+                    // Shift the channels to suit OpenGL
+                    int offset = 0;
+                    for (int y = 0; y < levelHeight; y++)
+                    {
+                        for (int x = 0; x < levelWidth; x++)
+                        {
+                            ushort pixel = BitConverter.ToUInt16(levelData, offset);
+                            pixel = (ushort)(((pixel & 0x0FFF) << 4) | ((pixel & 0xF000) >> 12));
+                            levelData[offset] = (byte)(pixel);
+                            levelData[offset + 1] = (byte)(pixel >> 8);
+                            offset += 2;
+                        }
+                    }
+                }
+                break;
+
+                case SurfaceFormat.NormalizedByte4:
+                {
+                    int bytesPerPixel = surfaceFormat.GetSize();
+                    int pitch = levelWidth * bytesPerPixel;
+                    for (int y = 0; y < levelHeight; y++)
+                    {
+                        for (int x = 0; x < levelWidth; x++)
+                        {
+                            int color = BitConverter.ToInt32(levelData, y * pitch + x * bytesPerPixel);
+                            levelData[y * pitch + x * 4] = (byte)(((color >> 16) & 0xff)); //R:=W
+                            levelData[y * pitch + x * 4 + 1] = (byte)(((color >> 8) & 0xff)); //G:=V
+                            levelData[y * pitch + x * 4 + 2] = (byte)(((color) & 0xff)); //B:=U
+                            levelData[y * pitch + x * 4 + 3] = (byte)(((color >> 24) & 0xff)); //A:=Q
+                        }
+                    }
+                }
+                break;
+            }
+            return levelData;
+        }
     }
 }

--- a/MonoGame.Framework/Graphics/Image2D.cs
+++ b/MonoGame.Framework/Graphics/Image2D.cs
@@ -3,16 +3,16 @@ using Microsoft.Xna.Framework.Graphics;
 using StbImageSharp;
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace MonoGame.Framework.Graphics
 {
     /// <summary>
     /// 2D Image in the <see cref="SurfaceFormat.Color"/> format
     /// </summary>
-    public class Image2D
+    public class Image2D : IDisposable
     {
-        private readonly byte[] _data;
+        private readonly byte[] _pixelData;
+        private bool _isDisposed;
 
         /// <summary>
         /// Width of the image
@@ -25,11 +25,11 @@ namespace MonoGame.Framework.Graphics
         public int Height { get; private set; }
 
         /// <summary>
-        /// Data of the image in the RGBA format
+        /// Data of the image in the RGBA format.
         /// </summary>
-        public byte[] Data
+        public byte[] PixelData
         {
-            get { return _data; }
+            get { return _pixelData; }
         }
 
         /// <summary>
@@ -43,100 +43,83 @@ namespace MonoGame.Framework.Graphics
             get
             {
                 var basePos = (y * Width + x) * 4;
-                return new Color(_data[basePos],
-                    _data[basePos + 1],
-                    _data[basePos + 2],
-                    _data[basePos + 3]);
+                return new Color(_pixelData[basePos],
+                    _pixelData[basePos + 1],
+                    _pixelData[basePos + 2],
+                    _pixelData[basePos + 3]);
             }
 
             set
             {
                 var basePos = (y * Width + x) * 4;
-                _data[basePos] = value.R;
-                _data[basePos + 1] = value.G;
-                _data[basePos + 2] = value.B;
-                _data[basePos + 3] = value.A;
+                _pixelData[basePos] = value.R;
+                _pixelData[basePos + 1] = value.G;
+                _pixelData[basePos + 2] = value.B;
+                _pixelData[basePos + 3] = value.A;
             }
         }
 
-
         /// <summary>
-        /// Constructs a <see cref="Image2D"/> of the specified size
+        /// Constructs a <see cref="Image2D"/> of the specified size,
         /// </summary>
         /// <param name="width"></param>
         /// <param name="height"></param>
         public Image2D(int width, int height)
         {
             if (width <= 0)
-            {
                 throw new ArgumentOutOfRangeException("width");
-            }
-
             if (height <= 0)
-            {
                 throw new ArgumentOutOfRangeException("height");
-            }
 
             Width = width;
             Height = height;
-
-            _data = new byte[width * height * 4];
+            _pixelData = new byte[width * height * 4];
         }
 
         /// <summary>
-        /// Constructs a <see cref="Image2D"/> of the specified size and containing specified data
+        /// Constructs a <see cref="Image2D"/> of the specified size and containing specified data.
         /// </summary>
+        /// <param name="pixelData"></param>
         /// <param name="width"></param>
         /// <param name="height"></param>
-        /// <param name="data"></param>
-        public Image2D(int width, int height, byte[] data)
+        public Image2D(byte[] pixelData, int width, int height)
         {
-            if (width <= 0)
-            {
-                throw new ArgumentOutOfRangeException("width");
-            }
-
-            if (height <= 0)
-            {
-                throw new ArgumentOutOfRangeException("height");
-            }
-
-            if (data == null)
-            {
+            if (pixelData == null)
                 throw new ArgumentNullException("data");
-            }
+            if (width <= 0)
+                throw new ArgumentOutOfRangeException("width");
+            if (height <= 0)
+                throw new ArgumentOutOfRangeException("height");
 
-            var length = width * height * 4;
-            if (data.Length != length)
+            int length = width * height * 4;
+            if (pixelData.Length != length)
             {
                 throw new ArgumentException(string.Format("Inconsistent data length: expected={0}, provided={1}", length,
-                    data.Length));
+                    pixelData.Length));
             }
 
             Width = width;
             Height = height;
-            _data = data;
+            _pixelData = pixelData;
         }
 
         /// <summary>
-        /// Creates Texture2D from this image
+        /// Creates Texture2D from this image.
         /// </summary>
-        /// <param name="graphicsDevice"></param>
-        /// <returns></returns>
         public Texture2D CreateTexture2D(GraphicsDevice graphicsDevice)
         {
             var texture = new Texture2D(graphicsDevice, Width, Height, false, SurfaceFormat.Color);
-            texture.SetData(_data);
+            texture.SetData(_pixelData);
             return texture;
         }
 
         /// <summary>
-        /// Loads an image in PNG, JPG, BMP, GIF or TGA format from the stream
+        /// Loads an image in PNG, JPG, BMP, GIF or TGA format from the stream.
         /// </summary>
-        /// <param name="stream"></param>
-        /// <returns></returns>
         public unsafe static Image2D FromStream(Stream stream)
         {
+            // TODO: reduce allocations here by not using seeking at all
+
             ImageResult result;
             if (stream.CanSeek)
             {
@@ -152,8 +135,26 @@ namespace MonoGame.Framework.Graphics
                     result = ImageResult.FromStream(ms, ColorComponents.RedGreenBlueAlpha);
                 }
             }
+            return new Image2D(result.Data, result.Width, result.Height);
+        }
 
-            return new Image2D(result.Width, result.Height, result.Data);
+        protected virtual void Dispose(bool disposing)
+        {
+            // Dispose is empty for now but may be utilized in the future.
+
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                }
+                _isDisposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/Image2D.cs
+++ b/MonoGame.Framework/Graphics/Image2D.cs
@@ -118,6 +118,12 @@ namespace MonoGame.Framework.Graphics
         /// </summary>
         public unsafe static Image2D FromStream(Stream stream)
         {
+            // Rewind stream if it is at end
+            if (stream.CanSeek && stream.Length == stream.Position)
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+            }
+
             // TODO: reduce allocations here by not using seeking at all
 
             ImageResult result;

--- a/MonoGame.Framework/Graphics/Image2D.cs
+++ b/MonoGame.Framework/Graphics/Image2D.cs
@@ -137,12 +137,6 @@ namespace MonoGame.Framework.Graphics
         /// <returns></returns>
         public unsafe static Image2D FromStream(Stream stream)
         {
-            // Rewind stream if it is at end
-            if (stream.CanSeek && stream.Length == stream.Position)
-            {
-                stream.Seek(0, SeekOrigin.Begin);
-            }
-
             ImageResult result;
             if (stream.CanSeek)
             {

--- a/MonoGame.Framework/Graphics/Image2D.cs
+++ b/MonoGame.Framework/Graphics/Image2D.cs
@@ -12,7 +12,7 @@ namespace MonoGame.Framework.Graphics
     /// </summary>
     public class Image2D
     {
-        private readonly Color[] _data;
+        private readonly byte[] _data;
 
         /// <summary>
         /// Width of the image
@@ -25,9 +25,9 @@ namespace MonoGame.Framework.Graphics
         public int Height { get; private set; }
 
         /// <summary>
-        /// Data of the image
+        /// Data of the image in the RGBA format
         /// </summary>
-        public Color[] Data
+        public byte[] Data
         {
             get { return _data; }
         }
@@ -42,12 +42,20 @@ namespace MonoGame.Framework.Graphics
         {
             get
             {
-                return _data[y * Width + x];
+                var basePos = (y * Width + x) * 4;
+                return new Color(_data[basePos],
+                    _data[basePos + 1],
+                    _data[basePos + 2],
+                    _data[basePos + 3]);
             }
 
             set
             {
-                _data[y * Width + x] = value;
+                var basePos = (y * Width + x) * 4;
+                _data[basePos] = value.R;
+                _data[basePos + 1] = value.G;
+                _data[basePos + 2] = value.B;
+                _data[basePos + 3] = value.A;
             }
         }
 
@@ -72,7 +80,7 @@ namespace MonoGame.Framework.Graphics
             Width = width;
             Height = height;
 
-            _data = new Color[width * height];
+            _data = new byte[width * height * 4];
         }
 
         /// <summary>
@@ -81,7 +89,7 @@ namespace MonoGame.Framework.Graphics
         /// <param name="width"></param>
         /// <param name="height"></param>
         /// <param name="data"></param>
-        public Image2D(int width, int height, Color[] data)
+        public Image2D(int width, int height, byte[] data)
         {
             if (width <= 0)
             {
@@ -98,7 +106,7 @@ namespace MonoGame.Framework.Graphics
                 throw new ArgumentNullException("data");
             }
 
-            var length = width * height;
+            var length = width * height * 4;
             if (data.Length != length)
             {
                 throw new ArgumentException(string.Format("Inconsistent data length: expected={0}, provided={1}", length,
@@ -151,14 +159,7 @@ namespace MonoGame.Framework.Graphics
                 }
             }
 
-            // Convert to managed color array
-            var data = new Color[result.Width * result.Height];
-            fixed (Color* dest = data)
-            {
-                Marshal.Copy(result.Data, 0, new IntPtr(dest), result.Data.Length);
-            }
-
-            return new Image2D(result.Width, result.Height, data);
+            return new Image2D(result.Width, result.Height, result.Data);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/Image2D.cs
+++ b/MonoGame.Framework/Graphics/Image2D.cs
@@ -1,0 +1,139 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Utilities;
+using System;
+using System.IO;
+
+namespace MonoGame.Framework.Graphics
+{
+    /// <summary>
+    /// 2D Image in the <see cref="SurfaceFormat.Color"/> format
+    /// </summary>
+    public class Image2D
+    {
+        private readonly Color[] _data;
+
+        /// <summary>
+        /// Width of the image
+        /// </summary>
+        public int Width { get; private set; }
+
+        /// <summary>
+        /// Height of the image
+        /// </summary>
+        public int Height { get; private set; }
+
+        /// <summary>
+        /// Data of the image
+        /// </summary>
+        public Color[] Data
+        {
+            get { return _data; }
+        }
+
+        /// <summary>
+        /// Color at the specified coordinate
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public Color this[int x, int y]
+        {
+            get
+            {
+                return _data[y * Width + x];
+            }
+
+            set
+            {
+                _data[y * Width + x] = value;
+            }
+        }
+
+
+        /// <summary>
+        /// Constructs a <see cref="Image2D"/> of the specified size
+        /// </summary>
+        /// <param name="width"></param>
+        /// <param name="height"></param>
+        public Image2D(int width, int height)
+        {
+            if (width <= 0)
+            {
+                throw new ArgumentOutOfRangeException("width");
+            }
+
+            if (height <= 0)
+            {
+                throw new ArgumentOutOfRangeException("height");
+            }
+
+            Width = width;
+            Height = height;
+
+            _data = new Color[width * height];
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="Image2D"/> of the specified size and containing specified data
+        /// </summary>
+        /// <param name="width"></param>
+        /// <param name="height"></param>
+        /// <param name="data"></param>
+        public Image2D(int width, int height, Color[] data)
+        {
+            if (width <= 0)
+            {
+                throw new ArgumentOutOfRangeException("width");
+            }
+
+            if (height <= 0)
+            {
+                throw new ArgumentOutOfRangeException("height");
+            }
+
+            if (data == null)
+            {
+                throw new ArgumentNullException("data");
+            }
+
+            var length = width * height;
+            if (data.Length != length)
+            {
+                throw new ArgumentException(string.Format("Inconsistent data length: expected={0}, provided={1}", length,
+                    data.Length));
+            }
+
+            Width = width;
+            Height = height;
+            _data = data;
+        }
+
+        /// <summary>
+        /// Creates Texture2D from this image
+        /// </summary>
+        /// <param name="graphicsDevice"></param>
+        /// <returns></returns>
+        public Texture2D CreateTexture2D(GraphicsDevice graphicsDevice)
+        {
+            var texture = new Texture2D(graphicsDevice, Width, Height, false, SurfaceFormat.Color);
+            texture.SetData(_data);
+            return texture;
+        }
+
+        /// <summary>
+        /// Loads an image in PNG, JPG, BMP, GIF or TGA format from the stream
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <returns></returns>
+        public static Image2D FromStream(Stream stream)
+        {
+            int x, y;
+            int comp;
+
+            var data = ImageReader.ReadColor(stream, out x, out y, out comp);
+
+            return new Image2D(x, y, data);
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/Image2DArray.cs
+++ b/MonoGame.Framework/Graphics/Image2DArray.cs
@@ -1,0 +1,56 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace MonoGame.Framework.Graphics
+{
+    public class Image2DArray : IReadOnlyList<Image2D>
+    {
+        internal Image2D[] _array;
+        private int _width;
+        private int _height;
+
+        public Image2D this[int index]
+        {
+            get { return _array[index]; }
+            internal set
+            {
+                _array[index] = value;
+            }
+        }
+
+        public int Count { get { return _array.Length; } }
+
+        public int Width { get { return _width; } }
+
+        public int Height { get { return _height; } }
+
+        public Image2DArray(int width, int height, Image2D[] array)
+        {
+            if (width <= 0)
+                throw new ArgumentOutOfRangeException("width");
+            if (height <= 0)
+                throw new ArgumentOutOfRangeException("height");
+            if (array == null)
+                throw new ArgumentNullException("array");
+
+            _array = array;
+            _width = width;
+            _height = height;
+        }
+
+        public IEnumerator<Image2D> GetEnumerator()
+        {
+            return ((IEnumerable<Image2D>)_array).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _array.GetEnumerator();
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
 using MonoGame.Framework.Utilities;
 
@@ -19,10 +18,10 @@ namespace Microsoft.Xna.Framework.Graphics
             SwapChainRenderTarget,
         }
 
-		internal int width;
-		internal int height;
+        internal int width;
+        internal int height;
         internal int ArraySize;
-                
+
         internal float TexelWidth { get; private set; }
         internal float TexelHeight { get; private set; }
 
@@ -33,7 +32,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             get
             {
-				return new Rectangle(0, 0, this.width, this.height);
+                return new Rectangle(0, 0, this.width, this.height);
             }
         }
 
@@ -74,7 +73,7 @@ namespace Microsoft.Xna.Framework.Graphics
         public Texture2D(GraphicsDevice graphicsDevice, int width, int height, bool mipmap, SurfaceFormat format, int arraySize)
             : this(graphicsDevice, width, height, mipmap, format, SurfaceType.Texture, false, arraySize)
         {
-            
+
         }
 
         /// <summary>
@@ -90,15 +89,15 @@ namespace Microsoft.Xna.Framework.Graphics
             : this(graphicsDevice, width, height, mipmap, format, type, false, 1)
         {
         }
-        
+
         protected Texture2D(GraphicsDevice graphicsDevice, int width, int height, bool mipmap, SurfaceFormat format, SurfaceType type, bool shared, int arraySize)
-		{
+        {
             if (graphicsDevice == null)
                 throw new ArgumentNullException("graphicsDevice", FrameworkResources.ResourceCreationWhenDeviceIsNull);
             if (width <= 0)
-                throw new ArgumentOutOfRangeException("width","Texture width must be greater than zero");
+                throw new ArgumentOutOfRangeException("width", "Texture width must be greater than zero");
             if (height <= 0)
-                throw new ArgumentOutOfRangeException("height","Texture height must be greater than zero");
+                throw new ArgumentOutOfRangeException("height", "Texture height must be greater than zero");
             if (arraySize > 1 && !graphicsDevice.GraphicsCapabilities.SupportsTextureArrays)
                 throw new ArgumentException("Texture arrays are not supported on this graphics device", "arraySize");
 
@@ -113,8 +112,8 @@ namespace Microsoft.Xna.Framework.Graphics
             this.ArraySize = arraySize;
 
             // Texture will be assigned by the swap chain.
-		    if (type == SurfaceType.SwapChainRenderTarget)
-		        return;
+            if (type == SurfaceType.SwapChainRenderTarget)
+                return;
 
             PlatformConstruct(width, height, mipmap, format, type, shared);
         }
@@ -169,7 +168,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="data">New data for the texture</param>
         /// <param name="startIndex">Start position of data</param>
         /// <param name="elementCount"></param>
-        public void SetData<T>(int level, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct 
+        public void SetData<T>(int level, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct
         {
             Rectangle checkedRect;
             ValidateParams(level, 0, rect, data, startIndex, elementCount, out checkedRect);
@@ -186,20 +185,20 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="data">New data for the texture</param>
         /// <param name="startIndex">Start position of data</param>
         /// <param name="elementCount"></param>
-		public void SetData<T>(T[] data, int startIndex, int elementCount) where T : struct
+        public void SetData<T>(T[] data, int startIndex, int elementCount) where T : struct
         {
             Rectangle checkedRect;
             ValidateParams(0, 0, null, data, startIndex, elementCount, out checkedRect);
             PlatformSetData(0, data, startIndex, elementCount);
         }
 
-		/// <summary>
+        /// <summary>
         /// Changes the texture's pixels
         /// </summary>
         /// <typeparam name="T">New data for the texture</typeparam>
         /// <param name="data"></param>
-		public void SetData<T>(T[] data) where T : struct
-		{
+        public void SetData<T>(T[] data) where T : struct
+        {
             Rectangle checkedRect;
             ValidateParams(0, 0, null, data, 0, data.Length, out checkedRect);
             PlatformSetData(0, data, 0, data.Length);
@@ -249,10 +248,10 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="data">Destination array for the texture data</param>
         /// <param name="startIndex">First position in data where to write the pixel data</param>
         /// <param name="elementCount">Number of pixels to read</param>
-		public void GetData<T>(T[] data, int startIndex, int elementCount) where T : struct
-		{
-			this.GetData(0, null, data, startIndex, elementCount);
-		}
+        public void GetData<T>(T[] data, int startIndex, int elementCount) where T : struct
+        {
+            this.GetData(0, null, data, startIndex, elementCount);
+        }
 
         /// <summary>
         /// Retrieves the contents of the texture
@@ -261,12 +260,12 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="data">Destination array for the texture data</param>
-        public void GetData<T> (T[] data) where T : struct
-		{
-		    if (data == null)
-		        throw new ArgumentNullException("data");
-			this.GetData(0, null, data, 0, data.Length);
-		}
+        public void GetData<T>(T[] data) where T : struct
+        {
+            if (data == null)
+                throw new ArgumentNullException("data");
+            this.GetData(0, null, data, 0, data.Length);
+        }
 
         /// <summary>
         /// Creates a <see cref="Texture2D"/> from a file, supported formats bmp, gif, jpg, png, tif and dds (only for simple textures).
@@ -301,7 +300,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// result in black color data.
         /// </remarks>
         public static Texture2D FromStream(GraphicsDevice graphicsDevice, Stream stream)
-		{
+        {
             if (graphicsDevice == null)
                 throw new ArgumentNullException("graphicsDevice");
             if (stream == null)
@@ -311,7 +310,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 return PlatformFromStream(graphicsDevice, stream);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 throw new InvalidOperationException("This image format is not supported", e);
             }
@@ -357,8 +356,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        private void ValidateParams<T>(int level, int arraySlice, Rectangle? rect, T[] data,
-            int startIndex, int elementCount, out Rectangle checkedRect) where T : struct
+        private void ValidateParams<T>(
+            int level, int arraySlice, Rectangle? rect, out int tSize, out int dataByteSize, out Rectangle checkedRect)
+            where T : struct
         {
             var textureBounds = new Rectangle(0, 0, Math.Max(width >> level, 1), Math.Max(height >> level, 1));
             checkedRect = rect ?? textureBounds;
@@ -370,18 +370,12 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("arraySlice must be smaller than the ArraySize of this texture and larger than 0.", "arraySlice");
             if (!textureBounds.Contains(checkedRect) || checkedRect.Width <= 0 || checkedRect.Height <= 0)
                 throw new ArgumentException("Rectangle must be inside the texture bounds", "rect");
-            if (data == null)
-                throw new ArgumentNullException("data");
-            var tSize = ReflectionHelpers.SizeOf<T>.Get();
+
+            tSize = ReflectionHelpers.SizeOf<T>.Get();
             var fSize = Format.GetSize();
             if (tSize > fSize || fSize % tSize != 0)
                 throw new ArgumentException("Type T is of an invalid size for the format of this texture.", "T");
-            if (startIndex < 0 || startIndex >= data.Length)
-                throw new ArgumentException("startIndex must be at least zero and smaller than data.Length.", "startIndex");
-            if (data.Length < startIndex + elementCount)
-                throw new ArgumentException("The data array is too small.");
 
-            int dataByteSize;
             if (Format.IsCompressedFormat())
             {
                 int blockWidth, blockHeight;
@@ -418,171 +412,251 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 dataByteSize = checkedRect.Width * checkedRect.Height * fSize;
             }
-            if (elementCount * tSize != dataByteSize)
-                throw new ArgumentException(string.Format("elementCount is not the right size, " +
-                                            "elementCount * sizeof(T) is {0}, but data size is {1}.",
-                                            elementCount * tSize, dataByteSize), "elementCount");
         }
 
-        internal Color[] GetColorData()
+        private void ValidateParams<T>(
+            int level, int arraySlice, Rectangle? rect, T[] data,
+            int startIndex, int elementCount, out Rectangle checkedRect)
+            where T : struct
         {
-            int colorDataLength = Width * Height;
-            var colorData = new Color[colorDataLength];
+            if (data == null)
+                throw new ArgumentNullException("data");
+
+            int tSize;
+            int dataByteSize;
+            ValidateParams<T>(level, arraySlice, rect, out tSize, out dataByteSize, out checkedRect);
+
+            if (startIndex < 0 || startIndex >= data.Length)
+                throw new ArgumentException("startIndex must be at least zero and smaller than data.Length.", "startIndex");
+            if (data.Length < startIndex + elementCount)
+                throw new ArgumentException("The data array is too small.");
+
+            if (elementCount * tSize != dataByteSize)
+            {
+                throw new ArgumentException(string.Format(
+                    "elementCount is not the right size, " +
+                    "elementCount * sizeof(T) is {0}, but data size is {1}.",
+                    elementCount * tSize, dataByteSize), "elementCount");
+            }
+        }
+
+        internal unsafe void GetColorData(int level, int arraySlice, Color[] buffer, Rectangle rectangle)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+
+            int pixelCount = rectangle.Width * rectangle.Height;
+
+            // Only pin buffers after GetData so we don't put extra strain on GC
+            // (GetData allocates a lot right now)
 
             switch (Format)
             {
-                case SurfaceFormat.Single:
-                    var floatData = new float[colorDataLength];
-                    GetData(floatData);
+                case SurfaceFormat.Color:
+                    GetData(level, arraySlice, rectangle, buffer, 0, buffer.Length);
+                    break;
 
-                    for (int i = 0; i < colorDataLength; i++)
+                case SurfaceFormat.Single:
+                {
+                    float[] sourceData = new float[pixelCount];
+                    GetData(level, arraySlice, rectangle, sourceData, 0, sourceData.Length);
+                    fixed (float* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        float brightness = floatData[i];
-                        // Export as a greyscale image.
-                        colorData[i] = new Color(brightness, brightness, brightness);
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            float brightness = sourceData[i];
+                            // Export as a greyscale image.
+                            dst[i] = new Color(brightness, brightness, brightness);
+                        }
                     }
                     break;
-
-                case SurfaceFormat.Color:
-                    GetData(colorData);
-                    break;
+                }
 
                 case SurfaceFormat.Alpha8:
-                    var alpha8Data = new Alpha8[colorDataLength];
-                    GetData(alpha8Data);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    Alpha8[] sourceData = new Alpha8[pixelCount];
+                    GetData(sourceData);
+                    fixed (Alpha8* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(alpha8Data[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(
+                                byte.MaxValue, byte.MaxValue, byte.MaxValue, sourceData[i].PackedValue);
+                        }
                     }
-
                     break;
+                }
 
                 case SurfaceFormat.Bgr565:
-                    var bgr565Data = new Bgr565[colorDataLength];
-                    GetData(bgr565Data);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    Bgr565[] sourceData = new Bgr565[pixelCount];
+                    GetData(sourceData);
+                    fixed (Bgr565* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(bgr565Data[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(sourceData[i].ToVector4());
+                        }
                     }
-
                     break;
+                }
 
                 case SurfaceFormat.Bgra4444:
-                    var bgra4444Data = new Bgra4444[colorDataLength];
-                    GetData(bgra4444Data);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    Bgra4444[] sourceData = new Bgra4444[pixelCount];
+                    GetData(sourceData);
+                    fixed (Bgra4444* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(bgra4444Data[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(sourceData[i].ToVector4());
+                        }
                     }
-
                     break;
+                }
 
                 case SurfaceFormat.Bgra5551:
-                    var bgra5551Data = new Bgra5551[colorDataLength];
-                    GetData(bgra5551Data);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    Bgra5551[] sourceData = new Bgra5551[pixelCount];
+                    GetData(sourceData);
+                    fixed (Bgra5551* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(bgra5551Data[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(sourceData[i].ToVector4());
+                        }
                     }
                     break;
+                }
 
                 case SurfaceFormat.HalfSingle:
-                    var halfSingleData = new HalfSingle[colorDataLength];
-                    GetData(halfSingleData);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    HalfSingle[] sourceData = new HalfSingle[pixelCount];
+                    GetData(sourceData);
+                    fixed (HalfSingle* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(halfSingleData[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(sourceData[i].ToVector4());
+                        }
                     }
-
                     break;
+                }
 
                 case SurfaceFormat.HalfVector2:
-                    var halfVector2Data = new HalfVector2[colorDataLength];
-                    GetData(halfVector2Data);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    HalfVector2[] sourceData = new HalfVector2[pixelCount];
+                    GetData(sourceData);
+                    fixed (HalfVector2* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(halfVector2Data[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(sourceData[i].ToVector4());
+                        }
                     }
-
                     break;
+                }
 
                 case SurfaceFormat.HalfVector4:
-                    var halfVector4Data = new HalfVector4[colorDataLength];
-                    GetData(halfVector4Data);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    HalfVector4[] sourceData = new HalfVector4[pixelCount];
+                    GetData(sourceData);
+                    fixed (HalfVector4* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(halfVector4Data[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(sourceData[i].ToVector4());
+                        }
                     }
-
                     break;
+                }
 
                 case SurfaceFormat.NormalizedByte2:
-                    var normalizedByte2Data = new NormalizedByte2[colorDataLength];
-                    GetData(normalizedByte2Data);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    NormalizedByte2[] sourceData = new NormalizedByte2[pixelCount];
+                    GetData(sourceData);
+                    fixed (NormalizedByte2* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(normalizedByte2Data[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(sourceData[i].ToVector4());
+                        }
                     }
-
                     break;
+                }
 
                 case SurfaceFormat.NormalizedByte4:
-                    var normalizedByte4Data = new NormalizedByte4[colorDataLength];
-                    GetData(normalizedByte4Data);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    NormalizedByte4[] sourceData = new NormalizedByte4[pixelCount];
+                    GetData(sourceData);
+                    fixed (NormalizedByte4* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(normalizedByte4Data[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(sourceData[i].ToVector4());
+                        }
                     }
-
                     break;
+                }
 
                 case SurfaceFormat.Rg32:
-                    var rg32Data = new Rg32[colorDataLength];
-                    GetData(rg32Data);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    Rg32[] sourceData = new Rg32[pixelCount];
+                    GetData(sourceData);
+                    fixed (Rg32* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(rg32Data[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(sourceData[i].ToVector4());
+                        }
                     }
-
                     break;
+                }
 
                 case SurfaceFormat.Rgba64:
-                    var rgba64Data = new Rgba64[colorDataLength];
-                    GetData(rgba64Data);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    Rgba64[] sourceData = new Rgba64[pixelCount];
+                    GetData(sourceData);
+                    fixed (Rgba64* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(rgba64Data[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(sourceData[i].ToVector4());
+                        }
                     }
-
                     break;
+                }
 
                 case SurfaceFormat.Rgba1010102:
-                    var rgba1010102Data = new Rgba1010102[colorDataLength];
-                    GetData(rgba1010102Data);
-
-                    for (int i = 0; i < colorDataLength; i++)
+                {
+                    Rgba1010102[] sourceData = new Rgba1010102[pixelCount];
+                    GetData(sourceData);
+                    fixed (Rgba1010102* src = sourceData)
+                    fixed (Color* dst = buffer)
                     {
-                        colorData[i] = new Color(rgba1010102Data[i].ToVector4());
+                        for (int i = 0; i < pixelCount; i++)
+                        {
+                            dst[i] = new Color(sourceData[i].ToVector4());
+                        }
                     }
-
                     break;
+                }
 
                 default:
                     throw new Exception("Texture surface format not supported");
             }
-
-            return colorData;
         }
     }
 }

--- a/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
@@ -65,11 +65,6 @@
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp"/>
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp"/>
   </ItemGroup>
-  
-  <ItemGroup>
-    <Compile Include="..\ThirdParty\StbImageSharp\src\StbImageSharp\**\*.cs" LinkBase="Utilities\StbImageSharp"/>
-    <Compile Include="..\ThirdParty\StbImageWriteSharp\src\StbImageWriteSharp\**\*.cs" LinkBase="Utilities\StbImageWriteSharp"/>
-  </ItemGroup>
 
   <ItemGroup>
     <Content Include="MonoGame.Framework.WindowsUniversal.targets" PackagePath="build;lib\uap10.0\MonoGame.Framework" />

--- a/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
@@ -65,6 +65,11 @@
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp"/>
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp"/>
   </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Include="..\ThirdParty\StbImageSharp\src\StbImageSharp\**\*.cs" LinkBase="Utilities\StbImageSharp"/>
+    <Compile Include="..\ThirdParty\StbImageWriteSharp\src\StbImageWriteSharp\**\*.cs" LinkBase="Utilities\StbImageWriteSharp"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Content Include="MonoGame.Framework.WindowsUniversal.targets" PackagePath="build;lib\uap10.0\MonoGame.Framework" />

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         private unsafe static Texture2D PlatformFromStream(GraphicsDevice graphicsDevice, Stream stream)
         {
+            // Rewind stream if it is at end
+            if (stream.CanSeek && stream.Length == stream.Position)
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+            }
+            
             using (Image2D image = Image2D.FromStream(stream))
             {
                 // XNA blacks out any pixels with an alpha of zero.

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using MonoGame.Framework.Graphics;
 using StbImageSharp;
 using StbImageWriteSharp;
 using System;
@@ -13,12 +14,6 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         private unsafe static Texture2D PlatformFromStream(GraphicsDevice graphicsDevice, Stream stream)
         {
-            // Rewind stream if it is at end
-            if (stream.CanSeek && stream.Length == stream.Position)
-            {
-                stream.Seek(0, SeekOrigin.Begin);
-            }
-
             ImageResult result;
             if (stream.CanSeek)
             {

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
@@ -2,11 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using MonoGame.Framework.Graphics;
-using StbImageSharp;
-using StbImageWriteSharp;
 using System;
 using System.IO;
+using MonoGame.Framework.Graphics;
+using StbImageWriteSharp;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -14,51 +13,38 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         private unsafe static Texture2D PlatformFromStream(GraphicsDevice graphicsDevice, Stream stream)
         {
-            ImageResult result;
-            if (stream.CanSeek)
+            using (Image2D image = Image2D.FromStream(stream))
             {
-                result = ImageResult.FromStream(stream, StbImageSharp.ColorComponents.RedGreenBlueAlpha);
-            }
-            else
-            {
-                // If stream doesnt provide seek functionaly, use MemoryStream instead
-                using (var ms = new MemoryStream())
+                // XNA blacks out any pixels with an alpha of zero.
+                fixed (byte* b = image.PixelData)
                 {
-                    stream.CopyTo(ms);
-                    ms.Seek(0, SeekOrigin.Begin);
-                    result = ImageResult.FromStream(ms, StbImageSharp.ColorComponents.RedGreenBlueAlpha);
-                }
-            }
-
-            // XNA blacks out any pixels with an alpha of zero.
-            fixed (byte* b = &result.Data[0])
-            {
-                for (var i = 0; i < result.Data.Length; i += 4)
-                {
-                    if (b[i + 3] == 0)
+                    int length = image.PixelData.Length;
+                    for (int i = 0; i < length; i += 4)
                     {
-                        b[i + 0] = 0;
-                        b[i + 1] = 0;
-                        b[i + 2] = 0;
+                        if (b[i + 3] == 0)
+                        {
+                            b[i + 0] = 0;
+                            b[i + 1] = 0;
+                            b[i + 2] = 0;
+                        }
                     }
                 }
+
+                Texture2D texture = new Texture2D(graphicsDevice, image.Width, image.Height);
+                texture.SetData(image.PixelData);
+
+                return texture;
             }
-
-            Texture2D texture = null;
-            texture = new Texture2D(graphicsDevice, result.Width, result.Height);
-            texture.SetData(result.Data);
-
-            return texture;
         }
 
         private void PlatformSaveAsJpeg(Stream stream, int width, int height)
         {
-            SaveAsImage(stream, width, height, ImageWriterFormat.Jpg);
+            SaveAsImage(stream, 0, 0, new Rectangle(0, 0, width, height), ImageWriterFormat.Jpg);
         }
 
         private void PlatformSaveAsPng(Stream stream, int width, int height)
         {
-            SaveAsImage(stream, width, height, ImageWriterFormat.Png);
+            SaveAsImage(stream, 0, 0, new Rectangle(0, 0, width, height), ImageWriterFormat.Png);
         }
 
         private enum ImageWriterFormat
@@ -67,45 +53,34 @@ namespace Microsoft.Xna.Framework.Graphics
             Png
         }
 
-        private unsafe void SaveAsImage(Stream stream, int width, int height, ImageWriterFormat format)
+        private unsafe void SaveAsImage(Stream stream, int level, int arraySlice, Rectangle? rectangle, ImageWriterFormat format)
         {
             if (stream == null)
-            {
-                throw new ArgumentNullException("stream", "'stream' cannot be null (Nothing in Visual Basic)");
-            }
-            if (width <= 0)
-            {
-                throw new ArgumentOutOfRangeException("width", width, "'width' cannot be less than or equal to zero");
-            }
-            if (height <= 0)
-            {
-                throw new ArgumentOutOfRangeException("height", height, "'height' cannot be less than or equal to zero");
-            }
-            Color[] data = null;
-            try
-            {
-                data = GetColorData();
+                throw new ArgumentNullException("stream", "'stream' may not be null (Nothing in Visual Basic)");
 
-                // Write
-                fixed (Color* ptr = &data[0])
-                {
-                    var writer = new ImageWriter();
-                    switch (format)
-                    {
-                        case ImageWriterFormat.Jpg:
-                            writer.WriteJpg(ptr, width, height, StbImageWriteSharp.ColorComponents.RedGreenBlueAlpha, stream, 90);
-                            break;
-                        case ImageWriterFormat.Png:
-                            writer.WritePng(ptr, width, height, StbImageWriteSharp.ColorComponents.RedGreenBlueAlpha, stream);
-                            break;
-                    }
-                }
-            }
-            finally
+            int tSize;
+            int dataByteSize;
+            Rectangle checkedRect;
+            ValidateParams<Color>(level, arraySlice, rectangle, out tSize, out dataByteSize, out checkedRect);
+
+            Color[] data = new Color[checkedRect.Width * checkedRect.Height];
+            GetColorData(level, arraySlice, data, checkedRect);
+
+            ColorComponents colorComp = ColorComponents.RedGreenBlueAlpha;
+
+            // Write
+            fixed (Color* ptr = data)
             {
-                if (data != null)
+                var writer = new ImageWriter();
+                switch (format)
                 {
-                    data = null;
+                    case ImageWriterFormat.Jpg:
+                        writer.WriteJpg(ptr, checkedRect.Width, checkedRect.Height, colorComp, stream, 90);
+                        break;
+
+                    case ImageWriterFormat.Png:
+                        writer.WritePng(ptr, checkedRect.Height, checkedRect.Height, colorComp, stream);
+                        break;
                 }
             }
         }

--- a/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
+++ b/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Framework.Graphics;
+using MonoGame.Utilities;
 using NUnit.Framework;
 using StbImageSharp;
 using StbImageWriteSharp;
@@ -127,6 +129,31 @@ namespace MonoGame.Tests.Graphics
         }
 
         [TestCase]
+        public void Image2DFromStream()
+        {
+            Image2D texture;
+            using (var stream = File.OpenRead("Assets/Textures/red_128.png"))
+            {
+                texture = Image2D.FromStream(stream);
+            }
+
+            Assert.AreEqual(8, texture.Width);
+            Assert.AreEqual(8, texture.Height);
+
+            for (var y = 0; y < texture.Height; ++y)
+            {
+                for (var x = 0; x < texture.Width; ++x)
+                {
+                    var c = texture[x, y];
+                    Assert.AreEqual(255, c.R);
+                    Assert.AreEqual(0, c.G);
+                    Assert.AreEqual(0, c.B);
+                    Assert.AreEqual(128, c.A);
+                }
+            }
+        }
+
+        [TestCase]
         public void FromStreamBlackAlpha()
         {
             // XNA will make any pixel with an alpha value
@@ -150,7 +177,7 @@ namespace MonoGame.Tests.Graphics
                 }
             }
         }
-        
+
         [Test]
         public void ZeroSizeShouldFailTest()
         {
@@ -645,7 +672,7 @@ namespace MonoGame.Tests.Graphics
 #endif
         public void LoadOddSizedDxtCompressed()
         {
-            // This is testing that DXT compressed mip levels that 
+            // This is testing that DXT compressed mip levels that
             // are not a multiple of 4 are properly loaded.
 
             var t = content.Load<Texture2D>(Paths.Texture("red_668_dxt"));
@@ -675,9 +702,9 @@ namespace MonoGame.Tests.Graphics
                     Assert.AreEqual(0,      b2[p + 1]);
                     Assert.AreEqual(0,      b2[p + 2]);
                     Assert.AreEqual(255,    b2[p + 3]);
-                }            
+                }
             }
-                        
+
             t.Dispose();
         }
 
@@ -766,7 +793,7 @@ namespace MonoGame.Tests.Graphics
             t.GetData(3, new Rectangle(0,0,2,2), b2, 0, bs);
             t.GetData(4, new Rectangle(0,0,1,1), b2, 0, bs);
             t.SetData(3, new Rectangle(0,0,2,2), b2, 0, bs);
-            
+
             // would be rounded, but the rectangle is outside the texture area so it wil throw before rounding
             Assert.Throws<ArgumentException>(() => t.GetData(3, new Rectangle(1, 1, 2, 2), b, 0, bs));
             Assert.Throws<ArgumentException>(() => t.GetData(3, new Rectangle(0, 0, 3, 3), b, 0, bs));

--- a/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
+++ b/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Framework.Graphics;
-using MonoGame.Utilities;
 using NUnit.Framework;
 using StbImageSharp;
 using StbImageWriteSharp;

--- a/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
+++ b/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
@@ -8,6 +8,8 @@ using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Framework.Graphics;
+
+using MonoGame.Utilities;
 using NUnit.Framework;
 using StbImageSharp;
 using StbImageWriteSharp;

--- a/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
+++ b/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
@@ -9,7 +9,6 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Framework.Graphics;
 
-using MonoGame.Utilities;
 using NUnit.Framework;
 using StbImageSharp;
 using StbImageWriteSharp;


### PR DESCRIPTION
This PR will allow a developer to do following:
```c#
int width, height;
byte[] data;
using(var stream = File.Open("myImage.jpg"))
{
  Texture2D.RawImageFromStream(stream, out width, out height, out data);
}

// Various processing
// ...

// Create Texture2D from it
var texture = new Texture2D(GraphicsDevice, width, height);
texture.SetData(data);

```
I think it is helpful feature. As one can easily do various processing to image(i.e. premultiply alpha) before creating Texture2D from it.

Of course, same could be archieved using Texture2D.GetData. But it would require more code. Also I am unsure that all platforms support it.