### PR TITLE
Fix typo in VS2013 Shared Project Template

### DIFF
--- a/ProjectTemplates/VisualStudio2013/MonoGameShared/Game1.cs
+++ b/ProjectTemplates/VisualStudio2013/MonoGameShared/Game1.cs
@@ -8,7 +8,7 @@ using Microsoft.Xna.Framework.Input;
 
 #endregion
 
-namespace $safeprojectnme$
+namespace $safeprojectname$
 {
     /// <summary>
     /// This is the main type for your game.


### PR DESCRIPTION
 - Change namespace $safeprojectnme$ to read $safeprojectname$