### PR TITLE
Fix memory leak for abandoned (finalized) SoundEffect instance

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -346,11 +346,9 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformDispose(bool disposing)
         {
-            if (disposing)
-            {
-                if (_dataStream != null)
-                    _dataStream.Dispose();
-            }
+            if (_dataStream != null)
+                _dataStream.Dispose();
+            
             _dataStream = null;
         }
 


### PR DESCRIPTION
Hi guys,

I'm loading OGG files into `byte[]` and creating `SoundEffect` instances from that.
I just noticed that `SoundEffect` implementation for XAudio leaks memory if I don't call `Dispose()` explicitly. This pull requests fixes the issue for me.

`DataStream` instance doesn't release the memory blob in its finalization so it seems we have to call `Dispose()` explicitly for it in `SoundEffect.XAudio.cs`.

I simply don't know whether I still have references on the `SoundEffect` (again, it's not loaded from Content) and prefer to delegate this to GC. I wrap it in a weak reference just in case I will need the instance and it's still alive - so I can skip loading OGG file again and it's a pretty simple yet effective cache implementation.

Regards!