### PR TITLE
[WinDX] FIX: Soft-fullscreen resolution may be incorrect

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -104,6 +104,7 @@ namespace MonoGame.Framework
             {
                 _wasMoved = true;
                 Form.Location = new Point(value.X, value.Y);
+                RefreshAdapter();
             }
         }
 
@@ -371,14 +372,18 @@ namespace MonoGame.Framework
             if (Game.Window == this)
             {
                 UpdateBackBufferSize();
-
-                // the display that the window is on might have changed, so we need to
-                // check and possibly update the Adapter of the GraphicsDevice
-                if (Game.GraphicsDevice != null)
-                    Game.GraphicsDevice.RefreshAdapter();
+                RefreshAdapter();
             }
 
             OnClientSizeChanged();
+        }
+
+        private void RefreshAdapter()
+        {
+            // the display that the window is on might have changed, so we need to
+            // check and possibly update the Adapter of the GraphicsDevice
+            if (Game.GraphicsDevice != null)
+                Game.GraphicsDevice.RefreshAdapter();
         }
 
         private void UpdateBackBufferSize()


### PR DESCRIPTION
For the Windows DirectX build, the resolution used for soft-fullscreen may be incorrect if the window position was programmatically changed (i.e. via `GameWindow.Position`).

This is because the adapter was not refreshed after changing the position. So if the window moves to a different display with a different resolution, then soft-fullscreen will end up using the resolution of the previous display.

This PR fixes this by refreshing the adapter after `GameWindow.Position` is set.

(cc @Jjagg because I know you are familiar with this particular area of code)