### PR TITLE
AssemblyHelper: Protect GetCustomAttribute in try/catch

### DIFF
--- a/MonoGame.Framework/Utilities/AssemblyHelper.cs
+++ b/MonoGame.Framework/Utilities/AssemblyHelper.cs
@@ -19,9 +19,16 @@ namespace MonoGame.Utilities
             if (assembly != null)
             {
                 // Use the Title attribute of the Assembly if possible.
-                var assemblyTitleAtt = ((AssemblyTitleAttribute)Attribute.GetCustomAttribute(assembly, typeof(AssemblyTitleAttribute)));
-                if (assemblyTitleAtt != null)
-                    windowTitle = assemblyTitleAtt.Title;
+                try
+                {
+                    var assemblyTitleAtt = ((AssemblyTitleAttribute)Attribute.GetCustomAttribute(assembly, typeof(AssemblyTitleAttribute)));
+                    if (assemblyTitleAtt != null)
+                        windowTitle = assemblyTitleAtt.Title;
+                }
+                catch
+                {
+                    // Nope, wasn't possible :/
+                }
 
                 // Otherwise, fallback to the Name of the assembly.
                 if (string.IsNullOrEmpty(windowTitle))


### PR DESCRIPTION
This simply adds a try/catch to the GetCustomAttribute call used to get the Assembly's Title attribute.

This fix is helpful for runtime environments where this function isn't available or implemented for this particular type of attribute, other than that this should not affect any other environment.