### PR TITLE
SharpDX COM object memory leak fix

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -362,12 +362,16 @@ namespace Microsoft.Xna.Framework.Graphics
 
             var fconv = new FormatConverter(imgfactory);
 
-            fconv.Initialize(
-                decoder.GetFrame(0),
-                PixelFormat.Format32bppRGBA,
-                BitmapDitherType.None, null,
-                0.0, BitmapPaletteType.Custom);
-
+            using (var frame = decoder.GetFrame(0))
+            {
+                fconv.Initialize(
+                    frame,
+                    PixelFormat.Format32bppRGBA,
+                    BitmapDitherType.None,
+                    null,
+                    0.0,
+                    BitmapPaletteType.Custom);
+            }
             return fconv;
         }
 


### PR DESCRIPTION
BitmapDecoder.GetFrame() returns a BitmapFrameDecode object which is a COM object and must be disposed.