### PR TITLE
Begin show keyboard uap xaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ Test/*.csproj
 
 Installers/MacOS/Scripts/Framework/postinstall
 IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/MonoGame.Framework.dll.config
+/GuideTests

--- a/MonoGame.Framework/MonoGame.Framework.Net.WindowsUniversal.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Net.WindowsUniversal.csproj
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <FileAlignment>512</FileAlignment>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{9CE2FA93-3D41-4025-B228-3D9D81F19BE0}</ProjectGuid>
+    <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Microsoft.Xna.Framework</RootNamespace>
+    <AssemblyName>MonoGame.Framework.Net</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>1591,0436</NoWarn>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+    <LangVersion>Default</LangVersion>
+    <DefaultLanguage>en-US</DefaultLanguage>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <DebugType>full</DebugType>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
+    <OutputPath>bin\WindowsUniversal\AnyCPU\Debug</OutputPath>
+    <IntermediateOutputPath>obj\WindowsUniversal\AnyCPU\Debug</IntermediateOutputPath>
+    <DocumentationFile>bin\WindowsUniversal\AnyCPU\Debug\MonoGame.Framework.Net.xml</DocumentationFile>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UAP;WINRT;DIRECTX;DIRECTX11_1;WINDOWS_MEDIA_ENGINE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <OutputPath>bin\WindowsUniversal\AnyCPU\Release</OutputPath>
+    <IntermediateOutputPath>obj\WindowsUniversal\AnyCPU\Release</IntermediateOutputPath>
+    <DocumentationFile>bin\WindowsUniversal\AnyCPU\Release\MonoGame.Framework.Net.xml</DocumentationFile>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UAP;WINRT;DIRECTX;DIRECTX11_1;WINDOWS_MEDIA_ENGINE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Page Include="WindowsUniversal\GuideUIResources\KeyboardInputUserControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="GamerServices\AchievementCollection.cs" />
+    <Compile Include="GamerServices\Achievement.cs" />
+    <Compile Include="GamerServices\FriendCollection.cs" />
+    <Compile Include="GamerServices\FriendGamer.cs" />
+    <Compile Include="GamerServices\GamerCollection.cs" />
+    <Compile Include="GamerServices\Gamer.cs" />
+    <Compile Include="GamerServices\GamerDefaults.cs" />
+    <Compile Include="GamerServices\GamerPresence.cs" />
+    <Compile Include="GamerServices\GamerPresenceMode.cs" />
+    <Compile Include="GamerServices\GamerPrivileges.cs" />
+    <Compile Include="GamerServices\GamerPrivilegeSetting.cs" />
+    <Compile Include="GamerServices\GamerProfile.cs" />
+    <Compile Include="GamerServices\GamerZone.cs" />
+    <Compile Include="GamerServices\LeaderboardEntry.cs" />
+    <Compile Include="GamerServices\LeaderboardIdentity.cs" />
+    <Compile Include="GamerServices\LeaderboardKey.cs" />
+    <Compile Include="GamerServices\LeaderboardReader.cs" />
+    <Compile Include="GamerServices\LeaderboardWriter.cs" />
+    <Compile Include="GamerServices\MessageBoxIcon.cs" />
+    <Compile Include="GamerServices\PropertyDictionary.cs" />
+    <Compile Include="GamerServices\SignedInGamerCollection.cs" />
+    <Compile Include="WindowsUniversal\GamerServices\SignedInGamer.cs">
+      <Platforms>WindowsUniversal</Platforms>
+    </Compile>
+    <Compile Include="WindowsUniversal\GuideUIResources\KeyboardInputUserControl.xaml.cs">
+      <DependentUpon>KeyboardInputUserControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Windows\GamerServices\Guide.cs">
+      <Platforms>Windows,WindowsUniversal</Platforms>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <PropertyGroup>
+    <_PostBuildHookTimestamp>@(IntermediateAssembly->'%(FullPath).timestamp')</_PostBuildHookTimestamp>
+    <_PostBuildHookHostPlatform>$(Platform)</_PostBuildHookHostPlatform>
+  </PropertyGroup>
+  <Target Name="PostBuildHooks" Inputs="@(IntermediateAssembly);@(ReferencePath)" Outputs="@(IntermediateAssembly);$(_PostBuildHookTimestamp)" AfterTargets="CoreCompile" BeforeTargets="AfterCompile">
+    <Touch Files="$(_PostBuildHookTimestamp)" AlwaysCreate="True" />
+  </Target>
+  <ItemGroup>
+    <ProjectReference Include="MonoGame.Framework.WindowsUniversal.csproj">
+      <Project>{09C41A48-7BF3-4A46-9EB8-CE95B4C27CA9}</Project>
+      <Name>MonoGame.Framework.WindowsUniversal</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ProjectExtensions>
+    <MonoDevelop>
+      <Properties>
+        <Policies>
+          <TextStylePolicy inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/x-csharp" />
+          <CSharpFormattingPolicy IndentSwitchSection="True" NewLinesForBracesInProperties="True" NewLinesForBracesInAccessors="True" NewLinesForBracesInAnonymousMethods="True" NewLinesForBracesInControlBlocks="True" NewLinesForBracesInAnonymousTypes="True" NewLinesForBracesInObjectCollectionArrayInitializers="True" NewLinesForBracesInLambdaExpressionBody="True" NewLineForElse="True" NewLineForCatch="True" NewLineForFinally="True" NewLineForMembersInObjectInit="True" NewLineForMembersInAnonymousTypes="True" NewLineForClausesInQuery="True" SpacingAfterMethodDeclarationName="False" SpaceAfterMethodCallName="False" SpaceBeforeOpenSquareBracket="False" inheritsSet="Mono" inheritsScope="text/x-csharp" scope="text/x-csharp" />
+        </Policies>
+      </Properties>
+    </MonoDevelop>
+  </ProjectExtensions>
+</Project>

--- a/MonoGame.Framework/Windows/GamerServices/Guide.cs
+++ b/MonoGame.Framework/Windows/GamerServices/Guide.cs
@@ -46,20 +46,16 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
-using Windows.ApplicationModel.Core;
+
+#if WINDOWS_UAP
+using System.Threading.Tasks;
+using Windows.UI.Core;
+using Windows.UI.Popups;
 using Windows.Services.Store;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Microsoft.Xna.Framework.WindowsUniversal.GuideUIResources;
-#if WINDOWS_UAP
-using System.Threading.Tasks;
-using Windows.ApplicationModel;
-using Windows.ApplicationModel.Store;
-using Windows.UI.Core;
-using Windows.UI.Popups;
-using Windows.System;
-using Microsoft.Xna.Framework.Input;
+
 #else
 using System.Runtime.Remoting.Messaging;
 #if !(WINDOWS && DIRECTX)

--- a/MonoGame.Framework/Windows/GamerServices/Guide.cs
+++ b/MonoGame.Framework/Windows/GamerServices/Guide.cs
@@ -308,8 +308,8 @@ namespace Microsoft.Xna.Framework.GamerServices
 
 
 #if !WINDOWS_UAP
-ShowKeyboardInputDelegate ski = ShowKeyboardInput;
-            //	return ski.BeginInvoke(player, title, description, defaultText, usePasswordMode, callback, ski);
+            ShowKeyboardInputDelegate ski = ShowKeyboardInput;
+            return ski.BeginInvoke(player, title, description, defaultText, usePasswordMode, callback, ski);
 #else
             IsVisible = true;
             return ShowKeyboardInput(player, title, description, defaultText, usePasswordMode, callback, state);

--- a/MonoGame.Framework/Windows/GamerServices/Guide.cs
+++ b/MonoGame.Framework/Windows/GamerServices/Guide.cs
@@ -54,8 +54,6 @@ using Windows.UI.Popups;
 using Windows.Services.Store;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Microsoft.Xna.Framework.WindowsUniversal.GuideUIResources;
-
 #else
 using System.Runtime.Remoting.Messaging;
 #if !(WINDOWS && DIRECTX)

--- a/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml
+++ b/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml
@@ -1,8 +1,8 @@
 ﻿<UserControl
-    x:Class="Microsoft.Xna.Framework.WindowsUniversal.GuideUIResources.KeyboardInputUserControl"
+    x:Class="Microsoft.Xna.Framework.GamerServices.KeyboardInputUserControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.Xna.Framework.WindowsUniversal.GuideUIResources"
+    xmlns:local="using:Microsoft.Xna.Framework.GamerServices"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">

--- a/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml
+++ b/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml
@@ -1,0 +1,89 @@
+﻿<UserControl
+    x:Class="Microsoft.Xna.Framework.WindowsUniversal.GuideUIResources.KeyboardInputUserControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Microsoft.Xna.Framework.WindowsUniversal.GuideUIResources"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <UserControl.Resources>
+        <AcrylicBrush x:Key="DimBackground"
+                      BackgroundSource="Backdrop"
+                      TintColor="Gray"
+                      TintOpacity="0.2"
+                      FallbackColor="#80808080"
+        />
+
+        <AcrylicBrush x:Key="BackdropBrush60Perc"
+                      BackgroundSource="Backdrop"
+                      TintColor="Black"
+                      TintOpacity="0.6"
+                      FallbackColor="Gray"
+        />
+
+        <AcrylicBrush x:Key="BackdropBrush40Perc"
+                      BackgroundSource="Backdrop"
+                      TintColor="Black"
+                      TintOpacity="0.4"
+                      FallbackColor="Gray"
+        />
+
+        <AcrylicBrush x:Key="BackdropBrush40WhitePerc"
+                      BackgroundSource="Backdrop"
+                      TintColor="White"
+                      TintOpacity="0.4"
+                      FallbackColor="White"
+        />
+
+
+        <AcrylicBrush x:Key="BackdropBrush40BluePerc"
+                      BackgroundSource="Backdrop"
+                      TintColor="CornflowerBlue"
+                      TintOpacity="0.4"
+                      FallbackColor="CornflowerBlue"
+        />
+    </UserControl.Resources>
+    <Grid Background="{ThemeResource DimBackground}">
+
+        <Grid>
+
+            <Grid VerticalAlignment="Center" Grid.Column="1" Padding="30">
+                <Rectangle Stroke="Black" Margin="10" RadiusX="2" RadiusY="2" Opacity="0.3"/>
+                <Rectangle Stroke="Black" Margin="9" RadiusX="3" RadiusY="3" Opacity="0.27"/>
+                <Rectangle Stroke="Black" Margin="8" RadiusX="4" RadiusY="4" Opacity="0.24"/>
+                <Rectangle Stroke="Black" Margin="7" RadiusX="5" RadiusY="5" Opacity="0.21"/>
+                <Rectangle Stroke="Black" Margin="6" RadiusX="6" RadiusY="6" Opacity="0.18"/>
+                <Rectangle Stroke="Black" Margin="5" RadiusX="7" RadiusY="7" Opacity="0.15"/>
+                <Rectangle Stroke="Black" Margin="4" RadiusX="8" RadiusY="8" Opacity="0.12"/>
+                <Rectangle Stroke="Black" Margin="3" RadiusX="9" RadiusY="9" Opacity="0.09"/>
+                <Rectangle Stroke="Black" Margin="2" RadiusX="10" RadiusY="10" Opacity="0.06"/>
+                <Rectangle Stroke="Black" Margin="1" RadiusX="11" RadiusY="11" Opacity="0.03"/>
+                <Rectangle Stroke="Black" Margin="0" RadiusX="12" RadiusY="12" Opacity="0.05"/>
+                <Grid Margin="10">
+                <Grid Background="{ThemeResource BackdropBrush40Perc}">
+                    <StackPanel Margin="0,0,0,0">
+                        <Grid Background="{ThemeResource BackdropBrush40BluePerc}" Grid.Row="1" Grid.Column="1" >
+                            <TextBlock FontSize="36" x:Name="Title" Margin="10,0,0,0">Title</TextBlock>
+                        </Grid>
+                        <TextBlock FontSize="28" Margin="15" x:Name="Description"></TextBlock>
+                        <TextBox Margin="10,10,10,50" x:Name="TextEntry" FontSize="24"></TextBox>
+
+                        <Grid Background="{ThemeResource BackdropBrush60Perc}">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button Margin="15" Tapped="CancelTapped" Background="{ThemeResource BackdropBrush40WhitePerc}" FontSize="24" Width="120">Cancel</Button>
+                                <Button Margin="15" Tapped="OkayTapped"  Background="{ThemeResource BackdropBrush40WhitePerc}" FontSize="24"  Width="120">Okay</Button>
+
+                            </StackPanel>
+                        </Grid>
+                    </StackPanel>
+
+                </Grid>
+</Grid>
+               
+            </Grid>
+        </Grid>
+
+      
+
+    </Grid>
+</UserControl>

--- a/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml
+++ b/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml
@@ -67,6 +67,7 @@
                         </Grid>
                         <TextBlock FontSize="28" Margin="15" x:Name="Description"></TextBlock>
                         <TextBox Margin="10,10,10,50" x:Name="TextEntry" FontSize="24"></TextBox>
+                            <PasswordBox Margin="10,10,10,50" x:Name="PasswordEntry" FontSize="24"></PasswordBox>
 
                         <Grid Background="{ThemeResource BackdropBrush60Perc}">
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">

--- a/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml.cs
+++ b/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml.cs
@@ -16,7 +16,7 @@ using Windows.UI.Xaml.Navigation;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
-namespace Microsoft.Xna.Framework.WindowsUniversal.GuideUIResources
+namespace Microsoft.Xna.Framework.GamerServices
 {
     public sealed partial class KeyboardInputUserControl : UserControl
     {

--- a/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml.cs
+++ b/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Xna.Framework.WindowsUniversal.GuideUIResources
     {
         private TaskCompletionSource<string> tcs;
         private Action closeMe;
+        private bool passWordMode;
         public KeyboardInputUserControl(TaskCompletionSource<string> _tcs)
         {
            
@@ -30,7 +31,7 @@ namespace Microsoft.Xna.Framework.WindowsUniversal.GuideUIResources
             this.InitializeComponent();
         }
 
-        public void SetValues(string title, string description, string defaultText = "", Action _closeMe = null)
+        public void SetValues(string title, string description, bool passwordMode, string defaultText = "", Action _closeMe = null)
         {
             closeMe = _closeMe;
             this.Title.Text = title;
@@ -40,11 +41,26 @@ namespace Microsoft.Xna.Framework.WindowsUniversal.GuideUIResources
                 TextEntry.Text = defaultText;
             }
 
+            this.passWordMode = passwordMode;
+            if (passwordMode)
+            {
+                TextEntry.Visibility = Visibility.Collapsed;
+                PasswordEntry.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                TextEntry.Visibility = Visibility.Visible;
+                PasswordEntry.Visibility = Visibility.Collapsed;
+            }
+
         }
 
         private void OkayTapped(object sender, TappedRoutedEventArgs e)
         {
-            tcs.TrySetResult(TextEntry.Text);
+            string txt;
+            txt = passWordMode ? PasswordEntry.Password : TextEntry.Text;
+
+            tcs.TrySetResult(txt);
             closeMe?.Invoke();
         }
 

--- a/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml.cs
+++ b/MonoGame.Framework/WindowsUniversal/GuideUIResources/KeyboardInputUserControl.xaml.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Microsoft.Xna.Framework.WindowsUniversal.GuideUIResources
+{
+    public sealed partial class KeyboardInputUserControl : UserControl
+    {
+        private TaskCompletionSource<string> tcs;
+        private Action closeMe;
+        public KeyboardInputUserControl(TaskCompletionSource<string> _tcs)
+        {
+           
+            tcs = _tcs;
+            
+            this.InitializeComponent();
+        }
+
+        public void SetValues(string title, string description, string defaultText = "", Action _closeMe = null)
+        {
+            closeMe = _closeMe;
+            this.Title.Text = title;
+            this.Description.Text = description;
+            if (!string.IsNullOrWhiteSpace(defaultText))
+            {
+                TextEntry.Text = defaultText;
+            }
+
+        }
+
+        private void OkayTapped(object sender, TappedRoutedEventArgs e)
+        {
+            tcs.TrySetResult(TextEntry.Text);
+            closeMe?.Invoke();
+        }
+
+        private void CancelTapped(object sender, TappedRoutedEventArgs e)
+        {
+            tcs.TrySetCanceled();
+            closeMe?.Invoke();
+        }
+    }
+}


### PR DESCRIPTION
Add support for Guide.BeginShowKeyboard/Guide.EndShowKeyboard to UAP Xaml projects.

Have tried to ensure does not need any changes to existing projects, nor force a requirement for Framework.Net dll when you are not using Guide.


Style wise I have tried to keep the feel of 360 XNA whilst also using native design rules.

Supports standard and Password Boxes.

![guide beginshowkeyboard2](https://user-images.githubusercontent.com/2499871/38779634-038c6e32-40c3-11e8-994c-ac90d3773733.png)
