### PR TITLE
Fixing issue #6293 - Instanced geometry not visible / working on OpenGL when drawing non-instanced geometry with it

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -1060,6 +1060,8 @@ namespace Microsoft.Xna.Framework.Graphics
                                      indexElementType,
                                      indexOffsetInBytes);
             GraphicsExtensions.CheckGLError();
+
+            _attribsDirty = true;
         }
 
         private void PlatformDrawUserPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, VertexDeclaration vertexDeclaration, int vertexCount) where T : struct
@@ -1103,6 +1105,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			              vertexStart,
 			              vertexCount);
             GraphicsExtensions.CheckGLError();
+
+            _attribsDirty = true;
         }
 
         private void PlatformDrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, short[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct


### PR DESCRIPTION
This fix resolves the issues where drawing instanced geometry with non-instanced geometry results in only the non-instanced drawing being visible i.e. the instanced geometry is not drawn.

See issue #6293 

Thanks to @PumkinPudding for pointing out how to resolve this.