### PR TITLE
Added Round, Ceiling, Floor functions to Vector{2,3,4}

### DIFF
--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -341,7 +341,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Round this <see cref="Vector2"/> to a vector towards the positive infinity.
+        /// Round the members of this <see cref="Vector2"/> towards positive infinity.
         /// </summary>
         public void Ceiling()
         {
@@ -350,10 +350,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains values from another vector rounded towards positive infinity.
+        /// Creates a new <see cref="Vector2"/> that contains members from another vector rounded towards positive infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/>.</param>
-        /// <returns>Unit vector.</returns>
+        /// <returns>The rounded <see cref="Vector2"/>.</returns>
         public static Vector2 Ceiling(Vector2 value)
         {
             value.X = (float)Math.Ceiling(value.X);
@@ -362,10 +362,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains values from another vector rounded towards positive infinity.
+        /// Creates a new <see cref="Vector2"/> that contains members from another vector rounded towards positive infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/>.</param>
-        /// <param name="result">Unit vector as an output parameter.</param>
+        /// <param name="result">The rounded <see cref="Vector2"/>.</param>
         public static void Ceiling(ref Vector2 value, out Vector2 result)
         {
             result.X = (float)Math.Ceiling(value.X);
@@ -547,7 +547,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Round this <see cref="Vector2"/> to a vector towards the negative infinity.
+        /// Round the members of this <see cref="Vector2"/> towards negative infinity.
         /// </summary>
         public void Floor()
         {
@@ -556,10 +556,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains values from another vector rounded towards negative infinity.
+        /// Creates a new <see cref="Vector2"/> that contains members from another vector rounded towards negative infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/>.</param>
-        /// <returns>Unit vector.</returns>
+        /// <returns>The rounded <see cref="Vector2"/>.</returns>
         public static Vector2 Floor(Vector2 value)
         {
             value.X = (float)Math.Floor(value.X);
@@ -568,10 +568,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains values from another vector rounded towards negative infinity.
+        /// Creates a new <see cref="Vector2"/> that contains members from another vector rounded towards negative infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/>.</param>
-        /// <param name="result">Unit vector as an output parameter.</param>
+        /// <param name="result">The rounded <see cref="Vector2"/>.</param>
         public static void Floor(ref Vector2 value, out Vector2 result)
         {
             result.X = (float)Math.Floor(value.X);
@@ -882,7 +882,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Round this <see cref="Vector2"/> to a vector with the nearest integral value.
+        /// Round the members of this <see cref="Vector2"/> to the nearest integer value.
         /// </summary>
         public void Round()
         {
@@ -891,10 +891,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains rounded values from another vector.
+        /// Creates a new <see cref="Vector2"/> that contains members from another vector rounded to the nearest integer value.
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/>.</param>
-        /// <returns>Unit vector.</returns>
+        /// <returns>The rounded <see cref="Vector2"/>.</returns>
         public static Vector2 Round(Vector2 value)
         {
             value.X = (float)Math.Round(value.X);
@@ -903,10 +903,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains rounded values from another vector.
+        /// Creates a new <see cref="Vector2"/> that contains members from another vector rounded to the nearest integer value.
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/>.</param>
-        /// <param name="result">Unit vector as an output parameter.</param>
+        /// <param name="result">The rounded <see cref="Vector2"/>.</param>
         public static void Round(ref Vector2 value, out Vector2 result)
         {
             result.X = (float)Math.Round(value.X);

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -341,6 +341,38 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Round this <see cref="Vector2"/> to a vector towards the positive infinity.
+        /// </summary>
+        public void Ceiling()
+        {
+            X = (float)Math.Ceiling(X);
+            Y = (float)Math.Ceiling(Y);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector2"/> that contains values from another vector rounded towards positive infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector2 Ceiling(Vector2 value)
+        {
+            value.X = (float)Math.Ceiling(value.X);
+            value.Y = (float)Math.Ceiling(value.Y);
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector2"/> that contains values from another vector rounded towards positive infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
+        public static void Ceiling(ref Vector2 value, out Vector2 result)
+        {
+            result.X = (float)Math.Ceiling(value.X);
+            result.Y = (float)Math.Ceiling(value.Y);
+        }
+
+        /// <summary>
         /// Clamps the specified value within a range.
         /// </summary>
         /// <param name="value1">The value to clamp.</param>
@@ -512,6 +544,38 @@ namespace Microsoft.Xna.Framework
         public bool Equals(Vector2 other)
         {
             return (X == other.X) && (Y == other.Y);
+        }
+
+        /// <summary>
+        /// Round this <see cref="Vector2"/> to a vector towards the negative infinity.
+        /// </summary>
+        public void Floor()
+        {
+            X = (float)Math.Floor(X);
+            Y = (float)Math.Floor(Y);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector2"/> that contains values from another vector rounded towards negative infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector2 Floor(Vector2 value)
+        {
+            value.X = (float)Math.Floor(value.X);
+            value.Y = (float)Math.Floor(value.Y);
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector2"/> that contains values from another vector rounded towards negative infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
+        public static void Floor(ref Vector2 value, out Vector2 result)
+        {
+            result.X = (float)Math.Floor(value.X);
+            result.Y = (float)Math.Floor(value.Y);
         }
 
         /// <summary>
@@ -815,6 +879,38 @@ namespace Microsoft.Xna.Framework
             float val = 2.0f * ((vector.X * normal.X) + (vector.Y * normal.Y));
             result.X = vector.X - (normal.X * val);
             result.Y = vector.Y - (normal.Y * val);
+        }
+
+        /// <summary>
+        /// Round this <see cref="Vector2"/> to a vector with the nearest integral value.
+        /// </summary>
+        public void Round()
+        {
+            X = (float)Math.Round(X);
+            Y = (float)Math.Round(Y);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector2"/> that contains rounded values from another vector.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector2 Round(Vector2 value)
+        {
+            value.X = (float)Math.Round(value.X);
+            value.Y = (float)Math.Round(value.Y);
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector2"/> that contains rounded values from another vector.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
+        public static void Round(ref Vector2 value, out Vector2 result)
+        {
+            result.X = (float)Math.Round(value.X);
+            result.Y = (float)Math.Round(value.Y);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Round this <see cref="Vector3"/> to a vector towards the positive infinity.
+        /// Round the members of this <see cref="Vector3"/> towards positive infinity.
         /// </summary>
         public void Ceiling()
         {
@@ -313,10 +313,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector3"/> that contains values from another vector rounded towards positive infinity.
+        /// Creates a new <see cref="Vector3"/> that contains members from another vector rounded towards positive infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/>.</param>
-        /// <returns>Unit vector.</returns>
+        /// <returns>The rounded <see cref="Vector3"/>.</returns>
         public static Vector3 Ceiling(Vector3 value)
         {
             value.X = (float)Math.Ceiling(value.X);
@@ -326,10 +326,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector3"/> that contains values from another vector rounded towards positive infinity.
+        /// Creates a new <see cref="Vector3"/> that contains members from another vector rounded towards positive infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/>.</param>
-        /// <param name="result">Unit vector as an output parameter.</param>
+        /// <param name="result">The rounded <see cref="Vector3"/>.</param>
         public static void Ceiling(ref Vector3 value, out Vector3 result)
         {
             result.X = (float)Math.Ceiling(value.X);
@@ -552,7 +552,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Round this <see cref="Vector3"/> to a vector towards the negative infinity.
+        /// Round the members of this <see cref="Vector3"/> towards negative infinity.
         /// </summary>
         public void Floor()
         {
@@ -562,10 +562,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector3"/> that contains values from another vector rounded towards negative infinity.
+        /// Creates a new <see cref="Vector3"/> that contains members from another vector rounded towards negative infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/>.</param>
-        /// <returns>Unit vector.</returns>
+        /// <returns>The rounded <see cref="Vector3"/>.</returns>
         public static Vector3 Floor(Vector3 value)
         {
             value.X = (float)Math.Floor(value.X);
@@ -575,10 +575,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector3"/> that contains values from another vector rounded towards negative infinity.
+        /// Creates a new <see cref="Vector3"/> that contains members from another vector rounded towards negative infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/>.</param>
-        /// <param name="result">Unit vector as an output parameter.</param>
+        /// <param name="result">The rounded <see cref="Vector3"/>.</param>
         public static void Floor(ref Vector3 value, out Vector3 result)
         {
             result.X = (float)Math.Floor(value.X);
@@ -924,7 +924,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Round this <see cref="Vector3"/> to a vector with the nearest integral value.
+        /// Round the members of this <see cref="Vector3"/> towards the nearest integer value.
         /// </summary>
         public void Round()
         {
@@ -934,10 +934,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector3"/> that contains rounded values from another vector.
+        /// Creates a new <see cref="Vector3"/> that contains members from another vector rounded to the nearest integer value.
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/>.</param>
-        /// <returns>Unit vector.</returns>
+        /// <returns>The rounded <see cref="Vector3"/>.</returns>
         public static Vector3 Round(Vector3 value)
         {
             value.X = (float)Math.Round(value.X);
@@ -947,10 +947,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector3"/> that contains rounded values from another vector.
+        /// Creates a new <see cref="Vector3"/> that contains members from another vector rounded to the nearest integer value.
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/>.</param>
-        /// <param name="result">Unit vector as an output parameter.</param>
+        /// <param name="result">The rounded <see cref="Vector3"/>.</param>
         public static void Round(ref Vector3 value, out Vector3 result)
         {
             result.X = (float)Math.Round(value.X);

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -303,6 +303,41 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Round this <see cref="Vector3"/> to a vector towards the positive infinity.
+        /// </summary>
+        public void Ceiling()
+        {
+            X = (float)Math.Ceiling(X);
+            Y = (float)Math.Ceiling(Y);
+            Z = (float)Math.Ceiling(Z);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains values from another vector rounded towards positive infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector3 Ceiling(Vector3 value)
+        {
+            value.X = (float)Math.Ceiling(value.X);
+            value.Y = (float)Math.Ceiling(value.Y);
+            value.Z = (float)Math.Ceiling(value.Z);
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains values from another vector rounded towards positive infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
+        public static void Ceiling(ref Vector3 value, out Vector3 result)
+        {
+            result.X = (float)Math.Ceiling(value.X);
+            result.Y = (float)Math.Ceiling(value.Y);
+            result.Z = (float)Math.Ceiling(value.Z);
+        }
+
+        /// <summary>
         /// Clamps the specified value within a range.
         /// </summary>
         /// <param name="value1">The value to clamp.</param>
@@ -514,6 +549,41 @@ namespace Microsoft.Xna.Framework
             return  X == other.X && 
                     Y == other.Y &&
                     Z == other.Z;
+        }
+
+        /// <summary>
+        /// Round this <see cref="Vector3"/> to a vector towards the negative infinity.
+        /// </summary>
+        public void Floor()
+        {
+            X = (float)Math.Floor(X);
+            Y = (float)Math.Floor(Y);
+            Z = (float)Math.Floor(Z);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains values from another vector rounded towards negative infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector3 Floor(Vector3 value)
+        {
+            value.X = (float)Math.Floor(value.X);
+            value.Y = (float)Math.Floor(value.Y);
+            value.Z = (float)Math.Floor(value.Z);
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains values from another vector rounded towards negative infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
+        public static void Floor(ref Vector3 value, out Vector3 result)
+        {
+            result.X = (float)Math.Floor(value.X);
+            result.Y = (float)Math.Floor(value.Y);
+            result.Z = (float)Math.Floor(value.Z);
         }
 
         /// <summary>
@@ -851,6 +921,41 @@ namespace Microsoft.Xna.Framework
             result.X = vector.X - (2.0f * normal.X) * dotProduct;
             result.Y = vector.Y - (2.0f * normal.Y) * dotProduct;
             result.Z = vector.Z - (2.0f * normal.Z) * dotProduct;
+        }
+
+        /// <summary>
+        /// Round this <see cref="Vector3"/> to a vector with the nearest integral value.
+        /// </summary>
+        public void Round()
+        {
+            X = (float)Math.Round(X);
+            Y = (float)Math.Round(Y);
+            Z = (float)Math.Round(Z);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains rounded values from another vector.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector3 Round(Vector3 value)
+        {
+            value.X = (float)Math.Round(value.X);
+            value.Y = (float)Math.Round(value.Y);
+            value.Z = (float)Math.Round(value.Z);
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains rounded values from another vector.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
+        public static void Round(ref Vector3 value, out Vector3 result)
+        {
+            result.X = (float)Math.Round(value.X);
+            result.Y = (float)Math.Round(value.Y);
+            result.Z = (float)Math.Round(value.Z);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -288,6 +288,44 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Round this <see cref="Vector4"/> to a vector towards the positive infinity.
+        /// </summary>
+        public void Ceiling()
+        {
+            X = (float)Math.Ceiling(X);
+            Y = (float)Math.Ceiling(Y);
+            Z = (float)Math.Ceiling(Z);
+            W = (float)Math.Ceiling(W);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains values from another vector rounded towards positive infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector4 Ceiling(Vector4 value)
+        {
+            value.X = (float)Math.Ceiling(value.X);
+            value.Y = (float)Math.Ceiling(value.Y);
+            value.Z = (float)Math.Ceiling(value.Z);
+            value.W = (float)Math.Ceiling(value.W);
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains values from another vector rounded towards positive infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
+        public static void Ceiling(ref Vector4 value, out Vector4 result)
+        {
+            result.X = (float)Math.Ceiling(value.X);
+            result.Y = (float)Math.Ceiling(value.Y);
+            result.Z = (float)Math.Ceiling(value.Z);
+            result.W = (float)Math.Ceiling(value.W);
+        }
+
+        /// <summary>
         /// Clamps the specified value within a range.
         /// </summary>
         /// <param name="value1">The value to clamp.</param>
@@ -471,6 +509,44 @@ namespace Microsoft.Xna.Framework
                 && this.X == other.X
                 && this.Y == other.Y
                 && this.Z == other.Z;
+        }
+
+        /// <summary>
+        /// Round this <see cref="Vector4"/> to a vector towards the negative infinity.
+        /// </summary>
+        public void Floor()
+        {
+            X = (float)Math.Floor(X);
+            Y = (float)Math.Floor(Y);
+            Z = (float)Math.Floor(Z);
+            W = (float)Math.Floor(W);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains values from another vector rounded towards negative infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector4 Floor(Vector4 value)
+        {
+            value.X = (float)Math.Floor(value.X);
+            value.Y = (float)Math.Floor(value.Y);
+            value.Z = (float)Math.Floor(value.Z);
+            value.W = (float)Math.Floor(value.W);
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains values from another vector rounded towards negative infinity.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
+        public static void Floor(ref Vector4 value, out Vector4 result)
+        {
+            result.X = (float)Math.Floor(value.X);
+            result.Y = (float)Math.Floor(value.Y);
+            result.Z = (float)Math.Floor(value.Z);
+            result.W = (float)Math.Floor(value.W);
         }
 
         /// <summary>
@@ -787,6 +863,44 @@ namespace Microsoft.Xna.Framework
             result.X = value.X * factor;
             result.Y = value.Y * factor;
             result.Z = value.Z * factor;
+        }
+
+        /// <summary>
+        /// Round this <see cref="Vector4"/> to a vector with the nearest integral value.
+        /// </summary>
+        public void Round()
+        {
+            X = (float)Math.Round(X);
+            Y = (float)Math.Round(Y);
+            Z = (float)Math.Round(Z);
+            W = (float)Math.Round(W);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains rounded values from another vector.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector4 Round(Vector4 value)
+        {
+            value.X = (float)Math.Round(value.X);
+            value.Y = (float)Math.Round(value.Y);
+            value.Z = (float)Math.Round(value.Z);
+            value.W = (float)Math.Round(value.W);
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains rounded values from another vector.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
+        public static void Round(ref Vector4 value, out Vector4 result)
+        {
+            result.X = (float)Math.Round(value.X);
+            result.Y = (float)Math.Round(value.Y);
+            result.Z = (float)Math.Round(value.Z);
+            result.W = (float)Math.Round(value.W);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Round this <see cref="Vector4"/> to a vector towards the positive infinity.
+        /// Round the members of this <see cref="Vector4"/> towards positive infinity.
         /// </summary>
         public void Ceiling()
         {
@@ -299,10 +299,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector4"/> that contains values from another vector rounded towards positive infinity.
+        /// Creates a new <see cref="Vector4"/> that contains members from another vector rounded towards positive infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/>.</param>
-        /// <returns>Unit vector.</returns>
+        /// <returns>The rounded <see cref="Vector4"/>.</returns>
         public static Vector4 Ceiling(Vector4 value)
         {
             value.X = (float)Math.Ceiling(value.X);
@@ -313,10 +313,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector4"/> that contains values from another vector rounded towards positive infinity.
+        /// Creates a new <see cref="Vector4"/> that contains members from another vector rounded towards positive infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/>.</param>
-        /// <param name="result">Unit vector as an output parameter.</param>
+        /// <param name="result">The rounded <see cref="Vector4"/>.</param>
         public static void Ceiling(ref Vector4 value, out Vector4 result)
         {
             result.X = (float)Math.Ceiling(value.X);
@@ -512,7 +512,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Round this <see cref="Vector4"/> to a vector towards the negative infinity.
+        /// Round the members of this <see cref="Vector4"/> towards negative infinity.
         /// </summary>
         public void Floor()
         {
@@ -523,10 +523,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector4"/> that contains values from another vector rounded towards negative infinity.
+        /// Creates a new <see cref="Vector4"/> that contains members from another vector rounded towards negative infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/>.</param>
-        /// <returns>Unit vector.</returns>
+        /// <returns>The rounded <see cref="Vector4"/>.</returns>
         public static Vector4 Floor(Vector4 value)
         {
             value.X = (float)Math.Floor(value.X);
@@ -537,10 +537,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector4"/> that contains values from another vector rounded towards negative infinity.
+        /// Creates a new <see cref="Vector4"/> that contains members from another vector rounded towards negative infinity.
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/>.</param>
-        /// <param name="result">Unit vector as an output parameter.</param>
+        /// <param name="result">The rounded <see cref="Vector4"/>.</param>
         public static void Floor(ref Vector4 value, out Vector4 result)
         {
             result.X = (float)Math.Floor(value.X);
@@ -866,7 +866,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Round this <see cref="Vector4"/> to a vector with the nearest integral value.
+        /// Round the members of this <see cref="Vector4"/> to the nearest integer value.
         /// </summary>
         public void Round()
         {
@@ -877,10 +877,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector4"/> that contains rounded values from another vector.
+        /// Creates a new <see cref="Vector4"/> that contains members from another vector rounded to the nearest integer value.
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/>.</param>
-        /// <returns>Unit vector.</returns>
+        /// <returns>The rounded <see cref="Vector4"/>.</returns>
         public static Vector4 Round(Vector4 value)
         {
             value.X = (float)Math.Round(value.X);
@@ -891,10 +891,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector4"/> that contains rounded values from another vector.
+        /// Creates a new <see cref="Vector4"/> that contains members from another vector rounded to the nearest integer value.
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/>.</param>
-        /// <param name="result">Unit vector as an output parameter.</param>
+        /// <param name="result">The rounded <see cref="Vector4"/>.</param>
         public static void Round(ref Vector4 value, out Vector4 result)
         {
             result.X = (float)Math.Round(value.X);

--- a/Test/Framework/Vector2Test.cs
+++ b/Test/Framework/Vector2Test.cs
@@ -438,6 +438,48 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(x, vector2.X);
             Assert.AreEqual(y, vector2.Y);
         }
+
+        [Test]
+        public void Round()
+        {
+            Vector2 vector2 = new Vector2(0.4f, 0.6f);
+
+            // CEILING
+
+            Vector2 ceilMember = vector2;
+            ceilMember.Ceiling();
+
+            Vector2 ceilResult;
+            Vector2.Ceiling(ref vector2, out ceilResult);
+
+            Assert.AreEqual(new Vector2(1.0f, 1.0f), ceilMember);
+            Assert.AreEqual(new Vector2(1.0f, 1.0f), Vector2.Ceiling(vector2));
+            Assert.AreEqual(new Vector2(1.0f, 1.0f), ceilResult);
+
+            // FLOOR
+
+            Vector2 floorMember = vector2;
+            floorMember.Floor();
+
+            Vector2 floorResult;
+            Vector2.Floor(ref vector2, out floorResult);
+
+            Assert.AreEqual(new Vector2(0.0f, 0.0f), floorMember);
+            Assert.AreEqual(new Vector2(0.0f, 0.0f), Vector2.Floor(vector2));
+            Assert.AreEqual(new Vector2(0.0f, 0.0f), floorResult);
+
+            // ROUND
+
+            Vector2 roundMember = vector2;
+            roundMember.Round();
+
+            Vector2 roundResult;
+            Vector2.Round(ref vector2, out roundResult);
+
+            Assert.AreEqual(new Vector2(0.0f, 1.0f), roundMember);
+            Assert.AreEqual(new Vector2(0.0f, 1.0f), Vector2.Round(vector2));
+            Assert.AreEqual(new Vector2(0.0f, 1.0f), roundResult);
+        }
 #endif
     }
 }

--- a/Test/Framework/Vector3Test.cs
+++ b/Test/Framework/Vector3Test.cs
@@ -125,6 +125,48 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(y, vector3.Y);
             Assert.AreEqual(z, vector3.Z);
         }
+
+        [Test]
+        public void Round()
+        {
+            Vector3 vector3 = new Vector3(0.4f, 0.6f, 1.0f);
+
+            // CEILING
+
+            Vector3 ceilMember = vector3;
+            ceilMember.Ceiling();
+
+            Vector3 ceilResult;
+            Vector3.Ceiling(ref vector3, out ceilResult);
+
+            Assert.AreEqual(new Vector3(1.0f, 1.0f, 1.0f), ceilMember);
+            Assert.AreEqual(new Vector3(1.0f, 1.0f, 1.0f), Vector3.Ceiling(vector3));
+            Assert.AreEqual(new Vector3(1.0f, 1.0f, 1.0f), ceilResult);
+
+            // FLOOR
+
+            Vector3 floorMember = vector3;
+            floorMember.Floor();
+
+            Vector3 floorResult;
+            Vector3.Floor(ref vector3, out floorResult);
+
+            Assert.AreEqual(new Vector3(0.0f, 0.0f, 1.0f), floorMember);
+            Assert.AreEqual(new Vector3(0.0f, 0.0f, 1.0f), Vector3.Floor(vector3));
+            Assert.AreEqual(new Vector3(0.0f, 0.0f, 1.0f), floorResult);
+
+            // ROUND
+
+            Vector3 roundMember = vector3;
+            roundMember.Round();
+
+            Vector3 roundResult;
+            Vector3.Round(ref vector3, out roundResult);
+
+            Assert.AreEqual(new Vector3(0.0f, 1.0f, 1.0f), roundMember);
+            Assert.AreEqual(new Vector3(0.0f, 1.0f, 1.0f), Vector3.Round(vector3));
+            Assert.AreEqual(new Vector3(0.0f, 1.0f, 1.0f), roundResult);
+        }
 #endif
     }
 }

--- a/Test/Framework/Vector4Test.cs
+++ b/Test/Framework/Vector4Test.cs
@@ -185,6 +185,48 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(z, vector4.Z);
             Assert.AreEqual(w, vector4.W);
         }
+
+        [Test]
+        public void Round()
+        {
+            Vector4 vector4 = new Vector4(0.0f, 0.4f, 0.6f, 1.0f);
+
+            // CEILING
+
+            Vector4 ceilMember = vector4;
+            ceilMember.Ceiling();
+
+            Vector4 ceilResult;
+            Vector4.Ceiling(ref vector4, out ceilResult);
+
+            Assert.AreEqual(new Vector4(0.0f, 1.0f, 1.0f, 1.0f), ceilMember);
+            Assert.AreEqual(new Vector4(0.0f, 1.0f, 1.0f, 1.0f), Vector4.Ceiling(vector4));
+            Assert.AreEqual(new Vector4(0.0f, 1.0f, 1.0f, 1.0f), ceilResult);
+
+            // FLOOR
+
+            Vector4 floorMember = vector4;
+            floorMember.Floor();
+
+            Vector4 floorResult;
+            Vector4.Floor(ref vector4, out floorResult);
+
+            Assert.AreEqual(new Vector4(0.0f, 0.0f, 0.0f, 1.0f), floorMember);
+            Assert.AreEqual(new Vector4(0.0f, 0.0f, 0.0f, 1.0f), Vector4.Floor(vector4));
+            Assert.AreEqual(new Vector4(0.0f, 0.0f, 0.0f, 1.0f), floorResult);
+
+            // ROUND
+
+            Vector4 roundMember = vector4;
+            roundMember.Round();
+
+            Vector4 roundResult;
+            Vector4.Round(ref vector4, out roundResult);
+
+            Assert.AreEqual(new Vector4(0.0f, 0.0f, 1.0f, 1.0f), roundMember);
+            Assert.AreEqual(new Vector4(0.0f, 0.0f, 1.0f, 1.0f), Vector4.Round(vector4));
+            Assert.AreEqual(new Vector4(0.0f, 0.0f, 1.0f, 1.0f), roundResult);
+        }
 #endif
     }
 }


### PR DESCRIPTION
Needed these a couple of times. All of the overloads are based on the `Normalize` functions. 