### PR TITLE
Store debug delegate to avoid its garbage collection

### DIFF
--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -1172,8 +1172,10 @@ namespace MonoGame.OpenGL
         internal delegate void VertexAttribDivisorDelegate (int location, int frequency);
         internal static VertexAttribDivisorDelegate VertexAttribDivisor;
 
+#if DEBUG
         [UnmanagedFunctionPointer (CallingConvention.StdCall)]
         delegate void DebugMessageCallbackProc (int source, int type, int id, int severity, int length, IntPtr message, IntPtr userParam);
+        static DebugMessageCallbackProc DebugProc;
         [System.Security.SuppressUnmanagedCodeSecurity ()]
         [MonoNativeFunctionWrapper]
         delegate void DebugMessageCallbackDelegate (DebugMessageCallbackProc callback, IntPtr userParam);
@@ -1182,7 +1184,6 @@ namespace MonoGame.OpenGL
         internal delegate void ErrorDelegate (string message);
         internal static event ErrorDelegate OnError;
 
-#if DEBUG
         static void DebugMessageCallbackHandler(int source, int type, int id, int severity, int length, IntPtr message, IntPtr userParam)
         {
             var errorMessage = Marshal.PtrToStringAnsi(message);
@@ -1341,7 +1342,8 @@ namespace MonoGame.OpenGL
                 DebugMessageCallback = LoadEntryPoint<DebugMessageCallbackDelegate>("glDebugMessageCallback");
                 if (DebugMessageCallback != null)
                 {
-                    DebugMessageCallback(DebugMessageCallbackHandler, IntPtr.Zero);
+                    DebugProc = DebugMessageCallbackHandler;
+                    DebugMessageCallback(DebugProc, IntPtr.Zero);
                     Enable(EnableCap.DebugOutput);
                     Enable(EnableCap.DebugOutputSynchronous);
                 }


### PR DESCRIPTION
Storing a delegate before passing it to OpenGL in order to avoid it from being gabarge collected and throw exceptions while debugging.

Fixes #6316

cc @tomspilman @cra0zy @KonajuGames 