### PR TITLE
Fix crash in Windows when mgcb file is in root directory.

### DIFF
--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -657,6 +657,10 @@ namespace MonoGame.Tools.Pipeline
         {
             var path = GetFullPath(GetCurrentPath());
 
+            // if path is root of drive in windows (C:) return C:\ instead.
+            //  Should no break anything unless file/directory names end with :
+            if (path[path.Length - 1] == ':') path += "\\";
+
             List<string> files;
             if (!View.ChooseContentFile(path, out files))
                 return;


### PR DESCRIPTION
Changes path to include "" if path ends in ":".

In Windows the root directory is returned as "C:"; which crashes the file open dialog when passed in as default directory. This code appends the "" yielding "C:" which is valid in all contexts.

Should not break anything, unless someone names a directory or file that ends in ":"

Application note: The Pipeline tool also requires an "obj " directory to exist prior to building.