### PR TITLE
Wait building assemblies before running MGCB.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -80,7 +80,7 @@
     </BuildDependsOn>
   </PropertyGroup>
 
-  <Target Name="RunContentBuilder">
+  <Target Name="RunContentBuilder" DependsOnTargets="Compile">
     <Exec Condition=" '%(ContentReferences.FullPath)' != '' "
           Command="$(MonoGameContentBuilderCmd) /@:&quot;%(ContentReferences.FullPath)&quot; $(Header) /outputDir:&quot;%(ContentReferences.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReferences.ContentIntermediateOutputDir)&quot;"
           WorkingDirectory="%(ContentReferences.RootDir)%(ContentReferences.Directory)" />


### PR DESCRIPTION
MGCB files may contain references to custom content processors libraries
that needs to be built before running the MGCB command.

Changed RunContentBuilder target so it runs after dlls are built,
so /reference: can be resolved.