### PR TITLE
Indicate which elements are out of order. Rather than indicating only…

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                             continue;
                         
                         // We failed to find a required element.
-                        throw new InvalidContentException(string.Format("The Xml element `{0}` is required!", info.Attribute.ElementName));
+                        throw new InvalidContentException(string.Format("The Xml element `{0}` is required, But found '{1}' instead, try swappping elements as they are out of order", info.Attribute.ElementName, input.Xml.Name));
                     }
                 }
 


### PR DESCRIPTION
… missing element.

It would be better to point the user to a documentation page indicating proper XML Schema for additional info. See #6338.