### PR TITLE
Added a BeginCalled property to SpriteBatch to tell when Begin was called

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -38,6 +38,11 @@ namespace Microsoft.Xna.Framework.Graphics
         internal static bool NeedsHalfPixelOffset;
 
         /// <summary>
+		/// Tells whether Begin has already been called on this SpriteBatch.
+		/// </summary>
+		public bool BeginCalled { get { return _beginCalled; } }
+        
+        /// <summary>
         /// Constructs a <see cref="SpriteBatch"/>.
         /// </summary>
         /// <param name="graphicsDevice">The <see cref="GraphicsDevice"/>, which will be used for sprite rendering.</param>


### PR DESCRIPTION
I added this simple property in SpriteBatch to check if Begin was called. I always thought it was a bit off that SpriteBatch throws an exception saying Begin was already called while there is no way to check for it.

I'm thinking of this similarly to data structures, such as a Stack, that throw InvalidOperationExceptions. In those structures, you can check for the precondition. I think it makes sense for SpriteBatch to be capable of doing so as well.