### PR TITLE
Updated MGCB and Pipeline EXEs to use Net Framework 4.7.1 instead of 4.5.0

### DIFF
--- a/Build/Projects/MGCB.definition
+++ b/Build/Projects/MGCB.definition
@@ -16,13 +16,13 @@
 
     <FrameworkVersions>
       <Platform Name="Windows">
-        <Version>v4.6.2</Version>
+        <Version>v4.5</Version>
       </Platform>      
       <Platform Name="MacOS">
-        <Version>v4.6.2</Version>
+        <Version>v4.5</Version>
       </Platform>
       <Platform Name="Linux">
-        <Version>v4.6.2</Version>
+        <Version>v4.5</Version>
       </Platform>      
     </FrameworkVersions>
     

--- a/Build/Projects/MGCB.definition
+++ b/Build/Projects/MGCB.definition
@@ -17,15 +17,13 @@
     <FrameworkVersions>
       <Platform Name="Windows">
         <Version>v4.7.1</Version>
-      </Platform>
-      <!--
+      </Platform>      
       <Platform Name="MacOS">
-        <Version>4.0</Version>
+        <Version>v4.7.1</Version>
       </Platform>
       <Platform Name="Linux">
-        <Version>4.0</Version>
-      </Platform>
-      -->
+        <Version>v4.7.1</Version>
+      </Platform>      
     </FrameworkVersions>
     
     <LangVersion>Default</LangVersion>

--- a/Build/Projects/MGCB.definition
+++ b/Build/Projects/MGCB.definition
@@ -16,13 +16,13 @@
 
     <FrameworkVersions>
       <Platform Name="Windows">
-        <Version>v4.5</Version>
+        <Version>v4.7.1</Version>
       </Platform>      
       <Platform Name="MacOS">
-        <Version>v4.5</Version>
+        <Version>v4.7.1</Version>
       </Platform>
       <Platform Name="Linux">
-        <Version>v4.5</Version>
+        <Version>v4.7.1</Version>
       </Platform>      
     </FrameworkVersions>
     

--- a/Build/Projects/MGCB.definition
+++ b/Build/Projects/MGCB.definition
@@ -13,6 +13,20 @@
   </References>
 
   <Properties>
+
+    <FrameworkVersions>
+      <Platform Name="Windows">
+        <Version>v4.7.1</Version>
+      </Platform>
+      <!--
+      <Platform Name="MacOS">
+        <Version>4.0</Version>
+      </Platform>
+      <Platform Name="Linux">
+        <Version>4.0</Version>
+      </Platform>
+      -->
+    </FrameworkVersions>
     
     <LangVersion>Default</LangVersion>
     <NoWarn>1591,0436</NoWarn>

--- a/Build/Projects/MGCB.definition
+++ b/Build/Projects/MGCB.definition
@@ -16,13 +16,13 @@
 
     <FrameworkVersions>
       <Platform Name="Windows">
-        <Version>v4.7.1</Version>
+        <Version>v4.6.2</Version>
       </Platform>      
       <Platform Name="MacOS">
-        <Version>v4.5</Version>
+        <Version>v4.6.2</Version>
       </Platform>
       <Platform Name="Linux">
-        <Version>v4.5</Version>
+        <Version>v4.6.2</Version>
       </Platform>      
     </FrameworkVersions>
     

--- a/Build/Projects/MGCB.definition
+++ b/Build/Projects/MGCB.definition
@@ -19,10 +19,10 @@
         <Version>v4.7.1</Version>
       </Platform>      
       <Platform Name="MacOS">
-        <Version>v4.7.1</Version>
+        <Version>v4.5</Version>
       </Platform>
       <Platform Name="Linux">
-        <Version>v4.7.1</Version>
+        <Version>v4.5</Version>
       </Platform>      
     </FrameworkVersions>
     

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -15,6 +15,18 @@
 
   <Properties>
 
+    <FrameworkVersions>
+      <Platform Name="Windows">
+        <Version>v4.7.1</Version>
+      </Platform>
+      <Platform Name="MacOS">
+        <Version>v4.7.1</Version>
+      </Platform>
+      <Platform Name="Linux">
+        <Version>v4.7.1</Version>
+      </Platform>
+    </FrameworkVersions>
+
     <LangVersion>Default</LangVersion>
     <NoWarn>1591,0436</NoWarn>
     <MonoDevelopPoliciesFile>Build/MonoDevelopPolicies.xml</MonoDevelopPoliciesFile>

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -17,17 +17,17 @@
   </References>
 
   <Properties>
-    
+
     <FrameworkVersions>
       <Platform Name="Windows">
         <Version>v4.7.1</Version>
-      </Platform>      
+      </Platform>
       <Platform Name="MacOS">
-        <Version>v4.7.1</Version>
+        <Version>v4.5</Version>
       </Platform>
       <Platform Name="Linux">
-        <Version>v4.7.1</Version>
-      </Platform>      
+        <Version>v4.5</Version>
+      </Platform>
     </FrameworkVersions>
     
     <LangVersion>Default</LangVersion>

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -20,13 +20,13 @@
 
     <FrameworkVersions>
       <Platform Name="Windows">
-        <Version>v4.6.2</Version>
+        <Version>v4.5</Version>
       </Platform>
       <Platform Name="MacOS">
-        <Version>v4.6.2</Version>
+        <Version>v4.5</Version>
       </Platform>
       <Platform Name="Linux">
-        <Version>v4.6.2</Version>
+        <Version>v4.5</Version>
       </Platform>
     </FrameworkVersions>
     

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -17,6 +17,21 @@
   </References>
 
   <Properties>
+    
+    <FrameworkVersions>
+      <Platform Name="Windows">
+        <Version>v4.7.1</Version>
+      </Platform>
+      <!--
+      <Platform Name="MacOS">
+        <Version>4.0</Version>
+      </Platform>
+      <Platform Name="Linux">
+        <Version>4.0</Version>
+      </Platform>
+      -->
+    </FrameworkVersions>
+    
     <LangVersion>Default</LangVersion>
     <NoWarn>1591,0436</NoWarn>
     <MonoDevelopPoliciesFile>Build/MonoDevelopPolicies.xml</MonoDevelopPoliciesFile>

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -20,13 +20,13 @@
 
     <FrameworkVersions>
       <Platform Name="Windows">
-        <Version>v4.5</Version>
+        <Version>v4.7.1</Version>
       </Platform>
       <Platform Name="MacOS">
-        <Version>v4.5</Version>
+        <Version>v4.7.1</Version>
       </Platform>
       <Platform Name="Linux">
-        <Version>v4.5</Version>
+        <Version>v4.7.1</Version>
       </Platform>
     </FrameworkVersions>
     

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -21,15 +21,13 @@
     <FrameworkVersions>
       <Platform Name="Windows">
         <Version>v4.7.1</Version>
-      </Platform>
-      <!--
+      </Platform>      
       <Platform Name="MacOS">
-        <Version>4.0</Version>
+        <Version>v4.7.1</Version>
       </Platform>
       <Platform Name="Linux">
-        <Version>4.0</Version>
-      </Platform>
-      -->
+        <Version>v4.7.1</Version>
+      </Platform>      
     </FrameworkVersions>
     
     <LangVersion>Default</LangVersion>

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -20,13 +20,13 @@
 
     <FrameworkVersions>
       <Platform Name="Windows">
-        <Version>v4.7.1</Version>
+        <Version>v4.6.2</Version>
       </Platform>
       <Platform Name="MacOS">
-        <Version>v4.5</Version>
+        <Version>v4.6.2</Version>
       </Platform>
       <Platform Name="Linux">
-        <Version>v4.5</Version>
+        <Version>v4.6.2</Version>
       </Platform>
     </FrameworkVersions>
     


### PR DESCRIPTION
Right now, MGCB and the Pipeline command line tool target Net Framework 4.5.0 on windows. That means that it is not possible to create content processor plugins which depend on assemblies with higher version, or net standard assemblies.

In order to solve the issue, I've raised the framework version from 4.5.0 to 4.7.1

This change only affects:
- MGCB.exe
- Pipeline.exe

Also, I've only changed it for Windows, since I don't know which are the latest version of MONO on mac and linux.... I've left the properties commented so others might fill in the appropiate values if needed.


