### PR TITLE
Removed dead links and updated tutorial section of webpage

### DIFF
--- a/Documentation/tutorials.md
+++ b/Documentation/tutorials.md
@@ -5,6 +5,7 @@ Links to various tutorials and articles to help you get started with MonoGame.
 
 ### Microsoft
 Tara Walker's "Building a Shooter Game" tutorial series.
+
  - [Part 1: Overview, Installation, MonoGame 3.0 Project Creation](http://blogs.msdn.com/b/tarawalker/archive/2012/12/04/windows-8-game-development-using-c-xna-and-monogame-3-0-building-a-shooter-game-walkthrough-part-1-overview-installation-monogame-3-0-project-creation.aspx)
  - [Part 2: Creating the Shooter/Player Asset of the Game](http://blogs.msdn.com/b/tarawalker/archive/2012/12/10/windows-8-game-development-using-c-xna-and-monogame-3-0-building-a-shooter-game-walkthrough-part-2-creating-the-shooter-player-asset-of-the-game.aspx)
  - [Part 3: Updating Graphics using Content Pipeline with MonoGame](http://blogs.msdn.com/b/tarawalker/archive/2013/01/04/windows-8-game-development-using-c-xna-and-monogame-3-0-building-a-shooter-game-walkthrough-part-3-updating-graphics-using-content-pipeline-with-monogame.aspx)
@@ -14,12 +15,10 @@ Tara Walker's "Building a Shooter Game" tutorial series.
  - [Part 7: Creating Projectiles and Detecting Collisions](http://chrisongames.blogspot.com/2014/12/windows-8-game-development-using-c-xna.html)
  - [Part 8: Creating Explosions using Sprite Animations](http://chrisongames.blogspot.com/2015/02/windows-8-game-development-using-c-xna.html)
  - [Part 9: Adding Sound Effects and Game Music](http://chrisongames.blogspot.com/2015/12/windows-810-game-development-using-c.html)
- 
-### Nokia
- - [XNA Games On Windows Phone 8 with MonoGame](http://www.developer.nokia.com/Community/Wiki/XNA_Games_On_Windows_Phone_8_with_Monogame) ([in Portugese](http://www.developer.nokia.com/Community/Wiki/XNA_Jogos_no_Windows_Phone_8_com_Monogame))
- - [MonoGame on Windows Phone 8 Post-Processing Your Game](http://www.developer.nokia.com/Community/Wiki/MonoGame_on_Windows_Phone_8_Post-Processing_Your_Game)
- - [MonoGame on Windows Phone 8 Lighting and Normal Mapping Your Game](http://www.developer.nokia.com/Community/Wiki/MonoGame_on_Windows_Phone_8_Lighting_and_Normal_Mapping_Your_Game)
- - [Loading levels built with 3D World Studio](http://www.developer.nokia.com/Community/Wiki/MonoGame_on_Windows_Phone_%E2%80%93_A_Tutorial_on_Building_Levels_for_3D_games)
+
+### Animation and sprite sheets
+
+* [How to create animations and sprite sheets for MonoGame](https://www.codeandweb.com/texturepacker/tutorials/how-to-create-sprite-sheets-and-animations-with-monogame)
 
 ### Neil Danson's F# series
  - [Part 1 - MacOS](http://neildanson.wordpress.com/2013/07/30/f-and-monogame/)
@@ -30,9 +29,6 @@ Tara Walker's "Building a Shooter Game" tutorial series.
 ### Others
  - [Making a platformer in F# with MonoGame](http://bruinbrown.wordpress.com/2013/10/06/making-a-platformer-in-f-with-monogame/)
  - [XNA 4.0 Shader Programming / HLSL](http://digitalerr0r.wordpress.com/tutorials/)
- - [Porting to Android - MonoGame, Textures and SpriteSheets](http://www.pencelgames.com/blog/porting-android-monogame-textures-and-spritesheets)
- - [Porting to Android - Performance on Devices](http://www.pencelgames.com/blog/porting-android-performance-devices)
- - [BMFont rendering with MonoGame](http://www.craftworkgames.com/blog/tutorial-bmfont-rendering-with-monogame/)
  - [RB Whitaker's MonoGame Tutorials](http://rbwhitaker.wikidot.com/monogame-tutorials)
  - [RB Whitaker's XNA Tutorials including sharers, 2D, 3D, Game loops, advancted topics](http://rbwhitaker.wikidot.com/xna-tutorials)
  - [Setting window position tutorial](http://projectdrake.net/blog/?p=176)
@@ -41,13 +37,12 @@ Tara Walker's "Building a Shooter Game" tutorial series.
  - [Porting a Windows Phone 7 Game to Android](http://warrenburch.blogspot.co.uk/2011/12/porting-windows-phone-7-game-to-android.html)
  - [A series on embedding MonoGame/WinGL into WinForms](http://jaquadro.com/2013/03/bringing-your-xna-winforms-controls-to-monogame-opengl/)
  - [French articles about MonoGame on Linux, Windows and Windows 8](http://www.demonixis.net/blog/category/tutoriels/tuto-xna/)
- - [Building Games for Windows 8 with MonoGame](http://tjclifton.com/2013/06/16/building-games-for-windows-8-with-monogame-part-1/)
  - [Dark Genesis Blog](http://darkgenesis.zenithmoon.com/tag/monogame/)
  - [MonoGame "Hello World" on Mac OS X and Xamarin Studio](http://jaquadro.com/2013/09/monogame-hello-world-on-mac-os-x-and-xamarin-studio/)
  - [Solving Resolution Independent Rendering And 2D Camera Using Monogame](http://blog.roboblob.com/2013/07/27/solving-resolution-independent-rendering-and-2d-camera-using-monogame/)
  - [XNA is Dead; Long Live the New XNA, MonoGame](http://www.codemag.com/Article/1411081)
  - [Make Santa Jump - Making an endless runner game in F# using MonoGame](http://timjones.tw/blog/archive/2014/12/28/make-santa-jump-game-in-fsharp-using-monogame)
- - [Running MonoGame on Android Wear] (http://crossplatform.io/running-monogame-on-android-wear/)
+ - [Running MonoGame on Android Wear](http://crossplatform.io/running-monogame-on-android-wear/)
  
 ## Video Tutorials
 


### PR DESCRIPTION
Removed dead links from tutorials:

* www.developer.nokia.com
* www.pencelgames.com
* www.craftworkgames.com
* http://tjclifton.com

Fixed link rendering of link to *Running MonoGame on Android Wear*

Added new tutorial: [How to create animations and sprite sheets for MonoGame](https://www.codeandweb.com/texturepacker/tutorials/how-to-create-sprite-sheets-and-animations-with-monogame)
