### PR TITLE
Fixing many events that are being raised with incorrect senders.

### DIFF
--- a/MonoGame.Framework/DrawableGameComponent.cs
+++ b/MonoGame.Framework/DrawableGameComponent.cs
@@ -68,12 +68,12 @@ namespace Microsoft.Xna.Framework
 
         protected virtual void OnVisibleChanged(object sender, EventArgs args)
         {
-            EventHelpers.Raise(this, VisibleChanged, args);
+            EventHelpers.Raise(sender, VisibleChanged, args);
         }
 
         protected virtual void OnDrawOrderChanged(object sender, EventArgs args)
         {
-            EventHelpers.Raise(this, DrawOrderChanged, args);
+            EventHelpers.Raise(sender, DrawOrderChanged, args);
         }
     }
 }

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -567,19 +567,19 @@ namespace Microsoft.Xna.Framework
 
         protected virtual void OnExiting(object sender, EventArgs args)
         {
-            EventHelpers.Raise(this, Exiting, args);
+            EventHelpers.Raise(sender, Exiting, args);
         }
 		
-		protected virtual void OnActivated (object sender, EventArgs args)
+		protected virtual void OnActivated(object sender, EventArgs args)
 		{
 			AssertNotDisposed();
-            EventHelpers.Raise(this, Activated, args);
+            EventHelpers.Raise(sender, Activated, args);
 		}
 		
-		protected virtual void OnDeactivated (object sender, EventArgs args)
+		protected virtual void OnDeactivated(object sender, EventArgs args)
 		{
 			AssertNotDisposed();
-            EventHelpers.Raise(this, Deactivated, args);
+            EventHelpers.Raise(sender, Deactivated, args);
 		}
 
         #endregion Protected Methods

--- a/MonoGame.Framework/GameComponent.cs
+++ b/MonoGame.Framework/GameComponent.cs
@@ -58,12 +58,12 @@ namespace Microsoft.Xna.Framework
 
         protected virtual void OnUpdateOrderChanged(object sender, EventArgs args)
         {
-            EventHelpers.Raise(this, UpdateOrderChanged, args);
+            EventHelpers.Raise(sender, UpdateOrderChanged, args);
         }
 
         protected virtual void OnEnabledChanged(object sender, EventArgs args)
         {
-            EventHelpers.Raise(this, EnabledChanged, args);
+            EventHelpers.Raise(sender, EnabledChanged, args);
         }
 
         /// <summary>


### PR DESCRIPTION
I believe that these are all of the places where the incorrect `this` was being raised instead of `sender`.  The one exception is the `TextInput` event which will soon be fixed by #6361.