### PR TITLE
[DesktopGL] NormalizedByte2/4 texture format

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -654,16 +654,12 @@ namespace Microsoft.Xna.Framework.Graphics
                 break;
 
             case SurfaceFormat.NormalizedByte2:
-                if (!supportsNormalized)
-                    goto case InvalidFormat;
                 glInternalFormat = PixelInternalFormat.Rg8i;
                 glFormat = PixelFormat.Rg;
                 glType = PixelType.Byte;
                 break;
 
             case SurfaceFormat.NormalizedByte4:
-                if (!supportsNormalized)
-                    goto case InvalidFormat;
                 glInternalFormat = PixelInternalFormat.Rgba8i;
                 glFormat = PixelFormat.Rgba;
                 glType = PixelType.Byte;

--- a/MonoGame.Framework/Graphics/SurfaceFormat.cs
+++ b/MonoGame.Framework/Graphics/SurfaceFormat.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         NormalizedByte2,
         /// <summary>
-        /// Signed 16-bit bump-map format for store 8 bits per channel.
+        /// Signed 32-bit bump-map format for store 8 bits per channel.
         /// </summary>
         NormalizedByte4,
         /// <summary>


### PR DESCRIPTION
This PR removes the check for 'supportsNormalized' for
NormalizedByte2/4.

NormalizedByte2/4 are signed 8bits per component formats.
'supportsNormalized' queries the GL_EXT_texture_norm16 which is a later
16bits per component format.