### PR TITLE
Added a garbageless GetGlyphs overload

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -125,7 +125,8 @@ namespace Microsoft.Xna.Framework.Graphics
         public Dictionary<char, Glyph> GetGlyphs()
         {
             var glyphsDictionary = new Dictionary<char, Glyph>(_glyphs.Length, CharComparer.Default);
-            GetGlyphs(glyphsDictionary);
+            foreach (var glyph in _glyphs)
+                glyphsDictionary.Add(glyph.Character, glyph);
             return glyphsDictionary;
         }
 

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -125,9 +125,18 @@ namespace Microsoft.Xna.Framework.Graphics
         public Dictionary<char, Glyph> GetGlyphs()
         {
             var glyphsDictionary = new Dictionary<char, Glyph>(_glyphs.Length, CharComparer.Default);
-            foreach(var glyph in _glyphs)
-                glyphsDictionary.Add(glyph.Character, glyph);
+            GetGlyphs(glyphsDictionary);
             return glyphsDictionary;
+        }
+
+        /// <summary>
+        /// Adds the glyphs in this SpriteFont to an existing dictionary.
+        /// </summary>
+        /// <param name="glyphDict">An existing dictionary with a key of type char and a value of type Glyph.</param>
+        public void GetGlyphs(Dictionary<char, Glyph> glyphDict)
+        {
+            foreach (var glyph in _glyphs)
+                glyphDict.Add(glyph.Character, glyph);
         }
 
 		/// <summary>


### PR DESCRIPTION
This commit adds a `GetGlyphs` overload that takes in a `Dictionary<char, Glyph>` and adds all glyphs in the SpriteFont to it. This lets you reuse a dictionary if desired.

Use-case: I have a dialogue system in [this](https://github.com/tdeeb/PaperMarioBattleSystem/blob/master/PaperMarioBattleSystem/PaperMarioBattleSystem/Classes/Dialogue/DialogueBubble.cs#L225) project that renders each character separately based on parsed text routines, which include adjusting the position, color, and scale of each character. When the font is changed, I have a usable dictionary that I can clear and repopulate with the new font's glyphs, but I am forced to discard it. This new overload allows you to keep an existing dictionary and still obtain the glyphs from the font.