### PR TITLE
[WinDX] FIX: Support video adapters which only support feature levels above 9_1

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
@@ -115,12 +115,25 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if(UseReferenceDevice)
                 return true;
+
+            FeatureLevel highestSupportedLevel;
+            try
+            {
+                highestSupportedLevel = SharpDX.Direct3D11.Device.GetSupportedFeatureLevel();
+            }
+            catch (SharpDX.SharpDXException ex)
+            {
+                if (ex.ResultCode == SharpDX.DXGI.ResultCode.Unsupported) // No supported feature levels!
+                    return false;
+                throw;
+            }
+
             switch(graphicsProfile)
             {
                 case GraphicsProfile.Reach:
-                    return SharpDX.Direct3D11.Device.IsSupportedFeatureLevel(_adapter, FeatureLevel.Level_9_1);
+                    return (highestSupportedLevel >= FeatureLevel.Level_9_1);
                 case GraphicsProfile.HiDef:
-                    return SharpDX.Direct3D11.Device.IsSupportedFeatureLevel(_adapter, FeatureLevel.Level_10_0);
+                    return (highestSupportedLevel >= FeatureLevel.Level_10_0);
                 default:
                     throw new InvalidOperationException();
             }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -514,31 +514,31 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Pass the preferred feature levels based on the
             // target profile that may have been set by the user.
-            var featureLevels = new List<FeatureLevel>();
+            FeatureLevel[] featureLevels;
             if (GraphicsProfile == GraphicsProfile.HiDef)
             {
-                featureLevels.Add(FeatureLevel.Level_11_0);
-                featureLevels.Add(FeatureLevel.Level_10_1);
-                featureLevels.Add(FeatureLevel.Level_10_0);
+                featureLevels = new[]
+                    {
+                        FeatureLevel.Level_11_0,
+                        FeatureLevel.Level_10_1,
+                        FeatureLevel.Level_10_0,
+                        // Feature levels below 10 are not supported for the HiDef profile
+                    };
             }
-
-            // We can not give featureLevels for granted in GraphicsProfile.Reach
-            FeatureLevel supportedFeatureLevel = 0;
-            try
+            else // Reach profile
             {
-                supportedFeatureLevel = SharpDX.Direct3D11.Device.GetSupportedFeatureLevel();
+                featureLevels = new[]
+                    {
+                        // For the Reach profile, first try use the highest supported 9_X feature level
+                        FeatureLevel.Level_9_3,
+                        FeatureLevel.Level_9_2,
+                        FeatureLevel.Level_9_1,
+                        // If level 9 is not supported, then just use the highest supported level
+                        FeatureLevel.Level_11_0,
+                        FeatureLevel.Level_10_1,
+                        FeatureLevel.Level_10_0,
+                    };
             }
-            catch (SharpDX.SharpDXException)
-            {
-                // if GetSupportedFeatureLevel() fails, do not crash the initialization. Program can run without this.
-            }
-
-            if (supportedFeatureLevel >= FeatureLevel.Level_9_3)
-                featureLevels.Add(FeatureLevel.Level_9_3);
-            if (supportedFeatureLevel >= FeatureLevel.Level_9_2)
-                featureLevels.Add(FeatureLevel.Level_9_2);
-            if (supportedFeatureLevel >= FeatureLevel.Level_9_1)
-                featureLevels.Add(FeatureLevel.Level_9_1);
 
             var driverType = DriverType.Hardware;   //Default value
             switch (GraphicsAdapter.UseDriverType)
@@ -555,7 +555,7 @@ namespace Microsoft.Xna.Framework.Graphics
             try
             {
                 // Create the Direct3D device.
-                using (var defaultDevice = new SharpDX.Direct3D11.Device(driverType, creationFlags, featureLevels.ToArray()))
+                using (var defaultDevice = new SharpDX.Direct3D11.Device(driverType, creationFlags, featureLevels))
                     _d3dDevice = defaultDevice.QueryInterface<SharpDX.Direct3D11.Device>();
             }
             catch (SharpDXException)
@@ -563,7 +563,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // Try again without the debug flag.  This allows debug builds to run
                 // on machines that don't have the debug runtime installed.
                 creationFlags &= ~SharpDX.Direct3D11.DeviceCreationFlags.Debug;
-                using (var defaultDevice = new SharpDX.Direct3D11.Device(driverType, creationFlags, featureLevels.ToArray()))
+                using (var defaultDevice = new SharpDX.Direct3D11.Device(driverType, creationFlags, featureLevels))
                     _d3dDevice = defaultDevice.QueryInterface<SharpDX.Direct3D11.Device>();
             }
 


### PR DESCRIPTION
I came across an unusual case with a users PC where the graphics device failed to be created with the Reach profile, even though the adapter supported Direct3D 10.1. (fwiw, the users video adapter was an ATI Radeon HD 4800 Series.)

I found the problem was that it reported supporting feature levels 10_0 and 10_1, but did not report support for any of the 9_X feature levels. Because MonoGame was specifically checking for feature level 9_1 support for the Reach profile, this caused it to fail.

This PR fixes this by checking for a minimum of feature level 9_1 support instead.