### PR TITLE
Add implicit conversion between Point and ValueTuple<int,int>

### DIFF
--- a/MonoGame.Framework/Point.cs
+++ b/MonoGame.Framework/Point.cs
@@ -157,6 +157,26 @@ namespace Microsoft.Xna.Framework
             return !a.Equals(b);
         }
 
+        /// <summary>
+        /// Creates a <see cref="Point"/> from the values of a <see cref="ValueTuple{Int32,Int32}"/>.
+        /// </summary>
+        /// <param name="value"><see cref="ValueTuple{Int32,Int32}"/> to get the values from.</param>
+        /// <returns><see cref="Point"/> with the values of <paramref name="value"/>.</returns>
+        public static implicit operator Point((int, int) value)
+        {
+            return new Point(value.Item1, value.Item2);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ValueTuple{Int32,Int32}"/> from the values of a <see cref="Point"/>.
+        /// </summary>
+        /// <param name="value"><see cref="Point"/> to get the values from.</param>
+        /// <returns><see cref="ValueTuple{Int32,Int32}"/> with the values of <paramref name="value"/>.</returns>
+        public static implicit operator (int, int)(Point value)
+        {
+            return (value.X, value.Y);
+        }
+
         #endregion
 
         #region Public methods


### PR DESCRIPTION
Added implicit operators to and from a value tuple (int, int) in Point.cs. I personally use value tuples a lot, and so this is very handy when dealing with Points.
```
Point a = (7, 7);
Point b = new ValueTuple<int, int>(7, 7);
(int, int) c = a;
ValueTuple<int, int> d = b;
```
 Additionally, mathematical operators of Point can now be used with (int, int) value tuples:
```
var a = (40, 25);
var b = (70, 10);
Point c = (Point)a * b; // Point: {X:2800 Y:250}
(int, int) d = (Point)a * b; // ValueTuple<int, int>: (2800, 250)
(int, int) e = (Point)b * (77, 7) / a; // ValueTuple<int, int>: (134, 2)
// var f = a * b; // error
```