### PR TITLE
MGCB now generates content building statistics.

### DIFF
--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -432,6 +432,8 @@
     <Compile Include="ContentProcessor.cs" />
     <Compile Include="ContentProcessorAttribute.cs" />
     <Compile Include="ContentProcessorContext.cs" />
+    <Compile Include="ContentStats.cs" />
+    <Compile Include="ContentStatsCollection.cs" />
     <Compile Include="DdsLoader.cs" />
     <Compile Include="EffectImporter.cs" />
     <Compile Include="ExternalReference.cs" />

--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -58,6 +58,8 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         public string OutputDirectory { get; private set; }
         public string IntermediateDirectory { get; private set; }
 
+        public ContentStatsCollection ContentStats { get; private set; }
+
         private ContentCompiler _compiler;
 
         public ContentBuildLogger Logger { get; set; }
@@ -104,18 +106,22 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             OutputDirectory = PathHelper.NormalizeDirectory(outputDir);
             IntermediateDirectory = PathHelper.NormalizeDirectory(intermediateDir);
 
-	    RegisterCustomConverters ();
+	        RegisterCustomConverters();
+
+            // Load the previous content stats.            
+            ContentStats = new ContentStatsCollection();
+            ContentStats.PreviousStats = ContentStatsCollection.Read(intermediateDir);
         }
 
-	public void AssignTypeConverter<TType, TTypeConverter> ()
-	{
-		TypeDescriptor.AddAttributes (typeof (TType), new TypeConverterAttribute (typeof (TTypeConverter)));
-	}
+	    public void AssignTypeConverter<TType, TTypeConverter> ()
+	    {
+		    TypeDescriptor.AddAttributes (typeof (TType), new TypeConverterAttribute (typeof (TTypeConverter)));
+	    }
 
-	private void RegisterCustomConverters ()
-	{
-		AssignTypeConverter<Microsoft.Xna.Framework.Color, StringToColorConverter> ();
-	}
+	    private void RegisterCustomConverters ()
+	    {
+		    AssignTypeConverter<Microsoft.Xna.Framework.Color, StringToColorConverter> ();
+	    }
 
         public void AddAssembly(string assemblyFilePath)
         {
@@ -606,6 +612,8 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 // Do we need to rebuild?
                 if (rebuild)
                 {
+                    var startTime = DateTime.UtcNow;
+
                     // Import and process the content.
                     var processedObject = ProcessContent(pipelineEvent);
 
@@ -618,6 +626,16 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
                     // Store the new event into the intermediate folder.
                     pipelineEvent.Save(eventFilepath);
+
+                    var buildTime = DateTime.UtcNow - startTime;
+
+                    // Record stat for this file.
+                    ContentStats.RecordStats(pipelineEvent.SourceFile, pipelineEvent.DestFile, pipelineEvent.Processor, processedObject.GetType(), (float)buildTime.TotalSeconds);
+                }
+                else
+                {
+                    // Copy the stats from the previous build.
+                    ContentStats.CopyPreviousStats(pipelineEvent.SourceFile);
                 }
             }
             finally

--- a/MonoGame.Framework.Content.Pipeline/ContentStats.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentStats.cs
@@ -1,0 +1,49 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline
+{
+    /// <summary>
+    /// Content building statistics for a single source content file.
+    /// </summary>
+    public struct ContentStats
+    {
+        /// <summary>
+        /// The absolute path to the source content file.
+        /// </summary>
+        public string SourceFile;
+
+        /// <summary>
+        /// The absolute path to the destination content file.
+        /// </summary>
+        public string DestFile;
+
+        /// <summary>
+        /// The content processor type name.
+        /// </summary>
+        public string ProcessorType;
+
+        /// <summary>
+        /// The content type name.
+        /// </summary>
+        public string ContentType;
+
+        /// <summary>
+        /// The source file size in bytes.
+        /// </summary>
+        public long SourceFileSize;
+
+        /// <summary>
+        /// The destination file size in bytes.
+        /// </summary>
+        public long DestFileSize;
+
+        /// <summary>
+        /// The content build time in seconds.
+        /// </summary>
+        public float BuildSeconds;
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/ContentStatsCollection.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentStatsCollection.cs
@@ -1,0 +1,227 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline
+{
+    /// <summary>
+    /// A collection of content building statistics for use in diagnosing content issues.
+    /// </summary>
+    public class ContentStatsCollection
+    {
+        private static readonly string _header = "Source File,Dest File,Processor Type,Content Type,Source File Size,Dest File Size,Build Seconds";
+        private static readonly Regex _split = new Regex(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
+
+        private readonly object _locker = new object();
+        private readonly Dictionary<string, ContentStats> _statsBySource = new Dictionary<string, ContentStats>(1024);
+
+        public static readonly string Extension = ".mgstats";
+
+        /// <summary>
+        /// Optionally used for copying stats that were stored in another collection.
+        /// </summary>
+        public ContentStatsCollection PreviousStats { get; set; }
+
+        /// <summary>
+        ///  The internal content statistics dictionary.
+        /// </summary>
+        public IReadOnlyDictionary<string, ContentStats> Stats
+        {
+            get { return _statsBySource; }
+        }
+
+        /// <summary>
+        ///  Get the content statistics for a source file and returns true if found.
+        /// </summary>
+        public bool TryGetStats(string sourceFile, out ContentStats stats)
+        {
+            lock (_locker)
+            {
+                if (!_statsBySource.TryGetValue(sourceFile, out stats))
+                    return false;
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Clears all the content statistics.
+        /// </summary>
+        public void Reset()
+        {
+            lock (_locker)
+                _statsBySource.Clear();
+        }
+
+        /// <summary>
+        /// Store content building stats for a source file.
+        /// </summary>
+        /// <param name="sourceFile">The absolute path to the source asset file.</param>
+        /// <param name="destFile">The absolute path to the destination content file.</param>
+        /// <param name="processorType">The type name of the content processor.</param>
+        /// <param name="contentType">The content type object.</param>
+        /// <param name="buildSeconds">The build time in seconds.</param>
+        public void RecordStats(string sourceFile, string destFile, string processorType, Type contentType, float buildSeconds)
+        {
+            var sourceSize = new FileInfo(sourceFile).Length;
+            var destSize = new FileInfo(destFile).Length;
+
+            lock (_locker)
+            {
+                ContentStats stats;
+                _statsBySource.TryGetValue(sourceFile, out stats);
+
+                stats.SourceFile = sourceFile;
+                stats.DestFile = destFile;
+
+                stats.SourceFileSize = sourceSize;
+                stats.DestFileSize = destSize;
+
+                stats.ContentType = GetFriendlyTypeName(contentType);
+                stats.ProcessorType = processorType;
+
+                stats.BuildSeconds = buildSeconds;
+
+                _statsBySource[stats.SourceFile] = stats;
+            }
+        }
+
+        /// <summary>
+        /// Copy content building stats to the current collection from the PreviousStats.
+        /// </summary>
+        /// <param name="sourceFile">The absolute path to the source asset file.</param>
+        public void CopyPreviousStats(string sourceFile)
+        {
+            if (PreviousStats == null)
+                return;
+
+            lock (_locker)
+            {
+                if (_statsBySource.ContainsKey(sourceFile))
+                    return;
+
+                ContentStats stats;
+                if (PreviousStats.TryGetStats(sourceFile, out stats))
+                    _statsBySource[stats.SourceFile] = stats;
+            }
+        }
+
+        private static string GetFriendlyTypeName(Type type)
+        {
+            if (type == null)
+                return "";
+            if (type == typeof(int))
+                return "int";
+            else if (type == typeof(short))
+                return "short";
+            else if (type == typeof(byte))
+                return "byte";
+            else if (type == typeof(bool))
+                return "bool";
+            else if (type == typeof(long))
+                return "long";
+            else if (type == typeof(float))
+                return "float";
+            else if (type == typeof(double))
+                return "double";
+            else if (type == typeof(decimal))
+                return "decimal";
+            else if (type == typeof(string))
+                return "string";
+            else if (type.IsArray)
+                return GetFriendlyTypeName(type.GetElementType()) + "[" + new string(',', type.GetArrayRank() - 1) + "]";
+            else if (type.IsGenericType)
+                return type.Name.Split('`')[0] + "<" + string.Join(", ", type.GetGenericArguments().Select(x => GetFriendlyTypeName(x)).ToArray()) + ">";
+            else
+                return type.Name;
+        }
+
+        /// <summary>
+        /// Load the content statistics from a folder.
+        /// </summary>
+        /// <param name="outputPath">The folder where the .mgstats file can be found.</param>
+        /// <returns>Returns the content statistics or an empty collection.</returns>
+        public static ContentStatsCollection Read(string outputPath)
+        {
+            var collection = new ContentStatsCollection();
+
+            var filePath = Path.Combine(outputPath, Extension);
+            try
+            {
+                var lines = File.ReadAllLines(filePath);
+
+                // The first line is the CSV header... if it doesn't match then
+                // assume the data is invalid or changed formats.
+                if (lines[0] != _header)
+                    return collection;
+
+                for (var i = 1; i < lines.Length; i++)
+                {
+                    var columns = _split.Split(lines[i]);
+                    if (columns.Length != 7)
+                        continue;
+
+                    ContentStats stats;
+                    stats.SourceFile = columns[0].Trim('"');
+                    stats.DestFile = columns[1].Trim('"');
+                    stats.ProcessorType = columns[2].Trim('"');
+                    stats.ContentType = columns[3].Trim('"');
+                    stats.SourceFileSize = long.Parse(columns[4]);
+                    stats.DestFileSize = long.Parse(columns[5]);
+                    stats.BuildSeconds = float.Parse(columns[6]);
+
+                    if (!collection._statsBySource.ContainsKey(stats.SourceFile))
+                        collection._statsBySource.Add(stats.SourceFile, stats);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Assume the file didn't exist or was incorrectly
+                // formatted... either way we start from fresh data.
+                collection.Reset();
+            }
+
+            return collection;
+        }
+
+        /// <summary>
+        /// Write the content statistics to a folder with the .mgstats file name.
+        /// </summary>
+        /// <param name="outputPath">The folder to write the .mgstats file.</param>
+        public void Write(string outputPath)
+        {
+            var filePath = Path.Combine(outputPath, Extension);
+            using (var textWriter = new StreamWriter(filePath, false, new UTF8Encoding(false)))
+            {
+                // Sort the items alphabetically to ensure a consistent output
+                // and better mergability of the resulting file.
+                var contentStats = _statsBySource.Values.OrderBy(c => c.SourceFile, StringComparer.InvariantCulture).ToList();
+
+                textWriter.WriteLine(_header);
+                foreach (var stats in contentStats)
+                    textWriter.WriteLine("\"{0}\",\"{1}\",\"{2}\",\"{3}\",{4},{5},{6}", stats.SourceFile, stats.DestFile, stats.ProcessorType, stats.ContentType, stats.SourceFileSize, stats.DestFileSize, stats.BuildSeconds);
+            }
+        }
+
+        /// <summary>
+        /// Merge in statistics from PreviousStats that do not exist in this collection.
+        /// </summary>
+        public void MergePreviousStats()
+        {
+            if (PreviousStats == null)
+                return;
+
+            foreach (var stats in PreviousStats._statsBySource.Values)
+            {
+                if (!_statsBySource.ContainsKey(stats.SourceFile))
+                    _statsBySource.Add(stats.SourceFile, stats);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the feature where `MGCB.exe` will generate a CSV file `.mgstats` to the intermediate folder during content building.  This stats file contains per-content item information which can be used to diagnose a ton of different content issues.

Currently we record the following stats:

  - Source File
  - Dest File
  - Processor Type
   - Content Type
   - Source File Size
   - Dest File Size
   - Build Seconds

We can expand this with more information in the future if needed.

The implementation takes care to cache the stats and incrementally update them on rebuilds of selected content.

This is just the first part of this feature.  It will be followed up with a stand alone viewer that can be launched from the Pipeline tool to analyze and visualize the generated stats in a more useful format.

See https://github.com/MonoGame/MonoGame/issues/5126.