### PR TITLE
Restore EnsureExecutable

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                 RedirectStandardInput = true,
             };
 
+            EnsureExecutable(fullPath);
+
             using (var process = new Process())
             {
                 process.StartInfo = processInfo;
@@ -143,6 +145,32 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             }
 
             return null;
+        }
+
+        /// <summary>   
+        /// Ensures the specified executable has the executable bit set.  If the    
+        /// executable doesn't have the executable bit set on Linux or Mac OS, then 
+        /// Mono will refuse to execute it. 
+        /// </summary>  
+        /// <param name="path">The full path to the executable.</param> 
+        private static void EnsureExecutable(string path)
+        {
+#if LINUX || MACOS
+            if (path == "/bin/bash")
+                return;
+
+            try
+            {
+
+                var p = Process.Start("chmod", "u+x '" + path + "'");
+                p.WaitForExit();
+            }
+            catch
+            {
+                // This platform may not have chmod in the path, in which case we can't 
+                // do anything reasonable here. 
+            }
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Removed it because it was crashing in case of not having permissions to modify the executable, this is no longer happening and we are gonna need this if we ever wanna package up tools inside nugets (nuget packages don't preserve permissions for files on Unix platforms).