### PR TITLE
Add KeyCode in TextInputEventArgs on Windows DX

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -325,11 +325,11 @@ namespace MonoGame.Framework
         }
 
         [DllImport("user32.dll")]
-        private static extern short VkKeyScan(char ch);
+        private static extern short VkKeyScanEx(char ch, IntPtr dwhkl);
 
         private void OnKeyPress(object sender, KeyPressEventArgs e)
         {
-            var key = (Keys) (VkKeyScan(e.KeyChar) & 0xff);
+            var key = (Keys) (VkKeyScanEx(e.KeyChar, InputLanguage.CurrentInputLanguage.Handle) & 0xff);
             OnTextInput(sender, new TextInputEventArgs(e.KeyChar, key));
         }
 

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -15,6 +15,7 @@ using Microsoft.Xna.Framework.Input;
 using Microsoft.Xna.Framework.Input.Touch;
 using Microsoft.Xna.Framework.Windows;
 using ButtonState = Microsoft.Xna.Framework.Input.ButtonState;
+using Keys = Microsoft.Xna.Framework.Input.Keys;
 using Point = System.Drawing.Point;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;
 using XnaPoint = Microsoft.Xna.Framework.Point;
@@ -323,9 +324,13 @@ namespace MonoGame.Framework
             }
         }
 
+        [DllImport("user32.dll")]
+        private static extern short VkKeyScan(char ch);
+
         private void OnKeyPress(object sender, KeyPressEventArgs e)
         {
-            OnTextInput(sender, new TextInputEventArgs(e.KeyChar));
+            var key = (Keys) (VkKeyScan(e.KeyChar) & 0xff);
+            OnTextInput(sender, new TextInputEventArgs(e.KeyChar, key));
         }
 
         internal void Initialize(int width, int height)


### PR DESCRIPTION
Fixes the Windows DX part of #6447. 

I should note that this solution isn't always correct as you cannot translate a character to a key unambiguously. For example pressing the divide key on my numpad gives a forward slash character which is translated back to OemQuestion because it can also be used to type a forward slash. Similarly all other numpad keys are never reported.

The alternative is to store the key pressed in WinForms' KeyDown event as was done in #4931, but that isn't foolproof either and more hacky to implement.