### PR TITLE
Add new GamePad.GetState() overloads to support different dead zone modes

### DIFF
--- a/MonoGame.Framework/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Input/GamePad.Android.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Xna.Framework.Input
             return capabilities;
         }
 
-        private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
+        private static GamePadState PlatformGetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
         {
             var gamePad = GamePads[index];
             GamePadState state = GamePadState.Default;
@@ -137,7 +137,7 @@ namespace Microsoft.Xna.Framework.Input
                     return state;
                 }
 
-                GamePadThumbSticks thumbSticks = new GamePadThumbSticks(gamePad._leftStick, gamePad._rightStick, deadZoneMode);
+                GamePadThumbSticks thumbSticks = new GamePadThumbSticks(gamePad._leftStick, gamePad._rightStick, leftDeadZoneMode, rightDeadZoneMode);
 
                 state = new GamePadState(
                     thumbSticks,

--- a/MonoGame.Framework/Input/GamePad.IOS.cs
+++ b/MonoGame.Framework/Input/GamePad.IOS.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Xna.Framework.Input
             return capabilities;
         }
 
-        private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
+        private static GamePadState PlatformGetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
         {
             var ind = (GCControllerPlayerIndex)index;
 
@@ -213,7 +213,7 @@ namespace Microsoft.Xna.Framework.Input
                 }
             }
             var state = new GamePadState(
-                new GamePadThumbSticks(leftThumbStickPosition, rightThumbStickPosition),
+                new GamePadThumbSticks(leftThumbStickPosition, rightThumbStickPosition, leftDeadZoneMode, rightDeadZoneMode),
                 new GamePadTriggers(leftTriggerValue, rightTriggerValue),
                 new GamePadButtons(buttons),
                 new GamePadDPad(Up, Down, Left, Right));

--- a/MonoGame.Framework/Input/GamePad.MacOS.cs
+++ b/MonoGame.Framework/Input/GamePad.MacOS.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Xna.Framework.Input
             return new GamePadCapabilities { IsConnected = false };
         }
                
-        private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
+        private static GamePadState PlatformGetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
         {
             return new GamePadState() { IsConnected = false };
         }

--- a/MonoGame.Framework/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Input/GamePad.SDL.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Xna.Framework.Input
             return axis / 32767f;
         }
 
-        private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
+        private static GamePadState PlatformGetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
         {
             if (!Gamepads.ContainsKey(index))
                 return GamePadState.Default;
@@ -243,7 +243,8 @@ namespace Microsoft.Xna.Framework.Input
                         GetFromSdlAxis(Sdl.GameController.GetAxis(gdevice, Sdl.GameController.Axis.RightX)),
                         GetFromSdlAxis(Sdl.GameController.GetAxis(gdevice, Sdl.GameController.Axis.RightY)) * -1f
                     ),
-                    deadZoneMode
+                    leftDeadZoneMode,
+                    rightDeadZoneMode
                 );
 
             var triggers = new GamePadTriggers(

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Xna.Framework.Input
             return state;
         }
 
-        private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
+        private static GamePadState PlatformGetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
         {
             if (index >= WGI.Gamepad.Gamepads.Count)
                 return (index == 0 ? GetDefaultState() : GamePadState.Default);
@@ -76,7 +76,8 @@ namespace Microsoft.Xna.Framework.Input
             var sticks = new GamePadThumbSticks(
                     new Vector2((float)state.LeftThumbstickX, (float)state.LeftThumbstickY),
                     new Vector2((float)state.RightThumbstickX, (float)state.RightThumbstickY),
-                    deadZoneMode
+                    leftDeadZoneMode,
+					rightDeadZoneMode
                 );
 
             var triggers = new GamePadTriggers(

--- a/MonoGame.Framework/Input/GamePad.Web.cs
+++ b/MonoGame.Framework/Input/GamePad.Web.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Xna.Framework.Input
             };
         }
 
-        private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
+        private static GamePadState PlatformGetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
         {
             var state = GamePadState.Default;
             var jcap = Joystick.GetCapabilities(index);
@@ -102,7 +102,8 @@ namespace Microsoft.Xna.Framework.Input
                     new GamePadThumbSticks(
                         new Vector2(gpc.AxisPressed("leftx", jstate), gpc.AxisPressed("lefty", jstate)),
                         new Vector2(gpc.AxisPressed("rightx", jstate), gpc.AxisPressed("righty", jstate)),
-                        deadZoneMode
+                        leftDeadZoneMode,
+						rightDeadZoneMode
                     );
                 
                 var dpad = 

--- a/MonoGame.Framework/Input/GamePad.XInput.cs
+++ b/MonoGame.Framework/Input/GamePad.XInput.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Xna.Framework.Input
             return state;
         }
 
-        private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
+        private static GamePadState PlatformGetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
         {
             // If the device was disconneced then wait for 
             // the timeout to elapsed before we test it again.
@@ -184,7 +184,8 @@ namespace Microsoft.Xna.Framework.Input
             var thumbSticks = new GamePadThumbSticks(
                 leftPosition: new Vector2(gamepad.LeftThumbX, gamepad.LeftThumbY) / (float)short.MaxValue,
                 rightPosition: new Vector2(gamepad.RightThumbX, gamepad.RightThumbY) / (float)short.MaxValue,
-                    deadZoneMode: deadZoneMode);
+                    leftDeadZoneMode: leftDeadZoneMode,
+					rightDeadZoneMode: rightDeadZoneMode);
 
             var triggers = new GamePadTriggers(
                     leftTrigger: gamepad.LeftTrigger / (float)byte.MaxValue,

--- a/MonoGame.Framework/Input/GamePad.cs
+++ b/MonoGame.Framework/Input/GamePad.cs
@@ -74,11 +74,37 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="deadZoneMode">Enumerated value that specifies what dead zone type to use.</param>
         /// <returns>The state of the controller.</returns>
         public static GamePadState GetState(int index, GamePadDeadZone deadZoneMode)
+        {           
+            return GetState(index, deadZoneMode, deadZoneMode);
+        }
+
+        /// <summary>
+        /// Gets the current state of a game pad controller, using a specified dead zone
+        /// on analog stick positions.
+        /// </summary>
+        /// <param name="playerIndex">Player index for the controller you want to query.</param>
+        /// <param name="leftDeadZoneMode">Enumerated value that specifies what dead zone type to use for the left stick.</param>
+        /// <param name="rightDeadZoneMode">Enumerated value that specifies what dead zone type to use for the right stick.</param>
+        /// <returns>The state of the controller.</returns>
+        public static GamePadState GetState(PlayerIndex playerIndex, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
+        {
+            return GetState((int)playerIndex, leftDeadZoneMode, rightDeadZoneMode);
+        }
+
+        /// <summary>
+        /// Gets the current state of a game pad controller, using a specified dead zone
+        /// on analog stick positions.
+        /// </summary>
+        /// <param name="index">Index for the controller you want to query.</param>
+        /// <param name="leftDeadZoneMode">Enumerated value that specifies what dead zone type to use for the left stick.</param>
+        /// <param name="rightDeadZoneMode">Enumerated value that specifies what dead zone type to use for the right stick.</param>
+        /// <returns>The state of the controller.</returns>
+        public static GamePadState GetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
         {
             if (index < 0 || index >= PlatformGetMaxNumberOfGamePads())
                 return GamePadState.Default;
-            
-            return PlatformGetState(index, deadZoneMode);
+
+            return PlatformGetState(index, leftDeadZoneMode, rightDeadZoneMode);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Input/GamePad.tvOS.cs
+++ b/MonoGame.Framework/Input/GamePad.tvOS.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Xna.Framework.Input
             return new GamePadCapabilities { IsConnected = false };
         }
                
-        private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
+        private static GamePadState PlatformGetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
         {
             var ind = (GCControllerPlayerIndex)index;
 
@@ -151,7 +151,7 @@ namespace Microsoft.Xna.Framework.Input
                 }
             }
             var state = new GamePadState(
-                new GamePadThumbSticks(leftThumbStickPosition, rightThumbStickPosition),
+                new GamePadThumbSticks(leftThumbStickPosition, rightThumbStickPosition, leftDeadZoneMode, rightDeadZoneMode),
                 new GamePadTriggers(leftTriggerValue, rightTriggerValue),
                 new GamePadButtons(buttons.ToArray()),
                 new GamePadDPad (Up, Down, Left, Right));

--- a/MonoGame.Framework/Input/GamePadThumbSticks.cs
+++ b/MonoGame.Framework/Input/GamePadThumbSticks.cs
@@ -50,57 +50,9 @@ namespace Microsoft.Xna.Framework.Input
 
         internal GamePadThumbSticks(Vector2 leftPosition, Vector2 rightPosition, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode) : this()
         {
-            // XNA applies dead zones before rounding/clamping values. The public ctor does not allow this because the dead zone must be known before
-
             // Apply dead zone
-            switch (leftDeadZoneMode)
-            {
-                case GamePadDeadZone.None:
-                    _left = leftPosition;
-                    break;
-                case GamePadDeadZone.IndependentAxes:
-                    _left = ExcludeIndependentAxesDeadZone(leftPosition, leftThumbDeadZone);
-                    break;
-                case GamePadDeadZone.Circular:
-                    _left = ExcludeCircularDeadZone(leftPosition, leftThumbDeadZone);
-                    break;
-            }
-
-            // Apply clamp
-            if (rightDeadZoneMode == GamePadDeadZone.Circular)
-            {
-                if (_left.LengthSquared() > 1f)
-                    _left.Normalize();
-            }
-            else
-            {
-                _left = new Vector2(MathHelper.Clamp(Left.X, -1f, 1f), MathHelper.Clamp(Left.Y, -1f, 1f));
-            }
-
-            // Apply dead zone
-            switch (rightDeadZoneMode)
-            {
-                case GamePadDeadZone.None:
-                    _right = rightPosition;
-                    break;
-                case GamePadDeadZone.IndependentAxes:
-                    _right = ExcludeIndependentAxesDeadZone(rightPosition, rightThumbDeadZone);
-                    break;
-                case GamePadDeadZone.Circular:
-                    _right = ExcludeCircularDeadZone(rightPosition, rightThumbDeadZone);
-                    break;
-            }
-
-            // Apply clamp
-            if (leftDeadZoneMode == GamePadDeadZone.Circular)
-            {
-                if (_right.LengthSquared() > 1f)
-                    _right.Normalize();
-            }
-            else
-            {
-                _right = new Vector2(MathHelper.Clamp(Right.X, -1f, 1f), MathHelper.Clamp(Right.Y, -1f, 1f));
-            }
+            _left = ApplyDeadZone(leftDeadZoneMode, leftThumbDeadZone, leftPosition);
+            _right = ApplyDeadZone(rightDeadZoneMode, rightThumbDeadZone, rightPosition);
 
             // VirtualButtons should always behave like deadzone is IndependentAxes. 
             // This is consistent with XNA behaviour and generally most convenient (e.g. for menu navigation)
@@ -125,6 +77,37 @@ namespace Microsoft.Xna.Framework.Input
                 _virtualButtons |= Buttons.RightThumbstickDown;
             else if (rightPosition.Y > rightThumbDeadZone)
                 _virtualButtons |= Buttons.RightThumbstickUp;
+        }
+
+        private Vector2 ApplyDeadZone(GamePadDeadZone deadZoneMode, float deadZone, Vector2 thumbstickPosition)
+        {
+            // XNA applies dead zones before rounding/clamping values. The public ctor does not allow this because the dead zone must be known before
+
+            // Apply dead zone
+            switch (deadZoneMode)
+            {
+                case GamePadDeadZone.None:
+                    break;
+                case GamePadDeadZone.IndependentAxes:
+                    thumbstickPosition = ExcludeIndependentAxesDeadZone(thumbstickPosition, deadZone);
+                    break;
+                case GamePadDeadZone.Circular:
+                    thumbstickPosition = ExcludeCircularDeadZone(thumbstickPosition, deadZone);
+                    break;
+            }
+
+            // Apply clamp
+            if (deadZoneMode == GamePadDeadZone.Circular)
+            {
+                if (thumbstickPosition.LengthSquared() > 1f)
+                    thumbstickPosition.Normalize();
+            }
+            else
+            {
+                thumbstickPosition = new Vector2(MathHelper.Clamp(thumbstickPosition.X, -1f, 1f), MathHelper.Clamp(thumbstickPosition.Y, -1f, 1f));
+            }
+
+            return thumbstickPosition;
         }
 
         private Vector2 ExcludeIndependentAxesDeadZone(Vector2 value, float deadZone)

--- a/MonoGame.Framework/Input/GamePadThumbSticks.cs
+++ b/MonoGame.Framework/Input/GamePadThumbSticks.cs
@@ -43,43 +43,62 @@ namespace Microsoft.Xna.Framework.Input
         }
 
         public GamePadThumbSticks(Vector2 leftPosition, Vector2 rightPosition)
-            : this(leftPosition, rightPosition, GamePadDeadZone.None)
+            : this(leftPosition, rightPosition, GamePadDeadZone.None, GamePadDeadZone.None)
         {
             
         }
 
-        internal GamePadThumbSticks(Vector2 leftPosition, Vector2 rightPosition, GamePadDeadZone deadZoneMode) : this()
+        internal GamePadThumbSticks(Vector2 leftPosition, Vector2 rightPosition, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode) : this()
         {
             // XNA applies dead zones before rounding/clamping values. The public ctor does not allow this because the dead zone must be known before
 
             // Apply dead zone
-            switch (deadZoneMode)
+            switch (leftDeadZoneMode)
             {
                 case GamePadDeadZone.None:
                     _left = leftPosition;
-                    _right = rightPosition;
                     break;
                 case GamePadDeadZone.IndependentAxes:
                     _left = ExcludeIndependentAxesDeadZone(leftPosition, leftThumbDeadZone);
-                    _right = ExcludeIndependentAxesDeadZone(rightPosition, rightThumbDeadZone);
                     break;
                 case GamePadDeadZone.Circular:
                     _left = ExcludeCircularDeadZone(leftPosition, leftThumbDeadZone);
+                    break;
+            }
+
+            // Apply clamp
+            if (rightDeadZoneMode == GamePadDeadZone.Circular)
+            {
+                if (_left.LengthSquared() > 1f)
+                    _left.Normalize();
+            }
+            else
+            {
+                _left = new Vector2(MathHelper.Clamp(Left.X, -1f, 1f), MathHelper.Clamp(Left.Y, -1f, 1f));
+            }
+
+            // Apply dead zone
+            switch (rightDeadZoneMode)
+            {
+                case GamePadDeadZone.None:
+                    _right = rightPosition;
+                    break;
+                case GamePadDeadZone.IndependentAxes:
+                    _right = ExcludeIndependentAxesDeadZone(rightPosition, rightThumbDeadZone);
+                    break;
+                case GamePadDeadZone.Circular:
                     _right = ExcludeCircularDeadZone(rightPosition, rightThumbDeadZone);
                     break;
             }
 
             // Apply clamp
-            if (deadZoneMode == GamePadDeadZone.Circular)
+            if (leftDeadZoneMode == GamePadDeadZone.Circular)
             {
-                if (_left.LengthSquared() > 1f)
-                    _left.Normalize();
                 if (_right.LengthSquared() > 1f)
                     _right.Normalize();
             }
             else
             {
-                _left = new Vector2(MathHelper.Clamp(Left.X, -1f, 1f), MathHelper.Clamp(Left.Y, -1f, 1f));
                 _right = new Vector2(MathHelper.Clamp(Right.X, -1f, 1f), MathHelper.Clamp(Right.Y, -1f, 1f));
             }
 

--- a/Test/Framework/Input/GamePadTest.cs
+++ b/Test/Framework/Input/GamePadTest.cs
@@ -97,7 +97,7 @@ namespace MonoGame.Tests.Input
         [TestCaseSource("ThumbStickVirtualButtonsIgnoreDeadZoneTestCases")]
         public void ThumbStickVirtualButtonsIgnoreDeadZone(Vector2 left, Vector2 right, GamePadDeadZone deadZone, Buttons expectedButtons)
         {
-            var state = new GamePadState(new GamePadThumbSticks(left, right, deadZone), new GamePadTriggers(), new GamePadButtons(), new GamePadDPad());
+            var state = new GamePadState(new GamePadThumbSticks(left, right, deadZone, deadZone), new GamePadTriggers(), new GamePadButtons(), new GamePadDPad());
 
             Assert.AreEqual(expectedButtons, GetAllPressedButtons(state));
         }
@@ -157,19 +157,19 @@ namespace MonoGame.Tests.Input
             var left = Vector2.One;
             var right = Vector2.One;
 
-            var sticks = new GamePadThumbSticks(left, right, GamePadDeadZone.None);
+            var sticks = new GamePadThumbSticks(left, right, GamePadDeadZone.None, GamePadDeadZone.None);
             Assert.AreEqual(sticks.Left.X, 1);
             Assert.AreEqual(sticks.Left.Y, 1);
             Assert.AreEqual(sticks.Right.X, 1);
             Assert.AreEqual(sticks.Right.Y, 1);
 
-            sticks = new GamePadThumbSticks(left, right, GamePadDeadZone.IndependentAxes);
+            sticks = new GamePadThumbSticks(left, right, GamePadDeadZone.IndependentAxes, GamePadDeadZone.IndependentAxes);
             Assert.AreEqual(sticks.Left.X, 1);
             Assert.AreEqual(sticks.Left.Y, 1);
             Assert.AreEqual(sticks.Right.X, 1);
             Assert.AreEqual(sticks.Right.Y, 1);
 
-            sticks = new GamePadThumbSticks(left, right, GamePadDeadZone.Circular);
+            sticks = new GamePadThumbSticks(left, right, GamePadDeadZone.Circular, GamePadDeadZone.Circular);
             Assert.Less(sticks.Left.X, 1);
             Assert.Less(sticks.Left.Y, 1);
             Assert.Less(sticks.Right.X, 1);


### PR DESCRIPTION
Hello !

This is a proposal for new public overloads to apply different ```GamePadDeadZone``` for each thumb sticks.

```public static GamePadState GetState(PlayerIndex playerIndex, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)```

```public static GamePadState GetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)```