### PR TITLE
Added languages to some of the syntax highlighting in the docs

### DIFF
--- a/Documentation/2mgfx.md
+++ b/Documentation/2mgfx.md
@@ -38,7 +38,7 @@ If you use `/?`, `/help`, or simply pass no paramters to 2MGFX.exe you will get 
 ## Runtime Use
 The resulting compiled MGFX file can be used from your game code like so:
 
-```
+```csharp
 byte[] bytecode = File.ReadAllBytes("mycompiled.mgfx");
 var effect = new Effect(bytecode);
 ```

--- a/Documentation/adding_ttf_fonts.md
+++ b/Documentation/adding_ttf_fonts.md
@@ -6,31 +6,31 @@ Truetype fonts may be installed on the system, or added to the project manually 
 
 1. Create the .spritefont file.
 
-<p align="center">
+<p>
 <img src="images/adding_ttf_fonts_step_1.PNG"/>
 </p>
 
-<p align="center">
+<p>
 <img src="images/adding_ttf_fonts_step_2.PNG"/>
 </p>
 
 2- Open the newly created .spritefont file in your text editor of choice, find this line and change it to your selected .ttf font.
 If the font is installed on the system, just type the name of the font.
-```
+```xml
 <FontName>Arial</FontName>
 ```
 
 #### Usage Example
 Make a class variable of type Spritefont
-```
+```csharp
 SpriteFont font;
 ```
 Load the font in the LoadContent function
-```
+```csharp
 font = myGame.Content.Load<SpriteFont>("Fonts/myFont")
 ```
 Draw any text in the Draw function
-```
+```csharp
 spriteBatch.Begin();
 // Finds the center of the string in coordinates inside the text rectangle
 Vector2 textMiddlePoint = font.MeasureString(text) / 2;

--- a/Documentation/localization.md
+++ b/Documentation/localization.md
@@ -134,8 +134,10 @@ var myCharacter = Content.LoadLocalized<Texture2D>("MyCharacter");
 
 The decision on which localized asset to load is made by looking for a file with the following patterns
 
-	<AssetName>.<CurrentCulture.Name>
-	<AssetName>.<CurrentCulture.TwoLetterISOLanguageName>
+```xml
+<AssetName>.<CurrentCulture.Name>
+<AssetName>.<CurrentCulture.TwoLetterISOLanguageName>
+```
 
 These values are retrieved from 
 


### PR DESCRIPTION
Some parts of the syntax highlighting in the documentation was missing a language specification making it not look as good as it could look, I added the missing specifications.