### PR TITLE
Fix syntax highlighting in UWP.md

### DIFF
--- a/Documentation/UWP.md
+++ b/Documentation/UWP.md
@@ -21,7 +21,7 @@ Consider `Game1` needs some dependencies such as an `ISettingsRepository` to get
 
 For example, in a `MainActivity` on Android you would do:
 
-```c#
+```csharp
 _game = new Game1(
     new AndroidTextFileImporter(Assets),
     new AndroidSettingsRepository(this));
@@ -29,7 +29,7 @@ _game = new Game1(
 
 With the UWP implementation using `XamlGame` static initializer, you could do this:
 
-```c#
+```csharp
 _game = MonoGame.Framework.XamlGame<Game1>.Create(
 	launchArguments,
 	Window.Current.CoreWindow,


### PR DESCRIPTION
Noticed this looked wrong in the docs:

![screenshot_20181005-123708](https://user-images.githubusercontent.com/14875382/46530895-8f08ba00-c89b-11e8-8954-9317d7d4e8f3.png)
