### PR TITLE
Update custom effect docs

### DIFF
--- a/Documentation/custom_effects.md
+++ b/Documentation/custom_effects.md
@@ -73,13 +73,3 @@ These are some tips for writing or converting effects for use with MonoGame.
 * The effect compiler is aggressive about removing unused parameters, be sure the parameters you are setting are actually used.
 * Preshaders are not supported.
 * If you think you've found a bug porting a shader [please let us know](https://github.com/MonoGame/MonoGame/issues).
-
-# Roadmap
-There is still work to be done for better support of custom effects and shaders in MonoGame:
-
-* Support GLSL in FX files.
-  * Write a new preprocessor replacing [D3DPreprocess](http://msdn.microsoft.com/en-us/library/windows/desktop/dd607332.aspx).
-  * Replace MojoShader with [HL2GLSL](https://github.com/SickheadGames/HL2GLSL).
-* Create automated tests for custom effects.
-* Support PlayStation Suite shaders in MGFX tools and formats.
-* Support pre-compiled GLSL assembly instead of GLSL code.

--- a/Documentation/custom_effects.md
+++ b/Documentation/custom_effects.md
@@ -37,9 +37,9 @@ These are some tips for writing or converting effects for use with MonoGame.
 * The supported shader models when targeting DX are the following:
   * vs_4_0_level_9_1 and ps_4_0_level_9_1 
   * vs_4_0_level_9_3 and ps_4_0_level_9_3
-  * vs_4_0 and ps_4_0 (requires HiDef GraphicsProfile at runtime)
-  * vs_4_1 and ps_4_1 (requires HiDef GraphicsProfile at runtime)
-  * vs_5_0 and ps_5_0 (requires HiDef GraphicsProfile at runtime)
+  * vs_4_0 and ps_4_0 (requires `HiDef` `GraphicsProfile` at runtime)
+  * vs_4_1 and ps_4_1 (requires `HiDef` `GraphicsProfile` at runtime)
+  * vs_5_0 and ps_5_0 (requires `HiDef` `GraphicsProfile` at runtime)
 * When targeting GL platforms we automatically translate FX files to GLSL using a library called [MojoShader](http://icculus.org/mojoshader/).  The supported feature levels are the following:
   * vs_2_0 and ps_2_0
   * vs_3_0 and ps_3_0

--- a/Documentation/custom_effects.md
+++ b/Documentation/custom_effects.md
@@ -12,15 +12,16 @@ MGFX is MonoGame's own "FX" runtime and tools which with the following core goal
 * Easy to extend for future platforms and features.
 
 # Stock Effects
-The following stock effects in MonoGame and fully supported on current platforms:
+MonoGame has the following effects built-in and fully supported on current platforms:
 
+* SpriteEffect
 * BasicEffect
 * AlphaTestEffect
 * DualTextureEffect
 * EnvironmentMapEffect
 * SkinnedEffect
 
-Under the hood these effects use the same system and tools as one would for a custom Effect.  The source and pre-compiled versions of these effects can be found in the 'MonoGame.Framework\Graphics\Effect\Resources' folder.
+Under the hood these effects use the same system and tools as one would for a custom Effect.  The source and pre-compiled versions of these effects can be found in the ['MonoGame.Framework\Graphics\Effect\Resources'](https://github.com/MonoGame/MonoGame/tree/develop/MonoGame.Framework/Graphics/Effect/Resources) folder.
 
 If your game requires an extra little bit of performance you can easily hand edit the existing effects to remove unnecessary features or optimize for specific hardware and rebuild them with the MGFX tool.
 
@@ -33,16 +34,45 @@ To use a custom effect with MonoGame you must do one of the following (not both)
 ### Effect Writing Tips
 These are some tips for writing or converting effects for use with MonoGame.
 
-* Use the [DX11 feature levels](http://msdn.microsoft.com/en-us/library/windows/desktop/ff476876.aspx) `vs_4_0_level_9_1` or `ps_4_0_level_9_1` when targeting Windows 8 Metro applications and wanting to support all devices.  Higher shader models work, but might not run on all Windows 8 systems.
-* When targeting Windows Phone 8 you can use `vs_4_0_level_9_3` or `ps_4_0_level_9_3`.
-* When targeting GL platforms we automatically translate FX files to GLSL using a library called [MojoShader](http://icculus.org/mojoshader/).  It will only work with `vs_3_0` or `ps_3_0` or lower shaders.
-* Make sure the pixel shaders inputs exactly match the vertex shader outputs so the parameters are passed in the correct registers.
-* You can use `#if SM4` to add conditional code for DirectX platforms.
-* On DirectX platforms use the `SV_Position` semantic instead of `POSITION` in vertex shader inputs.
+* The supported shader models when targeting DX are the following:
+  * vs_4_0_level_9_1 and ps_4_0_level_9_1 
+  * vs_4_0_level_9_3 and ps_4_0_level_9_3
+  * vs_4_0 and ps_4_0 (requires HiDef GraphicsProfile at runtime)
+  * vs_4_1 and ps_4_1 (requires HiDef GraphicsProfile at runtime)
+  * vs_5_0 and ps_5_0 (requires HiDef GraphicsProfile at runtime)
+* When targeting GL platforms we automatically translate FX files to GLSL using a library called [MojoShader](http://icculus.org/mojoshader/).  The supported feature levels are the following:
+  * vs_2_0 and ps_2_0
+  * vs_3_0 and ps_3_0
+* You can use preprocessor checks to add conditional code or compilation depending on defined symbols. MonoGame defines the following symbols when compiling effects:
+  * `2MGFX`
+  * `HLSL` and `SM4` for DirectX
+  * `OpenGL` and `GLSL` for OpenGL
+  
+  As an example, you can conditionally set shader models depending on the platform with the following code:
+  ```
+  #if OPENGL
+      #define VS_SHADERMODEL vs_3_0
+      #define PS_SHADERMODEL ps_3_0
+  #else
+      #define VS_SHADERMODEL vs_4_0_level_9_1
+      #define PS_SHADERMODEL ps_4_0_level_9_1
+  #endif
+
+  technique
+  {
+      pass
+      {
+          VertexShader = compile VS_SHADERMODEL MainVS();
+          PixelShader = compile PS_SHADERMODEL MainPS();
+      }
+  };
+  ```
+  Custom symbols can be defined from the [Pipeline Tool](pipeline.md) or via [2MGFX](2mgfx.md).
+* Make sure the pixel shaders inputs **exactly match** the vertex shader outputs so the parameters are passed in the correct registers. The parameters need to have the same size and order. Omitting parameters might not break compilation, but can cause unexpected results.
 * Note that on GL platforms default values on Effect parameters do not work.  Either set the parameter from code or use a real constant like a #define.
-* Do not name your sampler `Sampler` - it will not compile.
-* The effect compiler is aggressive about removing unused paramters, be sure the parameters you are setting are actually used.
-* If you think you've found a bug porting a shader [please let us know](https://github.com/mono/MonoGame/issues).
+* The effect compiler is aggressive about removing unused parameters, be sure the parameters you are setting are actually used.
+* Preshaders are not supported.
+* If you think you've found a bug porting a shader [please let us know](https://github.com/MonoGame/MonoGame/issues).
 
 # Roadmap
 There is still work to be done for better support of custom effects and shaders in MonoGame:
@@ -50,6 +80,6 @@ There is still work to be done for better support of custom effects and shaders 
 * Support GLSL in FX files.
   * Write a new preprocessor replacing [D3DPreprocess](http://msdn.microsoft.com/en-us/library/windows/desktop/dd607332.aspx).
   * Replace MojoShader with [HL2GLSL](https://github.com/SickheadGames/HL2GLSL).
-* Create an automated tests for custom effects.
+* Create automated tests for custom effects.
 * Support PlayStation Suite shaders in MGFX tools and formats.
 * Support pre-compiled GLSL assembly instead of GLSL code.


### PR DESCRIPTION
Adds some information regarding shader models, defined symbols and fixes some typos. I really should've put this in a long time ago considering how many times I wrote this down in the forum.
Also add a note that preshaders are not supported (#5454).