### PR TITLE
Custom /define preprocessor parameter taken into account

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -32,7 +32,7 @@
       <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' != '' And !HasTrailingSlash('$(PlatformResourcePrefix)')">$(PlatformResourcePrefix)\</PlatformResourcePrefix>
       <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' == ''"></PlatformResourcePrefix>
       <MonoGameMGCBAdditionalArguments Condition="'$(MonoGameMGCBAdditionalArguments)' ==''">/quiet</MonoGameMGCBAdditionalArguments>
-      <Header>/platform:$(MonoGamePlatform) $(MonoGameMGCBAdditionalArguments)</Header>
+      <Header>/platform:$(MonoGamePlatform)</Header>
     </PropertyGroup>
 
     <!-- Get all Mono Game Content References and store them in a list -->
@@ -82,7 +82,7 @@
 
   <Target Name="RunContentBuilder">
     <Exec Condition=" '%(ContentReferences.FullPath)' != '' "
-          Command="$(MonoGameContentBuilderCmd) /@:&quot;%(ContentReferences.FullPath)&quot; $(Header) /outputDir:&quot;%(ContentReferences.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReferences.ContentIntermediateOutputDir)&quot;"
+          Command="$(MonoGameContentBuilderCmd) $(MonoGameMGCBAdditionalArguments) $(Header) /@:&quot;%(ContentReferences.FullPath)&quot; /outputDir:&quot;%(ContentReferences.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReferences.ContentIntermediateOutputDir)&quot;"
           WorkingDirectory="%(ContentReferences.RootDir)%(ContentReferences.Directory)" />
      <CreateItem Include="%(ContentReferences.RelativeFullPath)%(ContentReferences.ContentOutputDir)\**\*.*"
             AdditionalMetadata="ContentOutputDir=%(ContentReferences.ContentDirectory)">


### PR DESCRIPTION
File: MonoGame.Content.Builder.targets

Custom /define parameter only working when they are set right after the MGCB.exe command. 
E.g: MGCB.exe /define:Test=No /@:ContentReference.txt

To make this work I simply moved the $(MonoGameMGCBAdditionalArguments) property right after the $(MonoGameContentBuilderCmd) property in the "RunContentBuilder" target.

This helps when dynamically modifiyng the content respond file (.mgcb) and creating specific content in own build scenarios.

Originally occured here:
http://community.monogame.net/t/how-to-ignore-some-content-files-for-debug-builds/10946/7?u=sqrmin1

Additionally I placed the $(Header) property right behind $(MonoGameMGCBAdditionalArguments) to make the console output better readable (the following /outputDir and /intermediateDir can be pretty long). I tested this and it works.