### PR TITLE
Only handle MG window and exit when it's closed

### DIFF
--- a/MonoGame.Framework/SDL/SDL2.cs
+++ b/MonoGame.Framework/SDL/SDL2.cs
@@ -381,6 +381,10 @@ internal static class Sdl
         public static d_sdl_destroywindow Destroy = FuncLoader.LoadFunction<d_sdl_destroywindow>(NativeLibrary, "SDL_DestroyWindow");
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate uint d_sdl_getwindowid(IntPtr window);
+        public static d_sdl_getwindowid GetWindowId = FuncLoader.LoadFunction<d_sdl_getwindowid>(NativeLibrary, "SDL_GetWindowID");
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int d_sdl_getwindowdisplayindex(IntPtr window);
         private static d_sdl_getwindowdisplayindex SDL_GetWindowDisplayIndex = FuncLoader.LoadFunction<d_sdl_getwindowdisplayindex>(NativeLibrary, "SDL_GetWindowDisplayIndex");
 

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -171,14 +171,19 @@ namespace Microsoft.Xna.Framework
                 }
                 else if (ev.Type == Sdl.EventType.WindowEvent)
                 {
-                    if (ev.Window.EventID == Sdl.Window.EventId.Resized || ev.Window.EventID == Sdl.Window.EventId.SizeChanged)
-                        _view.ClientResize(ev.Window.Data1, ev.Window.Data2);
-                    else if (ev.Window.EventID == Sdl.Window.EventId.FocusGained)
-                        IsActive = true;
-                    else if (ev.Window.EventID == Sdl.Window.EventId.FocusLost)
-                        IsActive = false;
-                    else if (ev.Window.EventID == Sdl.Window.EventId.Moved)
-                        _view.Moved();
+                    if (ev.Window.WindowID == _view.Id)
+                    {
+                        if (ev.Window.EventID == Sdl.Window.EventId.Resized || ev.Window.EventID == Sdl.Window.EventId.SizeChanged)
+                            _view.ClientResize(ev.Window.Data1, ev.Window.Data2);
+                        else if (ev.Window.EventID == Sdl.Window.EventId.FocusGained)
+                            IsActive = true;
+                        else if (ev.Window.EventID == Sdl.Window.EventId.FocusLost)
+                            IsActive = false;
+                        else if (ev.Window.EventID == Sdl.Window.EventId.Moved)
+                            _view.Moved();
+                        else if (ev.Window.EventID == Sdl.Window.EventId.Close)
+                            _isExiting++;
+                    }
                 }
             }
         }
@@ -230,7 +235,6 @@ namespace Microsoft.Xna.Framework
         {
             if (Game.GraphicsDevice != null)
                 Game.GraphicsDevice.Present();
-
         }
 
         protected override void Dispose(bool disposing)

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -80,9 +80,8 @@ namespace Microsoft.Xna.Framework
             }
         }
 
-        internal uint Id;
-
         public static GameWindow Instance;
+        public uint? Id;
         public bool IsFullScreen;
 
         internal readonly Game _game;

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -80,6 +80,8 @@ namespace Microsoft.Xna.Framework
             }
         }
 
+        internal uint Id;
+
         public static GameWindow Instance;
         public bool IsFullScreen;
 
@@ -154,6 +156,8 @@ namespace Microsoft.Xna.Framework
 
             _handle = Sdl.Window.Create(AssemblyHelper.GetDefaultWindowTitle(),
                 winx, winy, _width, _height, initflags);
+
+            Id = Sdl.Window.GetWindowId(_handle);
 
             if (_icon != IntPtr.Zero)
                 Sdl.Window.SetIcon(_handle, _icon);


### PR DESCRIPTION
Checks the window id so we only handle window events for the window we created. Also sets the exit flag when that window is closed. Fixes #6432.