### PR TITLE
MGCB improvements

### DIFF
--- a/Documentation/mgcb.md
+++ b/Documentation/mgcb.md
@@ -121,7 +121,7 @@ Instructs the content builder to build the specified content file using the prev
 ```
 This defines a text response file (sometimes called a command file) that contains the same options and switches you would normally find on the command line.
 
-Each switch is specified on a new line.  Comment lines are prefixed with #.  You can specify multiple response files or mix normal command line switches with response files.
+Each switch is specified on a new line.  Comment lines are prefixed with #. These lines are removed by a preprocessor. You can specify multiple response files or mix normal command line switches with response files.
 
 An example response file could look like this:
 ```
@@ -154,9 +154,11 @@ Sets or creates a preprocessor parameter with the given name and value.
 $if <name>=<value>
 $endif
 ```
+
 Preprocessor macros are intended to allow conditionals within a response file.
 
-The preprocess step is what expands a response file command into its composite commands for each line in the file. However, a line is only emitted if all conditionals which contain the line evaluate true.
+Preprocessor symbols can be defined from the command line with the `define` option or in a response file with the `$set` directive.
+
 ```
 <example command line>
 MGCB.exe /define:BuildEffects=No /@:example.mgcb
@@ -167,6 +169,26 @@ $if BuildEffects=Yes
    /processor:EffectProcessor
    /build:Effects\custom.fx
    # all other effects here....
+$endif
+```
+
+```
+$set BuildEffects=Yes
+
+$if BuildEffects=Yes
+    # ...
+    # This is executed
+$endif
+```
+
+For booleans you can omit a value to set a symbol and to check if it is set:
+
+```
+$set BuildEffects
+
+$if BuildEffects
+    # ...
+    # This is executed
 $endif
 ```
 

--- a/Tools/MGCB/BuildContent.cs
+++ b/Tools/MGCB/BuildContent.cs
@@ -50,19 +50,29 @@ namespace MGCB
             Directory.SetCurrentDirectory(path);
         }
 
+        private string _outputDir = string.Empty;
+
         [CommandLineParameter(
             Name = "outputDir",
             Flag = "o",
             ValueName = "path",
             Description = "The directory where all content is written.")]
-        public string OutputDir = string.Empty;
+        public void SetOutputDir(string path)
+        {
+            _outputDir = Path.GetFullPath(path);
+        }
+
+        private string _intermediateDir = string.Empty;
 
         [CommandLineParameter(
             Name = "intermediateDir",
             Flag = "n",
             ValueName = "path",
             Description = "The directory where all intermediate files are written.")]
-        public string IntermediateDir = string.Empty;
+        public void SetIntermediateDir(string path)
+        {
+            _intermediateDir = Path.GetFullPath(path);
+        }
 
         [CommandLineParameter(
             Name = "rebuild",
@@ -276,11 +286,11 @@ namespace MGCB
         {
             var projectDirectory = PathHelper.Normalize(Directory.GetCurrentDirectory());
 
-            var outputPath = ReplaceSymbols (OutputDir);
+            var outputPath = ReplaceSymbols(_outputDir);
             if (!Path.IsPathRooted(outputPath))
                 outputPath = PathHelper.Normalize(Path.GetFullPath(Path.Combine(projectDirectory, outputPath)));
 
-            var intermediatePath = ReplaceSymbols (IntermediateDir);
+            var intermediatePath = ReplaceSymbols(_intermediateDir);
             if (!Path.IsPathRooted(intermediatePath))
                 intermediatePath = PathHelper.Normalize(Path.GetFullPath(Path.Combine(projectDirectory, intermediatePath)));
             

--- a/Tools/MGCB/CommandLineParser.cs
+++ b/Tools/MGCB/CommandLineParser.cs
@@ -21,72 +21,13 @@ namespace MGCB
     {
         public static MGBuildParser Instance;
 
-        #region Supporting Types
-
-        public class PreprocessorProperty
-        {
-            public string Name;            
-            public string CurrentValue;
-
-            public PreprocessorProperty()
-            {
-                Name = string.Empty;
-                CurrentValue = string.Empty;
-            }
-        }
-
-        public class PreprocessorPropertyCollection
-        {
-            private readonly List<PreprocessorProperty> _properties;
-
-            public PreprocessorPropertyCollection()
-            {
-                _properties = new List<PreprocessorProperty>();
-            }
-
-            public string this[string name]
-            {
-                get
-                {
-                    foreach (var i in _properties)
-                    {
-                        if (i.Name.Equals(name))
-                            return i.CurrentValue;
-                    }
-
-                    return null;
-                }
-
-                set
-                {
-                    foreach (var i in _properties)
-                    {
-                        if (i.Name.Equals(name))
-                        {
-                            i.CurrentValue = value;
-                            return;
-                        }
-                    }
-
-                    var prop = new PreprocessorProperty()
-                        {
-                            Name = name,
-                            CurrentValue = value,
-                        };
-                    _properties.Add(prop);
-                }
-            }
-        }
-
-        #endregion
-
         private readonly object _optionsObject;
         private readonly Queue<MemberInfo> _requiredOptions;
         private readonly Dictionary<string, MemberInfo> _optionalOptions;
         private readonly Dictionary<string, string> _flags;
         private readonly List<string> _requiredUsageHelp;
 
-        public readonly PreprocessorPropertyCollection _properties;
+        public readonly Dictionary<string, string> _properties;
 
         public delegate void ErrorCallback(string msg, object[] args);
         public event ErrorCallback OnError;
@@ -100,7 +41,7 @@ namespace MGCB
             _optionalOptions = new Dictionary<string, MemberInfo>();
             _requiredUsageHelp = new List<string>();
 
-            _properties = new PreprocessorPropertyCollection();
+            _properties = new Dictionary<string, string>();
 
             // Reflect to find what commandline options are available...
 
@@ -219,122 +160,116 @@ namespace MGCB
         private IEnumerable<string> Preprocess(IEnumerable<string> args)
         {
             var output = new List<string>();
-            var lines = new List<string>(args);
-            var ifstack = new Stack<Tuple<string, string>>();
-            var fileStack = new Stack<string>();
-
-            while (lines.Count > 0)
-            {            
-                var arg = lines[0];
-                lines.RemoveAt(0);
-
-                if (arg.StartsWith("# Begin:"))
-                {
-                    var file = arg.Substring(8);
-                    fileStack.Push(file);
-                    continue;
-                }
-
-                if (arg.StartsWith("# End:"))
-                {
-                    fileStack.Pop();
-                    continue;
-                }
-
-                if (arg.StartsWith("$endif"))
-                {
-                    ifstack.Pop();
-                    continue;
-                }
-                
-                if (ifstack.Count > 0)
-                {
-                    var skip = false;
-                    foreach (var i in ifstack)
-                    {
-                        var val = _properties[i.Item1];
-                        if (!(i.Item2).Equals(val))
-                        {
-                            skip = true;
-                            break;
-                        }
-                    }
-
-                    if (skip)
-                        continue;
-                }
-
-                if (arg.StartsWith("$set"))
-                {
-                    var words = arg.Substring(5).Split('=');
-                    var name = words[0];
-                    var value = words[1];
-
-                    _properties[name] = value;
-
-                    continue;
-                }
-
-                if (arg.StartsWith("$if"))
-                {
-                    if (fileStack.Count == 0)
-                        throw new Exception("$if is invalid outside of a response file.");
-
-                    var words = arg.Substring(4).Split('=');
-                    var name = words[0];
-                    var value = words[1];
-
-                    var condition = new Tuple<string, string>(name, value);
-                    ifstack.Push(condition);
-                    
-                    continue;
-                }
-
-                if (arg.StartsWith("/define:") || arg.StartsWith("--define:"))
-                {
-                    var words = arg.Substring(8).Split('=');
-                    var name = words[0];
-                    var value = words[1];
-
-                    _properties[name] = value;
-
-                    continue;
-
-                }
-
-                if (arg.StartsWith("/@") || arg.StartsWith("--@") || arg.StartsWith("-@")
-                    || (arg.EndsWith(".mgcb") && File.Exists(arg)))
-                {
-                    var file = arg;
-                    if (!File.Exists(arg))
-                        file = arg.Substring(arg.StartsWith("--@") ? 4 : 3);
-
-                    var commands = File.ReadAllLines(file);
-                    var offset = 0;
-                    lines.Insert(0, string.Format("# Begin:{0} ", file));
-                    offset++;
-
-                    for (var j = 0; j < commands.Length; j++)
-                    {
-                        var line = commands[j];
-                        if (string.IsNullOrEmpty(line))
-                            continue;
-                        if (line.StartsWith("#"))
-                            continue;
-
-                        lines.Insert(offset, line);
-                        offset++;
-                    }
-
-                    lines.Insert(offset, string.Format("# End:{0}", file));
-
-                    continue;
-                }                
-                
-                output.Add(arg);
-            }
+            var ifstack = new Stack<IfCondition>();
+            foreach (var arg in args)
+                ParsePreprocessArg(arg, output, ifstack, false);
 
             return output.ToArray();
+        }
+
+        private void ParsePreprocessArg(string arg, List<string> output, Stack<IfCondition> ifstack, bool inResponseFile)
+        {
+            if (arg.StartsWith("$endif"))
+            {
+                ifstack.Pop();
+                return;
+            }
+
+            if (ifstack.Count > 0)
+            {
+                foreach (var ifCondition in ifstack)
+                {
+                    var expected = ifCondition.Value;
+                    string actual;
+                    if (!_properties.TryGetValue(ifCondition.Key, out actual))
+                        return;
+                    if (expected != string.Empty && !expected.Equals(actual))
+                        return;
+                }
+            }
+
+            if (arg.StartsWith("$set "))
+            {
+                if (!inResponseFile)
+                    throw new Exception("$set is invalid outside of a response file.");
+                var words = arg.Substring(5).Split('=');
+                var name = words[0].Trim();
+                var value = words.Length > 1 ? words[1].Trim() : string.Empty;
+
+                _properties[name] = value;
+                return;
+            }
+
+            if (arg.StartsWith("$if "))
+            {
+                if (!inResponseFile)
+                    throw new Exception("$if is invalid outside of a response file.");
+
+                var words = arg.Substring(4).Split('=');
+                var name = words[0].Trim();
+                var value = words.Length > 1 ? words[1].Trim() : string.Empty;
+
+                var condition = new IfCondition(name, value);
+                ifstack.Push(condition);
+
+                return;
+            }
+
+            if (arg.StartsWith("/define:") || arg.StartsWith("--define:"))
+            {
+                arg = arg.Substring(arg[0] == '/' ? 8 : 9);
+
+                var words = arg.Split('=');
+                var name = words[0];
+                var value = words[1];
+
+                _properties[name] = value;
+
+                return;
+            }
+
+            if (arg.StartsWith("/@") || arg.StartsWith("--@") || arg.StartsWith("-@") || (arg.EndsWith(".mgcb")))
+            {
+                var file = arg;
+                if (file.StartsWith("/@") || file.StartsWith("-@"))
+                    file = arg.Substring(3);
+                if (file.StartsWith("--@"))
+                    file = arg.Substring(4);
+
+                file = Path.GetFullPath(file);
+
+                if (!File.Exists(file))
+                    throw new Exception(string.Format("File '{0}' does not exist.", file));
+
+                var prevDir = Directory.GetCurrentDirectory();
+                var dir = Path.GetDirectoryName(file);
+
+                if (prevDir != dir)
+                {
+                    // make sure the working dir is changed both during preprocessing and during execution
+                    Directory.SetCurrentDirectory(dir);
+                    output.Add("/workingDir:" + dir);
+                }
+
+                var lines = File.ReadAllLines(file);
+                foreach (var line in lines)
+                {
+                    if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#"))
+                        continue;
+
+                    ParsePreprocessArg(line, output, ifstack, true);
+                }
+
+                if (prevDir != dir)
+                {
+                    Directory.SetCurrentDirectory(prevDir);
+                    output.Add("/workingDir:" + prevDir);
+                }
+
+                return;
+            }
+
+            output.Add(arg);
         }
 
         private bool ParseFlags(string arg)
@@ -651,10 +586,21 @@ namespace MGCB
             }
         }
 
-
         static T GetAttribute<T>(ICustomAttributeProvider provider) where T : Attribute
         {
             return provider.GetCustomAttributes(typeof(T), false).OfType<T>().FirstOrDefault();
+        }
+
+        private struct IfCondition
+        {
+            public readonly string Key;
+            public readonly string Value;
+
+            public IfCondition(string key, string value)
+            {
+                Key = key;
+                Value = value;
+            }
         }
     }
 

--- a/Tools/MGCB/CommandLineParser.cs
+++ b/Tools/MGCB/CommandLineParser.cs
@@ -221,7 +221,7 @@ namespace MGCB
 
                 var words = arg.Split('=');
                 var name = words[0];
-                var value = words[1];
+                var value = words.Length > 1 ? words[1] : string.Empty;
 
                 _properties[name] = value;
 

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -249,6 +249,7 @@ namespace MonoGame.Tools.Pipeline
 
         public void OpenProject(string projectFilePath)
         {
+            projectFilePath = Path.GetFullPath(projectFilePath);
             CloseProject();
 
             if (OnProjectLoading != null)


### PR DESCRIPTION
- Response files can be run from any working directory (fixes #4190)
- Adds support for nested response files
  - In the Pipeline Tool this is limited to response files in the same directory as the opened project
    because we don't have a way to display the content otherwise.
- Fix a bug in parsing --define
- Improve MGCB parsing code readability
  - defines can just be stored in a Dictionary
  - Replace old style Tuple with struct
- Allow $set \<name\> and $if \<name\> without values (stored as empty string). 