### PR TITLE
Fix custom effect doc markdown

### DIFF
--- a/Documentation/custom_effects.md
+++ b/Documentation/custom_effects.md
@@ -35,14 +35,14 @@ To use a custom effect with MonoGame you must do one of the following (not both)
 These are some tips for writing or converting effects for use with MonoGame.
 
 * The supported shader models when targeting DX are the following:
-  * vs_4_0_level_9_1 and ps_4_0_level_9_1 
-  * vs_4_0_level_9_3 and ps_4_0_level_9_3
-  * vs_4_0 and ps_4_0 (requires `HiDef` `GraphicsProfile` at runtime)
-  * vs_4_1 and ps_4_1 (requires `HiDef` `GraphicsProfile` at runtime)
-  * vs_5_0 and ps_5_0 (requires `HiDef` `GraphicsProfile` at runtime)
+  * `vs_4_0_level_9_1` and `ps_4_0_level_9_1` 
+  * `vs_4_0_level_9_3` and `ps_4_0_level_9_3`
+  * `vs_4_0` and `ps_4_0` (requires `HiDef` `GraphicsProfile` at runtime)
+  * `vs_4_1` and `ps_4_1` (requires `HiDef` `GraphicsProfile` at runtime)
+  * `vs_5_0` and `ps_5_0` (requires `HiDef` `GraphicsProfile` at runtime)
 * When targeting GL platforms we automatically translate FX files to GLSL using a library called [MojoShader](http://icculus.org/mojoshader/).  The supported feature levels are the following:
-  * vs_2_0 and ps_2_0
-  * vs_3_0 and ps_3_0
+  * `vs_2_0` and `ps_2_0`
+  * `vs_3_0` and `ps_3_0`
 * You can use preprocessor checks to add conditional code or compilation depending on defined symbols. MonoGame defines the following symbols when compiling effects:
   * `2MGFX`
   * `HLSL` and `SM4` for DirectX


### PR DESCRIPTION
This didn't render right on the website:

![image](https://user-images.githubusercontent.com/14875382/46834446-b84dac80-cdab-11e8-8abe-7bcb4a363897.png)
