### PR TITLE
Enable standard derivatives extension for GLSL shaders

### DIFF
--- a/MonoGame.Framework/iOS/iOSGameViewController.cs
+++ b/MonoGame.Framework/iOS/iOSGameViewController.cs
@@ -145,6 +145,21 @@ namespace Microsoft.Xna.Framework
 
         #endregion
 
+        #region iOS 11 or newer
+
+        /// <summary>
+        /// Defer system gestures on all screen edges in full screen mode.
+        /// </summary>
+        public override UIRectEdge PreferredScreenEdgesDeferringSystemGestures
+        {
+            get
+            {
+                return _platform.Game.graphicsDeviceManager.IsFullScreen ? UIRectEdge.All : base.PreferredScreenEdgesDeferringSystemGestures;
+            }
+        }
+
+        #endregion
+
         #endif
 
         #if TVOS

--- a/Tools/2MGFX/ShaderData.mojo.cs
+++ b/Tools/2MGFX/ShaderData.mojo.cs
@@ -179,6 +179,13 @@ namespace TwoMGFX
 				"#endif\r\n" +
 				glslCode;
 
+			// Enable standard derivatives extension as necessary
+			if ((glslCode.IndexOf("dFdx", StringComparison.InvariantCulture) >= 0)
+				|| (glslCode.IndexOf("dFdy", StringComparison.InvariantCulture) >= 0))
+			{
+				glslCode = "#extension GL_OES_standard_derivatives : enable\r\n" + glslCode;
+			}
+
 			// Store the code for serialization.
 			dxshader.ShaderCode = Encoding.ASCII.GetBytes (glslCode);
 


### PR DESCRIPTION
Fix for issue #6499: Runtime exception "Shader Compilation Failed" on iOS and Android, works on Windows.