### PR TITLE
[Pipeline] Ensure intermediate output path exists before writing stats

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/ContentStatsCollection.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentStatsCollection.cs
@@ -196,6 +196,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// <param name="outputPath">The folder to write the .mgstats file.</param>
         public void Write(string outputPath)
         {
+            // ensure the output folder exists
+            Directory.CreateDirectory(outputPath);
             var filePath = Path.Combine(outputPath, Extension);
             using (var textWriter = new StreamWriter(filePath, false, new UTF8Encoding(false)))
             {


### PR DESCRIPTION
Fixes #6502.

Not sure when the intermediate output directory does not get created exactly, but this will prevent a crash if it does not exist when the stats are written away.