### PR TITLE
Fix for #6507

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
@@ -194,11 +194,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         {
             var output = new Texture2DContent { Identity = new ContentIdentity(filename) };
 
-            var reader = new ImageReader();
             int width, height, comp;
             byte[] data = null;
             using (var stream = File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.Read))
-                data = reader.Read(stream, out width, out height, out comp, Imaging.STBI_rgb_alpha);
+                data = ImageReader.Read(stream, out width, out height, out comp, Imaging.STBI_rgb_alpha);
 
             var face = new PixelBitmapContent<Color>(width, height);
             face.SetPixelData(data);

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -216,11 +216,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private unsafe static Texture2D PlatformFromStream(GraphicsDevice graphicsDevice, Stream stream)
         {
-            var reader = new ImageReader();
             int width, height, channels;
 
             // The data returned is always four channel BGRA
-            var data = reader.Read(stream, out width, out height, out channels, Imaging.STBI_rgb_alpha);
+            var data = ImageReader.Read(stream, out width, out height, out channels, Imaging.STBI_rgb_alpha);
 
             // XNA blacks out any pixels with an alpha of zero.
             if (channels == 4)

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -257,11 +257,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private unsafe static Texture2D PlatformFromStream(GraphicsDevice graphicsDevice, Stream stream)
         {
-            var reader = new ImageReader();
             int width, height, channels;
 
             // The data returned is always four channel BGRA
-            var data = reader.Read(stream, out width, out height, out channels, Imaging.STBI_rgb_alpha);
+            var data = ImageReader.Read(stream, out width, out height, out channels, Imaging.STBI_rgb_alpha);
 
             // XNA blacks out any pixels with an alpha of zero.
             if (channels == 4)

--- a/MonoGame.Framework/Utilities/Imaging/ImageReader.cs
+++ b/MonoGame.Framework/Utilities/Imaging/ImageReader.cs
@@ -4,59 +4,25 @@ using System.Runtime.InteropServices;
 
 namespace MonoGame.Utilities
 {
-    internal unsafe class ImageReader
+    internal static unsafe class ImageReader
     {
-        public class AnimatedGifFrame
+        public static byte[] Read(Stream stream, out int x, out int y, out int comp, int req_comp)
         {
-            public byte[] Data;
-            public int Delay;
-        }
-
-        private Stream _stream;
-        private byte[] _buffer = new byte[1024];
-
-        private readonly Imaging.stbi_io_callbacks _callbacks;
-
-        public ImageReader()
-        {
-            _callbacks = new Imaging.stbi_io_callbacks
+            byte[] bytes, data = null;
+            using (var ms = new MemoryStream())
             {
-                read = ReadCallback,
-                skip = SkipCallback,
-                eof = Eof
-            };
-        }
-
-        private int SkipCallback(void* user, int i)
-        {
-            return (int) _stream.Seek(i, SeekOrigin.Current);
-        }
-
-        private int Eof(void* user)
-        {
-            return _stream.CanRead ? 1 : 0;
-        }
-
-        private int ReadCallback(void* user, sbyte* data, int size)
-        {
-            if (size > _buffer.Length)
-            {
-                _buffer = new byte[size*2];
+                stream.CopyTo(ms);
+                bytes = ms.ToArray();
             }
 
-            var res = _stream.Read(_buffer, 0, size);
-            Marshal.Copy(_buffer, 0, new IntPtr(data), size);
-            return res;
-        }
-
-        public byte[] Read(Stream stream, out int x, out int y, out int comp, int req_comp)
-        {
-            _stream = stream;
-
+            int xx, yy, ccomp;
+            byte* result = null;
             try
             {
-                int xx, yy, ccomp;
-                var result = Imaging.stbi_load_from_callbacks(_callbacks, null, &xx, &yy, &ccomp, req_comp);
+                fixed (byte* b = bytes)
+                {
+                    result = Imaging.stbi_load_from_memory(b, bytes.Length, &xx, &yy, &ccomp, req_comp);
+                }
 
                 x = xx;
                 y = yy;
@@ -69,16 +35,18 @@ namespace MonoGame.Utilities
 
                 // Convert to array
                 var c = req_comp != 0 ? req_comp : comp;
-                var data = new byte[x*y*c];
+                data = new byte[x * y * c];
                 Marshal.Copy(new IntPtr(result), data, 0, data.Length);
-                Operations.Free(result);
-
-                return data;
             }
             finally
             {
-                _stream = null;
+                if (result != null)
+                {
+                    Operations.Free(result);
+                }
             }
+
+            return data;
         }
     }
 }


### PR DESCRIPTION
As some platforms doesnt support Stream.Seek(see #6507), I've made it so the image data is loaded into the memory and then parsed from there.