### PR TITLE
Fix for Texture2D.FromStream when MemoryStream is passed to it.

### DIFF
--- a/MonoGame.Framework/Utilities/Imaging/ImageReader.cs
+++ b/MonoGame.Framework/Utilities/Imaging/ImageReader.cs
@@ -9,9 +9,17 @@ namespace MonoGame.Utilities
         public static byte[] Read(Stream stream, out int x, out int y, out int comp, int req_comp)
         {
             byte[] bytes, data = null;
-            using (var ms = new MemoryStream())
+
+            var ms = stream as MemoryStream;
+            if (ms == null)
             {
-                stream.CopyTo(ms);
+                using (ms = new MemoryStream())
+                {
+                    stream.CopyTo(ms);
+                    bytes = ms.ToArray();
+                }
+            } else
+            {
                 bytes = ms.ToArray();
             }
 

--- a/Test/Framework/Graphics/Texture2DNonVisualTest.cs
+++ b/Test/Framework/Graphics/Texture2DNonVisualTest.cs
@@ -103,6 +103,35 @@ namespace MonoGame.Tests.Graphics
         }
 
         [TestCase]
+        public void FromMemoryStream()
+        {
+            // Make sure MemoryStream can be passed to Texture2D.FromStream
+            using (var ms = new MemoryStream())
+            {
+                using (var stream = File.OpenRead("Assets/Textures/red_128.png"))
+                {
+                    stream.CopyTo(ms);
+                }
+                using (var texture = Texture2D.FromStream(gd, ms))
+                {
+                    Assert.AreEqual(8, texture.Width);
+                    Assert.AreEqual(8, texture.Height);
+                    Assert.AreEqual(1, texture.LevelCount);
+                    var pngData = new Color[8 * 8];
+                    texture.GetData(pngData);
+
+                    for (var i = 0; i < pngData.Length; i++)
+                    {
+                        Assert.AreEqual(255, pngData[i].R);
+                        Assert.AreEqual(0, pngData[i].G);
+                        Assert.AreEqual(0, pngData[i].B);
+                        Assert.AreEqual(128, pngData[i].A);
+                    }
+                }
+            }
+        }
+
+        [TestCase]
         public void FromStreamBlackAlpha()
         {
             // XNA will make any pixel with an alpha value


### PR DESCRIPTION
A problem had been reported:
http://community.monogame.net/t/texture2d-fromstream-no-longer-works/11067

I was able to reproduce it. It seems there is a problem when MemoryStream is passed to Texture2D.FromStream.
This PR fixes it.