### PR TITLE
Added rewind to the start of the stream in the Texture2D.FromStream

### DIFF
--- a/MonoGame.Framework/Utilities/Imaging/ImageReader.cs
+++ b/MonoGame.Framework/Utilities/Imaging/ImageReader.cs
@@ -9,6 +9,13 @@ namespace MonoGame.Utilities
         public static byte[] Read(Stream stream, out int x, out int y, out int comp, int req_comp)
         {
             byte[] bytes, data = null;
+
+            // Rewind stream if it is at end
+            if (stream.CanSeek && stream.Length == stream.Position)
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+            }
+
             using (var ms = new MemoryStream())
             {
                 stream.CopyTo(ms);

--- a/Test/Framework/Graphics/Texture2DNonVisualTest.cs
+++ b/Test/Framework/Graphics/Texture2DNonVisualTest.cs
@@ -103,6 +103,35 @@ namespace MonoGame.Tests.Graphics
         }
 
         [TestCase]
+        public void FromStreamAtTheEnd()
+        {
+            // Check whether texture can be loaded if a stream being at its end
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var fileStream = File.OpenRead("Assets/Textures/red_128.png"))
+                {
+                    fileStream.CopyTo(memoryStream);
+                }
+                using (var texture = Texture2D.FromStream(gd, memoryStream))
+                {
+                    Assert.AreEqual(8, texture.Width);
+                    Assert.AreEqual(8, texture.Height);
+                    Assert.AreEqual(1, texture.LevelCount);
+                    var pngData = new Color[8 * 8];
+                    texture.GetData(pngData);
+
+                    for (var i = 0; i < pngData.Length; i++)
+                    {
+                        Assert.AreEqual(255, pngData[i].R);
+                        Assert.AreEqual(0, pngData[i].G);
+                        Assert.AreEqual(0, pngData[i].B);
+                        Assert.AreEqual(128, pngData[i].A);
+                    }
+                }
+            }
+        }
+
+        [TestCase]
         public void FromStreamBlackAlpha()
         {
             // XNA will make any pixel with an alpha value


### PR DESCRIPTION
Right now, following code doesnt work in the MG:
```c#
            using (var memoryStream = new MemoryStream())
            {
                using (var fileStream = File.OpenRead("d:\\temp\\default_uiskin.png"))
                {
                    fileStream.CopyTo(memoryStream);
                }

                _texture = Texture2D.FromStream(GraphicsDevice, memoryStream);
            }
```
Because memoryStream points to the end just before Texture2D.FromStream call.
While same code works well in the XNA.
This PR makes MG work same as XNA.