### PR TITLE
Improved accuracy of fixed time step (recreation of PR #4207)

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1190,6 +1190,9 @@
     <Compile Include="Utilities\ReflectionHelpers.Legacy.cs" >
       <Platforms>Angle,Linux,MacOS,Windows,WindowsGL,Web</Platforms>
     </Compile>
+    <Compile Include="Utilities\TimerHelper.cs">
+      <Platforms>Windows,WindowsGL</Platforms>
+    </Compile>
     <Compile Include="Utilities\Lz4Stream\Lz4DecoderStream.cs" />
     <Compile Include="Utilities\LzxStream\LzxDecoderStream.cs" />
     <Compile Include="Utilities\ZLibStream\ZlibStream.cs" />

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -411,6 +411,9 @@ namespace Microsoft.Xna.Framework
         private Stopwatch _gameTimer;
         private long _previousTicks = 0;
         private int _updateFrameLag;
+#if WINDOWS_UAP
+        private readonly object _locker = new object();
+#endif
 
         public void Tick()
         {
@@ -420,6 +423,16 @@ namespace Microsoft.Xna.Framework
             // modes across multiple devices and platforms.
 
         RetryTick:
+
+            if (!IsActive && (InactiveSleepTime.TotalMilliseconds >= 1.0))
+            {
+#if WINDOWS_UAP
+                lock (_locker)
+                    System.Threading.Monitor.Wait(_locker, (int)InactiveSleepTime.TotalMilliseconds);
+#else
+                System.Threading.Thread.Sleep((int)InactiveSleepTime.TotalMilliseconds);
+#endif
+            }
 
             // Advance the accumulated elapsed time.
             var currentTicks = _gameTimer.Elapsed.Ticks;

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -426,21 +426,14 @@ namespace Microsoft.Xna.Framework
             _accumulatedElapsedTime += TimeSpan.FromTicks(currentTicks - _previousTicks);
             _previousTicks = currentTicks;
 
-            // If we're in the fixed timestep mode and not enough time has elapsed
-            // to perform an update we sleep off the the remaining time to save battery
-            // life and/or release CPU time to other threads and processes.
             if (IsFixedTimeStep && _accumulatedElapsedTime < TargetElapsedTime)
             {
-                var sleepTime = (int)(TargetElapsedTime - _accumulatedElapsedTime).TotalMilliseconds;
-
-                // NOTE: While sleep can be inaccurate in general it is 
-                // accurate enough for frame limiting purposes if some
-                // fluctuation is an acceptable result.
-#if WINDOWS_UAP
-                Task.Delay(sleepTime).Wait();
-#else
-                System.Threading.Thread.Sleep(sleepTime);
+#if WINDOWS
+                // Sleep for as long as possible without overshooting the update time
+                var sleepTime = (TargetElapsedTime - _accumulatedElapsedTime).TotalMilliseconds;
+                Utilities.TimerHelper.SleepForNoMoreThan(sleepTime);
 #endif
+                // Keep looping until it's time to perform the next update
                 goto RetryTick;
             }
 

--- a/MonoGame.Framework/Utilities/TimerHelper.cs
+++ b/MonoGame.Framework/Utilities/TimerHelper.cs
@@ -1,0 +1,47 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Microsoft.Xna.Framework.Utilities
+{
+    internal static class TimerHelper
+    {
+        [DllImport("ntdll.dll", SetLastError = true)]
+        private static extern int NtQueryTimerResolution(out uint MinimumResolution, out uint MaximumResolution, out uint CurrentResolution);
+
+        private static readonly double LowestSleepThreshold;
+
+        static TimerHelper()
+        {
+            uint min, max, current;
+            NtQueryTimerResolution(out min, out max, out current);
+            LowestSleepThreshold = 1.0 + (max / 10000.0);
+        }
+
+        /// <summary>
+        /// Returns the current timer resolution in milliseconds
+        /// </summary>
+        public static double GetCurrentResolution()
+        {
+            uint min, max, current;
+            NtQueryTimerResolution(out min, out max, out current);
+            return current / 10000.0;
+        }
+
+        /// <summary>
+        /// Sleeps as long as possible without exceeding the specified period
+        /// </summary>
+        public static void SleepForNoMoreThan(double milliseconds)
+        {
+            // Assumption is that Thread.Sleep(t) will sleep for at least (t), and at most (t + timerResolution)
+            if (milliseconds < LowestSleepThreshold)
+                return;
+            var sleepTime = (int)(milliseconds - GetCurrentResolution());
+            if (sleepTime > 0)
+                Thread.Sleep(sleepTime);
+        }
+    }
+}


### PR DESCRIPTION
This is a recreation of PR #4207 to get it all clean and up to date so it can be merged (as per @Jjagg's request). It resolves #6526 (and #4202 - the original issue which was mistakenly closed).

There is a lot of detailed information, discussion, test results, and benchmarks in the original PR #4207 and issue #4202.

But to quickly re-cap -- The main problem with the accuracy of fixed time step is the `Sleep` method. It is not accurate and is dependant on the current resolution of the system timer (which is influenced by many things).

If the current timer resolution can be measured, it is possible to still use `Sleep` and compensate for any inaccuracy with it. But if the timer resolution can't be measured, then the only alternative which maintains accuracy is to spin the CPU.

This PR does the following:

- On Windows desktop platforms, it will sleep for as long as possible without overshooting the desired time. It will then spin the CPU for the remaining time.
- On other platforms (where I couldn't measure the timer resolution), it will spin the CPU to maintain accuracy. (This also seems to be the same behaviour as XNA.)
- Implements the [`Game.InactiveSleepTime`](https://docs.microsoft.com/en-us/previous-versions/windows/xna/bb197440(v%3dxnagamestudio.42)) feature from XNA so that sleeping can be performed when the game window is inactive. This helps alleviate the higher CPU usage resulting from CPU spinning.
- Gets rid of the garbage generation on Windows UAP platforms which came from the use of `Task.Delay`.