### PR TITLE
Exclude Windows "TimerHelper" code from DesktopGL build

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1191,7 +1191,7 @@
       <Platforms>Angle,Linux,MacOS,Windows,WindowsGL,Web</Platforms>
     </Compile>
     <Compile Include="Utilities\TimerHelper.cs">
-      <Platforms>Windows,WindowsGL</Platforms>
+      <Platforms>Windows</Platforms>
     </Compile>
     <Compile Include="Utilities\Lz4Stream\Lz4DecoderStream.cs" />
     <Compile Include="Utilities\LzxStream\LzxDecoderStream.cs" />

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -441,7 +441,7 @@ namespace Microsoft.Xna.Framework
 
             if (IsFixedTimeStep && _accumulatedElapsedTime < TargetElapsedTime)
             {
-#if WINDOWS
+#if WINDOWS && !DESKTOPGL
                 // Sleep for as long as possible without overshooting the update time
                 var sleepTime = (TargetElapsedTime - _accumulatedElapsedTime).TotalMilliseconds;
                 Utilities.TimerHelper.SleepForNoMoreThan(sleepTime);


### PR DESCRIPTION
This is an amendment to PR #6535. Due to some confusion, some Windows code was mistakenly included in the cross-platform DesktopGL build. This PR resolves this.

(cc @Jjagg @cra0zy @mrhelmut)