### PR TITLE
Grammar and syntax improvements to Markdown documents

### DIFF
--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -60,7 +60,7 @@ public class Foo
 ```
 
 ## Commenting
-Comments should be used to describe intention, algorithmic overview, and/or logical flow.  It would be ideal if, from reading the comments alone, someone other than the author could understand a function�s intended behavior and general operation. While there are no minimum comment requirements (and certainly some very small routines need no commenting at all) it is best that most routines have comments reflecting the programmer�s intent and approach.
+Comments should be used to describe intention, algorithmic overview, and/or logical flow.  It would be ideal if, from reading the comments alone, someone other than the author could understand a function's intended behavior and general operation. While there are no minimum comment requirements (and certainly some very small routines need no commenting at all), it is best that most routines have comments reflecting the programmer's intent and approach.
 
 Comments must provide added value or explanation to the code. Simply describing the code is not helpful or useful.
 ```
@@ -87,11 +87,11 @@ All methods should use XML doc comments. For internal dev comments, the `<devdoc
 public class Foo 
 {
     /// <summary>Public stuff about the method</summary>
-    /// <param name=�bar�>What a neat parameter!</param>
+    /// <param name="bar">What a neat parameter!</param>
     /// <devdoc>Cool internal stuff!</devdoc>
     public void MyMethod(int bar)
     {
-        �
+        ...
     }
 }
 ```
@@ -153,12 +153,12 @@ for (int i=0 ; i<100 ; ++i)     // Wrong
 ## Naming
 Follow all .NET Framework Design Guidelines for both internal and external members. Highlights of these include:
 * Do not use Hungarian notation
-* Do use an underscore prefix for member variables, e.g. `_foo`
+* Do use an underscore prefix for member variables, e.g. "_foo"
 * Do use camelCasing for member variables (first word all lowercase, subsequent words initial uppercase)
 * Do use camelCasing for parameters
 * Do use camelCasing for local variables
 * Do use PascalCasing for function, property, event, and class names (all words initial uppercase)
-* Do prefix interfaces names with �I�
+* Do prefix interfaces names with "I"
 * Do not prefix enums, classes, or delegates with any letter
 
 The reasons to extend the public rules (no Hungarian, underscore prefix for member variables, etc.) is to produce a consistent source code appearance. In addition, the goal is to have clean, readable source. Code legibility should be a primary goal.
@@ -181,29 +181,29 @@ namespace MyNamespace
         #endregion
 
         #region Properties
-        public int Foo { get { � } set { � } }
+        public int Foo { get { ... } set { ... } }
         #endregion
 
         #region Constructors
         public MyClass()
         {
-            �
+            ...
         }
         #endregion
 
         #region Events
-        public event EventHandler FooChanged { add { � } remove { � } }
+        public event EventHandler FooChanged { add { ... } remove { ... } }
         #endregion
 
         #region Methods
         void DoSomething()
         {
-            �
+            ...
         }
 
         void FindSomething()
         {
-            �
+            ...
         }
         #endregion
 
@@ -217,7 +217,7 @@ namespace MyNamespace
         #region Nested types
         class NestedType
         {
-            �
+            ...
         }
         #endregion
     }

--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -1,7 +1,7 @@
 > #### NOTE: This code style standard for MonoGame is a work in progress and much of the code does not currently conform to these rules.  This is something that will be addressed by the core team.
 
 # Introduction
-As the MonoGame project gains more traction and becomes more widely used, we are aiming to provide a more professional and consistent look to the large amount of source now in the project.  It was a broadly supported decision by the core development team to follow the Microsoft coding guidelines (the default provided in Visual Studio's C# editor).  These coding guidelines listed below have been based on a [MSDN blog post](http://blogs.msdn.com/b/brada/archive/2005/01/26/361363.aspx) from 2005 by Brad Abrams describing the internal coding guidelines at Microsoft, with some changes to suit our project.
+As the MonoGame project gains more traction and becomes more widely used, we aim to provide a more professional and consistent look to the large amount of source now in the project.  It was a broadly supported decision by the core development team to follow the Microsoft coding guidelines (the default provided in Visual Studio's C# editor).  These coding guidelines listed below are based on a [MSDN blog post](http://blogs.msdn.com/b/brada/archive/2005/01/26/361363.aspx) from 2005 by Brad Abrams describing the internal coding guidelines at Microsoft, with some changes to suit our project.
 # Coding Guidelines
 ## Tabs & Indenting
 Tab characters (\0x09) should not be used in code. All indentation should be done with 4 space characters.
@@ -60,7 +60,7 @@ public class Foo
 ```
 
 ## Commenting
-Comments should be used to describe intention, algorithmic overview, and/or logical flow.  It would be ideal, if from reading the comments alone, someone other than the author could understand a function’s intended behavior and general operation. While there are no minimum comment requirements and certainly some very small routines need no commenting at all, it is hoped that most routines will have comments reflecting the programmer’s intent and approach.
+Comments should be used to describe intention, algorithmic overview, and/or logical flow.  It would be ideal if, from reading the comments alone, someone other than the author could understand a functionï¿½s intended behavior and general operation. While there are no minimum comment requirements (and certainly some very small routines need no commenting at all) it is best that most routines have comments reflecting the programmerï¿½s intent and approach.
 
 Comments must provide added value or explanation to the code. Simply describing the code is not helpful or useful.
 ```
@@ -74,7 +74,7 @@ Comments must provide added value or explanation to the code. Simply describing 
 ```
 
 ### Copyright/License notice
-Each file should start with a copyright notice. To avoid errors in doc comment builds, you don’t want to use triple-slash doc comments. This is a short statement declaring the project name, copyright notice and directing the reader to the license document elsewhere in the project.
+Each file should start with a copyright notice. This is a short statement declaring the project name and copyright notice, and directing the reader to the license document elsewhere in the project. To avoid errors in doc comment builds, avoid using triple-slash doc comments.
 ```
 // MonoGame - Copyright (C) The MonoGame Team
 // This file is subject to the terms and conditions defined in
@@ -87,17 +87,17 @@ All methods should use XML doc comments. For internal dev comments, the `<devdoc
 public class Foo 
 {
     /// <summary>Public stuff about the method</summary>
-    /// <param name=”bar”>What a neat parameter!</param>
+    /// <param name=ï¿½barï¿½>What a neat parameter!</param>
     /// <devdoc>Cool internal stuff!</devdoc>
     public void MyMethod(int bar)
     {
-        …
+        ï¿½
     }
 }
 ```
 
 ### Comment Style
-The // (two slashes) style of comment tags should be used in most situations. Where ever possible, place comments above the code instead of beside it.  Here are some examples:
+The // (two slashes) style of comment tags should be used in most situations. Wherever possible, place comments above the code instead of beside it.  Here are some examples:
 ```
     // This is required for WebClient to work through the proxy
     GlobalProxySelection.Select = new WebProxy("http://itgproxy");
@@ -114,12 +114,12 @@ Do use a single space after a comma between function arguments.
 Console.In.Read(myChar, 0, 1);  // Right
 Console.In.Read(myChar,0,1);    // Wrong
 ```
-Do not use a space after the parenthesis and function arguments
+Do not use a space after the parenthesis and function arguments.
 ```
 CreateFoo(myChar, 0, 1)         // Right
 CreateFoo( myChar, 0, 1 )       // Wrong
 ```
-Do not use spaces between a function name and parenthesis.
+Do not use spaces between a function name and parentheses.
 ```
 CreateFoo()                     // Right
 CreateFoo ()                    // Wrong
@@ -129,22 +129,22 @@ Do not use spaces inside brackets.
 x = dataArray[index];           // Right
 x = dataArray[ index ];         // Wrong
 ```
-Do use a single space before flow control statements
+Do use a single space before flow control statements.
 ```
 while (x == y)                  // Right
 while(x==y)                     // Wrong
 ```
-Do use a single space before and after binary operators
+Do use a single space before and after binary operators.
 ```
 if (x == y)                     // Right
 if (x==y)                       // Wrong
 ```
-Do not use a space between a unary operator and the operand
+Do not use a space between a unary operator and the operand.
 ```
 ++i;                            // Right
 ++ i;                           // Wrong
 ```
-Do not use a space before a semi-colon. Do use a space after a semi-colon if there is more on the same line
+Do not use a space before a semi-colon. Do use a space after a semi-colon if there is more on the same line.
 ```
 for (int i = 0; i < 100; ++i)   // Right
 for (int i=0 ; i<100 ; ++i)     // Wrong
@@ -158,15 +158,15 @@ Follow all .NET Framework Design Guidelines for both internal and external membe
 * Do use camelCasing for parameters
 * Do use camelCasing for local variables
 * Do use PascalCasing for function, property, event, and class names (all words initial uppercase)
-* Do prefix interfaces names with “I”
+* Do prefix interfaces names with ï¿½Iï¿½
 * Do not prefix enums, classes, or delegates with any letter
 
-The reasons to extend the public rules (no Hungarian, underscore prefix for member variables, etc.) is to produce a consistent source code appearance. In addition a goal is to have clean readable source. Code legibility should be a primary goal.
+The reasons to extend the public rules (no Hungarian, underscore prefix for member variables, etc.) is to produce a consistent source code appearance. In addition, the goal is to have clean, readable source. Code legibility should be a primary goal.
 
 ## File Organization
 * Source files should contain only one public type, although multiple internal types are permitted if required
 * Source files should be given the name of the public type in the file
-* Directory names should follow the namespace for the class after `Framework`. For example, I would expect to find the public class `Microsoft.Xna.Framework.Graphics.GraphicsDevice` in **MonoGame.Framework\Graphics\GraphicsDevice.cs**
+* Directory names should follow the namespace for the class after `Framework`. For example, one would expect to find the public class `Microsoft.Xna.Framework.Graphics.GraphicsDevice` in **MonoGame.Framework\Graphics\GraphicsDevice.cs**
 * Class members should be grouped logically, and encapsulated into regions (Fields, Constructors, Properties, Events, Methods, Private interface implementations, Nested types)
 * Using statements should be before the namespace declaration.
 ```
@@ -181,29 +181,29 @@ namespace MyNamespace
         #endregion
 
         #region Properties
-        public int Foo { get { … } set { … } }
+        public int Foo { get { ï¿½ } set { ï¿½ } }
         #endregion
 
         #region Constructors
         public MyClass()
         {
-            …
+            ï¿½
         }
         #endregion
 
         #region Events
-        public event EventHandler FooChanged { add { … } remove { … } }
+        public event EventHandler FooChanged { add { ï¿½ } remove { ï¿½ } }
         #endregion
 
         #region Methods
         void DoSomething()
         {
-            …
+            ï¿½
         }
 
         void FindSomething()
         {
-            …
+            ï¿½
         }
         #endregion
 
@@ -217,7 +217,7 @@ namespace MyNamespace
         #region Nested types
         class NestedType
         {
-            …
+            ï¿½
         }
         #endregion
     }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We're happy that you have chosen to contribute to the MonoGame project.
 
-You are joining a group of hundreds of volunteers that have helped build MonoGame since 2009.  To organize these efforts the MonoGame Team has written this simple guide to help you.
+You are joining a group of hundreds of volunteers that have helped build MonoGame since 2009.  To organize these efforts, the MonoGame Team has written this simple guide to help you.
 
 Please read this document completely before contributing.
 
@@ -11,13 +11,13 @@ Please read this document completely before contributing.
 
 MonoGame has a `master` branch for stable releases and a `develop` branch for daily development.  New features and fixes are always submitted to the `develop` branch.
 
-If you are looking for ways to help you should start by looking at the [Help Wanted tasks](https://github.com/mono/MonoGame/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22).  Please let us know if you plan to work on an issue so that others are not duplicating work.
+If you are looking for ways to help, you should start by looking at the [Help Wanted tasks](https://github.com/mono/MonoGame/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22).  Please let us know if you plan to work on an issue so that others are not duplicating work.
 
 The MonoGame project follows standard [GitHub flow](https://guides.github.com/introduction/flow/index.html).  You should learn and be familiar with how to [use Git](https://help.github.com/articles/set-up-git/), how to [create a fork of MonoGame](https://help.github.com/articles/fork-a-repo/), and how to [submit a Pull Request](https://help.github.com/articles/using-pull-requests/).
 
-After you submit a PR the [MonoGame build server](http://teamcity.monogame.net/?guest=1) will build your changes and verify all tests pass.  Project maintainers and contributors will review your changes and provide constructive feedback to improve your submission.
+After you submit a PR, the [MonoGame build server](http://teamcity.monogame.net/?guest=1) will build your changes and verify all tests pass.  Project maintainers and contributors will review your changes and provide constructive feedback to improve your submission.
 
-Once satisfied that your changes are good for MonoGame we will merge it.
+Once we are satisfied that your changes are good for MonoGame, we will merge it.
 
 
 ## Quick Guidelines
@@ -41,7 +41,7 @@ Here are a few simple rules and suggestions to remember when contributing to Mon
 
 ## Decompiler Tools
 
-We prohibit tools like dotPeek, ILSpy, JustDecompiler, or .NET Reflector which convert compiled assemblies into readable code.
+We prohibit the use of tools like dotPeek, ILSpy, JustDecompiler, or .NET Reflector which convert compiled assemblies into readable code.
 
 There has been confusion on this point in the past, so we want to make this clear.  It is **NEVER ACCEPTABLE** to decompile copyrighted assemblies and submit that code to the MonoGame project.
 
@@ -51,9 +51,9 @@ There has been confusion on this point in the past, so we want to make this clea
 * It **DOES NOT** matter how small the bit of code you have stolen is.  
 * It **DOES NOT** matter what your opinion is of stealing code.
 
-If you did not write the code, you do not have ownership of the code, and you shouldn't submit it to MonoGame.
+If you did not write the code, you do not have ownership of the code and you shouldn't submit it to MonoGame.
 
-If we find a contribution in violation of copyright it will be immediately removed.  We will bar that contributor from the MonoGame project.
+If we find a contribution to be in violation of copyright, it will be immediately removed.  We will bar that contributor from the MonoGame project.
 
 
 ## Licensing
@@ -62,7 +62,7 @@ The MonoGame project is under the [Microsoft Public License](https://opensource.
 
 We accept contributions in "good faith" that it isn't bound to a conflicting license.  By submitting a PR you agree to distribute your work under the MonoGame license and copyright.
 
-To this end when submitting new files include the following in the header if appropriate:
+To this end, when submitting new files, include the following in the header if appropriate:
 ```csharp
 // MonoGame - Copyright (C) The MonoGame Team
 // This file is subject to the terms and conditions defined in
@@ -71,7 +71,7 @@ To this end when submitting new files include the following in the header if app
 
 ## Need More Help?
 
-If you need help please ask questions on our [community forums](http://community.monogame.net/) or come [chat on Gitter](https://gitter.im/mono/MonoGame).
+If you need help, please ask questions on our [community forums](http://community.monogame.net/) or come [chat on Gitter](https://gitter.im/mono/MonoGame).
 
 
 Thanks for reading this guide and helping make MonoGame great!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MonoGame
 
-One framework for creating powerful cross-platform games.  The spiritual successor to XNA with 1000's of titles shipped across desktop, mobile, and console platforms.  [MonoGame](http://www.monogame.net/) is a fully managed .NET open source game framework without any black boxes.  Create, develop and distribute your games your way.
+One framework for creating powerful cross-platform games.  The spiritual successor to XNA with thousands of titles shipped across desktop, mobile, and console platforms.  [MonoGame](http://www.monogame.net/) is a fully managed .NET open source game framework without any black boxes.  Create, develop and distribute your games your way.
 
 [![Join the chat at https://gitter.im/MonoGame/MonoGame](https://badges.gitter.im/MonoGame/MonoGame.svg)](https://gitter.im/MonoGame/MonoGame?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
@@ -63,7 +63,7 @@ If you are interested in contributing fixes or features to MonoGame, please read
 The full source code is available here from GitHub:
 
  * Clone the source: `git clone https://github.com/MonoGame/MonoGame.git`
- * Setup the submodules: `git submodule update --init`
+ * Set up the submodules: `git submodule update --init`
  * Run Protobuild.exe to generate project files and solutions.
    * If on Linux or Mac, run it with mono: `mono Protobuild.exe`
  * You can generate solutions for platforms that are not buildable from the current OS with: 
@@ -72,7 +72,7 @@ The full source code is available here from GitHub:
  * Open the solution for your target platform to build the game framework.
  * Open the solution for your development platform for building the pipeline and content tools.
 
-For the prerequisites for building from source please look at the [Requirements](REQUIREMENTS.md) file.
+For the prerequisites for building from source, please look at the [Requirements](REQUIREMENTS.md) file.
 
 A high level breakdown of the components of the framework:
 


### PR DESCRIPTION
This PR makes a few grammatical improvements to the project's Markdown files, and also replaces non-ASCII characters with their ASCII equivalents in the code style doc. Non-ASCII characters aren't guaranteed to display properly, while ASCII characters will pretty much always display properly.