### PR TITLE
[Pipeline Tool] Clear the current selections when excluding items in the pipeline UI

### DIFF
--- a/Tools/Pipeline/Common/PipelineController.ExcludeAction.cs
+++ b/Tools/Pipeline/Common/PipelineController.ExcludeAction.cs
@@ -72,6 +72,10 @@ namespace MonoGame.Tools.Pipeline
                 foreach (var sitem in _subitems)
                     _con._project.ContentItems.Remove(sitem);
 
+                //Since these items are removed from the project, manually clear the selection
+                _con.SelectedItems.Clear();
+                _con.SelectionChanged(_con.SelectedItems);
+
                 _con.View.EndTreeUpdate();
                 _con.ProjectDirty = true;
 


### PR DESCRIPTION
This PR clears the selection in the pipeline tool after excluding items. This prevents users from changing settings on items no longer in the project.