### PR TITLE
Fixes framebuffer object EXT loading and removes unused code

### DIFF
--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -551,81 +551,6 @@ namespace MonoGame.OpenGL
 
         internal static RenderApi BoundApi = RenderApi.GL;
 
-        internal partial class Ext
-        {
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate void GenRenderbuffersDelegate (int count, out int buffer);
-            internal static GenRenderbuffersDelegate GenRenderbuffers;
-
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate void BindRenderbufferDelegate (RenderbufferTarget target, int buffer);
-            internal static BindRenderbufferDelegate BindRenderbuffer;
-
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate void DeleteRenderbuffersDelegate (int count, ref int buffer);
-            internal static DeleteRenderbuffersDelegate DeleteRenderbuffers;
-
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate void RenderbufferStorageMultisampleDelegate (RenderbufferTarget target, int sampleCount,
-                RenderbufferStorage storage, int width, int height);
-            internal static RenderbufferStorageMultisampleDelegate RenderbufferStorageMultisample;
-
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate void GenFramebuffersDelegate (int count, out int buffer);
-            internal static GenFramebuffersDelegate GenFramebuffers;
-
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate void BindFramebufferDelegate (FramebufferTarget target, int buffer);
-            internal static BindFramebufferDelegate BindFramebuffer;
-
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate void DeleteFramebuffersDelegate (int count, ref int buffer);
-            internal static DeleteFramebuffersDelegate DeleteFramebuffers;
-
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate void FramebufferTexture2DDelegate (FramebufferTarget target, FramebufferAttachment attachement,
-                TextureTarget textureTarget, int texture, int level);
-            internal static FramebufferTexture2DDelegate FramebufferTexture2D;
-
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate void FramebufferRenderbufferDelegate (FramebufferTarget target, FramebufferAttachment attachement,
-                RenderbufferTarget renderBufferTarget, int buffer);
-            internal static FramebufferRenderbufferDelegate FramebufferRenderbuffer;
-
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate void GenerateMipmapDelegate (GenerateMipmapTarget target);
-            internal static GenerateMipmapDelegate GenerateMipmap;
-
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate void BlitFramebufferDelegate (int srcX0,
-                int srcY0,
-                int srcX1,
-                int srcY1,
-                int dstX0,
-                int dstY0,
-                int dstX1,
-                int dstY1,
-                ClearBufferMask mask,
-                BlitFramebufferFilter filter);
-            internal static BlitFramebufferDelegate BlitFramebuffer;
-
-            [System.Security.SuppressUnmanagedCodeSecurity ()]
-            [MonoNativeFunctionWrapper]
-            internal delegate FramebufferErrorCode CheckFramebufferStatusDelegate (FramebufferTarget target);
-            internal static CheckFramebufferStatusDelegate CheckFramebufferStatus;
-        }
-
         [System.Security.SuppressUnmanagedCodeSecurity ()]
         [MonoNativeFunctionWrapper]
         internal delegate void EnableVertexAttribArrayDelegate (int attrib);
@@ -1383,13 +1308,13 @@ namespace MonoGame.OpenGL
 
             LogExtensions();
             // now load Extensions :)
-            if (GL.RenderbufferStorageMultisample == null)
+            if (GL.GenRenderbuffers == null && Extensions.Contains("GL_EXT_framebuffer_object"))
             {
-                if (Extensions.Contains("GL_EXT_framebuffer_object"))
-                {
-                    GL.LoadFrameBufferObjectEXTEntryPoints();
-                }
-                else if (Extensions.Contains("GL_APPLE_framebuffer_multisample"))
+                GL.LoadFrameBufferObjectEXTEntryPoints();
+            }
+            if (GL.RenderbufferStorageMultisample == null)
+            {                
+                if (Extensions.Contains("GL_APPLE_framebuffer_multisample"))
                 {
                     GL.RenderbufferStorageMultisample = LoadFunction<GL.RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleAPPLE");
                     GL.BlitFramebuffer = LoadFunction<GL.BlitFramebufferDelegate>("glResolveMultisampleFramebufferAPPLE");
@@ -1411,22 +1336,6 @@ namespace MonoGame.OpenGL
                     GL.BlitFramebuffer = LoadFunction<GL.BlitFramebufferDelegate>("glBlitFramebufferNV");
                 }
             }
-        }
-
-        internal static void LoadFrameBufferObjectARBEntryPoints()
-        {
-            GenRenderbuffers = LoadFunction<GenRenderbuffersDelegate>("glGenRenderbuffers");
-            BindRenderbuffer = LoadFunction<BindRenderbufferDelegate>("glBindRenderbuffer");
-            DeleteRenderbuffers = LoadFunction<DeleteRenderbuffersDelegate>("glDeleteRenderbuffers");
-            GenFramebuffers = LoadFunction<GenFramebuffersDelegate>("glGenFramebuffers");
-            BindFramebuffer = LoadFunction<BindFramebufferDelegate>("glBindFramebuffer");
-            DeleteFramebuffers = LoadFunction<DeleteFramebuffersDelegate>("glDeleteFramebuffers");
-            FramebufferTexture2D = LoadFunction<FramebufferTexture2DDelegate>("glFramebufferTexture2D");
-            FramebufferRenderbuffer = LoadFunction<FramebufferRenderbufferDelegate>("glFramebufferRenderbuffer");
-            RenderbufferStorageMultisample = LoadFunction<RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisample");
-            GenerateMipmap = LoadFunction<GenerateMipmapDelegate>("glGenerateMipmap");
-            BlitFramebuffer = LoadFunction<BlitFramebufferDelegate>("glBlitFramebuffer");
-            CheckFramebufferStatus = LoadFunction<CheckFramebufferStatusDelegate>("glCheckFramebufferStatus");
         }
 
         internal static void LoadFrameBufferObjectEXTEntryPoints()


### PR DESCRIPTION
> The ```GL_EXT_framebuffer_object``` check and loading should be outside the ```if (GL.RenderbufferStorageMultisample == null)``` statement.
> Right now, the framebuffer object extension gets loaded only if ```glRenderbufferStorageMultisample``` didn't get loaded.

cc @jcsnider

Fixes #6561 