### PR TITLE
Fixes GL.RenderbufferStorage for devices that use the EXT entry points

### DIFF
--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -1348,6 +1348,7 @@ namespace MonoGame.OpenGL
             DeleteFramebuffers = LoadFunction<DeleteFramebuffersDelegate>("glDeleteFramebuffersEXT");
             FramebufferTexture2D = LoadFunction<FramebufferTexture2DDelegate>("glFramebufferTexture2DEXT");
             FramebufferRenderbuffer = LoadFunction<FramebufferRenderbufferDelegate>("glFramebufferRenderbufferEXT");
+            RenderbufferStorage = LoadFunction<RenderbufferStorageDelegate>("glRenderbufferStorageEXT");
             RenderbufferStorageMultisample = LoadFunction<RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleEXT");
             GenerateMipmap = LoadFunction<GenerateMipmapDelegate>("glGenerateMipmapEXT");
             BlitFramebuffer = LoadFunction<BlitFramebufferDelegate>("glBlitFramebufferEXT");

--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -1172,8 +1172,6 @@ namespace MonoGame.OpenGL
             ReadBuffer = LoadFunction<ReadBufferDelegate> ("glReadBuffer");
             DrawBuffer = LoadFunction<DrawBufferDelegate> ("glDrawBuffer");
 
-            RenderbufferStorage = LoadFunction<RenderbufferStorageDelegate> ("glRenderbufferStorage");
-
             // Render Target Support. These might be null if they are not supported
             // see GraphicsDevice.OpenGL.FramebufferHelper.cs for handling other extensions.
             GenRenderbuffers = LoadFunction<GenRenderbuffersDelegate> ("glGenRenderbuffers");
@@ -1184,6 +1182,7 @@ namespace MonoGame.OpenGL
             DeleteFramebuffers = LoadFunction<DeleteFramebuffersDelegate> ("glDeleteFramebuffers");
             FramebufferTexture2D = LoadFunction<FramebufferTexture2DDelegate> ("glFramebufferTexture2D");
             FramebufferRenderbuffer = LoadFunction<FramebufferRenderbufferDelegate> ("glFramebufferRenderbuffer");
+            RenderbufferStorage = LoadFunction<RenderbufferStorageDelegate> ("glRenderbufferStorage");
             RenderbufferStorageMultisample = LoadFunction<RenderbufferStorageMultisampleDelegate> ("glRenderbufferStorageMultisample");
             GenerateMipmap = LoadFunction<GenerateMipmapDelegate> ("glGenerateMipmap");
             BlitFramebuffer = LoadFunction<BlitFramebufferDelegate> ("glBlitFramebuffer");


### PR DESCRIPTION
Fixes GL.RenderbufferStorage function for devices that use the EXT entry points. Those devices crash when creating 0 sample render targets due to this function not currently being mapped.

Ref: https://github.com/MonoGame/MonoGame/issues/6561#issuecomment-441478319