### PR TITLE
Make some obvious things Serializable

### DIFF
--- a/MonoGame.Framework/BoundingBox.cs
+++ b/MonoGame.Framework/BoundingBox.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Xna.Framework
 {
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct BoundingBox : IEquatable<BoundingBox>
     {
 

--- a/MonoGame.Framework/BoundingFrustum.cs
+++ b/MonoGame.Framework/BoundingFrustum.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Xna.Framework
     /// Defines a viewing frustum for intersection operations.
     /// </summary>
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public class BoundingFrustum : IEquatable<BoundingFrustum>
     {
         #region Private Fields
@@ -121,6 +122,12 @@ namespace Microsoft.Xna.Framework
         #endregion
 
         #region Constructors
+
+        /// <summary>
+        /// Constructs an uninitialized frustrum for serializeability.
+        /// </summary>        
+        public BoundingFrustum()
+        {}
 
         /// <summary>
         /// Constructs the frustum by extracting the view planes from a matrix.

--- a/MonoGame.Framework/BoundingSphere.cs
+++ b/MonoGame.Framework/BoundingSphere.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Xna.Framework
     /// </summary>
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct BoundingSphere : IEquatable<BoundingSphere>
     {
         #region Public Fields

--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Xna.Framework
     /// </summary>
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct Color : IEquatable<Color>
     {
         static Color()

--- a/MonoGame.Framework/Input/GamePadButtons.cs
+++ b/MonoGame.Framework/Input/GamePadButtons.cs
@@ -2,11 +2,14 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
     /// A struct that represents the current button states for the controller.
     /// </summary>
+    [Serializable]
     public struct GamePadButtons
     {
         internal readonly Buttons _buttons;

--- a/MonoGame.Framework/Input/GamePadDPad.cs
+++ b/MonoGame.Framework/Input/GamePadDPad.cs
@@ -2,8 +2,11 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Input
 {
+    [Serializable]
     public struct GamePadDPad
     {
         /// <summary>

--- a/MonoGame.Framework/Input/GamePadState.cs
+++ b/MonoGame.Framework/Input/GamePadState.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
@@ -11,6 +13,7 @@ namespace Microsoft.Xna.Framework.Input
     /// This is implemented as a partial struct to allow for individual platforms
     /// to offer additional data without separate state queries to GamePad.
     /// </summary>
+    [Serializable]
     public partial struct GamePadState
     {
         /// <summary>

--- a/MonoGame.Framework/Input/GamePadThumbSticks.cs
+++ b/MonoGame.Framework/Input/GamePadThumbSticks.cs
@@ -2,11 +2,14 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
     /// A struct that represents the current stick (thumbstick) states for the controller.
     /// </summary>
+    [Serializable]
     public struct GamePadThumbSticks
     {
 #if DIRECTX && !WINDOWS_UAP

--- a/MonoGame.Framework/Input/GamePadTriggers.cs
+++ b/MonoGame.Framework/Input/GamePadTriggers.cs
@@ -2,11 +2,14 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
     /// A struct that countains information on the left and the right trigger buttons.
     /// </summary>
+    [Serializable]
     public struct GamePadTriggers
     {
         /// <summary>

--- a/MonoGame.Framework/Input/JoystickHat.cs
+++ b/MonoGame.Framework/Input/JoystickHat.cs
@@ -2,11 +2,14 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
     /// Describes joystick hat state.
     /// </summary>
+    [Serializable]
     public struct JoystickHat
     {
         /// <summary>

--- a/MonoGame.Framework/Input/JoystickState.cs
+++ b/MonoGame.Framework/Input/JoystickState.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
 using System.Linq;
 using System.Text;
 
@@ -10,6 +11,7 @@ namespace Microsoft.Xna.Framework.Input
     /// <summary>
     /// Describes current joystick state.
     /// </summary>
+    [Serializable]
     public struct JoystickState
     {
         /// <summary>

--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -2,14 +2,17 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
 using System.Collections.Generic;
+
 
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
     /// Holds the state of keystrokes by a keyboard.
-    /// </summary>
-	public struct KeyboardState
+    /// </summary>    
+    [Serializable]
+    public struct KeyboardState
     {
         // Used for the common situation where GetPressedKeys will return an empty array
         static Keys[] empty = new Keys[0];

--- a/MonoGame.Framework/Input/MouseState.cs
+++ b/MonoGame.Framework/Input/MouseState.cs
@@ -2,11 +2,14 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
     /// Represents a mouse state with cursor position and button press information.
     /// </summary>
+    [Serializable]
     public struct MouseState
     {
         int _x, _y;

--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Xna.Framework
     /// </summary>
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct Matrix : IEquatable<Matrix>
     {
         #region Public Constructors

--- a/MonoGame.Framework/Plane.cs
+++ b/MonoGame.Framework/Plane.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Xna.Framework
 	
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct Plane : IEquatable<Plane>
     {
         #region Public Fields

--- a/MonoGame.Framework/Point.cs
+++ b/MonoGame.Framework/Point.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Xna.Framework
     /// </summary>
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct Point : IEquatable<Point>
     {
         #region Private Fields

--- a/MonoGame.Framework/Quaternion.cs
+++ b/MonoGame.Framework/Quaternion.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Xna.Framework
     /// </summary>
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct Quaternion : IEquatable<Quaternion>
     {
         #region Private Fields

--- a/MonoGame.Framework/Ray.cs
+++ b/MonoGame.Framework/Ray.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Xna.Framework
 {
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct Ray : IEquatable<Ray>
     {
         #region Public Fields

--- a/MonoGame.Framework/Rectangle.cs
+++ b/MonoGame.Framework/Rectangle.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Xna.Framework
     /// </summary>
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct Rectangle : IEquatable<Rectangle>
     {
         #region Private Fields

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Xna.Framework
 #endif
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct Vector2 : IEquatable<Vector2>
     {
         #region Private Fields
@@ -116,7 +117,7 @@ namespace Microsoft.Xna.Framework
             this.X = value;
             this.Y = value;
         }
-
+        
         #endregion
 
         #region Operators

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Xna.Framework
 #endif
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct Vector3 : IEquatable<Vector3>
     {
         #region Private Fields

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Xna.Framework
 #endif
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
+    [Serializable]
     public struct Vector4 : IEquatable<Vector4>
     {
         #region Private Fields


### PR DESCRIPTION
Marking these types `[Serializable]` will make it easier to use various serialization libraries for multiplayer code, saving gamestate, and live code hotloading. I would like to do this for even more types like Textures, but those look to be rather involved and want to test the waters with these simpler cases first.

Classes also need to have a parameterless constructor for ease of use with serialization libraries.


