### PR TITLE
Fix for issue where plugins that reference types from other assemblies cause Pipeline to display the "Invalid / Missing importer" error

### DIFF
--- a/Tools/Pipeline/Common/PipelineTypes.cs
+++ b/Tools/Pipeline/Common/PipelineTypes.cs
@@ -522,7 +522,7 @@ namespace MonoGame.Tools.Pipeline
                 try
 #endif
                 {
-                    if (!asm.ToString().Contains("MonoGame"))
+                    if (!asm.ToString().Contains("MonoGame") || _pluginAssemblies.ContainsKey(asm.FullName))
                         continue;
 
                     var types = asm.GetTypes();

--- a/Tools/Pipeline/Common/PipelineTypes.cs
+++ b/Tools/Pipeline/Common/PipelineTypes.cs
@@ -367,6 +367,8 @@ namespace MonoGame.Tools.Pipeline
             _processors = null;
             Processors = null;
 
+            _pluginAssemblies = new HashSet<string>();
+
             ImportersStandardValuesCollection = null;
             ProcessorsStandardValuesCollection = null;
         }
@@ -464,7 +466,10 @@ namespace MonoGame.Tools.Pipeline
                     var referencedAssemblies = a.GetReferencedAssemblies();
 
                     foreach (var assembly in referencedAssemblies)
-                        _pluginAssemblies.Add(assembly.FullName);
+                    {
+                        if(!_pluginAssemblies.Contains(assembly.FullName))
+                            _pluginAssemblies.Add(assembly.FullName);
+                    }
 
                     var types = a.GetTypes();
                     ProcessTypes(types);

--- a/Tools/Pipeline/Common/PipelineTypes.cs
+++ b/Tools/Pipeline/Common/PipelineTypes.cs
@@ -465,6 +465,7 @@ namespace MonoGame.Tools.Pipeline
                     var a = Assembly.Load(File.ReadAllBytes(path));
                     var referencedAssemblies = a.GetReferencedAssemblies();
 
+                    _pluginAssemblies.Add(a.FullName);
                     foreach (var assembly in referencedAssemblies)
                     {
                         if(!_pluginAssemblies.Contains(assembly.FullName))


### PR DESCRIPTION
Fix for issue where plugins that reference types from other assemblies cause Pipeline to crash and/or display the "Invalid / Missing importer" error