### PR TITLE
Add ResourceContentManager to Mac build

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -501,7 +501,7 @@
     <Compile Include="Content\ContentTypeReaderManager.cs" />
     <Compile Include="Content\LzxDecoder.cs" />
     <Compile Include="Content\ResourceContentManager.cs">
-      <Platforms>Angle,Android,iOS,Linux,Windows,WindowsGL,tvOS</Platforms>
+      <Platforms>Angle,Android,iOS,Linux,Windows,WindowsGL,MacOS,tvOS</Platforms>
     </Compile>
 
 


### PR DESCRIPTION
Fixes #3939. Looks like this was never included at least since Protobuild was used.