### PR TITLE
Mark GetGlyphs as obsolete and make Glyphs return readonly array

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -654,7 +654,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
-            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.Glyphs)
+            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.GlyphsInternal)
             for (var i = 0; i < text.Length; ++i)
             {
                 var c = text[i];
@@ -821,7 +821,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
-            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.Glyphs)
+            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.GlyphsInternal)
             for (var i = 0; i < text.Length; ++i)
             {
                 var c = text[i];
@@ -937,7 +937,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
-            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.Glyphs)
+            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.GlyphsInternal)
             for (var i = 0; i < text.Length; ++i)
             {
                 var c = text[i];
@@ -1103,7 +1103,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
-            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.Glyphs)
+            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.GlyphsInternal)
             for (var i = 0; i < text.Length; ++i)
             {
                 var c = text[i];

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		
 		private readonly Texture2D _texture;
 
+        internal Glyph[] GlyphsInternal { get { return _glyphs; } }
+
 		/// <summary>
 		/// All the glyphs in this SpriteFont.
 		/// </summary>
@@ -214,7 +216,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			var offset = Vector2.Zero;
             var firstGlyphOfLine = true;
 
-            fixed (Glyph* pGlyphs = Glyphs)
+            fixed (Glyph* pGlyphs = _glyphs)
             for (var i = 0; i < text.Length; ++i)
             {
                 var c = text[i];
@@ -233,7 +235,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 var currentGlyphIndex = GetGlyphIndexOrDefault(c);
-                Debug.Assert(currentGlyphIndex >= 0 && currentGlyphIndex < Glyphs.Length, "currentGlyphIndex was outside the bounds of the array.");
+                Debug.Assert(currentGlyphIndex >= 0 && currentGlyphIndex < _glyphs.Length, "currentGlyphIndex was outside the bounds of the array.");
                 var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                 // The first character on a line might have a negative left side bearing.

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		/// <summary>
 		/// All the glyphs in this SpriteFont.
 		/// </summary>
-		public Glyph[] Glyphs { get { return _glyphs; } }
+        /// <remarks>Can be used to calculate character bounds when implementing custom SpriteFont rendering.</remarks>
+		public ReadOnlyCollection<Glyph> Glyphs { get { return Array.AsReadOnly(_glyphs); } }
 
 		class CharComparer: IEqualityComparer<char>
 		{
@@ -120,8 +121,9 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Returns a copy of the dictionary containing the glyphs in this SpriteFont.
         /// </summary>
-        /// <returns>A new Dictionary containing all of the glyphs inthis SpriteFont</returns>
+        /// <returns>A new Dictionary containing all of the glyphs in this SpriteFont</returns>
         /// <remarks>Can be used to calculate character bounds when implementing custom SpriteFont rendering.</remarks>
+        [Obsolete("This method is deprecated and will be removed in a future version. Use SpriteFont.Glyphs to get the glyphs in this SpriteFont.")]
         public Dictionary<char, Glyph> GetGlyphs()
         {
             var glyphsDictionary = new Dictionary<char, Glyph>(_glyphs.Length, CharComparer.Default);

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		/// All the glyphs in this SpriteFont.
 		/// </summary>
         /// <remarks>Can be used to calculate character bounds when implementing custom SpriteFont rendering.</remarks>
-		public ReadOnlyCollection<Glyph> Glyphs { get { return Array.AsReadOnly(_glyphs); } }
+		public ReadOnlyCollection<Glyph> Glyphs { get { return new ReadOnlyCollection<Glyph>(_glyphs); } }
 
 		class CharComparer: IEqualityComparer<char>
 		{


### PR DESCRIPTION
See #6374 for discussion.

#6126 added the `Glyphs` property. We should not expose the glyph array directly like that. This wraps the array to make it readonly. It also marks the `GetGlyphs` method as deprecated to urge users to use the `Glyphs` property that does not allocate a whole dictionary with copies of the glyphs. 

The changes to the `Glyphs` property are a breaking change, but considering it was only recently added and not available in XNA, I think it's not that bad. `GetGlyphs` has been around a bit longer, so I decided not to remove it immediately.