### PR TITLE
Fix loading OpenAL Soft in DesktopGL when # is in path

### DIFF
--- a/MonoGame.Framework/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Audio/OpenAL.cs
@@ -199,7 +199,7 @@ namespace MonoGame.OpenAL
 
 #if DESKTOPGL
             // Load bundled library
-            var assemblyLocation = Path.GetDirectoryName((new Uri(typeof(AL).Assembly.CodeBase)).LocalPath);
+            var assemblyLocation = Path.GetDirectoryName(typeof(AL).Assembly.Location);
             if (CurrentPlatform.OS == OS.Windows && Environment.Is64BitProcess)
                 ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x64/soft_oal.dll"));
             else if (CurrentPlatform.OS == OS.Windows && !Environment.Is64BitProcess)


### PR DESCRIPTION
Reported on the [forum](http://community.monogame.net/t/monogame-3-7-1-release/11173/5?u=jjagg).

This is the same issue as #6522 but for OpenAL Soft. 
