### PR TITLE
Add FromFile to Texture2D and SoundEffect

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -197,7 +197,6 @@ namespace Microsoft.Xna.Framework.Audio
         /// </item>
         /// </list>
         /// </remarks>
- 
         public static SoundEffect FromFile(string path)
         {
             if (path == null)

--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -181,6 +181,34 @@ namespace Microsoft.Xna.Framework.Audio
 
         /// <summary>
         /// Creates a new SoundEffect object based on the specified data stream.
+        /// This internally calls <see cref="FromStream"/>.
+        /// </summary>
+        /// <param name="path">The path to the audio file.</param>
+        /// <returns>The <see cref="SoundEffect"/> loaded from the given file.</returns>
+        /// <remarks>The stream must point to the head of a valid wave file in the RIFF bitstream format.  The formats supported are:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>8-bit unsigned PCM</description>
+        /// <description>16-bit signed PCM</description>
+        /// <description>24-bit signed PCM</description>
+        /// <description>32-bit IEEE float PCM</description>
+        /// <description>MS-ADPCM 4-bit compressed</description>
+        /// <description>IMA/ADPCM (IMA4) 4-bit compressed</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+ 
+        public static SoundEffect FromFile(string path)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            using (var stream = File.OpenRead(path))
+                return FromStream(stream);
+        }
+
+        /// <summary>
+        /// Creates a new SoundEffect object based on the specified data stream.
         /// </summary>
         /// <param name="stream">A stream containing the wave data.</param>
         /// <returns>A new SoundEffect object.</returns>

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -266,14 +266,35 @@ namespace Microsoft.Xna.Framework.Graphics
 		        throw new ArgumentNullException("data");
 			this.GetData(0, null, data, 0, data.Length);
 		}
-		
+
         /// <summary>
-        /// Creates a Texture2D from a stream, supported formats bmp, gif, jpg, png, tif and dds (only for simple textures).
+        /// Creates a <see cref="Texture2D"/> from a file, supported formats bmp, gif, jpg, png, tif and dds (only for simple textures).
+        /// May work with other formats, but will not work with tga files.
+        /// This internally calls <see cref="FromStream"/>.
+        /// </summary>
+        /// <param name="graphicsDevice">The graphics device to use to create the texture.</param>
+        /// <param name="path">The path to the image file.</param>
+        /// <returns>The <see cref="Texture2D"/> created from the given file.</returns>
+        /// <remarks>Note that different image decoders may generate slight differences between platforms, but perceptually 
+        /// the images should be identical.  This call does not premultiply the image alpha, but areas of zero alpha will
+        /// result in black color data.
+        /// </remarks>
+        public static Texture2D FromFile(GraphicsDevice graphicsDevice, string path)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            using (var stream = File.OpenRead(path))
+                return FromStream(graphicsDevice, stream);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Texture2D"/> from a stream, supported formats bmp, gif, jpg, png, tif and dds (only for simple textures).
         /// May work with other formats, but will not work with tga files.
         /// </summary>
-        /// <param name="graphicsDevice">The graphics device where the texture will be created.</param>
+        /// <param name="graphicsDevice">The graphics device to use to create the texture.</param>
         /// <param name="stream">The stream from which to read the image data.</param>
-        /// <returns>The <see cref="SurfaceFormat.Color"/> texture created from the image stream.</returns>
+        /// <returns>The <see cref="Texture2D"/> created from the image stream.</returns>
         /// <remarks>Note that different image decoders may generate slight differences between platforms, but perceptually 
         /// the images should be identical.  This call does not premultiply the image alpha, but areas of zero alpha will
         /// result in black color data.
@@ -288,7 +309,8 @@ namespace Microsoft.Xna.Framework.Graphics
             try
             {
                 return PlatformFromStream(graphicsDevice, stream);
-            }catch(Exception e)
+            }
+            catch(Exception e)
             {
                 throw new InvalidOperationException("This image format is not supported", e);
             }


### PR DESCRIPTION
Fixes #5761.

These are very simple methods that don't take maintenance and offer some convenience to users I think nice to have these. Should these be conditionally compiled only for DesktopGL and WindowsDX?