### PR TITLE
GraphicsDevice.DirectX: expose the D3D device context

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/EffectPass.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectPass.cs
@@ -105,6 +105,10 @@ namespace Microsoft.Xna.Framework.Graphics
                     device.SetConstantBuffer(ShaderStage.Pixel, c, cb);
                 }
             }
+            else
+            {
+                device.PixelShader = _pixelShader;
+            }
 
             // Set the render states if we have some.
             if (_rasterizerState != null)

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -103,6 +103,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Returns a handle to internal device context object. Valid only on DirectX platforms.
+        /// For usage, convert this to SharpDX.Direct3D11.DeviceContext.
+        /// </summary>
+        public object ContextHandle
+        {
+            get
+            {
+                return _d3dContext;
+            }
+        }
+
         private void PlatformSetup()
         {
             MaxTextureSlots = 16;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1087,7 +1087,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new InvalidOperationException("Texture arrays are not supported on this graphics device");
 
             if (renderTarget == null)
-                SetRenderTarget(null);
+                SetRenderTargets(null);
             else
                 SetRenderTargets(new RenderTargetBinding(renderTarget, arraySlice));
         }
@@ -1096,7 +1096,7 @@ namespace Microsoft.Xna.Framework.Graphics
         public void SetRenderTarget(RenderTarget3D renderTarget, int arraySlice)
         {
             if (renderTarget == null)
-                SetRenderTarget(null);
+                SetRenderTargets(null);
             else
                 SetRenderTargets(new RenderTargetBinding(renderTarget, arraySlice));
         }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1101,6 +1101,17 @@ namespace Microsoft.Xna.Framework.Graphics
                 SetRenderTargets(new RenderTargetBinding(renderTarget, arraySlice));
         }
 
+        public void SetRenderTarget(RenderTargetShadowCascade renderTarget)
+        {
+            if (!GraphicsCapabilities.SupportsTextureArrays)
+                throw new InvalidOperationException("Texture arrays are not supported on this graphics device");
+
+            if (renderTarget == null)
+                SetRenderTargets(null);
+            else
+                SetRenderTargets(new RenderTargetBinding(renderTarget));
+        }
+
         private void PlatformApplyDefaultRenderTarget()
         {
             // Set the default swap chain.

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1300,8 +1300,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (_vertexShader == null)
                 throw new InvalidOperationException("A vertex shader must be set!");
-            if (_pixelShader == null)
-                throw new InvalidOperationException("A pixel shader must be set!");
+            //if (_pixelShader == null)
+            //    throw new InvalidOperationException("A pixel shader must be set!");
 
             if (_vertexShaderDirty)
             {
@@ -1320,17 +1320,26 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (_pixelShaderDirty)
             {
-                _d3dContext.PixelShader.Set(_pixelShader.PixelShader);
-                _pixelShaderDirty = false;
-
+                if (_pixelShader != null)
+                {
+                    _d3dContext.PixelShader.Set(_pixelShader.PixelShader);
+                }
+                else
+                {
+                    _d3dContext.PixelShader.Set(null);
+                }
                 unchecked
                 {
                     _graphicsMetrics._pixelShaderCount++;
                 }
+                _pixelShaderDirty = false;
             }
 
             _vertexConstantBuffers.SetConstantBuffers(this);
-            _pixelConstantBuffers.SetConstantBuffers(this);
+            if (_pixelShader != null)
+            {
+                _pixelConstantBuffers.SetConstantBuffers(this);
+            }
 
             VertexTextures.SetTextures(this);
             VertexSamplerStates.PlatformSetSamplers(this);

--- a/MonoGame.Framework/Graphics/RenderTargetBinding.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetBinding.cs
@@ -88,6 +88,16 @@ namespace Microsoft.Xna.Framework.Graphics
             _depthFormat = renderTarget.DepthStencilFormat;
         }
 
+        public RenderTargetBinding(RenderTargetShadowCascade renderTarget)
+        {
+            if (renderTarget == null)
+                throw new ArgumentNullException("renderTarget");
+
+            _renderTarget = renderTarget;
+            _arraySlice = (int)CubeMapFace.PositiveX;
+            _depthFormat = renderTarget.DepthStencilFormat;
+        }
+
 #if DIRECTX
 
         public RenderTargetBinding(RenderTarget2D renderTarget, int arraySlice)

--- a/MonoGame.Framework/Graphics/RenderTargetShadowCascade.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetShadowCascade.DirectX.cs
@@ -1,0 +1,98 @@
+﻿using SharpDX.Direct3D;
+using SharpDX.Direct3D11;
+using SharpDX.DXGI;
+using Resource = SharpDX.Direct3D11.Resource;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public partial class RenderTargetShadowCascade
+    {
+        internal DepthStencilView _depthStencilView;
+
+        private void PlatformConstruct(GraphicsDevice graphicsDevice, int width, int height)
+        {
+            GenerateIfRequired();
+        }
+
+        private void GenerateIfRequired()
+        {
+            if (_depthStencilView != null)
+                return;
+
+            // see https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch10.html
+
+            var depthStencilViewDescription = new DepthStencilViewDescription();
+            depthStencilViewDescription.Format = SharpDX.DXGI.Format.D32_Float;
+            depthStencilViewDescription.Dimension = DepthStencilViewDimension.Texture2DArray;
+            depthStencilViewDescription.Texture2DArray.ArraySize = ArraySize;
+            depthStencilViewDescription.Texture2DArray.FirstArraySlice = 0;
+            depthStencilViewDescription.Texture2DArray.MipSlice = 0;
+            _depthStencilView = new DepthStencilView(GraphicsDevice._d3dDevice, GetTexture(), depthStencilViewDescription);
+        }
+
+        private void PlatformGraphicsDeviceResetting()
+        {
+            SharpDX.Utilities.Dispose(ref _depthStencilView);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                SharpDX.Utilities.Dispose(ref _depthStencilView);
+            }
+
+            base.Dispose(disposing);
+        }
+
+        RenderTargetView IRenderTarget.GetRenderTargetView(int arraySlice)
+        {
+            return null;
+        }
+
+        DepthStencilView IRenderTarget.GetDepthStencilView()
+        {
+            GenerateIfRequired();
+            return _depthStencilView;
+        }
+
+
+        internal override Resource CreateTexture()
+        {
+            var rt = base.CreateTexture();
+            return rt;
+        }
+
+        protected override ShaderResourceView CreateShaderResourceView()
+        {
+            var shaderResourceViewDescription = new ShaderResourceViewDescription();
+            shaderResourceViewDescription.Format = SharpDX.DXGI.Format.R32_Float;
+            shaderResourceViewDescription.Dimension = ShaderResourceViewDimension.Texture2DArray;
+            shaderResourceViewDescription.Texture2DArray.ArraySize = ArraySize;
+            shaderResourceViewDescription.Texture2DArray.FirstArraySlice = 0;
+            shaderResourceViewDescription.Texture2DArray.MipLevels = 1;
+
+            return new SharpDX.Direct3D11.ShaderResourceView(GraphicsDevice._d3dDevice, GetTexture(), shaderResourceViewDescription);
+        }
+
+        protected internal override Texture2DDescription GetTexture2DDescription()
+        {
+            var desc = new Texture2DDescription();
+            desc.Width = width;
+            desc.Height = height;
+            desc.MipLevels = 1;
+            desc.ArraySize = ArraySize;
+            desc.Format = SharpDX.DXGI.Format.R32_Typeless;
+            desc.BindFlags = BindFlags.DepthStencil | BindFlags.ShaderResource;
+            desc.CpuAccessFlags = CpuAccessFlags.None;
+            desc.SampleDescription = CreateSampleDescription();
+            desc.Usage = ResourceUsage.Default;
+            desc.OptionFlags = ResourceOptionFlags.None;
+
+            //if (_shared)
+            //    desc.OptionFlags |= ResourceOptionFlags.Shared;
+
+            return desc;
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/RenderTargetShadowCascade.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetShadowCascade.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public partial class RenderTargetShadowCascade : Texture2D, IRenderTarget
+    {
+        public DepthFormat DepthStencilFormat { get; private set; }
+
+        //public int MultiSampleCount { get; private set; }
+
+        public RenderTargetUsage RenderTargetUsage { get; private set; }
+
+        public bool IsContentLost { get { return false; } }
+
+        public event EventHandler<EventArgs> ContentLost;
+
+        private bool SuppressEventHandlerWarningsUntilEventsAreProperlyImplemented()
+        {
+            return ContentLost != null;
+        }
+
+        public RenderTargetShadowCascade(GraphicsDevice graphicsDevice, int width, int height, int arraySize)
+        : base(graphicsDevice, width, height, false, SurfaceFormat.Single, SurfaceType.Texture, false, arraySize)
+        {
+            //DepthFormat preferredDepthFormat = DepthFormat.Depth_R32_Typeless;
+            DepthStencilFormat = DepthFormat.Depth_R32_Typeless;
+            //MultiSampleCount = 0;
+            RenderTargetUsage = RenderTargetUsage.DiscardContents;
+
+            PlatformConstruct(graphicsDevice, width, height);
+        }
+
+        protected internal override void GraphicsDeviceResetting()
+        {
+            PlatformGraphicsDeviceResetting();
+            base.GraphicsDeviceResetting();
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/States/DepthFormat.cs
+++ b/MonoGame.Framework/Graphics/States/DepthFormat.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// 32-bit depth-stencil buffer. Where 24-bit depth and 8-bit for stencil used.
         /// </summary>
-		Depth24Stencil8
+		Depth24Stencil8,
+        //
+        Depth_R32_Typeless
     }
 }

--- a/MonoGame.Framework/Graphics/States/RasterizerState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.DirectX.cs
@@ -56,6 +56,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     case DepthFormat.Depth24Stencil8:
                         depthMul = 1 << 24 - 1;
                         break;
+                    case DepthFormat.Depth_R32_Typeless:
+                        depthMul = 1 << 32 - 1;
+                        break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -380,8 +380,8 @@ namespace Microsoft.Xna.Framework.Graphics
             desc.Height = height;
             desc.MipLevels = _levelCount;
             desc.ArraySize = ArraySize;
-            desc.Format = SharpDXHelper.ToFormat(_format);
-            desc.BindFlags = BindFlags.ShaderResource;
+            desc.Format = (_format != SurfaceFormat.Single) ? SharpDXHelper.ToFormat(_format) : SharpDX.DXGI.Format.R32_Typeless;
+            desc.BindFlags = (_format != SurfaceFormat.Single) ? BindFlags.ShaderResource : BindFlags.DepthStencil | BindFlags.ShaderResource;
             desc.CpuAccessFlags = CpuAccessFlags.None;
             desc.SampleDescription = CreateSampleDescription();
             desc.Usage = ResourceUsage.Default;

--- a/MonoGame.Framework/Windows/SharpDXHelper.cs
+++ b/MonoGame.Framework/Windows/SharpDXHelper.cs
@@ -51,6 +51,10 @@ namespace Microsoft.Xna.Framework
                 case DepthFormat.Depth24:
                 case DepthFormat.Depth24Stencil8:
                     return SharpDX.DXGI.Format.D24_UNorm_S8_UInt;
+
+                case DepthFormat.Depth_R32_Typeless:
+                    return SharpDX.DXGI.Format.R32_Typeless;
+
             }
         }
 


### PR DESCRIPTION
introduces a public readonly ContextHandle property that exposes the D3D device context
similar to the existing Handle property that expose the D3D device.