### PR TITLE
[WinDX] Avoid freezing while moving/resizing window

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -43,6 +43,9 @@ namespace MonoGame.Framework
         // true if window position was moved either through code or by dragging/resizing the form
         private bool _wasMoved;
 
+        private bool _isResizeTickEnabled;
+        private readonly System.Timers.Timer _resizeTickTimer;
+
         #region Internal Properties
 
         internal Game Game { get; private set; }
@@ -156,9 +159,13 @@ namespace MonoGame.Framework
             Form.MouseEnter += OnMouseEnter;
             Form.MouseLeave += OnMouseLeave;            
 
+            _resizeTickTimer = new System.Timers.Timer(1) { SynchronizingObject = Form, AutoReset = false };
+            _resizeTickTimer.Elapsed += OnResizeTick;
+
             Form.Activated += OnActivated;
             Form.Deactivate += OnDeactivate;
             Form.Resize += OnResize;
+            Form.ResizeBegin += OnResizeBegin;
             Form.ResizeEnd += OnResizeEnd;
 
             Form.KeyPress += OnKeyPress;
@@ -376,8 +383,26 @@ namespace MonoGame.Framework
             OnClientSizeChanged();
         }
 
+        private void OnResizeBegin(object sender, EventArgs e)
+        {
+            _isResizeTickEnabled = true;
+            _resizeTickTimer.Enabled = true;
+        }
+
+        private void OnResizeTick(object sender, System.Timers.ElapsedEventArgs e)
+        {
+            if (!_isResizeTickEnabled)
+                return;
+            UpdateWindows();
+            Game.Tick();
+            _resizeTickTimer.Enabled = true;
+        }
+
         private void OnResizeEnd(object sender, EventArgs eventArgs)
         {
+            _isResizeTickEnabled = false;
+            _resizeTickTimer.Enabled = false;
+
             _wasMoved = true;
             if (Game.Window == this)
             {


### PR DESCRIPTION
As discussed in issue #5656, this solution works around the game freezing while the window is being moved or resized.

This logic has been in the public release of my game for several months now and there doesn't seem to be any issues with it. It has also proven to be very useful for video playback as the timing for that seems to mess up if updates fall behind.

Note that update timing won't be accurate while this is engaged. But the important thing is that updates are still happening and not falling behind.

_Note that this doesn't resolve the related issue (#5656) as it only fixes the problem on the Windows DirectX build. The DesktopGL build will need a different fix._