### PR TITLE
Fix for #6595: Background music stopped on iOS game startup

### DIFF
--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -237,7 +237,8 @@ namespace Microsoft.Xna.Framework.Audio
 #elif IOS
                 AVAudioSession.SharedInstance().Init();
 
-                // NOTE: Do not override AVAudioSessionCategory set by the game developer per #6595.
+                // NOTE: Do not override AVAudioSessionCategory set by the game developer:
+                //       see https://github.com/MonoGame/MonoGame/issues/6595
 
                 EventHandler<AVAudioSessionInterruptionEventArgs> handler = delegate(object sender, AVAudioSessionInterruptionEventArgs e) {
                     switch (e.InterruptionType)

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -237,15 +237,7 @@ namespace Microsoft.Xna.Framework.Audio
 #elif IOS
                 AVAudioSession.SharedInstance().Init();
 
-                // This is the default audio session category on iOS.
-                //
-                //   Your audio is silenced by screen locking and by the Silent switch (called the Ring/Silent switch on iPhone).
-                //
-                //   By default, using this category implies that your app’s audio is nonmixable—activating your session will
-                //   interrupt any other audio sessions which are also nonmixable.
-                //
-                //
-                AVAudioSession.SharedInstance().SetCategory(AVAudioSessionCategory.SoloAmbient);
+                // NOTE: Do not override AVAudioSessionCategory set by the game developer per #6595.
 
                 EventHandler<AVAudioSessionInterruptionEventArgs> handler = delegate(object sender, AVAudioSessionInterruptionEventArgs e) {
                     switch (e.InterruptionType)


### PR DESCRIPTION
Removed the code in OpenALSoundController that was setting AVAudioSessionCategory to SoloAmbient and overriding the game developer setting.