### PR TITLE
Fixed GameUpdateRequiredException namespace

### DIFF
--- a/Build/Projects/MonoGame.Framework.Net.definition
+++ b/Build/Projects/MonoGame.Framework.Net.definition
@@ -65,6 +65,7 @@
     <Compile Include="GamerServices\GamerPrivilegeSetting.cs"/>
     <Compile Include="GamerServices\GamerProfile.cs"/>
     <Compile Include="GamerServices\GamerZone.cs"/>
+    <Compile Include="GamerServices\GameUpdateRequiredException.cs" />
     <Compile Include="GamerServices\LeaderboardEntry.cs"/>
     <Compile Include="GamerServices\LeaderboardIdentity.cs"/>
     <Compile Include="GamerServices\LeaderboardKey.cs"/>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -274,7 +274,6 @@
     <Compile Include="GameRunBehavior.cs" />
     <Compile Include="GameServiceContainer.cs" />
     <Compile Include="GameTime.cs" />
-    <Compile Include="GameUpdateRequiredException.cs" />
     <Compile Include="GameWindow.cs">
 	</Compile>
     <Compile Include="IDrawable.cs" />

--- a/MonoGame.Framework/GameUpdateRequiredException.cs
+++ b/MonoGame.Framework/GameUpdateRequiredException.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-namespace Microsoft.Xna.Framework
+namespace Microsoft.Xna.Framework.GamerServices
 {
     public class GameUpdateRequiredException : Exception
     {

--- a/MonoGame.Framework/GamerServices/GameUpdateRequiredException.cs
+++ b/MonoGame.Framework/GamerServices/GameUpdateRequiredException.cs
@@ -11,4 +11,3 @@ namespace Microsoft.Xna.Framework.GamerServices
 
     }
 }
-


### PR DESCRIPTION
It was previously in `Microsoft.Xna.Framework` but according to XNA docs it should be in `Microsoft.Xna.Framework.GamerServices`.

Closes #3059 