### PR TITLE
No alloc to marshal UTF-8 to string

### DIFF
--- a/MonoGame.Framework/Utilities/InteropHelpers.cs
+++ b/MonoGame.Framework/Utilities/InteropHelpers.cs
@@ -18,18 +18,13 @@ namespace MonoGame.Utilities
             if (handle == IntPtr.Zero)
                 return string.Empty;
 
-            var ptr = (byte*) handle;
-            while (*ptr != 0)
-                ptr++;
+            var start = (byte*) handle;
+            var end = start;
+            while (*end != 0)
+                end++;
 
-            var len = ptr - (byte*) handle;
-            if (len == 0)
-                return string.Empty;
-
-            var bytes = new byte[len];
-            Marshal.Copy(handle, bytes, 0, bytes.Length);
-
-            return Encoding.UTF8.GetString(bytes);
+            var len = (int) (end - start);
+            return Encoding.UTF8.GetString(start, len);
         }
     }
 }


### PR DESCRIPTION
There's no need to create an intermediate array when marshalling UTF-8 to a .NET string.