### PR TITLE
Support SoundEffect loop points on platforms using OpenAL

### DIFF
--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Xna.Framework.Audio
                 ALHelper.CheckError("Failed to fill buffer.");
             }
 
-            if (loopStart >= 0 && loopLength > 0)
+            if (OpenALSoundController.GetInstance.SupportsLoopPoints && loopStart >= 0 && loopLength > 0)
             {
                 //Loop end is loopStart + loopLength
                 int[] loopData = new int[2] { loopStart, loopStart + loopLength };

--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Xna.Framework.Audio
 			set;
 		}
 
-        public void BindDataBuffer(byte[] dataBuffer, ALFormat format, int size, int sampleRate, int sampleAlignment = 0)
+        public void BindDataBuffer(byte[] dataBuffer, ALFormat format, int size, int sampleRate, int sampleAlignment = 0, int loopStart = 0, int loopLength = 0)
         {
             if ((format == ALFormat.MonoMSAdpcm || format == ALFormat.StereoMSAdpcm) && !OpenALSoundController.GetInstance.SupportsAdpcm)
                 throw new InvalidOperationException("MS-ADPCM is not supported by this OpenAL driver");
@@ -56,6 +56,15 @@ namespace Microsoft.Xna.Framework.Audio
                 ALHelper.CheckError("Failed to fill buffer.");
             }
 
+            if (loopStart >= 0 && loopLength > 0)
+            {
+                //Loop end is loopStart + loopLength
+                int[] loopData = new int[2] { loopStart, loopStart + loopLength };
+
+                AL.Bufferiv(openALDataBuffer, ALBufferi.LoopSoftPointsExt, loopData);
+                ALHelper.CheckError("Failed to set loop points.");
+            }
+
             AL.BufferData(openALDataBuffer, openALFormat, dataBuffer, size, sampleRate);
             ALHelper.CheckError("Failed to fill buffer.");
 
@@ -70,7 +79,7 @@ namespace Microsoft.Xna.Framework.Audio
             Duration = (float)(unpackedSize / ((bits / 8) * channels)) / (float)sampleRate;
         }
 
-		public void Dispose()
+        public void Dispose()
 		{
             Dispose(true);
             GC.SuppressFinalize(this);

--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Xna.Framework.Audio
 			set;
 		}
 
-        public void BindDataBuffer(byte[] dataBuffer, ALFormat format, int size, int sampleRate, int sampleAlignment = 0, int loopStart = 0, int loopLength = 0)
+        public unsafe void BindDataBuffer(byte[] dataBuffer, ALFormat format, int size, int sampleRate, int sampleAlignment = 0, int loopStart = 0, int loopLength = 0)
         {
             if ((format == ALFormat.MonoMSAdpcm || format == ALFormat.StereoMSAdpcm) && !OpenALSoundController.GetInstance.SupportsAdpcm)
                 throw new InvalidOperationException("MS-ADPCM is not supported by this OpenAL driver");
@@ -73,7 +73,9 @@ namespace Microsoft.Xna.Framework.Audio
             if (OpenALSoundController.GetInstance.SupportsLoopPoints && formatLoopEnabled && loopStart >= 0 && loopLength > 0)
             {
                 //Loop end is loopStart + loopLength
-                int[] loopData = new int[2] { loopStart, loopStart + loopLength };
+                int* loopData = stackalloc int[2];
+                loopData[0] = loopStart;
+                loopData[1] = loopStart + loopLength;
 
                 AL.Bufferiv(openALDataBuffer, ALBufferi.LoopSoftPointsExt, loopData);
                 ALHelper.CheckError("Failed to set loop points.");

--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -56,7 +56,21 @@ namespace Microsoft.Xna.Framework.Audio
                 ALHelper.CheckError("Failed to fill buffer.");
             }
 
-            if (OpenALSoundController.GetInstance.SupportsLoopPoints && loopStart >= 0 && loopLength > 0)
+            bool formatLoopEnabled = true;
+
+            /* Formats that OpenAL Soft currently doesn't support loop points for:
+             * MonoIma4
+             * StereoIma4
+             * MonoMSAdpcm
+             * StereoMSAdpcm
+            */
+            if (format == ALFormat.MonoIma4 || format == ALFormat.StereoIma4
+                || format == ALFormat.MonoMSAdpcm || format == ALFormat.StereoMSAdpcm)
+            {
+                formatLoopEnabled = false;
+            }
+
+            if (OpenALSoundController.GetInstance.SupportsLoopPoints && formatLoopEnabled && loopStart >= 0 && loopLength > 0)
             {
                 //Loop end is loopStart + loopLength
                 int[] loopData = new int[2] { loopStart, loopStart + loopLength };

--- a/MonoGame.Framework/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Audio/OpenAL.cs
@@ -290,7 +290,7 @@ namespace MonoGame.OpenAL
         internal static d_algetbufferi GetBufferi = FuncLoader.LoadFunction<d_algetbufferi>(NativeLibrary, "alGetBufferi");
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void d_albufferiv(int bid, ALBufferi param, int[] values);
+        internal unsafe delegate void d_albufferiv(int bid, ALBufferi param, int* values);
         internal static d_albufferiv Bufferiv = FuncLoader.LoadFunction<d_albufferiv>(NativeLibrary, "alBufferiv");
 
         internal static void GetBuffer(int bid, ALGetBufferi param, out int value)

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Xna.Framework.Audio
         public bool SupportsAdpcm { get; private set; }
         public bool SupportsEfx { get; private set; }
         public bool SupportsIeee { get; private set; }
+        public bool SupportsLoopPoints { get; private set; }
 
         /// <summary>
         /// Sets up the hardware resources used by the controller.
@@ -281,6 +282,7 @@ namespace Microsoft.Xna.Framework.Audio
                     SupportsAdpcm = AL.IsExtensionPresent("AL_SOFT_MSADPCM");
                     SupportsEfx = AL.IsExtensionPresent("AL_EXT_EFX");
                     SupportsIeee = AL.IsExtensionPresent("AL_EXT_float32");
+                    SupportsLoopPoints = AL.IsExtensionPresent("AL_SOFT_loop_points");
                     return true;
                 }
             }

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Xna.Framework.Audio
 
             // bind buffer
             SoundBuffer = new OALSoundBuffer();
-            SoundBuffer.BindDataBuffer(buffer, format, count, sampleRate);
+            SoundBuffer.BindDataBuffer(buffer, format, count, sampleRate, loopStart, loopLength);
         }
 
         private void PlatformInitializeIeeeFloat(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
@@ -75,7 +75,7 @@ namespace Microsoft.Xna.Framework.Audio
 
             // bind buffer
             SoundBuffer = new OALSoundBuffer();
-            SoundBuffer.BindDataBuffer(buffer, format, count, sampleRate);
+            SoundBuffer.BindDataBuffer(buffer, format, count, sampleRate, loopStart, loopLength);
         }
 
         private void PlatformInitializeAdpcm(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int blockAlignment, int loopStart, int loopLength)
@@ -95,7 +95,7 @@ namespace Microsoft.Xna.Framework.Audio
             SoundBuffer = new OALSoundBuffer();
             // Buffer length must be aligned with the block alignment
             int alignedCount = count - (count % blockAlignment);
-            SoundBuffer.BindDataBuffer(buffer, format, alignedCount, sampleRate, sampleAlignment);
+            SoundBuffer.BindDataBuffer(buffer, format, alignedCount, sampleRate, sampleAlignment, loopStart, loopLength);
         }
 
         private void PlatformInitializeIma4(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int blockAlignment, int loopStart, int loopLength)
@@ -113,7 +113,7 @@ namespace Microsoft.Xna.Framework.Audio
 
             // bind buffer
             SoundBuffer = new OALSoundBuffer();
-            SoundBuffer.BindDataBuffer(buffer, format, count, sampleRate, sampleAlignment);
+            SoundBuffer.BindDataBuffer(buffer, format, count, sampleRate, sampleAlignment, loopStart, loopLength);
         }
 
         private void PlatformInitializeFormat(byte[] header, byte[] buffer, int bufferSize, int loopStart, int loopLength)


### PR DESCRIPTION
This PR uses the `loopStart` and `loopLength` parameters in SoundEffect constructors and passes them through `alBufferiv` using the `AL_LOOP_POINTS_SOFT` extension to set the loop points in a sound.

Related issues: #6534, #5186

I tested the example clip provided in #5186, but the XNB read the loopStart as 0. I'm not sure how to properly test this feature.