### PR TITLE
Fixed MGCB Build not cleaning empty projects

### DIFF
--- a/Tools/MGCB/Program.cs
+++ b/Tools/MGCB/Program.cs
@@ -42,32 +42,28 @@ namespace MGCB
                     System.Diagnostics.Debugger.Launch();
                 } catch (NotImplementedException) {
                     // not implemented under Mono
+                    Console.Error.WriteLine("The debugger is not implemented under Mono and thus is not supported on your platform.");
                 }
             }
 
-            if (content.HasWork)
+            // Print a startup message.            
+            var buildStarted = DateTime.Now;
+            if (!content.Quiet)
+                Console.WriteLine("Build started {0}\n", buildStarted);
+
+            // Let the content build.
+            int successCount, errorCount;
+            content.Build(out successCount, out errorCount);
+
+            // Print the finishing info.
+            if (!content.Quiet)
             {
-                // Print a startup message.            
-                var buildStarted = DateTime.Now;
-                if (!content.Quiet)
-                    Console.WriteLine("Build started {0}\n", buildStarted);
-
-                // Let the content build.
-                int successCount, errorCount;
-                content.Build(out successCount, out errorCount);
-
-                // Print the finishing info.
-                if (!content.Quiet)
-                {
-                    Console.WriteLine("\nBuild {0} succeeded, {1} failed.\n", successCount, errorCount);
-                    Console.WriteLine("Time elapsed {0:hh\\:mm\\:ss\\.ff}.", DateTime.Now - buildStarted);
-                }
-
-                // Return the error count.
-                return errorCount;
+                Console.WriteLine("\nBuild {0} succeeded, {1} failed.\n", successCount, errorCount);
+                Console.WriteLine("Time elapsed {0:hh\\:mm\\:ss\\.ff}.", DateTime.Now - buildStarted);
             }
 
-            return 0;
+            // Return the error count.
+            return errorCount;
         }
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the Build action for empty pipeline projects outputs nothing and doesn't clean them. It also adds an error message if the debugger attempts to run on a Mono platform it's not implemented on.

Related issue: #6241