### PR TITLE
Support TransformMatrix in SpriteEffect

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
@@ -12,13 +12,9 @@ namespace Microsoft.Xna.Framework.Graphics
     /// </summary>
     public class SpriteEffect : Effect
     {
-        #region Effect Parameters
-
-        EffectParameter matrixParam;
-
-        #endregion
-
-        #region Methods
+        private EffectParameter _matrixParam;
+        private Viewport _lastViewport;
+        private Matrix _projection;
 
         /// <summary>
         /// Creates a new SpriteEffect.
@@ -28,6 +24,11 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             CacheEffectParameters();
         }
+
+        /// <summary>
+        /// An optional matrix used to transform the sprite geometry. Uses <see cref="Matrix.Identity"/> if null.
+        /// </summary>
+        public Matrix? TransformMatrix { get; set; }
 
         /// <summary>
         /// Creates a new SpriteEffect by cloning parameter settings from an existing instance.
@@ -53,7 +54,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         void CacheEffectParameters()
         {
-            matrixParam = Parameters["MatrixTransform"];
+            _matrixParam = Parameters["MatrixTransform"];
         }
 
         /// <summary>
@@ -61,19 +62,27 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         protected internal override void OnApply()
         {
-            var viewport = GraphicsDevice.Viewport;
+            var vp = GraphicsDevice.Viewport;
+            if ((vp.Width != _lastViewport.Width) || (vp.Height != _lastViewport.Height))
+            {
+                // Normal 3D cameras look into the -z direction (z = 1 is in front of z = 0). The
+                // sprite batch layer depth is the opposite (z = 0 is in front of z = 1).
+                // --> We get the correct matrix with near plane 0 and far plane -1.
+                Matrix.CreateOrthographicOffCenter(0, vp.Width, vp.Height, 0, 0, -1, out _projection);
 
-            var projection = Matrix.CreateOrthographicOffCenter(0, viewport.Width, viewport.Height, 0, 0, 1);
-            var halfPixelOffset = Matrix.CreateTranslation(0, 0, 0);
+                if (SpriteBatch.NeedsHalfPixelOffset)
+                {
+                    _projection.M41 += -0.5f * _projection.M11;
+                    _projection.M42 += -0.5f * _projection.M22;
+                }
 
-            if (SpriteBatch.NeedsHalfPixelOffset){
-                halfPixelOffset += Matrix.CreateTranslation(-0.5f, -0.5f, 0);
+                _lastViewport = vp;
             }
 
-            matrixParam.SetValue(halfPixelOffset * projection);
+            if (TransformMatrix.HasValue)
+                _matrixParam.SetValue(TransformMatrix.GetValueOrDefault() * _projection);
+            else
+                _matrixParam.SetValue(_projection);
         }
-
-
-        #endregion
     }
 }


### PR DESCRIPTION
This exposes an optional transformation matrix in `SpriteEffect` so it can actually be used by `SpriteBatch`.
The transformation matrix works exactly like the matrix that can be passed to `SpriteBatch.Begin`. This also fixes `SpriteEffect` depth to work like `SpriteBatch` instead of reversed and improves caching for `SpriteEffect` as was done in `SpriteBatch`. 

This makes `SpriteBatch` a little simpler, makes `SpriteEffect` more useful and puts half pixel offset logic for sprites in one place (which was the driver for me, did this when working on #6621).