### PR TITLE
Optional sound system

### DIFF
--- a/MonoGame.Framework/Android/AndroidGamePlatform.cs
+++ b/MonoGame.Framework/Android/AndroidGamePlatform.cs
@@ -23,14 +23,6 @@ namespace Microsoft.Xna.Framework
             Window = _gameWindow;
 
             MediaLibrary.Context = Game.Activity;
-            try
-            {
-                OpenALSoundController soundControllerInstance = OpenALSoundController.GetInstance;
-            }
-            catch (DllNotFoundException ex)
-            {
-                throw (new NoAudioHardwareException("Failed to init OpenALSoundController", ex));
-            }
         }
 
         protected override void Dispose(bool disposing)

--- a/MonoGame.Framework/Audio/DynamicSoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/DynamicSoundEffectInstance.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             SoundEffect.Initialize();
             if (SoundEffect._systemState != SoundEffect.SoundSystemState.Initialized)
-                return;
+                throw new NoAudioHardwareException("Audio has failed to initialize. Call SoundEffect.Initialize() before sound operation to get more specific errors.");
 
             if ((sampleRate < 8000) || (sampleRate > 48000))
                 throw new ArgumentOutOfRangeException("sampleRate");

--- a/MonoGame.Framework/Audio/DynamicSoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/DynamicSoundEffectInstance.cs
@@ -76,6 +76,10 @@ namespace Microsoft.Xna.Framework.Audio
         /// <param name="channels">Number of channels (mono or stereo).</param>
         public DynamicSoundEffectInstance(int sampleRate, AudioChannels channels)
         {
+            SoundEffect.Initialize();
+            if (SoundEffect._systemState != SoundEffect.SoundSystemState.Initialized)
+                return;
+
             if ((sampleRate < 8000) || (sampleRate > 48000))
                 throw new ArgumentOutOfRangeException("sampleRate");
             if ((channels != AudioChannels.Mono) && (channels != AudioChannels.Stereo))

--- a/MonoGame.Framework/Audio/Microphone.cs
+++ b/MonoGame.Framework/Audio/Microphone.cs
@@ -115,6 +115,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             get
             {
+                SoundEffect.Initialize();                
                 if (_allMicrophones == null)
                     _allMicrophones = new List<Microphone>();
                 return new ReadOnlyCollection<Microphone>(_allMicrophones);

--- a/MonoGame.Framework/Audio/Microphone.cs
+++ b/MonoGame.Framework/Audio/Microphone.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// </summary>
         public static Microphone Default
         {
-            get { return _default; }
+            get { SoundEffect.Initialize(); return _default; }
         }       
 
         #endregion

--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Xna.Framework.Audio
 
         public void BindDataBuffer(byte[] dataBuffer, ALFormat format, int size, int sampleRate, int sampleAlignment = 0)
         {
-            if ((format == ALFormat.MonoMSAdpcm || format == ALFormat.StereoMSAdpcm) && !OpenALSoundController.GetInstance.SupportsAdpcm)
+            if ((format == ALFormat.MonoMSAdpcm || format == ALFormat.StereoMSAdpcm) && !OpenALSoundController.Instance.SupportsAdpcm)
                 throw new InvalidOperationException("MS-ADPCM is not supported by this OpenAL driver");
-            if ((format == ALFormat.MonoIma4 || format == ALFormat.StereoIma4) && !OpenALSoundController.GetInstance.SupportsIma4)
+            if ((format == ALFormat.MonoIma4 || format == ALFormat.StereoIma4) && !OpenALSoundController.Instance.SupportsIma4)
                 throw new InvalidOperationException("IMA/ADPCM is not supported by this OpenAL driver");
 
             openALFormat = format;

--- a/MonoGame.Framework/Audio/OggStream.cs
+++ b/MonoGame.Framework/Audio/OggStream.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Xna.Framework.Audio
 
             alBufferIds = AL.GenBuffers(bufferCount);
             ALHelper.CheckError("Failed to generate buffers.");
-            alSourceId = OpenALSoundController.GetInstance.ReserveSource();
+            alSourceId = OpenALSoundController.Instance.ReserveSource();
 
             if (OggStreamer.Instance.XRam.IsInitialized)
             {
@@ -238,7 +238,7 @@ namespace Microsoft.Xna.Framework.Audio
 
             AL.Source(alSourceId, ALSourcei.Buffer, 0);
             ALHelper.CheckError("Failed to free source from buffers.");
-            OpenALSoundController.GetInstance.RecycleSource(alSourceId);
+            OpenALSoundController.Instance.RecycleSource(alSourceId);
             AL.DeleteBuffers(alBufferIds);
             ALHelper.CheckError("Failed to delete buffer.");
             if (OggStreamer.Instance.Efx.IsInitialized)

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -286,29 +286,36 @@ namespace Microsoft.Xna.Framework.Audio
             return false;
         }
 
-		public static OpenALSoundController GetInstance
+        public static void EnsureInitialized()
+        {
+            if (_instance == null)
+            {
+                try
+                {
+                    _instance = new OpenALSoundController();
+                }
+                catch (DllNotFoundException)
+                {
+                    throw;
+                }
+                catch (NoAudioHardwareException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    throw (new NoAudioHardwareException("Failed to init OpenALSoundController", ex));
+                }
+            }
+        }
+
+
+        public static OpenALSoundController Instance
         {
 			get
             {
                 if (_instance == null)
-                {
-                    try
-                    {
-                        _instance = new OpenALSoundController();
-                    }
-                    catch (DllNotFoundException)
-                    {
-                        throw;
-                    }
-                    catch (NoAudioHardwareException)
-                    {
-                        throw;
-                    }
-                    catch (Exception ex)
-                    {
-                        throw (new NoAudioHardwareException("Failed to init OpenALSoundController", ex));
-                    }
-                }
+                    throw new NoAudioHardwareException("OpenAL context has failed to initialize. Call SoundEffect.Initialize() before sound operation to get more specific errors.");
 				return _instance;
 			}
 		}

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -291,8 +291,17 @@ namespace Microsoft.Xna.Framework.Audio
         {
 			get
             {
-				if (_instance == null)
-					_instance = new OpenALSoundController();
+                if (_instance == null)
+                {
+                    try
+                    {
+                        _instance = new OpenALSoundController();
+                    }
+                    catch (Exception ex)
+                    {
+                        throw (new NoAudioHardwareException("Failed to init OpenALSoundController", ex));
+                    }
+                }
 				return _instance;
 			}
 		}

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -108,6 +108,9 @@ namespace Microsoft.Xna.Framework.Audio
         /// </summary>
 		private OpenALSoundController()
         {
+            if (AL.NativeLibrary == IntPtr.Zero)
+                throw new DllNotFoundException("Couldn't initialize OpenAL because the native binaries couldn't be found.");
+
             if (!OpenSoundController())
             {
                 throw new NoAudioHardwareException("OpenAL device could not be initialized, see console output for details.");
@@ -148,10 +151,6 @@ namespace Microsoft.Xna.Framework.Audio
             {
                 _device = Alc.OpenDevice(string.Empty);
                 EffectsExtension.device = _device;
-            }
-            catch (DllNotFoundException ex)
-            {
-                throw ex;
             }
             catch (Exception ex)
             {
@@ -296,6 +295,14 @@ namespace Microsoft.Xna.Framework.Audio
                     try
                     {
                         _instance = new OpenALSoundController();
+                    }
+                    catch (DllNotFoundException)
+                    {
+                        throw;
+                    }
+                    catch (NoAudioHardwareException)
+                    {
+                        throw;
                     }
                     catch (Exception ex)
                     {

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -235,17 +235,9 @@ namespace Microsoft.Xna.Framework.Audio
 
 #endregion
 
-        internal static void InitializeSoundEffect()
+        internal static void PlatformInitialize()
         {
-            try
-            {
-                // Getting the instance for the first time initializes OpenAL
-                var oal = OpenALSoundController.GetInstance;
-            }
-            catch (DllNotFoundException ex)
-            {
-                throw new NoAudioHardwareException("Failed to init OpenALSoundController", ex);
-            }
+            var inst = OpenALSoundController.GetInstance;
         }
 
         internal static void PlatformShutdown()

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal static void PlatformInitialize()
         {
-            OpenALSoundController.EnsureInitialized();            
+            OpenALSoundController.EnsureInitialized();
         }
 
         internal static void PlatformShutdown()

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformInitializeIeeeFloat(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
         {
-            if (!OpenALSoundController.GetInstance.SupportsIeee)
+            if (!OpenALSoundController.Instance.SupportsIeee)
             {
                 // If 32-bit IEEE float is not supported, convert to 16-bit signed PCM
                 buffer = AudioLoader.ConvertFloatTo16(buffer, offset, count);
@@ -80,7 +80,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformInitializeAdpcm(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int blockAlignment, int loopStart, int loopLength)
         {
-            if (!OpenALSoundController.GetInstance.SupportsAdpcm)
+            if (!OpenALSoundController.Instance.SupportsAdpcm)
             {
                 // If MS-ADPCM is not supported, convert to 16-bit signed PCM
                 buffer = AudioLoader.ConvertMsAdpcmToPcm(buffer, offset, count, (int)channels, blockAlignment);
@@ -100,7 +100,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformInitializeIma4(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int blockAlignment, int loopStart, int loopLength)
         {
-            if (!OpenALSoundController.GetInstance.SupportsIma4)
+            if (!OpenALSoundController.Instance.SupportsIma4)
             {
                 // If IMA/ADPCM is not supported, convert to 16-bit signed PCM
                 buffer = AudioLoader.ConvertIma4ToPcm(buffer, offset, count, (int)channels, blockAlignment);
@@ -237,7 +237,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal static void PlatformInitialize()
         {
-            var inst = OpenALSoundController.GetInstance;
+            OpenALSoundController.EnsureInitialized();            
         }
 
         internal static void PlatformShutdown()

--- a/MonoGame.Framework/Audio/SoundEffect.Web.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.Web.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
         }
 
-        internal static void InitializeSoundEffect()
+        internal static void PlatformInitialize()
         {
         }
 

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// <summary>
         /// Initializes XAudio.
         /// </summary>
-        internal static void InitializeSoundEffect()
+        internal static void PlatformInitialize()
         {
             try
             {

--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             Initialize();
             if (_systemState != SoundSystemState.Initialized)
-                return;
+                throw new NoAudioHardwareException("Audio has failed to initialize. Call SoundEffect.Initialize() before sound operation to get more specific errors.");
 
             /*
               The Stream object must point to the head of a valid PCM wave file. Also, this wave file must be in the RIFF bitstream format.
@@ -50,7 +50,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             Initialize();
             if (_systemState != SoundSystemState.Initialized)
-                return;
+                throw new NoAudioHardwareException("Audio has failed to initialize. Call SoundEffect.Initialize() before sound operation to get more specific errors.");
 
             _duration = TimeSpan.FromMilliseconds(durationMs);
 
@@ -74,7 +74,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             Initialize();
             if (_systemState != SoundSystemState.Initialized)
-                return;
+                throw new NoAudioHardwareException("Audio has failed to initialize. Call SoundEffect.Initialize() before sound operation to get more specific errors.");
 
             // Handle the common case... the rest is platform specific.
             if (codec == MiniFormatTag.Pcm)
@@ -153,7 +153,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             Initialize();
             if (_systemState != SoundSystemState.Initialized)
-                return;
+                throw new NoAudioHardwareException("Audio has failed to initialize. Call SoundEffect.Initialize() before sound operation to get more specific errors.");
 
             if (sampleRate < 8000 || sampleRate > 48000)
                 throw new ArgumentOutOfRangeException("sampleRate");

--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Xna.Framework.Audio
         // Only used from SoundEffect.FromStream.
         private SoundEffect(Stream stream)
         {
+            Initialize();
+            if (_systemState != SoundSystemState.Initialized)
+                return;
+
             /*
               The Stream object must point to the head of a valid PCM wave file. Also, this wave file must be in the RIFF bitstream format.
               The audio format has the following restrictions:
@@ -44,6 +48,10 @@ namespace Microsoft.Xna.Framework.Audio
         // Only used from SoundEffectReader.
         internal SoundEffect(byte[] header, byte[] buffer, int bufferSize, int durationMs, int loopStart, int loopLength)
         {
+            Initialize();
+            if (_systemState != SoundSystemState.Initialized)
+                return;
+
             _duration = TimeSpan.FromMilliseconds(durationMs);
 
             // Peek at the format... handle regular PCM data.
@@ -64,6 +72,10 @@ namespace Microsoft.Xna.Framework.Audio
         // Only used from XACT WaveBank.
         internal SoundEffect(MiniFormatTag codec, byte[] buffer, int channels, int sampleRate, int blockAlignment, int loopStart, int loopLength)
         {
+            Initialize();
+            if (_systemState != SoundSystemState.Initialized)
+                return;
+
             // Handle the common case... the rest is platform specific.
             if (codec == MiniFormatTag.Pcm)
             {
@@ -73,6 +85,41 @@ namespace Microsoft.Xna.Framework.Audio
             }
 
             PlatformInitializeXact(codec, buffer, channels, sampleRate, blockAlignment, loopStart, loopLength, out _duration);
+        }
+
+        #endregion
+
+        #region Audio System Initialization
+
+        internal enum SoundSystemState
+        {
+            NotInitialized,
+            Initialized,
+            FailedToInitialized
+        }
+
+        internal static SoundSystemState _systemState = SoundSystemState.NotInitialized;
+
+        /// <summary>
+        /// Initializes the sound system for SoundEffect support.
+        /// This method is automatically called when a SoundEffect is loaded, a DynamicSoundEffectInstance is created, or Microphone.All is queried.
+        /// You can however call this method manually (preferably in, or before the Game constructor) to catch any Exception that may occur during the sound system initialization (and act accordingly).
+        /// </summary>
+        public static void Initialize()
+        {
+            if (_systemState != SoundSystemState.NotInitialized)
+                return;
+
+            try
+            {
+                PlatformInitialize();
+                _systemState = SoundSystemState.Initialized;
+            }
+            catch (Exception)
+            {
+                _systemState = SoundSystemState.FailedToInitialized;
+                throw;
+            }
         }
 
         #endregion
@@ -104,6 +151,10 @@ namespace Microsoft.Xna.Framework.Audio
         /// <remarks>This only supports uncompressed 16bit PCM wav data.</remarks>
         public SoundEffect(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
         {
+            Initialize();
+            if (_systemState != SoundSystemState.Initialized)
+                return;
+
             if (sampleRate < 8000 || sampleRate > 48000)
                 throw new ArgumentOutOfRangeException("sampleRate");
             if ((int)channels != 1 && (int)channels != 2)

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// </summary>
         internal void InitializeSound()
         {
-            controller = OpenALSoundController.GetInstance;
+            controller = OpenALSoundController.Instance;
         }
 
 #endregion // Initialization
@@ -174,7 +174,7 @@ namespace Microsoft.Xna.Framework.Audio
 
                 // Reset the SendFilter to 0 if we are NOT using reverb since 
                 // sources are recycled
-                if (OpenALSoundController.GetInstance.SupportsEfx)
+                if (OpenALSoundController.Instance.SupportsEfx)
                 {
                     OpenALSoundController.Efx.BindSourceToAuxiliarySlot(SourceId, 0, 0, 0);
                     ALHelper.CheckError("Failed to unset reverb.");

--- a/MonoGame.Framework/FrameworkDispatcher.cs
+++ b/MonoGame.Framework/FrameworkDispatcher.cs
@@ -38,9 +38,6 @@ namespace Microsoft.Xna.Framework
 
         private static void Initialize()
         {
-            // Initialize sound system
-            SoundEffect.InitializeSoundEffect();
-
             _initialized = true;
         }
     }

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -140,7 +140,8 @@ namespace Microsoft.Xna.Framework
 
                     ContentTypeReaderManager.ClearTypeCreators();
 
-                    SoundEffect.PlatformShutdown();
+                    if (SoundEffect._systemState == SoundEffect.SoundSystemState.Initialized)
+                        SoundEffect.PlatformShutdown();
                 }
 #if ANDROID
                 Activity = null;

--- a/MonoGame.Framework/Media/Song.NVorbis.cs
+++ b/MonoGame.Framework/Media/Song.NVorbis.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Xna.Framework.Media
 
         private void PlatformInitialize(string fileName)
         {
+            // init OpenAL if need be
+            var inst = OpenALSoundController.GetInstance;
+
             stream = new OggStream(fileName, OnFinishedPlaying);
             stream.Prepare();
 

--- a/MonoGame.Framework/Media/Song.NVorbis.cs
+++ b/MonoGame.Framework/Media/Song.NVorbis.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Xna.Framework.Media
         private void PlatformInitialize(string fileName)
         {
             // init OpenAL if need be
-            var inst = OpenALSoundController.GetInstance;
+            OpenALSoundController.EnsureInitialized();
 
             stream = new OggStream(fileName, OnFinishedPlaying);
             stream.Prepare();

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Runtime.InteropServices;
-using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using MonoGame.Utilities;
@@ -22,7 +21,6 @@ namespace Microsoft.Xna.Framework
         }
 
         private readonly Game _game;
-        private readonly OpenALSoundController _soundControllerInstance;
         private readonly List<Keys> _keys;
 
         private int _isExiting;
@@ -62,15 +60,6 @@ namespace Microsoft.Xna.Framework
 
             GamePad.InitDatabase();
             Window = _view = new SdlGameWindow(_game);
-
-            try
-            {
-                _soundControllerInstance = OpenALSoundController.GetInstance;
-            }
-            catch (DllNotFoundException ex)
-            {
-                throw (new NoAudioHardwareException("Failed to init OpenALSoundController", ex));
-            }
         }
 
         public override void BeforeInitialize ()

--- a/MonoGame.Framework/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/iOS/iOSGamePlatform.cs
@@ -95,16 +95,6 @@ namespace Microsoft.Xna.Framework
             base(game)
         {
             game.Services.AddService(typeof(iOSGamePlatform), this);
-			
-			// Setup our OpenALSoundController to handle our SoundBuffer pools
-            try
-            {
-                OpenALSoundController soundControllerInstance = OpenALSoundController.GetInstance;
-            }
-            catch (DllNotFoundException ex)
-            {
-                throw (new NoAudioHardwareException("Failed to init OpenALSoundController", ex));
-            }
 
             //This also runs the TitleContainer static constructor, ensuring it is done on the main thread
             Directory.SetCurrentDirectory(TitleContainer.Location);


### PR DESCRIPTION
Hey there,

This PR should make ```Microsoft.Xna.Framework.Media``` and ```Microsoft.Xna.Framework.Audio``` optional so that no sound system is initialized if none of those namespace are used. This should make MonoGame friendly to third party sound engine like FMOD or Wwise.

It addresses:
- #6515 exception types are now consistent (it's either ```DllNotFoundException``` or ```NoAudioHardwareException```)
- #6107 if no ```SoundEffect``` ```Song``` ```MediaPlayer``` ```Microphone``` or ```DynamicSoundEffectInstance``` are used, OpenAL won't get loaded and the dll can be removed from release packages
- #4717 this error can now be caught through ```SoundEffect.Initialize()``` and developers can make it so it is not fatal

As suggested previously, sound engine initialization is now done whenever ```SoundEffect``` ```Song``` ```MediaPlayer``` ```Microphone``` or ```DynamicSoundEffectInstance``` are constructed.
It is however possible to manually initialize the ```SoundEffect``` API by calling ```SoundEffect.Initialize()```. This allows developers to get any initialization errors and act accordingly (e.g. disabling sound, or make it fatal).

Fixes #6515 #6107 #4717

@Jjagg @cra0zy 
@tomspilman if this goes through, I'll try to get the console repos' compliant.