### PR TITLE
Added a garbageless GetPressedKeys overload

### DIFF
--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xna.Framework.Input
     /// <summary>
     /// Holds the state of keystrokes by a keyboard.
     /// </summary>
-	public struct KeyboardState : IEnumerable<Keys>
+	public struct KeyboardState
     {
         // Used for the common situation where GetPressedKeys will return an empty array
         static Keys[] empty = new Keys[0];
@@ -283,120 +283,6 @@ namespace Microsoft.Xna.Framework.Input
             if (keys5 != 0 && index < keys.Length) index = AddKeysToArray(keys5, 5 * 32, keys, index);
             if (keys6 != 0 && index < keys.Length) index = AddKeysToArray(keys6, 6 * 32, keys, index);
             if (keys7 != 0 && index < keys.Length) index = AddKeysToArray(keys7, 7 * 32, keys, index);
-        }
-
-        /// <summary>
-        /// Returns an enumerator of the pressed keys in the <see cref="KeyboardState"/>.
-        /// </summary>
-        /// <returns>An enumerable set of <see cref="Keys"/>.</returns>
-        public Enumerator GetEnumerator()
-        {
-            return new Enumerator(this);
-        }
-
-        /// <summary>
-        /// Returns an enumerator of the pressed keys in the <see cref="KeyboardState"/>.
-        /// </summary>
-        /// <returns>An enumerable set of <see cref="Keys"/>.</returns>
-        IEnumerator<Keys> IEnumerable<Keys>.GetEnumerator()
-        {
-            return new Enumerator(this);
-        }
-
-        /// <summary>
-        /// Returns an enumerator of the pressed keys in the <see cref="KeyboardState"/>.
-        /// </summary>
-        /// <returns>An enumerable set of objects.</returns>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return new Enumerator(this);
-        }
-
-        #endregion
-
-        #region Enumerator
-
-        /// <summary>
-        /// Allows iterating through the pressed keys in a <see cref="KeyboardState"/>.
-        /// </summary>
-        public struct Enumerator : IEnumerator<Keys>
-        {
-            private readonly KeyboardState _kbState;
-            private Keys _curKey;
-            private uint _curKeyset;
-            private int _curIndex;
-            private int _keysetNum;
-
-            public Enumerator(KeyboardState kbState)
-            {
-                _kbState = kbState;
-                _curKeyset = kbState.keys0;
-                _keysetNum = 0;
-                _curKey = Keys.None;
-                _curIndex = 0;
-            }
-
-            public Keys Current
-            {
-                get
-                {
-                    if (_keysetNum == 0 && _curIndex == 0) throw new System.Exception("Enumerator has not started yet!");
-                    if (_keysetNum >= 8) throw new System.Exception("Enumerator is already done enumerating!");
-
-                    return _curKey;
-                }
-            }
-
-            object IEnumerator.Current
-            {
-                get { return Current; }
-            }
-
-            public void Dispose()
-            {
-                
-            }
-
-            public bool MoveNext()
-            {
-                while (_keysetNum < 8)
-                {
-                    for (; _curIndex < 32; _curIndex++)
-                    {
-                        if ((_curKeyset & (1 << _curIndex)) != 0)
-                        {
-                            _curKey = (Keys)((_keysetNum * 32) + _curIndex);
-                            _curIndex++;
-                            return true;
-                        }
-                    }
-
-                    _curIndex = 0;
-                    _keysetNum++;
-
-                    switch(_keysetNum)
-                    {
-                        case 0: _curKeyset = _kbState.keys0; break;
-                        case 1: _curKeyset = _kbState.keys1; break;
-                        case 2: _curKeyset = _kbState.keys2; break;
-                        case 3: _curKeyset = _kbState.keys3; break;
-                        case 4: _curKeyset = _kbState.keys4; break;
-                        case 5: _curKeyset = _kbState.keys5; break;
-                        case 6: _curKeyset = _kbState.keys6; break;
-                        case 7: _curKeyset = _kbState.keys7; break;
-                    }
-                }
-                
-                return false;
-            }
-
-            public void Reset()
-            {
-                _curKey = Keys.None;
-                _curKeyset = _kbState.keys0;
-                _keysetNum = 0;
-                _curIndex = 0;
-            }
         }
 
         #endregion

--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -201,6 +201,17 @@ namespace Microsoft.Xna.Framework.Input
 
         #region GetPressedKeys()
 
+        /// <summary>
+        /// Returns the number of pressed keys in this <see cref="KeyboardState"/>.
+        /// </summary>
+        /// <returns>An integer representing the number of keys currently pressed in this <see cref="KeyboardState"/>.</returns>
+        public int GetPressedKeyCount()
+        {
+            uint count = CountBits(keys0) + CountBits(keys1) + CountBits(keys2) + CountBits(keys3)
+                    + CountBits(keys4) + CountBits(keys5) + CountBits(keys6) + CountBits(keys7);
+            return (int)count;
+        }
+
         private static uint CountBits(uint v)
         {
             // http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
@@ -287,7 +298,7 @@ namespace Microsoft.Xna.Framework.Input
         #endregion
 
 
-        #region Objet and Equality
+        #region Object and Equality
 
         /// <summary>
         /// Gets the hash code for <see cref="KeyboardState"/> instance.

--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <summary>
         /// Fills an array of values holding keys that are currently being pressed, returning how many elements were filled.
         /// </summary>
-        /// <param name="keys">The keys array to fill. It will fill as much as array holds.</param>
+        /// <param name="keys">The keys array to fill. This array is not cleared.</param>
         /// <returns>The number of keys filled into the array.</returns>
         public int GetPressedKeys(Keys[] keys)
         {

--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -219,6 +219,18 @@ namespace Microsoft.Xna.Framework.Input
             return index;
         }
 
+        private static int AddKeysToArrayConstrained(uint keys, int offset, Keys[] pressedKeys, int index)
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                if (index >= pressedKeys.Length) break;
+
+                if ((keys & (1 << i)) != 0)
+                    pressedKeys[index++] = (Keys)(offset + i);
+            }
+            return index;
+        }
+
         /// <summary>
         /// Returns an array of values holding keys that are currently being pressed.
         /// </summary>
@@ -242,6 +254,34 @@ namespace Microsoft.Xna.Framework.Input
             if (keys7 != 0) index = AddKeysToArray(keys7, 7 * 32, keys, index);
 
             return keys;
+        }
+
+        /// <summary>
+        /// Fills an array of values holding keys that are currently being pressed, returning how many elements were filled.
+        /// </summary>
+        /// <param name="keys">The keys array to fill. It will fill as much as array holds.</param>
+        /// <returns>The number of keys filled into the array.</returns>
+        public int GetPressedKeys(Keys[] keys)
+        {
+            if (keys == null)
+                throw new System.ArgumentNullException(nameof(keys));
+
+            uint count = CountBits(keys0) + CountBits(keys1) + CountBits(keys2) + CountBits(keys3)
+                    + CountBits(keys4) + CountBits(keys5) + CountBits(keys6) + CountBits(keys7);
+            if (count == 0)
+                return 0;
+
+            int index = 0;
+            if (keys0 != 0 && index < keys.Length) index = AddKeysToArrayConstrained(keys0, 0 * 32, keys, index);
+            if (keys1 != 0 && index < keys.Length) index = AddKeysToArrayConstrained(keys1, 1 * 32, keys, index);
+            if (keys2 != 0 && index < keys.Length) index = AddKeysToArrayConstrained(keys2, 2 * 32, keys, index);
+            if (keys3 != 0 && index < keys.Length) index = AddKeysToArrayConstrained(keys3, 3 * 32, keys, index);
+            if (keys4 != 0 && index < keys.Length) index = AddKeysToArrayConstrained(keys4, 4 * 32, keys, index);
+            if (keys5 != 0 && index < keys.Length) index = AddKeysToArrayConstrained(keys5, 5 * 32, keys, index);
+            if (keys6 != 0 && index < keys.Length) index = AddKeysToArrayConstrained(keys6, 6 * 32, keys, index);
+            if (keys7 != 0 && index < keys.Length) index = AddKeysToArrayConstrained(keys7, 7 * 32, keys, index);
+
+            return index;
         }
 
         #endregion

--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -366,6 +366,7 @@ namespace Microsoft.Xna.Framework.Input
                         if ((_curKeyset & (1 << _curIndex)) != 0)
                         {
                             _curKey = (Keys)((_keysetNum * 32) + _curIndex);
+                            _curIndex++;
                             return true;
                         }
                     }

--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Xna.Framework.Input
         public int GetPressedKeys(Keys[] keys)
         {
             if (keys == null)
-                throw new System.ArgumentNullException(nameof(keys));
+                throw new System.ArgumentNullException("keys");
 
             uint count = CountBits(keys0) + CountBits(keys1) + CountBits(keys2) + CountBits(keys3)
                     + CountBits(keys4) + CountBits(keys5) + CountBits(keys6) + CountBits(keys7);

--- a/Test/Framework/Input/KeyboardTest.cs
+++ b/Test/Framework/Input/KeyboardTest.cs
@@ -59,14 +59,6 @@ namespace MonoGame.Tests.Input
         }
 
         [TestCase(new[] { Keys.Up, Keys.A, Keys.Left, Keys.Oem8, Keys.Apps })]
-        public void TestPressedKeysEnumerator(Keys[] keys)
-        {
-            var state = new KeyboardState(keys);
-
-            CollectionAssert.AreEquivalent(state.GetPressedKeys(), state);
-        }
-
-        [TestCase(new[] { Keys.Up, Keys.A, Keys.Left, Keys.Oem8, Keys.Apps })]
         public void TestGetPressedKeysGarbageless(Keys[] keys)
         {
             var state = new KeyboardState(keys);

--- a/Test/Framework/Input/KeyboardTest.cs
+++ b/Test/Framework/Input/KeyboardTest.cs
@@ -57,5 +57,28 @@ namespace MonoGame.Tests.Input
         {
             Keyboard.GetState();
         }
+
+        [TestCase(new[] { Keys.Up, Keys.A, Keys.Left, Keys.Oem8, Keys.Apps })]
+        public void TestPressedKeysEnumerator(Keys[] keys)
+        {
+            var state = new KeyboardState(keys);
+
+            CollectionAssert.AreEquivalent(state.GetPressedKeys(), state);
+        }
+
+        [TestCase(new[] { Keys.Up, Keys.A, Keys.Left, Keys.Oem8, Keys.Apps })]
+        public void TestGetPressedKeysGarbageless(Keys[] keys)
+        {
+            var state = new KeyboardState(keys);
+
+            int count = state.GetPressedKeyCount();
+            Assert.AreEqual(keys.Length, count);
+
+            Keys[] newKeysArray = new Keys[count];
+
+            state.GetPressedKeys(newKeysArray);
+
+            CollectionAssert.AreEquivalent(keys, newKeysArray);
+        }
     }
 }


### PR DESCRIPTION
This PR adds an overload to `KeyboardState.GetPressedKeys` that takes in an array of keys to fill. It will fill as many as the array holds and return an `int` saying how many elements it filled in the array.

Relevant issue: #6602