### PR TITLE
[Android] Fixed support to XBox One Wireless gamepad.

### DIFF
--- a/MonoGame.Framework/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Input/GamePad.Android.cs
@@ -258,8 +258,17 @@ namespace Microsoft.Xna.Framework.Input
 
             gamePad._leftStick = new Vector2(e.GetAxisValue(Axis.X), -e.GetAxisValue(Axis.Y));
             gamePad._rightStick = new Vector2(e.GetAxisValue(Axis.Z), -e.GetAxisValue(Axis.Rz));
-            gamePad._leftTrigger = e.GetAxisValue(Axis.Ltrigger);
-            gamePad._rightTrigger = e.GetAxisValue(Axis.Rtrigger);
+
+            if (e.Device.Name == "Xbox Wireless Controller")
+            {
+                gamePad._leftTrigger = e.GetAxisValue(Axis.Brake);
+                gamePad._rightTrigger = e.GetAxisValue(Axis.Gas);
+            }
+            else
+            {
+                gamePad._leftTrigger = e.GetAxisValue(Axis.Ltrigger);
+                gamePad._rightTrigger = e.GetAxisValue(Axis.Rtrigger);
+            }
 
             if(!gamePad.DPadButtons)
             {

--- a/MonoGame.Framework/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Input/GamePad.Android.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
 using Android.Views;
 
 namespace Microsoft.Xna.Framework.Input
@@ -20,6 +21,16 @@ namespace Microsoft.Xna.Framework.Input
 
         public readonly GamePadCapabilities _capabilities;
 
+        public bool _hasCustomMapping = false;
+
+        public Axis _leftStickXCustomAxis = Axis.X;
+        public Axis _leftStickYCustomAxis = Axis.Y;
+        public Axis _rightStickXCustomAxis = Axis.Z;
+        public Axis _rightStickYCustomAxis = Axis.Rz;
+
+        public Axis _leftTriggerCustomAxis = Axis.Ltrigger;
+        public Axis _rightTriggerCustomAxis = Axis.Rtrigger;
+
         public AndroidGamePad(InputDevice device)
         {
             _device = device;
@@ -27,6 +38,12 @@ namespace Microsoft.Xna.Framework.Input
             _descriptor = device.Descriptor;
             _isConnected = true;
 
+            if (device.Name == "Xbox Wireless Controller")
+            {
+                _hasCustomMapping = true;
+                _leftTriggerCustomAxis = Axis.Brake;
+                _rightTriggerCustomAxis = Axis.Gas;
+            }
             _capabilities = CapabilitiesOfDevice(device);
         }
 
@@ -91,6 +108,50 @@ namespace Microsoft.Xna.Framework.Input
             capabilities.HasBackButton = hasMap[15];
 
             return capabilities;
+        }
+
+        internal void ProcessMotionEvent(MotionEvent e)
+        {
+            _leftStick = new Vector2(e.GetAxisValue(_leftStickXCustomAxis), -e.GetAxisValue(_leftStickYCustomAxis));
+            _rightStick = new Vector2(e.GetAxisValue(_rightStickXCustomAxis), -e.GetAxisValue(_rightStickYCustomAxis));
+
+            _leftTrigger = e.GetAxisValue(_leftTriggerCustomAxis);
+            _rightTrigger = e.GetAxisValue(_rightTriggerCustomAxis);
+
+            if (!DPadButtons)
+            {
+                if (e.GetAxisValue(Axis.HatX) < 0)
+                {
+                    _buttons |= Buttons.DPadLeft;
+                    _buttons &= ~Buttons.DPadRight;
+                }
+                else if (e.GetAxisValue(Axis.HatX) > 0)
+                {
+                    _buttons &= ~Buttons.DPadLeft;
+                    _buttons |= Buttons.DPadRight;
+                }
+                else
+                {
+                    _buttons &= ~Buttons.DPadLeft;
+                    _buttons &= ~Buttons.DPadRight;
+                }
+
+                if (e.GetAxisValue(Axis.HatY) < 0)
+                {
+                    _buttons |= Buttons.DPadUp;
+                    _buttons &= ~Buttons.DPadDown;
+                }
+                else if (e.GetAxisValue(Axis.HatY) > 0)
+                {
+                    _buttons &= ~Buttons.DPadUp;
+                    _buttons |= Buttons.DPadDown;
+                }
+                else
+                {
+                    _buttons &= ~Buttons.DPadUp;
+                    _buttons &= ~Buttons.DPadDown;
+                }
+            }
         }
     }
 
@@ -256,52 +317,51 @@ namespace Microsoft.Xna.Framework.Input
             if (e.Action != MotionEventActions.Move)
                 return false;
 
-            gamePad._leftStick = new Vector2(e.GetAxisValue(Axis.X), -e.GetAxisValue(Axis.Y));
-            gamePad._rightStick = new Vector2(e.GetAxisValue(Axis.Z), -e.GetAxisValue(Axis.Rz));
-
-            if (e.Device.Name == "Xbox Wireless Controller")
+            if (gamePad._hasCustomMapping)
             {
-                gamePad._leftTrigger = e.GetAxisValue(Axis.Brake);
-                gamePad._rightTrigger = e.GetAxisValue(Axis.Gas);
+                gamePad.ProcessMotionEvent(e);
             }
             else
             {
+                gamePad._leftStick = new Vector2(e.GetAxisValue(Axis.X), -e.GetAxisValue(Axis.Y));
+                gamePad._rightStick = new Vector2(e.GetAxisValue(Axis.Z), -e.GetAxisValue(Axis.Rz));
+
                 gamePad._leftTrigger = e.GetAxisValue(Axis.Ltrigger);
                 gamePad._rightTrigger = e.GetAxisValue(Axis.Rtrigger);
-            }
 
-            if(!gamePad.DPadButtons)
-            {
-                if(e.GetAxisValue(Axis.HatX) < 0)
+                if (!gamePad.DPadButtons)
                 {
-                    gamePad._buttons |= Buttons.DPadLeft;
-                    gamePad._buttons &= ~Buttons.DPadRight;
-                }
-                else if(e.GetAxisValue(Axis.HatX) > 0)
-                {
-                    gamePad._buttons &= ~Buttons.DPadLeft;
-                    gamePad._buttons |= Buttons.DPadRight;
-                }
-                else
-                {
-                    gamePad._buttons &= ~Buttons.DPadLeft;
-                    gamePad._buttons &= ~Buttons.DPadRight;
-                }
+                    if (e.GetAxisValue(Axis.HatX) < 0)
+                    {
+                        gamePad._buttons |= Buttons.DPadLeft;
+                        gamePad._buttons &= ~Buttons.DPadRight;
+                    }
+                    else if (e.GetAxisValue(Axis.HatX) > 0)
+                    {
+                        gamePad._buttons &= ~Buttons.DPadLeft;
+                        gamePad._buttons |= Buttons.DPadRight;
+                    }
+                    else
+                    {
+                        gamePad._buttons &= ~Buttons.DPadLeft;
+                        gamePad._buttons &= ~Buttons.DPadRight;
+                    }
 
-                if(e.GetAxisValue(Axis.HatY) < 0)
-                {
-                    gamePad._buttons |= Buttons.DPadUp;
-                    gamePad._buttons &= ~Buttons.DPadDown;
-                }
-                else if(e.GetAxisValue(Axis.HatY) > 0)
-                {
-                    gamePad._buttons &= ~Buttons.DPadUp;
-                    gamePad._buttons |= Buttons.DPadDown;
-                }
-                else
-                {
-                    gamePad._buttons &= ~Buttons.DPadUp;
-                    gamePad._buttons &= ~Buttons.DPadDown;
+                    if (e.GetAxisValue(Axis.HatY) < 0)
+                    {
+                        gamePad._buttons |= Buttons.DPadUp;
+                        gamePad._buttons &= ~Buttons.DPadDown;
+                    }
+                    else if (e.GetAxisValue(Axis.HatY) > 0)
+                    {
+                        gamePad._buttons &= ~Buttons.DPadUp;
+                        gamePad._buttons |= Buttons.DPadDown;
+                    }
+                    else
+                    {
+                        gamePad._buttons &= ~Buttons.DPadUp;
+                        gamePad._buttons &= ~Buttons.DPadDown;
+                    }
                 }
             }
 

--- a/MonoGame.Framework/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Input/GamePad.Android.cs
@@ -23,13 +23,16 @@ namespace Microsoft.Xna.Framework.Input
 
         public bool _hasCustomMapping = false;
 
-        public Axis _leftStickXCustomAxis = Axis.X;
-        public Axis _leftStickYCustomAxis = Axis.Y;
-        public Axis _rightStickXCustomAxis = Axis.Z;
-        public Axis _rightStickYCustomAxis = Axis.Rz;
+        Axis _leftStickXCustomAxis = Axis.X;
+        Axis _leftStickYCustomAxis = Axis.Y;
+        Axis _rightStickXCustomAxis = Axis.Z;
+        Axis _rightStickYCustomAxis = Axis.Rz;
 
-        public Axis _leftTriggerCustomAxis = Axis.Ltrigger;
-        public Axis _rightTriggerCustomAxis = Axis.Rtrigger;
+        Axis _leftTriggerCustomAxis = Axis.Ltrigger;
+        Axis _rightTriggerCustomAxis = Axis.Rtrigger;
+
+        Axis _dPadXCustomAxis = Axis.HatX;
+        Axis _dPadYCustomAxis = Axis.HatY;
 
         public AndroidGamePad(InputDevice device)
         {
@@ -120,12 +123,12 @@ namespace Microsoft.Xna.Framework.Input
 
             if (!DPadButtons)
             {
-                if (e.GetAxisValue(Axis.HatX) < 0)
+                if (e.GetAxisValue(_dPadXCustomAxis) < 0)
                 {
                     _buttons |= Buttons.DPadLeft;
                     _buttons &= ~Buttons.DPadRight;
                 }
-                else if (e.GetAxisValue(Axis.HatX) > 0)
+                else if (e.GetAxisValue(_dPadXCustomAxis) > 0)
                 {
                     _buttons &= ~Buttons.DPadLeft;
                     _buttons |= Buttons.DPadRight;
@@ -136,12 +139,12 @@ namespace Microsoft.Xna.Framework.Input
                     _buttons &= ~Buttons.DPadRight;
                 }
 
-                if (e.GetAxisValue(Axis.HatY) < 0)
+                if (e.GetAxisValue(_dPadYCustomAxis) < 0)
                 {
                     _buttons |= Buttons.DPadUp;
                     _buttons &= ~Buttons.DPadDown;
                 }
-                else if (e.GetAxisValue(Axis.HatY) > 0)
+                else if (e.GetAxisValue(_dPadYCustomAxis) > 0)
                 {
                     _buttons &= ~Buttons.DPadUp;
                     _buttons |= Buttons.DPadDown;
@@ -320,48 +323,47 @@ namespace Microsoft.Xna.Framework.Input
             if (gamePad._hasCustomMapping)
             {
                 gamePad.ProcessMotionEvent(e);
+                return true;
             }
-            else
+
+            gamePad._leftStick = new Vector2(e.GetAxisValue(Axis.X), -e.GetAxisValue(Axis.Y));
+            gamePad._rightStick = new Vector2(e.GetAxisValue(Axis.Z), -e.GetAxisValue(Axis.Rz));
+
+            gamePad._leftTrigger = e.GetAxisValue(Axis.Ltrigger);
+            gamePad._rightTrigger = e.GetAxisValue(Axis.Rtrigger);
+
+            if (!gamePad.DPadButtons)
             {
-                gamePad._leftStick = new Vector2(e.GetAxisValue(Axis.X), -e.GetAxisValue(Axis.Y));
-                gamePad._rightStick = new Vector2(e.GetAxisValue(Axis.Z), -e.GetAxisValue(Axis.Rz));
-
-                gamePad._leftTrigger = e.GetAxisValue(Axis.Ltrigger);
-                gamePad._rightTrigger = e.GetAxisValue(Axis.Rtrigger);
-
-                if (!gamePad.DPadButtons)
+                if (e.GetAxisValue(Axis.HatX) < 0)
                 {
-                    if (e.GetAxisValue(Axis.HatX) < 0)
-                    {
-                        gamePad._buttons |= Buttons.DPadLeft;
-                        gamePad._buttons &= ~Buttons.DPadRight;
-                    }
-                    else if (e.GetAxisValue(Axis.HatX) > 0)
-                    {
-                        gamePad._buttons &= ~Buttons.DPadLeft;
-                        gamePad._buttons |= Buttons.DPadRight;
-                    }
-                    else
-                    {
-                        gamePad._buttons &= ~Buttons.DPadLeft;
-                        gamePad._buttons &= ~Buttons.DPadRight;
-                    }
+                    gamePad._buttons |= Buttons.DPadLeft;
+                    gamePad._buttons &= ~Buttons.DPadRight;
+                }
+                else if (e.GetAxisValue(Axis.HatX) > 0)
+                {
+                    gamePad._buttons &= ~Buttons.DPadLeft;
+                    gamePad._buttons |= Buttons.DPadRight;
+                }
+                else
+                {
+                    gamePad._buttons &= ~Buttons.DPadLeft;
+                    gamePad._buttons &= ~Buttons.DPadRight;
+                }
 
-                    if (e.GetAxisValue(Axis.HatY) < 0)
-                    {
-                        gamePad._buttons |= Buttons.DPadUp;
-                        gamePad._buttons &= ~Buttons.DPadDown;
-                    }
-                    else if (e.GetAxisValue(Axis.HatY) > 0)
-                    {
-                        gamePad._buttons &= ~Buttons.DPadUp;
-                        gamePad._buttons |= Buttons.DPadDown;
-                    }
-                    else
-                    {
-                        gamePad._buttons &= ~Buttons.DPadUp;
-                        gamePad._buttons &= ~Buttons.DPadDown;
-                    }
+                if (e.GetAxisValue(Axis.HatY) < 0)
+                {
+                    gamePad._buttons |= Buttons.DPadUp;
+                    gamePad._buttons &= ~Buttons.DPadDown;
+                }
+                else if (e.GetAxisValue(Axis.HatY) > 0)
+                {
+                    gamePad._buttons &= ~Buttons.DPadUp;
+                    gamePad._buttons |= Buttons.DPadDown;
+                }
+                else
+                {
+                    gamePad._buttons &= ~Buttons.DPadUp;
+                    gamePad._buttons &= ~Buttons.DPadDown;
                 }
             }
 


### PR DESCRIPTION
Solves issue : https://github.com/MonoGame/MonoGame/issues/6646
Fixed support to XBox One Wireless gamepad. Triggers are now connected to the Gas and Brake axes as required.

(cherry picked from commit 77ca5b3156514905e7f75a9a1c04b0f1d5712588)