### PR TITLE
Removes finalizers from multiple classes

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/VideoContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/VideoContent.cs
@@ -110,7 +110,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/MonoGame.Framework.Content.Pipeline/VideoContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/VideoContent.cs
@@ -102,12 +102,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                         break;
                 }
             }
-        }
-
-        ~VideoContent()
-        {
-            Dispose(false);
-        }
+        }        
 
         /// <summary>
         /// Immediately releases the unmanaged resources used by this object.

--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -103,15 +103,6 @@ namespace Microsoft.Xna.Framework.Audio
             PlatformInitialize(buffer, sampleRate, channels);
         }
 
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="Microsoft.Xna.Framework.Audio.SoundEffectInstance"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~SoundEffectInstance()
-        {
-            Dispose(false);
-        }
-
         /// <summary>Applies 3D positioning to the SoundEffectInstance using a single listener.</summary>
         /// <param name="listener">Data about the listener.</param>
         /// <param name="emitter">Data about the source of emission.</param>

--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -180,7 +180,6 @@ namespace Microsoft.Xna.Framework.Audio
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Audio/Xact/AudioEngine.cs
+++ b/MonoGame.Framework/Audio/Xact/AudioEngine.cs
@@ -381,11 +381,6 @@ namespace Microsoft.Xna.Framework.Audio
             GC.SuppressFinalize(this);
         }
 
-        ~AudioEngine()
-        {
-            Dispose(false);
-        }
-
         private void Dispose(bool disposing)
         {
             if (IsDisposed) 

--- a/MonoGame.Framework/Audio/Xact/AudioEngine.cs
+++ b/MonoGame.Framework/Audio/Xact/AudioEngine.cs
@@ -378,7 +378,6 @@ namespace Microsoft.Xna.Framework.Audio
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         private void Dispose(bool disposing)

--- a/MonoGame.Framework/Audio/Xact/SoundBank.cs
+++ b/MonoGame.Framework/Audio/Xact/SoundBank.cs
@@ -332,11 +332,6 @@ namespace Microsoft.Xna.Framework.Audio
             GC.SuppressFinalize(this);
         }
 
-        ~SoundBank()
-        {
-            Dispose(false);
-        }
-
         private void Dispose(bool disposing)
         {
             if (IsDisposed)

--- a/MonoGame.Framework/Audio/Xact/SoundBank.cs
+++ b/MonoGame.Framework/Audio/Xact/SoundBank.cs
@@ -329,7 +329,6 @@ namespace Microsoft.Xna.Framework.Audio
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         private void Dispose(bool disposing)

--- a/MonoGame.Framework/Audio/Xact/WaveBank.cs
+++ b/MonoGame.Framework/Audio/Xact/WaveBank.cs
@@ -393,11 +393,6 @@ namespace Microsoft.Xna.Framework.Audio
             GC.SuppressFinalize(this);
         }
 
-        ~WaveBank()
-        {
-            Dispose(false);
-        }
-
         private void Dispose(bool disposing)
         {
             if (IsDisposed)

--- a/MonoGame.Framework/Audio/Xact/WaveBank.cs
+++ b/MonoGame.Framework/Audio/Xact/WaveBank.cs
@@ -390,7 +390,6 @@ namespace Microsoft.Xna.Framework.Audio
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         private void Dispose(bool disposing)

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -160,9 +160,6 @@ namespace Microsoft.Xna.Framework.Content
 		public void Dispose()
 		{
 			Dispose(true);
-			// Tell the garbage collector not to call the finalizer
-			// since all the cleanup will already be done.
-			GC.SuppressFinalize(this);
             // Once disposed, content manager wont be used again
             RemoveContentManager(this);
 		}

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -132,19 +132,6 @@ namespace Microsoft.Xna.Framework.Content
             }
         }
 
-		// Use C# destructor syntax for finalization code.
-		// This destructor will run only if the Dispose method
-		// does not get called.
-		// It gives your base class the opportunity to finalize.
-		// Do not provide destructors in types derived from this class.
-		~ContentManager()
-		{
-			// Do not re-create Dispose clean-up code here.
-			// Calling Dispose(false) is optimal in terms of
-			// readability and maintainability.
-			Dispose(false);
-		}
-
 		public ContentManager(IServiceProvider serviceProvider)
 		{
 			if (serviceProvider == null)

--- a/MonoGame.Framework/GameComponent.cs
+++ b/MonoGame.Framework/GameComponent.cs
@@ -45,12 +45,7 @@ namespace Microsoft.Xna.Framework
         public GameComponent(Game game)
         {
             this.Game = game;
-        }
-
-        ~GameComponent()
-        {
-            Dispose(false);
-        }
+        }        
 
         public virtual void Initialize() { }
 
@@ -77,7 +72,6 @@ namespace Microsoft.Xna.Framework
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         #region IComparable<GameComponent> Members

--- a/MonoGame.Framework/GamerServices/AchievementCollection.cs
+++ b/MonoGame.Framework/GamerServices/AchievementCollection.cs
@@ -133,7 +133,6 @@ namespace Microsoft.Xna.Framework.GamerServices
 		public void Dispose()
 	    {
             Dispose(true);
-            GC.SuppressFinalize(this);
 		}
 
         protected virtual void Dispose(bool disposing)

--- a/MonoGame.Framework/GamerServices/AchievementCollection.cs
+++ b/MonoGame.Framework/GamerServices/AchievementCollection.cs
@@ -52,11 +52,6 @@ namespace Microsoft.Xna.Framework.GamerServices
 		{
 			innerlist = new List<Achievement>();
 		}
-		
-        ~AchievementCollection()
-        {
-            Dispose(false);
-        }
 
 		#region Properties
 		public int Count

--- a/MonoGame.Framework/GamerServices/FriendCollection.cs
+++ b/MonoGame.Framework/GamerServices/FriendCollection.cs
@@ -52,11 +52,6 @@ namespace Microsoft.Xna.Framework.GamerServices
 		{
 			innerlist = new List<FriendGamer>();
 		}
-		
-        ~FriendCollection()
-        {
-            Dispose(false);
-        }
 
 		#region Properties
 		public int Count

--- a/MonoGame.Framework/GamerServices/FriendCollection.cs
+++ b/MonoGame.Framework/GamerServices/FriendCollection.cs
@@ -137,7 +137,6 @@ namespace Microsoft.Xna.Framework.GamerServices
 		public void Dispose()
 	    {
             Dispose(true);
-            GC.SuppressFinalize(this);
 		}
 		
         protected virtual void Dispose(bool disposing)

--- a/MonoGame.Framework/GamerServices/GamerProfile.cs
+++ b/MonoGame.Framework/GamerServices/GamerProfile.cs
@@ -49,27 +49,8 @@ using Microsoft.Xna.Framework.Graphics;
 namespace Microsoft.Xna.Framework.GamerServices
 {
 	
-	public sealed class GamerProfile : IDisposable
+	public sealed class GamerProfile
     {
-        ~GamerProfile()
-        {
-            Dispose(false);
-        }
-
-        #region IDisposable implementation
-
-        public void Dispose()
-		{
-            Dispose(true);
-            GC.SuppressFinalize(this);
-		}
-
-        private void Dispose(bool disposing)
-        {
-        }
-
-	    #endregion
-
 	#region Properties
 
         /*

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -517,7 +517,6 @@ namespace Microsoft.Xna.Framework.Graphics
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -273,11 +273,6 @@ namespace Microsoft.Xna.Framework.Graphics
             EffectCache = new Dictionary<int, Effect>();
         }
 
-        ~GraphicsDevice()
-        {
-            Dispose(false);
-        }
-
         internal int GetClampedMultisampleCount(int multiSampleCount)
         {
             if (multiSampleCount > 1)

--- a/MonoGame.Framework/Graphics/Vertices/InputLayoutCache.cs
+++ b/MonoGame.Framework/Graphics/Vertices/InputLayoutCache.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Xna.Framework.Graphics
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -220,7 +220,6 @@ namespace Microsoft.Xna.Framework
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -95,11 +95,6 @@ namespace Microsoft.Xna.Framework
             _game.Services.AddService(typeof(IGraphicsDeviceService), this);
         }
 
-        ~GraphicsDeviceManager()
-        {
-            Dispose(false);
-        }
-
         private void CreateDevice()
         {
             if (_graphicsDevice != null)

--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -64,11 +64,6 @@ namespace Microsoft.Xna.Framework.Media
             PlatformInitialize(fileName);
         }
 
-        ~Song()
-        {
-            Dispose(false);
-        }
-
         internal string FilePath
 		{
 			get { return _name; }

--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -85,7 +85,6 @@ namespace Microsoft.Xna.Framework.Media
 		public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
         
         void Dispose(bool disposing)

--- a/MonoGame.Framework/Media/Video.cs
+++ b/MonoGame.Framework/Media/Video.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Xna.Framework.Media
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         void Dispose(bool disposing)

--- a/MonoGame.Framework/Media/Video.cs
+++ b/MonoGame.Framework/Media/Video.cs
@@ -65,11 +65,6 @@ namespace Microsoft.Xna.Framework.Media
 #endif
         }
 
-        ~Video()
-        {
-            Dispose(false);
-        }
-
         #endregion
 
         #region IDisposable Implementation

--- a/MonoGame.Framework/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.cs
@@ -286,7 +286,6 @@ namespace Microsoft.Xna.Framework.Media
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         private void Dispose(bool disposing)

--- a/MonoGame.Framework/Net/NetworkSession.cs
+++ b/MonoGame.Framework/Net/NetworkSession.cs
@@ -91,11 +91,6 @@ namespace Microsoft.Xna.Framework.Net
 		{
 			activeSessions.Add(this);
 		}
-		
-        ~NetworkSession()
-        {
-            Dispose(false);
-        }
 
 		private NetworkSessionType sessionType;
 		private int maxGamers;

--- a/MonoGame.Framework/Net/NetworkSession.cs
+++ b/MonoGame.Framework/Net/NetworkSession.cs
@@ -224,8 +224,7 @@ namespace Microsoft.Xna.Framework.Net
 
 		public void Dispose ()
 		{
-			this.Dispose(true);
-			GC.SuppressFinalize(this);				
+			this.Dispose(true);			
 		}
 		
 		public void Dispose (bool disposing) 


### PR DESCRIPTION
Discussed [here](https://github.com/MonoGame/MonoGame/issues/6279).

I removed finalizers which can be proven (or guessed with a high probability) to do little to nothing useful. The ones I left intact are the ones that are linked to some magic logic and global state handling. I hope this PR would make the code of this awesome framework more manageable.

At the time of writing the tests for this PR are passing at least as good as original "develop" branch on my local machine (1 error in `Debug` mode, 1 error + 1 failure in `Release` mode).