### PR TITLE
Added selective ContentManager asset unloading

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -471,6 +471,58 @@ namespace Microsoft.Xna.Framework.Content
 		    loadedAssets.Clear();
 		}
 
+        /// <summary>
+        /// Unloads a single asset.
+        /// </summary>
+        /// <param name="assetName">The name of the asset to unload. This cannot be null.</param>
+        public virtual void UnloadAsset(string assetName)
+        {
+            if (string.IsNullOrEmpty(assetName))
+            {
+                throw new ArgumentNullException("assetName");
+            }
+            if (disposed)
+            {
+                throw new ObjectDisposedException("ContentManager");
+            }
+
+            //Check if the asset exists
+            object asset;
+            if (loadedAssets.TryGetValue(assetName, out asset))
+            {
+                //Check if it's disposable and remove it from the disposable list if so
+                var disposable = asset as IDisposable;
+                if (disposable != null)
+                {
+                    disposable.Dispose();
+                    disposableAssets.Remove(disposable);
+                }
+
+                loadedAssets.Remove(assetName);
+            }
+        }
+
+        /// <summary>
+        /// Unloads a set of assets.
+        /// </summary>
+        /// <param name="assetNames">The names of the assets to unload.</param>
+        public virtual void UnloadAssets(IList<string> assetNames)
+        {
+            if (assetNames == null)
+            {
+                throw new ArgumentNullException("assetNames");
+            }
+            if (disposed)
+            {
+                throw new ObjectDisposedException("ContentManager");
+            }
+
+            for (int i = 0; i < assetNames.Count; i++)
+            {
+                UnloadAsset(assetNames[i]);
+            }
+        }
+
 		public string RootDirectory
 		{
 			get


### PR DESCRIPTION
This PR adds two new methods to ContentManager: 

1. `UnloadAsset` - Unloads a single asset and disposes it if it's disposable
2. `UnloadAssets` - Takes in an `IList<string>` of asset names to unload and disposes the associated assets if they're disposable

Relevant issue: https://github.com/MonoGame/MonoGame/issues/6164