### PR TITLE
Reduce garbage from TextInput

### DIFF
--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Xna.Framework {
 		/// </remarks>
 		public event EventHandler<TextInputEventArgs> TextInput;
 
-        public bool IsTextInputHandled { get { return TextInput != null; } }
+        internal bool IsTextInputHandled { get { return TextInput != null; } }
 #endif
 
 		#endregion Events

--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -102,6 +102,8 @@ namespace Microsoft.Xna.Framework {
 		/// This event is only supported on the Windows DirectX, Windows OpenGL and Linux platforms.
 		/// </remarks>
 		public event EventHandler<TextInputEventArgs> TextInput;
+
+        public bool IsTextInputHandled { get { return TextInput != null; } }
 #endif
 
 		#endregion Events


### PR DESCRIPTION
Hey there,

This is a proposal to start addressing #6360.

It removes the string manipulations and decodes each UTF8 characters individually and sends them to the event handler.
It also skips the event processing if there is no event handler attached to ```GameWindow.TextInput```.

This should:
- remove all garbage if ```TextInput``` isn't used when pressing keys (which I believe is the most important fix here)
- greatly reduce garbage when actually using ```TextInput```

There is still some garbage generated from this line when attaching an handler to ```TextInput```:
https://github.com/MonoGame/MonoGame/blob/b1a49e4ae60eaf62169d08c791d4f9a913b495b3/MonoGame.Framework/SDL/SDLGameWindow.cs#L302

We will have to figure out (in another PR?) what to do with event args types.

Also, it should be noted that this PR comes with a limitation (note that the original code also has this limitation): it doesn't support UTF8 characters that are encoded on more than 2 bytes (because ```TextInputEventArgs``` is limited by the ```char``` type). Chinese, Japanese, and Korean won't be supported.

This should be addressed in another PR I guess (at the same time as addressing the event args type?).

Partly fixes #6360