### PR TITLE
Add HKCU traversal for font descriptions

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -226,21 +226,23 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             if (CurrentPlatform.OS == OS.Windows)
             {
                 var fontDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Fonts");
-                var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts", false);
-
-                foreach (var font in key.GetValueNames().OrderBy(x => x))
+                foreach (var key in new RegistryKey[] { Registry.LocalMachine, Registry.CurrentUser })
                 {
-                    if (font.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+                    var subkey = key.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts", false);
+                    foreach (var font in subkey.GetValueNames().OrderBy(x => x))
                     {
-                        var fontPath = key.GetValue(font).ToString();
+                        if (font.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            var fontPath = subkey.GetValue(font).ToString();
 
-                        // The registry value might have trailing NUL characters
-                        // See https://github.com/MonoGame/MonoGame/issues/4061
-                        var nulIndex = fontPath.IndexOf('\0');
-                        if (nulIndex != -1)
-                            fontPath = fontPath.Substring(0, nulIndex);
+                            // The registry value might have trailing NUL characters
+                            // See https://github.com/MonoGame/MonoGame/issues/4061
+                            var nulIndex = fontPath.IndexOf('\0');
+                            if (nulIndex != -1)
+                                fontPath = fontPath.Substring(0, nulIndex);
 
-                        return Path.IsPathRooted(fontPath) ? fontPath : Path.Combine(fontDirectory, fontPath);
+                            return Path.IsPathRooted(fontPath) ? fontPath : Path.Combine(fontDirectory, fontPath);
+                        }
                     }
                 }
             }


### PR DESCRIPTION

This PR makes FontDescriptionProcessor also traverse HKCU if the font isn't found in HKLM

Windows 1809 changed font installation behavior. Now fonts are installed by default in the local user's AppData and subsequently registered in HKCU instead of HKLM. This was made presumably so that non-administrator accounts may install custom fonts:

![New context menu options](https://ds6w2weopglbu.cloudfront.net/storage/02-22/B165A.png)

![Registry](https://ds6w2weopglbu.cloudfront.net/storage/02-22/4D499.png)
