### PR TITLE
Fix for loading native libraries on Amazon Fire HD 8

### DIFF
--- a/MonoGame.Framework/Utilities/FuncLoader.Android.cs
+++ b/MonoGame.Framework/Utilities/FuncLoader.Android.cs
@@ -1,4 +1,6 @@
+using Android.App;
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace MonoGame.Utilities
@@ -15,7 +17,27 @@ namespace MonoGame.Utilities
 
         public static IntPtr LoadLibrary(string libname)
         {
-            return dlopen(libname, RTLD_LAZY);
+            // Let the OS search for the library by default.
+            IntPtr lib = dlopen(libname, RTLD_LAZY);
+            if (lib != IntPtr.Zero)
+            {
+                Console.WriteLine("FuncLoader.LoadLibrary {0}", libname);
+                return lib;
+            }
+
+            // Some Android devices won't search the native library path
+            // for the library, so we have to do it manually here.
+            var nlibpath = Application.Context.ApplicationInfo.NativeLibraryDir;
+            var libpath = Path.Combine(nlibpath, libname);
+            lib = dlopen(libpath, RTLD_LAZY);
+            if (lib != IntPtr.Zero)
+            {	
+                Console.WriteLine("FuncLoader.LoadLibrary {0}", libpath);
+                return lib;
+            }
+
+            Console.WriteLine("FuncLoader.LoadLibrary {0} Not Found!", libname);
+            return IntPtr.Zero;
         }
 
         public static T LoadFunction<T>(IntPtr library, string function, bool throwIfNotFound = false)


### PR DESCRIPTION
This fixes loading native libraries on some Android devices.

In my case the Amazon Fire HD 8 tablet was not loading `libopenal32.so` without this change to explicitly load from the library path.

I also added a little logging to make it easier to spot issues when working from the Android console log.