### PR TITLE
Fix #6676

### DIFF
--- a/Tools/Pipeline/Common/PipelineTypes.cs
+++ b/Tools/Pipeline/Common/PipelineTypes.cs
@@ -166,6 +166,7 @@ namespace MonoGame.Tools.Pipeline
         {
             public ContentProcessorAttribute Attribute;
             public Type Type;
+            public string Path;
         }
 
         private static List<ImporterInfo> _importers;
@@ -305,7 +306,9 @@ namespace MonoGame.Tools.Pipeline
             cur = 0;
             foreach (var item in _processors)
             {
+                _currentAssemblyDirectory = Path.GetDirectoryName(item.Path);
                 var obj = Activator.CreateInstance(item.Type);
+                _currentAssemblyDirectory = null;
                 var typeProperties = item.Type.GetProperties(bindings);
                 var properties = new List<ProcessorTypeDescription.Property>();
                 foreach (var i in typeProperties)
@@ -456,7 +459,7 @@ namespace MonoGame.Tools.Pipeline
                         continue;
 
                     var types = asm.GetTypes();
-                    ProcessTypes(types);
+                    ProcessTypes(types, asm.Location);
                 }
 #if SHIPPING
                 catch (Exception e)
@@ -478,7 +481,7 @@ namespace MonoGame.Tools.Pipeline
 
                     var a = Assembly.Load(File.ReadAllBytes(path));
                     var types = a.GetTypes();
-                    ProcessTypes(types);
+                    ProcessTypes(types, path);
 
                     var watch = new FileSystemWatcher();
                     watch.Path = Path.GetDirectoryName(path);
@@ -509,7 +512,7 @@ namespace MonoGame.Tools.Pipeline
             _currentAssemblyDirectory = null;
         }
 
-        private static void ProcessTypes(IEnumerable<Type> types)
+        private static void ProcessTypes(IEnumerable<Type> types, string path)
         {
             foreach (var t in types)
             {
@@ -539,7 +542,7 @@ namespace MonoGame.Tools.Pipeline
                     if (attributes.Length != 0)
                     {
                         var processorAttribute = attributes[0] as ContentProcessorAttribute;
-                        _processors.Add(new ProcessorInfo { Attribute = processorAttribute, Type = t });
+                        _processors.Add(new ProcessorInfo { Attribute = processorAttribute, Type = t, Path = path });
                     }
                 }
             }

--- a/Tools/Pipeline/Common/PipelineTypes.cs
+++ b/Tools/Pipeline/Common/PipelineTypes.cs
@@ -459,7 +459,7 @@ namespace MonoGame.Tools.Pipeline
                         continue;
 
                     var types = asm.GetTypes();
-                    ProcessTypes(types, asm.Location);
+                    ProcessTypes(types, null);
                 }
 #if SHIPPING
                 catch (Exception e)


### PR DESCRIPTION
See #6676. I noticed that _currentAssemblyDirectory is used explicitly for the CurrentDomain_AssemblyResolve event, but unfortunately that event does not get called until after the current assembly is marked null. I think some recent changes to how the pipeline tool loads assemblies offloaded the resolution of referenced assemblies until one of their processors is constructed through Activator.CreateInstance(...). An issue I see with this going forward is that referenced assemblies will only be loaded correctly if they exist in the same directory as the referencing assembly. If anyone can think of a more robust solution, I'm all ears, but I'm also not super up to date with assembly resolution logic.

I apologize if I performed any steps in the issue creation or pull request process, I haven't really contributed to a repository that is not my own before.