### PR TITLE
Adding capacity parameter to SpriteBatch ctor

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -37,8 +37,9 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Constructs a <see cref="SpriteBatch"/>.
         /// </summary>
         /// <param name="graphicsDevice">The <see cref="GraphicsDevice"/>, which will be used for sprite rendering.</param>
+        /// <param name="capacity">The initial capacity of the internal array holding batch items (the value will be rounded to the next multiple of 64).</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="graphicsDevice"/> is null.</exception>
-        public SpriteBatch (GraphicsDevice graphicsDevice)
+        public SpriteBatch (GraphicsDevice graphicsDevice, int capacity = 0)
 		{
 			if (graphicsDevice == null)
             {
@@ -50,7 +51,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _spriteEffect = new SpriteEffect(graphicsDevice);
             _spritePass = _spriteEffect.CurrentTechnique.Passes[0];
 
-            _batcher = new SpriteBatcher(graphicsDevice);
+            _batcher = new SpriteBatcher(graphicsDevice, capacity);
 
             _beginCalled = false;
 		}

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -54,17 +54,22 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private VertexPositionColorTexture[] _vertexArray;
 
-		public SpriteBatcher (GraphicsDevice device)
+        public SpriteBatcher(GraphicsDevice device, int capacity = 0)
 		{
             _device = device;
 
-			_batchItemList = new SpriteBatchItem[InitialBatchSize];
+            if (capacity <= 0)
+                capacity = InitialBatchSize;
+            else
+                capacity = (capacity + 63) & (~63); // ensure chunks of 64.
+
+            _batchItemList = new SpriteBatchItem[capacity];
             _batchItemCount = 0;
 
-            for (int i = 0; i < InitialBatchSize; i++)
+            for (int i = 0; i < capacity; i++)
                 _batchItemList[i] = new SpriteBatchItem();
 
-            EnsureArrayCapacity(InitialBatchSize);
+            EnsureArrayCapacity(capacity);
 		}
 
         /// <summary>


### PR DESCRIPTION
Hey there,

I'd like to propose the addition of a parameter to the ```SpriteBatch``` constructor to have a control over its initial batch items capacity. The intention is to give a finer control of the memory allocations and garbage generation to developers (e.g. increasing the batch size right away to avoid any runtime array resizing).

This PR shouldn't break anything and should remain backward compatible.

@Jjagg @cra0zy @tomspilman 