### PR TITLE
Added contextual build option for content pipeline

### DIFF
--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -397,8 +397,13 @@ namespace MonoGame.Tools.Pipeline
                 if (item.OriginalPath.StartsWith(dir.OriginalPath + "/"))
                     yield return item;
         }
-
         public void RebuildItems()
+        {
+            BuildItems(true);
+        }
+
+
+        public void BuildItems(bool rebuild = false)
         {
             var items = new List<IProjectItem>();
 
@@ -440,7 +445,8 @@ namespace MonoGame.Tools.Pipeline
             }
 
             // Run the build the command.
-            var commands = string.Format("/@:\"{0}\" /rebuild /incremental", tempPath);
+            var commands = string.Format("/@:\"{0}\" {1} /incremental", tempPath, rebuild ? "/rebuild" : string.Empty);
+
             if (PipelineSettings.Default.DebugMode)
                 commands += " /launchdebugger";
             BuildCommand(commands);
@@ -1050,6 +1056,9 @@ namespace MonoGame.Tools.Pipeline
             info.Rename = exists && oneselected && !(SelectedItem is PipelineProject);
             info.Delete = exists && info.Exclude;
             info.RebuildItem = exists && somethingselected && !ProjectBuilding;
+            info.BuildItem = exists && somethingselected && !ProjectBuilding;
         }
+
+
     }
 }

--- a/Tools/Pipeline/MainWindow.cs
+++ b/Tools/Pipeline/MainWindow.cs
@@ -409,6 +409,7 @@ namespace MonoGame.Tools.Pipeline
             cmdOpenItemLocation.Enabled = info.OpenItemLocation;
             cmdOpenOutputItemLocation.Enabled = info.OpenOutputItemLocation;
             cmdCopyAssetName.Enabled = info.CopyAssetPath;
+            cmdBuildItem.Enabled = info.BuildItem;
             cmdRebuildItem.Enabled = info.RebuildItem;
 
             // Visibility of menu items can't be changed so 
@@ -426,6 +427,8 @@ namespace MonoGame.Tools.Pipeline
             AddContextMenu(cmOpenItemLocation, ref sep);
             AddContextMenu(cmOpenOutputItemLocation, ref sep);
             AddContextMenu(cmCopyAssetPath, ref sep);
+            AddSeparator(ref sep);
+            AddContextMenu(cmBuildItem, ref sep);
             AddContextMenu(cmRebuildItem, ref sep);
             AddSeparator(ref sep);
             AddContextMenu(cmExclude, ref sep);
@@ -684,6 +687,11 @@ namespace MonoGame.Tools.Pipeline
         private void CmdRebuildItem_Executed(object sender, EventArgs e)
         {
             PipelineController.Instance.RebuildItems();
+        }
+
+        private void CmdBuildItem_Executed(object sender, EventArgs e)
+        {
+            PipelineController.Instance.BuildItems();
         }
 
         #endregion

--- a/Tools/Pipeline/MainWindow.eto.cs
+++ b/Tools/Pipeline/MainWindow.eto.cs
@@ -32,12 +32,12 @@ namespace MonoGame.Tools.Pipeline
         public Command cmdBuild, cmdRebuild, cmdClean, cmdCancelBuild;
         public CheckCommand cmdDebugMode;
         public Command cmdHelp, cmdAbout;
-        public Command cmdOpenItem, cmdOpenItemWith, cmdOpenItemLocation, cmdOpenOutputItemLocation, cmdCopyAssetName, cmdRebuildItem;
+        public Command cmdOpenItem, cmdOpenItemWith, cmdOpenItemLocation, cmdOpenOutputItemLocation, cmdCopyAssetName, cmdRebuildItem, cmdBuildItem;
 
         ToolBar toolbar;
         ButtonMenuItem menuFile, menuRecent, menuEdit, menuAdd, menuView, menuBuild, menuHelp;
         ToolItem toolBuild, toolRebuild, toolClean, toolCancelBuild;
-        MenuItem cmOpenItem, cmOpenItemWith, cmOpenItemLocation, cmOpenOutputItemLocation, cmCopyAssetPath, cmRebuildItem, cmExclude, cmRename, cmDelete;
+        MenuItem cmOpenItem, cmOpenItemWith, cmOpenItemLocation, cmOpenOutputItemLocation, cmCopyAssetPath, cmRebuildItem, cmBuildItem, cmExclude, cmRename, cmDelete;
         ButtonMenuItem cmAdd;
 
         ProjectControl projectControl;
@@ -121,7 +121,9 @@ namespace MonoGame.Tools.Pipeline
             cmdOpenOutputItemLocation.Executed += CmdOpenOutputItemLocation_Executed;
             cmdCopyAssetName.Executed += CmdCopyAssetPath_Executed;
             cmdRebuildItem.Executed += CmdRebuildItem_Executed;
-        }
+            cmdBuildItem.Executed += CmdBuildItem_Executed;
+
+         }
 
         private void InitalizeCommands()
         {
@@ -265,9 +267,15 @@ namespace MonoGame.Tools.Pipeline
             cmdCopyAssetName = new Command();
             cmdCopyAssetName.MenuText = "Copy Asset Name";
 
+            cmdBuildItem = new Command();
+            cmdBuildItem.Image = Global.GetEtoIcon("Commands.Build.png");
+            cmdBuildItem.MenuText = "Build";
+
             cmdRebuildItem = new Command();
             cmdRebuildItem.Image = Global.GetEtoIcon("Commands.Rebuild.png");
             cmdRebuildItem.MenuText = "Rebuild";
+
+
         }
 
         private void InitalizeMenu()
@@ -353,6 +361,7 @@ namespace MonoGame.Tools.Pipeline
             cmOpenOutputItemLocation = cmdOpenOutputItemLocation.CreateMenuItem();
             cmCopyAssetPath = cmdCopyAssetName.CreateMenuItem();
             cmRebuildItem = cmdRebuildItem.CreateMenuItem();
+            cmBuildItem = cmdBuildItem.CreateMenuItem();
             cmExclude = cmdExclude.CreateMenuItem();
             cmRename = cmdRename.CreateMenuItem();
             cmDelete = cmdDelete.CreateMenuItem();


### PR DESCRIPTION
This allows you to build a folder or item without having to rebuild all of it.

When working on fixing content that is failing the pipeline being able to just build a folder rather than rebuild saves a lot of time. 