### PR TITLE
Catch ArgumentException in MGCB Pipeline GUI

### DIFF
--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -499,9 +499,16 @@ namespace MonoGame.Tools.Pipeline
         private void DoBuild(string commands)
         {
             Encoding encoding;
-            try {
+            try
+            { 
                 encoding = Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
-            } catch (NotSupportedException) {
+            }
+            catch (NotSupportedException)
+            {
+                encoding = Encoding.UTF8;
+            }
+            catch (ArgumentException)
+            {
                 encoding = Encoding.UTF8;
             }
             var currentDir = Environment.CurrentDirectory;
@@ -543,7 +550,7 @@ namespace MonoGame.Tools.Pipeline
             // can run after we've already finished.
             lock (_buildTask)
                 _buildProcess = null;
-        }
+            }
 
         public void CancelBuild()
         {


### PR DESCRIPTION
using CurrentCulture "en-SE" yields OEMCodePage 1, which, when passed in to Encoding.GetEncoding on PipelineController.cs ln 504, throws ArgumentException.
This causes all content building via the MGCB GUI to fail silently.

It's not clear to me why this method sometimes generates ArgumentException instead of NotSupportedException, but the docs ( https://docs.microsoft.com/en-us/dotnet/api/system.text.encoding.getencoding?view=netframework-4.7.2 ) recommend catching both.