### PR TITLE
Inline Vector2 operator/ and Point.ToVector2()

### DIFF
--- a/MonoGame.Framework/Point.cs
+++ b/MonoGame.Framework/Point.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -211,6 +212,7 @@ namespace Microsoft.Xna.Framework
         /// Gets a <see cref="Vector2"/> representation for this object.
         /// </summary>
         /// <returns>A <see cref="Vector2"/> representation for this object.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector2 ToVector2()
         {
             return new Vector2(X, Y);

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -204,6 +205,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/> on the left of the div sign.</param>
         /// <param name="value2">Divisor <see cref="Vector2"/> on the right of the div sign.</param>
         /// <returns>The result of dividing the vectors.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 operator /(Vector2 value1, Vector2 value2)
         {
             value1.X /= value2.X;
@@ -217,6 +219,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/> on the left of the div sign.</param>
         /// <param name="divider">Divisor scalar on the right of the div sign.</param>
         /// <returns>The result of dividing a vector by a scalar.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 operator /(Vector2 value1, float divider)
         {
             float factor = 1 / divider;


### PR DESCRIPTION
Using [Inlining Analyzer](https://github.com/szehetner/InliningAnalyzer) on a game it seems that both `Vector2.operator/` and `Point.ToVector2()` fail to inline on .Net Core.
(only `Point.ToVector2()` fails on .Net Framework)

All other operators on these types and `Vector2.ToPoint()` inline fine.

Sticking `[MethodImpl(MethodImplOptions.AggressiveInlining)]` on these fixes the issue for both of them.

Here's a shoddy benchmark table for before and after inlining on Core and CoreRt.
```
|           Method |    Job | Runtime |      Mean |     Error |    StdDev |
|----------------- |------- |-------- |----------:|----------:|----------:|
|       TestVector |   Core |    Core | 36.003 ns | 0.3508 ns | 0.3281 ns |
| TestVectorInline |   Core |    Core | 20.166 ns | 0.3670 ns | 0.3433 ns |
|                  |        |         |           |           |           |
|        TestPoint |   Core |    Core |  6.601 ns | 0.0291 ns | 0.0258 ns |
|  TestPointInline |   Core |    Core |  5.391 ns | 0.0522 ns | 0.0488 ns |
|                  |        |         |           |           |           |
|       TestVector | CoreRT |  CoreRT | 38.954 ns | 0.3712 ns | 0.3472 ns |
| TestVectorInline | CoreRT |  CoreRT | 23.508 ns | 0.2259 ns | 0.2113 ns |
|                  |        |         |           |           |           |
|        TestPoint | CoreRT |  CoreRT | 10.106 ns | 0.1724 ns | 0.1613 ns |
|  TestPointInline | CoreRT |  CoreRT |  9.109 ns | 0.0680 ns | 0.0568 ns |
```

Code used:
```csharp
[Benchmark]
public Vector2 TestVector()
{ 
    var unitX = new Vector2(1.0f, 0.0f);
    var unitY = new Vector2(0.0f, 1.0f);
    unitX = unitX / 1.0f;
    return unitX / unitY;
}

[Benchmark]
public Vector2 TestPoint()
{
    var point = new Point(5, 25);
    return point.ToVector2();
}
```