### PR TITLE
Fix compression in PngWriter

### DIFF
--- a/MonoGame.Framework/Utilities/Png/PngWriter.cs
+++ b/MonoGame.Framework/Utilities/Png/PngWriter.cs
@@ -55,22 +55,17 @@ namespace MonoGame.Utilities.Png
             var encodedPixelData = EncodePixelData(texture2D);
             var compressedPixelData = new MemoryStream();
 
-            try
-            {
-                using (var deflateStream = new ZlibStream(new MemoryStream(encodedPixelData), CompressionMode.Compress))
-                {
-                    deflateStream.CopyTo(compressedPixelData);
-                }
-            }
-            catch (Exception exception)
-            {
-                throw new Exception("An error occurred during DEFLATE compression.", exception);
-            }
-            
+            var deflateStream = new ZlibStream(compressedPixelData, CompressionMode.Compress);
+            deflateStream.Write(encodedPixelData, 0, encodedPixelData.Length);
+            deflateStream.Finish();
+
             var dataChunk = new DataChunk();
             dataChunk.Data = compressedPixelData.ToArray();
             var dataChunkBytes = dataChunk.Encode();
             outputStream.Write(dataChunkBytes, 0, dataChunkBytes.Length);
+
+            deflateStream.Dispose();
+            compressedPixelData.Dispose();
 
             // write end chunk
             var endChunk = new EndChunk();

--- a/MonoGame.Framework/Utilities/Png/PngWriter.cs
+++ b/MonoGame.Framework/Utilities/Png/PngWriter.cs
@@ -55,9 +55,17 @@ namespace MonoGame.Utilities.Png
             var encodedPixelData = EncodePixelData(texture2D);
             var compressedPixelData = new MemoryStream();
 
-            var deflateStream = new ZlibStream(compressedPixelData, CompressionMode.Compress);
-            deflateStream.Write(encodedPixelData, 0, encodedPixelData.Length);
-            deflateStream.Finish();
+            ZlibStream deflateStream = null;
+            try
+            {
+                deflateStream = new ZlibStream(compressedPixelData, CompressionMode.Compress);
+                deflateStream.Write(encodedPixelData, 0, encodedPixelData.Length);
+                deflateStream.Finish();
+            }
+            catch (Exception exception)
+            {
+                throw new Exception("An error occurred during DEFLATE compression.", exception);
+            }
 
             var dataChunk = new DataChunk();
             dataChunk.Data = compressedPixelData.ToArray();

--- a/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
+++ b/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
@@ -540,6 +540,16 @@ namespace MonoGame.Utilities
         }
 
         /// <summary>
+        /// Finish and flush.
+        /// TODO: shouldn't Flush just do this all the time?
+        /// </summary>
+        public void Finish()
+        {
+            _baseStream.Finish();
+            Flush();
+        }
+
+        /// <summary>
         /// Reading this property always throws a <see cref="NotSupportedException"/>.
         /// </summary>
         public override long Length
@@ -1606,7 +1616,7 @@ namespace MonoGame.Utilities
                     : _z.Inflate(_flushMode);
                 if (rc != ZlibConstants.Z_OK && rc != ZlibConstants.Z_STREAM_END)
                     throw new ZlibException((_wantCompress ? "de" : "in") + "flating: " + _z.Message);
-
+                
                 //if (_workingBuffer.Length - _z.AvailableBytesOut > 0)
                 _stream.Write(_workingBuffer, 0, _workingBuffer.Length - _z.AvailableBytesOut);
 
@@ -1622,7 +1632,7 @@ namespace MonoGame.Utilities
 
 
 
-        private void finish()
+        public void Finish()
         {
             if (_z == null) return;
 


### PR DESCRIPTION
See #6703 

Note: this fix is a bit hacky, it exposes an unused private method to force ZlibStream to finish deflating.