### PR TITLE
We are able to type CJK characters in MonoGame now.

### DIFF
--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -89,7 +89,21 @@ namespace Microsoft.Xna.Framework {
 		public event EventHandler<EventArgs> OrientationChanged;
 		public event EventHandler<EventArgs> ScreenDeviceNameChanged;
 
-#if WINDOWS || WINDOWS_UAP || DESKTOPGL|| ANGLE
+        /// <summary>
+        /// Allows input to be entered, the input device will then send text events through the input manager
+        /// </summary>
+        public virtual void EnableTextInput() { }
+
+        /// <summary>
+        /// Disallows text input to be entered, will close any IME active and stop sending text events
+        /// </summary>
+        public virtual void DisableTextInput() { }
+
+        /// <summary>
+        /// Use this function to set the rectangle used to type Unicode text inputs if IME supported.
+        /// In SDL2, this method call gives the OS a hint for where to show the candidate text list, since the OS doesn't know where you want to draw the text you received via SDL_TEXTEDITING event.
+        /// </summary>
+        public virtual void SetTextInputRect(Rectangle rect) { }
 
         /// <summary>
 		/// Use this event to retrieve text for objects like textbox's.
@@ -104,7 +118,6 @@ namespace Microsoft.Xna.Framework {
 		public event EventHandler<TextInputEventArgs> TextInput;
 
         internal bool IsTextInputHandled { get { return TextInput != null; } }
-#endif
 
 		#endregion Events
 
@@ -145,12 +158,10 @@ namespace Microsoft.Xna.Framework {
             EventHelpers.Raise(this, ScreenDeviceNameChanged, EventArgs.Empty);
 		}
 
-#if WINDOWS || WINDOWS_UAP || DESKTOPGL || ANGLE
 		protected void OnTextInput(object sender, TextInputEventArgs e)
 		{
             EventHelpers.Raise(this, TextInput, e);
 		}
-#endif
 
 		protected internal abstract void SetSupportedOrientations (DisplayOrientation orientations);
 		protected abstract void SetTitle (string title);

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -148,6 +148,7 @@ internal static class Sdl
         public GameController.DeviceEvent ControllerDevice;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
     public struct Rectangle
     {
         public int X;
@@ -777,6 +778,18 @@ internal static class Sdl
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate Keymod d_sdl_getmodstate();
         public static d_sdl_getmodstate GetModState = FuncLoader.LoadFunction<d_sdl_getmodstate>(NativeLibrary, "SDL_GetModState");
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void d_sdl_starttextinput();
+        public static d_sdl_starttextinput StartTextInput = FuncLoader.LoadFunction<d_sdl_starttextinput>(NativeLibrary, "SDL_StartTextInput");
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void d_sdl_stoptextinput();
+        public static d_sdl_stoptextinput StopTextInput = FuncLoader.LoadFunction<d_sdl_stoptextinput>(NativeLibrary, "SDL_StopTextInput");
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void d_sdl_settextinputrect(ref Rectangle rect);
+        public static d_sdl_settextinputrect SetTextInputRect = FuncLoader.LoadFunction<d_sdl_settextinputrect>(NativeLibrary, "SDL_SetTextInputRect");
     }
 
     public static class Joystick

--- a/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
@@ -300,6 +300,11 @@ namespace Microsoft.Xna.Framework
             OnClientSizeChanged();
         }
 
+        public void CallTextInput(string text, Keys key = Keys.None)
+        {
+            OnTextInput(this, new TextInputEventArgs() { Key = key, Text = text, Type = TextInputEventType.Input });
+        }
+
         public void CallTextInput(char c, Keys key = Keys.None)
         {
             OnTextInput(this, new TextInputEventArgs(c, key));
@@ -333,6 +338,28 @@ namespace Microsoft.Xna.Framework
                 Sdl.FreeSurface(_icon);
 
             _disposed = true;
+        }
+
+        public override void EnableTextInput()
+        {
+            Sdl.Keyboard.StartTextInput();
+        }
+
+        public override void DisableTextInput()
+        {
+            Sdl.Keyboard.StopTextInput();
+        }
+
+        public override void SetTextInputRect(Rectangle rect)
+        {
+            var sdlRect = new Sdl.Rectangle()
+            {
+                Width = rect.Width,
+                Height = rect.Height,
+                X = rect.X,
+                Y = rect.Y
+            };
+            Sdl.Keyboard.SetTextInputRect(ref sdlRect);
         }
     }
 }

--- a/MonoGame.Framework/Platform/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Platform/Windows/WinFormsGameWindow.cs
@@ -339,7 +339,11 @@ namespace MonoGame.Framework
 
         private void OnKeyPress(object sender, KeyPressEventArgs e)
         {
+            if (!Form.TextInputEnabled)
+                return;
+
             var key = (Keys) (VkKeyScanEx(e.KeyChar, InputLanguage.CurrentInputLanguage.Handle) & 0xff);
+
             OnTextInput(sender, new TextInputEventArgs(e.KeyChar, key));
         }
 
@@ -607,6 +611,21 @@ namespace MonoGame.Framework
 
             if (raiseClientSizeChanged)
                 OnClientSizeChanged();
+        }
+
+        public override void EnableTextInput()
+        {
+            Form.EnableTextInput();
+        }
+
+        public override void DisableTextInput()
+        {
+            Form.DisableTextInput();
+        }
+
+        public void OnTextInput(TextInputEventArgs args)
+        {
+            OnTextInput(this, args);
         }
 
         #endregion

--- a/MonoGame.Framework/TextInputEventArgs.cs
+++ b/MonoGame.Framework/TextInputEventArgs.cs
@@ -7,26 +7,35 @@ using Microsoft.Xna.Framework.Input;
 
 namespace Microsoft.Xna.Framework
 {
+    public enum TextInputEventType
+    {
+        /// <summary>
+        /// When new text is entered
+        /// </summary>
+        Input,
+
+        /// <summary>
+        /// This the current text that has not yet been entered but is still being edited
+        /// </summary>
+        Composition,
+    }
+
     /// <summary>
     /// This class is used for the game window's TextInput event as EventArgs.
     /// </summary>
     public class TextInputEventArgs : EventArgs
     {
-        char character;
-        public TextInputEventArgs(char character, Keys key = Keys.None)
+        public string Text = string.Empty;
+        public TextInputEventType Type;
+
+        public TextInputEventArgs(char text, Keys key = Keys.None)
         {
-            this.character = character;
+            this.Text = text.ToString();
             this.Key = key;
         }
-        public char Character
-        {
-            get
-            {
-                return character;
-            }
-        }
-        public Keys Key {
-            get; private set;
-        }
+
+        public TextInputEventArgs() { }
+
+        public Keys Key { get; set; } = Keys.None;
     }
 }


### PR DESCRIPTION
This commit may not be feature-complete for IME support, but workable at least, and it need to test on different OS platform and versions.

Need more support on **Text Composition** and **Candidate List** 

Test environment: 
1. DirectX - Win10, IME works perfectly.
2. SDL- Windows, IME works, but no candidate list windows showing up, which is a bug in SDL2 https://bugzilla.libsdl.org/show_bug.cgi?id=3421