### PR TITLE
Basic performance enhancements to Texture2D.DirectX.cs

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
@@ -164,9 +164,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     {
                         // for 4x4 block compression formats an element is one block, so elementsInRow
                         // and number of rows are 1/4 of number of pixels in width and height of the rectangle
-                        // >>2 is Equivalent to /4 for int
-                        elementsInRow >>= 2;
-                        rows >>=2;
+                        elementsInRow /= 4;
+                        rows /= 4;
                     }
                     var rowSize = elementSize * elementsInRow;
                     if (rowSize == databox.RowPitch)
@@ -181,9 +180,8 @@ namespace Microsoft.Xna.Framework.Graphics
                         for (var row = 0; row < rows; row++)
                         {
                             int i;
-                            // pre-evaluate non-dependant condition (32 bits of memory vs (1 add, 1 multiply and 1 divide per iteration))
-                            int condition =  (row + 1) * rowSize / elementSizeInByte;
-                            for (i = row * rowSize / elementSizeInByte; i < condition; i++)
+                            int maxElements =  (row + 1) * rowSize / elementSizeInByte;
+                            for (i = row * rowSize / elementSizeInByte; i < maxElements; i++)
                                 data[i + startIndex] = stream.Read<T>();
 
                             if (i >= elementCount)
@@ -264,8 +262,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             for (int row = 0; row < (uint)pixelHeight; row++)
             {
-            // Move row specific calculations out of inner loop 
-            int rowxPixelWidth = row * pixelWidth * 4;
+                int rowxPixelWidth = row * pixelWidth * 4;
                 for (int col = 0; col < (uint)pixelWidth; col++)
                 {
                     offset = rowxPixelWidth + (col * 4);


### PR DESCRIPTION
Changed /4 to >>2 since they are the same thing when using int, but much faster(Lines 168-169).  Moved a non-dependent expensive conditional expression of the loop (this was not being optimized by the compiler) out side of the loop(Line 185).The duplicated division "rowSize / elementSizeInByte", on line 186, is not worth the memory, since it is only evaluated twice(185,186)   Moved evaluations only dependent on the outer loop to the outer loop instead of calculating them each iteration of the inner loop(Line 268).

Potential Drawbacks: the added 8 bytes of storage might impact low memory, high CPU platforms: Since this targets DirectX, the additional memory requirements(8 bytes) should **never** be the limiting factor(given the CPU power requirements on laptops, memory usage is almost completely free in terms of power usage(due to memory refresh cycles), and the CPU usage reduction far outweighs the memory overhead).  Depending on GC settings, this should not be much of an issue anyway, since the new variables only scope to the local function.  The /4 to >>2 improvements are completely free. 

As far as correctness:
 1. Does an (int/4) == (int >> 2) ? 
 2. The Conditional "int condition =  (row + 1) * rowSize / elementSizeInByte;"
   is identical to the existing "for" condition.
 3.  int rowxPixelWidth = row * pixelWidth * 4; evaluates the row dependent pixel width for use within its following inner loop.

If the previous three assertions are true, correctness is a mathematically proven fact(assuming correct and rational nonzero inputs).