### PR TITLE
Fix for #6728. GraphicsDevice.SetVertexBuffers generating garbage every frame

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Xna.Framework.Graphics
         private IndexBuffer _indexBuffer;
         private bool _indexBufferDirty;
 
+        private VertexBufferBinding[] _vertexBufferBindings;
+
         private readonly RenderTargetBinding[] _currentRenderTargetBindings = new RenderTargetBinding[4];
         private int _currentRenderTargetCount;
         private readonly RenderTargetBinding[] _tempRenderTargetBinding = new RenderTargetBinding[1];
@@ -324,6 +326,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Force set the buffers and shaders on next ApplyState() call
             _vertexBuffers = new VertexBufferBindings(_maxVertexBufferSlots);
+            _vertexBufferBindings = new VertexBufferBinding[_maxVertexBufferSlots];
             _vertexBuffersDirty = true;
             _indexBufferDirty = true;
             _vertexShaderDirty = true;
@@ -889,6 +892,54 @@ namespace Microsoft.Xna.Framework.Graphics
             _vertexBuffersDirty |= (vertexBuffer == null)
                                    ? _vertexBuffers.Clear()
                                    : _vertexBuffers.Set(vertexBuffer, vertexOffset);
+        }
+
+        private void _SetVertexBuffers(VertexBufferBinding[] vertexBuffers, int bindingCount)
+        {
+            if (vertexBuffers == null || vertexBuffers.Length == 0 || bindingCount == 0)
+            {
+                _vertexBuffersDirty |= _vertexBuffers.Clear();
+            }
+            else
+            {
+                if (vertexBuffers.Length > _maxVertexBufferSlots || bindingCount > _maxVertexBufferSlots)
+                {
+                    var message = string.Format(CultureInfo.InvariantCulture, "Max number of vertex buffers is {0}.", _maxVertexBufferSlots);
+                    throw new ArgumentOutOfRangeException("vertexBuffers", message);
+                }
+
+                _vertexBuffersDirty |= _vertexBuffers.Set(vertexBuffers, bindingCount);
+            }
+        }
+
+        public void SetVertexBuffers(VertexBufferBinding vertexBuffer)
+        {
+            _vertexBufferBindings[0] = vertexBuffer;
+            _SetVertexBuffers(_vertexBufferBindings, 1);
+        }
+
+        public void SetVertexBuffers(VertexBufferBinding vertexBufferA, VertexBufferBinding vertexBufferB)
+        {
+            _vertexBufferBindings[0] = vertexBufferA;
+            _vertexBufferBindings[1] = vertexBufferB;
+            _SetVertexBuffers(_vertexBufferBindings, 2);
+        }
+
+        public void SetVertexBuffers(VertexBufferBinding vertexBufferA, VertexBufferBinding vertexBufferB, VertexBufferBinding vertexBufferC)
+        {
+            _vertexBufferBindings[0] = vertexBufferA;
+            _vertexBufferBindings[1] = vertexBufferB;
+            _vertexBufferBindings[2] = vertexBufferC;
+            _SetVertexBuffers(_vertexBufferBindings, 3);
+        }
+
+        public void SetVertexBuffers(VertexBufferBinding vertexBufferA, VertexBufferBinding vertexBufferB, VertexBufferBinding vertexBufferC, VertexBufferBinding vertexBufferD)
+        {
+            _vertexBufferBindings[0] = vertexBufferA;
+            _vertexBufferBindings[1] = vertexBufferB;
+            _vertexBufferBindings[2] = vertexBufferC;
+            _vertexBufferBindings[3] = vertexBufferD;
+            _SetVertexBuffers(_vertexBufferBindings, 4);
         }
 
         public void SetVertexBuffers(params VertexBufferBinding[] vertexBuffers)

--- a/MonoGame.Framework/Graphics/Vertices/VertexBufferBindings.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBufferBindings.cs
@@ -98,12 +98,19 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </returns>
         public bool Set(params VertexBufferBinding[] vertexBufferBindings)
         {
+            return Set(vertexBufferBindings, vertexBufferBindings.Length);
+        }
+
+        public bool Set(VertexBufferBinding[] vertexBufferBindings, int bindingCount)
+        {
             Debug.Assert(vertexBufferBindings != null);
             Debug.Assert(vertexBufferBindings.Length > 0);
-            Debug.Assert(vertexBufferBindings.Length <= _vertexBuffers.Length);
+            Debug.Assert(bindingCount > 0);
+            Debug.Assert(bindingCount <= vertexBufferBindings.Length);
+            Debug.Assert(bindingCount <= _vertexBuffers.Length);
 
             bool isDirty = false;
-            for (int i = 0; i < vertexBufferBindings.Length; i++)
+            for (int i = 0; i < bindingCount; i++)
             {
                 Debug.Assert(vertexBufferBindings[i].VertexBuffer != null);
 
@@ -121,9 +128,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 isDirty = true;
             }
 
-            if (Count > vertexBufferBindings.Length)
+            if (Count > bindingCount)
             {
-                int startIndex = vertexBufferBindings.Length;
+                int startIndex = bindingCount;
                 int length = Count - startIndex;
                 Array.Clear(VertexDeclarations, startIndex, length);
                 Array.Clear(InstanceFrequencies, startIndex, length);
@@ -132,7 +139,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 isDirty = true;
             }
 
-            Count = vertexBufferBindings.Length;
+            Count = bindingCount;
             return isDirty;
         }
 


### PR DESCRIPTION
Per #6728 ... This fixes the garbage generate by the params version of SetVertexBuffers().

@tomspilman  Replacing the previous PR I submitted for the same issue.

I moved the changes for this fix to a branch so I can work on some other changes without conflicting with these. The changes are exactly the same, and I tested and verified them again.

When you have some time, please re-target this to the appropriate release.

Thanks!