### PR TITLE
fixing #5702

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -512,7 +512,10 @@ namespace Microsoft.Xna.Framework
             }
 
             if (_shouldExit)
+            {
                 Platform.Exit();
+                _shouldExit = false; //prevents perpetual exiting on platforms supporting resume.
+            }
         }
 
         #endregion


### PR DESCRIPTION
Resolves #5702 by resetting the exit flag after the platform-specific code has done it's job.