### PR TITLE
[SDL] Fix rumble infinity threshold

### DIFF
--- a/MonoGame.Framework/SDL/SDL2.cs
+++ b/MonoGame.Framework/SDL/SDL2.cs
@@ -993,7 +993,10 @@ internal static class Sdl
 
     public static class Haptic
     {
-        public const uint Infinity = 4292967295U;
+        // For some reason, different game controllers have different maximum value supported
+        // Also, the more the value is close to their limit, the more they tend to randomly ignore it
+        // Hence, we're setting an abitrary safe value as a maximum
+        public const uint Infinity = 1000000U;
 
         public enum EffectId : ushort
         {


### PR DESCRIPTION
Hi there,

I just noticed that ```Sdl.Haptic.Infinity``` has issues with most (if not all) game controllers.

This value is used to set vibration for an "unlimited" time and is a ```uint``` set to ```UInt32.MaxValue```.

While this is correct regarding the SDL documentation, it appears that this value is actually unsupported by most game controllers. Rumble will not even trigger or stop after just a few milliseconds.

By fiddling a bit, I've noticed that controllers all have different maximum values allowed.
For instance, the Xbox One controller has a maximum of ```2147483679U``` (half max value), and some other controllers have half that value or even lower.
Also: the more the value is close to this maximum, the more the controller might simply ignore the command.

So I figured that it is highly advisable to limit the vibration duration to a very safe value that all game controllers will support without any bottleneck.

I don't know what can be a safe value here, so I arbitrary set it to 100 seconds (which works with all the controllers I tested).

@cra0zy @Jjagg 