### PR TITLE
Added an additional multiply operator overload to Color with the scale first

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1748,24 +1748,29 @@ namespace Microsoft.Xna.Framework
                 (int)MathHelper.LerpPrecise(value1.A, value2.A, amount));
         }
 		
-	/// <summary>
+	    /// <summary>
         /// Multiply <see cref="Color"/> by value.
         /// </summary>
         /// <param name="value">Source <see cref="Color"/>.</param>
         /// <param name="scale">Multiplicator.</param>
         /// <returns>Multiplication result.</returns>
-	public static Color Multiply(Color value, float scale)
-	{
-	    return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
-	}
+	    public static Color Multiply(Color value, float scale)
+	    {
+	        return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
+	    }
 	
-	/// <summary>
+	    /// <summary>
         /// Multiply <see cref="Color"/> by value.
         /// </summary>
         /// <param name="value">Source <see cref="Color"/>.</param>
         /// <param name="scale">Multiplicator.</param>
         /// <returns>Multiplication result.</returns>
-	public static Color operator *(Color value, float scale)
+	    public static Color operator *(Color value, float scale)
+        {
+            return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
+        }
+
+        public static Color operator *(float scale, Color value)
         {
             return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
         }

--- a/Test/Framework/ColorTest.cs
+++ b/Test/Framework/ColorTest.cs
@@ -102,46 +102,65 @@ namespace MonoGame.Tests.Framework
         {
             var color = new Color(1, 2, 3, 4);
 
+            // Operator comparison
+            Assert.AreEqual(color * 1.0f, 1.0f * color);
+
             // Test 1.0 scale.
             Assert.AreEqual(color, color * 1.0f);
+            Assert.AreEqual(color, 1.0f * color);
             Assert.AreEqual(color, Color.Multiply(color, 1.0f));
             Assert.AreEqual(color * 1.0f, Color.Multiply(color, 1.0f));
+            Assert.AreEqual(1.0f * color, Color.Multiply(color, 1.0f));
 
             // Test 0.999 scale.
             var almostOne = new Color(0, 1, 2, 3);
             Assert.AreEqual(almostOne, color * 0.999f);
+            Assert.AreEqual(almostOne, 0.999f * color);
             Assert.AreEqual(almostOne, Color.Multiply(color, 0.999f));
             Assert.AreEqual(color * 0.999f, Color.Multiply(color, 0.999f));
+            Assert.AreEqual(0.999f * color, Color.Multiply(color, 0.999f));
 
             // Test 1.001 scale.
             Assert.AreEqual(color, color * 1.001f);
+            Assert.AreEqual(color, 1.001f * color);
             Assert.AreEqual(color, Color.Multiply(color, 1.001f));
             Assert.AreEqual(color * 1.001f, Color.Multiply(color, 1.001f));
+            Assert.AreEqual(1.001f * color, Color.Multiply(color, 1.001f));
 
             // Test 0.0 scale.
             Assert.AreEqual(Color.Transparent, color * 0.0f);
+            Assert.AreEqual(Color.Transparent, 0.0f * color);
             Assert.AreEqual(Color.Transparent, Color.Multiply(color, 0.0f));
             Assert.AreEqual(color * 0.0f, Color.Multiply(color, 0.0f));
+            Assert.AreEqual(0.0f * color, Color.Multiply(color, 0.0f));
 
             // Test 0.001 scale.
             Assert.AreEqual(Color.Transparent, color * 0.001f);
+            Assert.AreEqual(Color.Transparent, 0.001f * color);
             Assert.AreEqual(Color.Transparent, Color.Multiply(color, 0.001f));
             Assert.AreEqual(color * 0.001f, Color.Multiply(color, 0.001f));
+            Assert.AreEqual(0.001f * color, Color.Multiply(color, 0.001f));
 
             // Test -0.001 scale.
             Assert.AreEqual(Color.Transparent, color * -0.001f);
+            Assert.AreEqual(Color.Transparent, -0.001f * color);
             Assert.AreEqual(Color.Transparent, Color.Multiply(color, -0.001f));
             Assert.AreEqual(color * -0.001f, Color.Multiply(color, -0.001f));
+            Assert.AreEqual(-0.001f * color, Color.Multiply(color, -0.001f));
 
             // Test for overflow.
             Assert.AreEqual(Color.White, color * 300.0f);
+            Assert.AreEqual(Color.White, 300.0f * color);
             Assert.AreEqual(Color.White, Color.Multiply(color, 300.0f));
             Assert.AreEqual(color * 300.0f, Color.Multiply(color, 300.0f));
+            Assert.AreEqual(300.0f * color, Color.Multiply(color, 300.0f));
 
             // Test for underflow.
             Assert.AreEqual(Color.Transparent, color * -1.0f);
+            Assert.AreEqual(Color.Transparent, -1.0f * color);
             Assert.AreEqual(Color.Transparent, Color.Multiply(color, -1.0f));
             Assert.AreEqual(color * -1.0f, Color.Multiply(color, -1.0f));
+            Assert.AreEqual(-1.0f * color, Color.Multiply(color, -1.0f));
         }
 
         [Test]


### PR DESCRIPTION
This PR adds a new overloaded multiply operator to `Color` so the scale can be specified first as a convenience. For instance, this allows the following when previously it would not compile: `Color color = 0.5f * Color.White`. This PR also uses this operator in the Color multiplication tests.

Relevant issue: https://github.com/MonoGame/MonoGame/issues/6746