### PR TITLE
[Pipeline Tool]: Fix assembly load API used for custom user references

### DIFF
--- a/Tools/Pipeline/Common/PipelineTypes.cs
+++ b/Tools/Pipeline/Common/PipelineTypes.cs
@@ -448,7 +448,7 @@ namespace MonoGame.Tools.Pipeline
             {
                 try
                 {
-                    var a = Assembly.Load(path);
+                    var a = Assembly.LoadFrom(path);
                     var types = a.GetTypes();
                     ProcessTypes(types);
                 }


### PR DESCRIPTION
Assemblies are currently loaded using the wrong API. The first is the current API being used, and the latter is the correct one for file paths.

[Assembly.Load(string)](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.load?view=netframework-4.8#System_Reflection_Assembly_Load_System_String_): Loads an assembly given the long form of its name.
[Assembly.LoadFrom(string)](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.loadfrom?view=netframework-4.8#System_Reflection_Assembly_LoadFrom_System_String_): Loads an assembly given its file name or path.