### PR TITLE
Setup DesktopGL project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ Documentation/Output/
 
 # Protobuild Generated Files
 MonoGame.Framework.Content.Pipeline/*.csproj
+MonoGame.Framework/*.csproj
 Tools/2MGFX/*.csproj
 Tools/MGCB/*.csproj
 Tools/Pipeline/*.csproj

--- a/MonoGame.Framework.DesktopGL.sln
+++ b/MonoGame.Framework.DesktopGL.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.DesktopGL", "MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj", "{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Debug|x64.Build.0 = Debug|Any CPU
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Debug|x86.Build.0 = Debug|Any CPU
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Release|x64.ActiveCfg = Release|Any CPU
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Release|x64.Build.0 = Release|Any CPU
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Release|x86.ActiveCfg = Release|Any CPU
+		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/MonoGame.Framework/Directory.Build.props
+++ b/MonoGame.Framework/Directory.Build.props
@@ -1,8 +1,14 @@
 <Project>
   <PropertyGroup>
-    <MonoGamePlatform>$(MSBuildProjectName.Substring(9))</MonoGamePlatform>
+    <MonoGamePlatform>$(MSBuildProjectName.Substring(19))</MonoGamePlatform>
     <BaseIntermediateOutputPath>obj\$(MonoGamePlatform)</BaseIntermediateOutputPath>
     <BaseOutputPath>bin\$(MonoGamePlatform)</BaseOutputPath>
+    <RootNamespace>Microsoft.Xna.Framework</RootNamespace>
+    <PackageIconUrl>https://pbs.twimg.com/profile_images/487954549441691649/O3KsHAsb_400x400.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/MonoGame/MonoGame/tree/core</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/MonoGame/MonoGame/tree/core</RepositoryUrl>
+    <Authors>MonoGame Team</Authors>
+    <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
   </PropertyGroup>
 </Project>
 

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -1,0 +1,208 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <DefineConstants>OPENGL;OPENAL;XNADESIGNPROVIDED;LINUX;DESKTOPGL;SUPPORTS_EFX;NETSTANDARD</DefineConstants>
+    <AssemblyName>MonoGame.Framework</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Description>MonoGame is an open source implementation of the Microsoft XNA 4.x Framework. The goal is to make it easy for XNA developers to create cross-platform games with extremely high code reuse.
+
+This package provides you with MonoGame Framework that uses OpenGL for rendering and works on Windows, Linux and MacOS.</Description>
+    <PackageTags>monogame;.net core;core;.net standard;standard;desktopgl</PackageTags>
+    <PackageId>MonoGame.Framework.DesktopGL</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Platform\**\*" />
+    <Compile Remove="Properties\**\*" />
+    <Compile Remove="Graphics\GraphicsAdapter.cs" />
+    <Compile Remove="Media\Video.cs" />
+    <Compile Remove="Media\VideoPlayer.cs" />
+    <Compile Remove="Media\VideoSoundtrackType.cs" />
+    <Compile Remove="Content\ContentReaders\VideoReader.cs" />
+    <Compile Remove="Input\MessageBox.cs" />
+    <Compile Remove="Input\KeyboardInput.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Platform\**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Platform\TitleContainer.Desktop.cs" />
+    <Compile Include="Platform\Audio\OggStream.cs" />
+    <Compile Include="Platform\Graphics\OpenGL.Common.cs" />
+    <Compile Include="Platform\SDL\SDL2.cs" />
+    <Compile Include="Platform\SDL\SDLGamePlatform.cs" />
+    <Compile Include="Platform\SDL\SDLGameWindow.cs" />
+    <Compile Include="Platform\Utilities\AssemblyHelper.cs" />
+    <Compile Include="Platform\Utilities\CurrentPlatform.cs" />
+    <Compile Include="Platform\Utilities\FuncLoader.Desktop.cs" />
+    <Compile Include="Platform\Utilities\InteropHelpers.cs" />
+    <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
+    <Compile Include="Platform\Media\MediaLibrary.Default.cs" />
+    <Compile Include="Platform\Media\MediaPlayer.Default.cs" />
+    <Compile Include="Platform\Media\Song.NVorbis.cs" />
+    <Compile Include="Platform\Input\GamePad.SDL.cs" />
+    <Compile Include="Platform\Input\Joystick.SDL.cs" />
+    <Compile Include="Platform\Input\Keyboard.SDL.cs" />
+    <Compile Include="Platform\Input\KeyboardUtil.SDL.cs" />
+    <Compile Include="Platform\Input\Mouse.SDL.cs" />
+    <Compile Include="Platform\Input\MouseCursor.SDL.cs" />
+    <Compile Include="Platform\Graphics\GraphicsContext.SDL.cs" />
+    <Compile Include="Platform\Graphics\OpenGL.SDL.cs" />
+    <Compile Include="Platform\Graphics\WindowInfo.SDL.cs" />
+    <Compile Include="Platform\Graphics\GraphicsAdapter.Legacy.cs" />
+    <Compile Include="Platform\GamePlatform.Desktop.cs" />
+    <Compile Include="Platform\GraphicsDeviceManager.SDL.cs" />
+
+    <!-- NVorbis -->
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\BufferedReadStream.cs">
+      <Link>Platform\NVorbis\BufferedReadStream.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\DataPacket.cs">
+      <Link>Platform\NVorbis\DataPacket.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Huffman.cs">
+      <Link>Platform\NVorbis\Huffman.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IContainerReader.cs">
+      <Link>Platform\NVorbis\IContainerReader.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IPacketProvider.cs">
+      <Link>Platform\NVorbis\IPacketProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IVorbisStreamStatus.cs">
+      <Link>Platform\NVorbis\IVorbisStreamStatus.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Mdct.cs">
+      <Link>Platform\NVorbis\Mdct.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\NewStreamEventArgs.cs">
+      <Link>Platform\NVorbis\NewStreamEventArgs.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\ParameterChangeEventArgs.cs">
+      <Link>Platform\NVorbis\ParameterChangeEventArgs.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\RingBuffer.cs">
+      <Link>Platform\NVorbis\RingBuffer.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\StreamReadBuffer.cs">
+      <Link>Platform\NVorbis\StreamReadBuffer.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Utils.cs">
+      <Link>Platform\NVorbis\Utils.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisCodebook.cs">
+      <Link>Platform\NVorbis\VorbisCodebook.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisFloor.cs">
+      <Link>Platform\NVorbis\VorbisFloor.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisMapping.cs">
+      <Link>Platform\NVorbis\VorbisMapping.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisMode.cs">
+      <Link>Platform\NVorbis\VorbisMode.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisReader.cs">
+      <Link>Platform\NVorbis\VorbisReader.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisResidue.cs">
+      <Link>Platform\NVorbis\VorbisResidue.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisStreamDecoder.cs">
+      <Link>Platform\NVorbis\VorbisStreamDecoder.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisTime.cs">
+      <Link>Platform\NVorbis\VorbisTime.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggContainerReader.cs">
+      <Link>Platform\NVorbis\Ogg\OggContainerReader.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggCrc.cs">
+      <Link>Platform\NVorbis\Ogg\OggCrc.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPacket.cs">
+      <Link>Platform\NVorbis\Ogg\OggPacket.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPacketReader.cs">
+      <Link>Platform\NVorbis\Ogg\OggPacketReader.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPageFlags.cs">
+      <Link>Platform\NVorbis\Ogg\OggPageFlags.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="MonoGame.bmp">
+      <LogicalName>MonoGame.bmp</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\ThirdParty\SDL_GameControllerDB\gamecontrollerdb.txt">
+      <LogicalName>gamecontrollerdb.txt</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\ThirdParty\Dependencies\openal-soft\Windows\x86\soft_oal.dll" PackagePath="runtimes\win-x86\native" Visible="false" />
+    <Content Include="..\ThirdParty\Dependencies\SDL\Windows\x86\SDL2.dll" PackagePath="runtimes\win-x86\native" Visible="false" />
+    
+    <Content Include="..\ThirdParty\Dependencies\openal-soft\Windows\x64\soft_oal.dll" PackagePath="runtimes\win-x64\native" Visible="false" />
+    <Content Include="..\ThirdParty\Dependencies\SDL\Windows\x64\SDL2.dll" PackagePath="runtimes\win-x64\native" Visible="false" />
+    
+    <Content Include="..\ThirdParty\Dependencies\openal-soft\Linux\x64\libopenal.so.1" PackagePath="runtimes\linux-x64\native" Visible="false" />
+    <Content Include="..\ThirdParty\Dependencies\SDL\Linux\x64\libSDL2-2.0.so.0" PackagePath="runtimes\linux-x64\native" Visible="false" />
+    
+    <Content Include="..\ThirdParty\Dependencies\openal-soft\MacOS\Universal\libopenal.1.dylib" PackagePath="runtimes\osx\native" Visible="false" />
+    <Content Include="..\ThirdParty\Dependencies\SDL\MacOS\Universal\libSDL2-2.0.0.dylib" PackagePath="runtimes\osx\native" Visible="false" />
+
+    <Content Include="MonoGame.Framework.DesktopGL.targets" PackagePath="build" />
+  </ItemGroup>
+
+  <!-- Needed when compiling by referencing the project from source -->
+  <ItemGroup>
+    <None Include="..\ThirdParty\Dependencies\SDL\Windows\x86\SDL2.dll">
+      <Link>x86\SDL2.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\SDL\Windows\x64\SDL2.dll">
+      <Link>x64\SDL2.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\openal-soft\Windows\x86\soft_oal.dll">
+      <Link>x86\soft_oal.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\openal-soft\Windows\x64\soft_oal.dll">
+      <Link>x64\soft_oal.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\SDL\Linux\x86\libSDL2-2.0.so.0">
+      <Link>x86\libSDL2-2.0.so.0</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\SDL\Linux\x64\libSDL2-2.0.so.0">
+      <Link>x64\libSDL2-2.0.so.0</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\openal-soft\Linux\x86\libopenal.so.1">
+      <Link>x86\libopenal.so.1</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\openal-soft\Linux\x64\libopenal.so.1">
+      <Link>x64\libopenal.so.1</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\SDL\MacOS\Universal\libSDL2-2.0.0.dylib">
+      <Link>libSDL2-2.0.0.dylib</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\openal-soft\MacOS\Universal\libopenal.1.dylib">
+      <Link>libopenal.1.dylib</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <Import Project="Platform\OpenGL.targets" />
+  <Import Project="Platform\OpenAL.targets" />
+</Project>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.targets
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.targets
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MonoGamePlatform>DesktopGL</MonoGamePlatform>
+  </PropertyGroup>
+
+  <Target Name="CopyDesktopGLNative" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <_lib_winx64 Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\*.*" />
+      <_lib_winx86 Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x86\native\*.*" />
+      <_lib_linux Include="$(MSBuildThisFileDirectory)\..\runtimes\linux-x64\native\*.*" />
+      <_lib_osx Include="$(MSBuildThisFileDirectory)\..\runtimes\osx\native\*.*" />
+    </ItemGroup>
+  
+    <Copy SourceFiles="@(_lib_winx64)" DestinationFolder="$(OutDir)\x64" />
+    <Copy SourceFiles="@(_lib_winx86)" DestinationFolder="$(OutDir)\x86" />
+    <Copy SourceFiles="@(_lib_linux)" DestinationFolder="$(OutDir)\x64" />
+    <Copy SourceFiles="@(_lib_osx)" DestinationFolder="$(OutDir)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
Notes:
- Restored the csproj ignore to .gitignore, we should force csproj files until move is done
- Added DesktopGL project
  - This targets both `.netstandard2.0` and `.net451`, and this means that the nuget will be referencable by older projects as well
- Project file is a nuget package file at the same time :)
- I'm cheating because this isn't connected to the build bot, and is not breaking any stuff as our project name was never .DesktopGL.csproj

How to build nuget:
```sh
dotnet restore MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
msbuild /t:Pack /p:Version=3.8.0.3 MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
```

CC. @Jjagg 