### PR TITLE
Fix SpriteBatch test that manually applied half pixel offset

### DIFF
--- a/Test/Framework/Graphics/SpriteBatchTest.cs
+++ b/Test/Framework/Graphics/SpriteBatchTest.cs
@@ -456,13 +456,8 @@ namespace MonoGame.Tests.Graphics {
             _spriteBatch.End();
 
             // Test viewport/effect BasicEffect (Vertex & Pixel shader)
-#if DIRECTX
-            Matrix halfPixelOffset = Matrix.Identity;
-#else            
-            Matrix halfPixelOffset = Matrix.CreateTranslation(-0.5f, -0.5f, 0);
-#endif
 
-            _effect.Projection = halfPixelOffset * Matrix.CreateOrthographicOffCenter(0, gd.Viewport.Width, gd.Viewport.Height, 0, 0, 1);
+            _effect.Projection = Matrix.CreateOrthographicOffCenter(0, gd.Viewport.Width, gd.Viewport.Height, 0, 0, 1);
             
             gd.Viewport = rvp;
             _spriteBatch.Begin(sortMode, BlendState.AlphaBlend, null, null, null, _effect);
@@ -478,7 +473,7 @@ namespace MonoGame.Tests.Graphics {
             // Test BasicEffect (Vertex & Pixel shader)
             // re-apply projection when viewport dimensions change
             gd.Viewport = rvp;
-            _effect.Projection = halfPixelOffset * Matrix.CreateOrthographicOffCenter(0, gd.Viewport.Width, gd.Viewport.Height, 0, 0, 1);
+            _effect.Projection = Matrix.CreateOrthographicOffCenter(0, gd.Viewport.Width, gd.Viewport.Height, 0, 0, 1);
             _spriteBatch.Begin(sortMode, BlendState.AlphaBlend, null, null, null, _effect);
             _spriteBatch.Draw(_texture, new Vector2(10, 210), null, Color.White);
             gd.Viewport = mvp;
@@ -486,7 +481,7 @@ namespace MonoGame.Tests.Graphics {
             gd.Viewport = lvp;
             _spriteBatch.Draw(_texture3, new Vector2(130, 210), null, Color.White);
             gd.Viewport = vp;
-            _effect.Projection = halfPixelOffset * Matrix.CreateOrthographicOffCenter(0, gd.Viewport.Width, gd.Viewport.Height, 0, 0, 1);
+            _effect.Projection = Matrix.CreateOrthographicOffCenter(0, gd.Viewport.Width, gd.Viewport.Height, 0, 0, 1);
             _spriteBatch.Draw(_texture2, new Vector2(190, 210), null, Color.White);
             _spriteBatch.End();
             


### PR DESCRIPTION
Supersedes #6766.
This might need the reference image to be updated.