### PR TITLE
Fix MSBuild location for build bot in NANT script

### DIFF
--- a/default.build
+++ b/default.build
@@ -4,8 +4,7 @@
   <description>The MonoGame automated build script.</description>
 
   <property name="os" value="${operating-system::get-platform(environment::get-operating-system())}" />
-  <property name="msbuild12dir" value="C:\Program Files (x86)\MSBuild\12.0\Bin" />
-  <property name="msbuild14dir" value="C:\Program Files (x86)\MSBuild\14.0\Bin" />
+  <property name="msbuilddir" value="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\" />
   
   <!-- Helper default target. -->
   <target   name="build" 
@@ -204,8 +203,8 @@
         <exec program="${nuget3path}/nuget.exe " commandline='restore MonoGame.Framework\MonoGame.Framework.WindowsUniversal.project.json -NonInteractive' />
         <exec program="${nuget3path}/nuget.exe " commandline='restore MonoGame.Framework.Net\MonoGame.Framework.Net.WindowsUniversal.project.json -NonInteractive' />
 
-        <exec program="${msbuild14dir}\msbuild.exe " commandline='MonoGame.Framework.WindowsUniversal.sln /t:Clean /p:Configuration=Release /p:Platform="Any CPU"' />
-        <exec program="${msbuild14dir}\msbuild.exe " commandline='MonoGame.Framework.WindowsUniversal.sln /t:Build /p:Configuration=Release /p:Platform="Any CPU"' />
+        <exec program="${msbuilddir}\msbuild.exe " commandline='MonoGame.Framework.WindowsUniversal.sln /t:Clean /p:Configuration=Release /p:Platform="Any CPU"' />
+        <exec program="${msbuilddir}\msbuild.exe " commandline='MonoGame.Framework.WindowsUniversal.sln /t:Build /p:Configuration=Release /p:Platform="Any CPU"' />
 
       </if>
     </if>


### PR DESCRIPTION
Build bot should use VS2019 MSBuild. I assumed the default location, hope that's correct. @tomspilman 
The new CAKE script uses [vswhere](https://github.com/microsoft/vswhere) to find msbuild, so that should will also work on user machines if they have VS2019 in different locations.