### PR TITLE
Update Android template

### DIFF
--- a/ProjectTemplates/DotNetTemplate/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
+++ b/ProjectTemplates/DotNetTemplate/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
@@ -24,8 +24,6 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
-
-    <MonoGamePlatform>Android</MonoGamePlatform>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ProjectTemplates/DotNetTemplate/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
+++ b/ProjectTemplates/DotNetTemplate/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
@@ -14,13 +14,18 @@
     <FileAlignment>512</FileAlignment>
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions>.m4a</AndroidStoreUncompressedFileExtensions>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
-    <MonoGamePlatform>Android</MonoGamePlatform>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+
+    <MonoGamePlatform>Android</MonoGamePlatform>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -68,7 +73,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
-    <PackageReference Include="MonoGame.Framework.Android" Version="3.7.0.1708" />
+    <PackageReference Include="MonoGame.Framework.Android" Version="3.7.*" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Updated by comparing to the template created by VS2019.
This also requires a NuGet restore before building, same as UWP (#6796).