### PR TITLE
CAKE General Improvements

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.AndroidCore.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.AndroidCore.csproj
@@ -72,7 +72,7 @@ This package provides you with MonoGame Framework that works on Android.</Descri
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="MonoGame.Framework.AndroidCore.targets" PackagePath="build" />
+    <None Include="MonoGame.Framework.AndroidCore.targets" Pack="true" PackagePath="build" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.AndroidCore.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.AndroidCore.csproj
@@ -72,7 +72,7 @@ This package provides you with MonoGame Framework that works on Android.</Descri
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="MonoGame.Framework.AndroidCore.targets" PackagePath="build" />
+    <None Include="MonoGame.Framework.AndroidCore.targets" PackagePath="build" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build.ps1
+++ b/build.ps1
@@ -226,6 +226,7 @@ if ($ShowDescription) { $cakeArguments += "-showdescription" }
 if ($DryRun) { $cakeArguments += "-dryrun" }
 if ($Experimental) { $cakeArguments += "-experimental" }
 if ($Mono) { $cakeArguments += "-mono" }
+$cakeArguments += "-paths_tools=$TOOLS_DIR"
 $cakeArguments += $ScriptArgs
 
 # Start Cake

--- a/build.sh
+++ b/build.sh
@@ -97,5 +97,5 @@ fi
 if $SHOW_VERSION; then
     exec mono "$CAKE_EXE" -version
 else
-    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
+    exec mono "$CAKE_EXE" $SCRIPT -paths_tools="$TOOLS_DIR" -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
 fi


### PR DESCRIPTION
Stuff done:
- Fixed Cake plugins still using tools folder
- Fixed Xamarin.Android warning regarding Content tag
- Build fails on Windows if MSBuild is not found
- Xamarin Android is built from Linux if its installed
- Simplified future msbuild path finding by using Criteria and a bit of magic! (we don't need a variable for each platform now)