### PR TITLE
Add macOS sln and csproj

### DIFF
--- a/MonoGame.Framework.DesktopGL.MacOS.sln
+++ b/MonoGame.Framework.DesktopGL.MacOS.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.DesktopGL.MacOS", "MonoGame.Framework\MonoGame.Framework.DesktopGL.MacOS.csproj", "{63476583-C7C4-4388-A181-AEFCB4462936}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Debug|x64.Build.0 = Debug|Any CPU
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Debug|x86.Build.0 = Debug|Any CPU
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Release|x64.ActiveCfg = Release|Any CPU
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Release|x64.Build.0 = Release|Any CPU
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Release|x86.ActiveCfg = Release|Any CPU
+		{63476583-C7C4-4388-A181-AEFCB4462936}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.MacOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.MacOS.csproj
@@ -1,0 +1,172 @@
+<Project Sdk="MSBuild.Sdk.Extras">
+
+  <PropertyGroup>
+    <TargetFramework>xamarin.mac</TargetFramework>
+    <DefineConstants>DESKTOPGL;MONOMAC;XNADESIGNPROVIDED</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <Description>MonoGame is an open source implementation of the Microsoft XNA 4.x Framework. The goal is to make it easy for XNA developers to create cross-platform games with extremely high code reuse.
+
+This package is the same as MonoGame.Framework.DesktopGL, but has Mac-specific extensions to
+implement video playback. This package will only run on macOS.</Description>
+    <PackageTags>monogame;.net core;core;.net standard;standard;desktopgl;mac</PackageTags>
+    <PackageId>MonoGame.Framework.DesktopGL.MacOS</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="bin\**\*" />
+    <Compile Remove="obj\**\*" />
+    <Compile Remove="Platform\**\*" />
+    <Compile Remove="Properties\**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Platform\**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Graphics\GraphicsAdapter.cs" />
+    <Compile Remove="Input\MessageBox.cs" />
+    <Compile Remove="Input\KeyboardInput.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Platform\Audio\OggStream.cs" />
+    <Compile Include="Platform\GamePlatform.Desktop.cs" />
+    <Compile Include="Platform\Graphics\GraphicsAdapter.Legacy.cs" />
+    <Compile Include="Platform\Graphics\GraphicsContext.SDL.cs" />
+    <Compile Include="Platform\Graphics\OpenGL.Common.cs" />
+    <Compile Include="Platform\Graphics\OpenGL.SDL.cs" />
+    <Compile Include="Platform\Graphics\WindowInfo.SDL.cs" />
+    <Compile Include="Platform\GraphicsDeviceManager.SDL.cs" />
+    <Compile Include="Platform\Input\GamePad.SDL.cs" />
+    <Compile Include="Platform\Input\Joystick.SDL.cs" />
+    <Compile Include="Platform\Input\Keyboard.SDL.cs" />
+    <Compile Include="Platform\Input\KeyboardUtil.SDL.cs" />
+    <Compile Include="Platform\Input\Mouse.SDL.cs" />
+    <Compile Include="Platform\Input\MouseCursor.SDL.cs" />
+    <Compile Include="Platform\Media\MediaLibrary.Default.cs" />
+    <Compile Include="Platform\Media\MediaPlayer.Default.cs" />
+    <Compile Include="Platform\Media\Song.NVorbis.cs" />
+    <Compile Include="Platform\Media\Video.MacOS.cs" />
+    <Compile Include="Platform\Media\VideoPlayer.MacOS.cs" />
+    <Compile Include="Platform\PrimaryThreadLoader.cs" />
+    <Compile Include="Platform\SDL\SDL2.cs" />
+    <Compile Include="Platform\SDL\SDLGamePlatform.cs" />
+    <Compile Include="Platform\SDL\SDLGameWindow.cs" />
+    <Compile Include="Platform\TitleContainer.Desktop.cs" />
+    <Compile Include="Platform\Utilities\AssemblyHelper.cs" />
+    <Compile Include="Platform\Utilities\CurrentPlatform.cs" />
+    <Compile Include="Platform\Utilities\FuncLoader.Desktop.cs" />
+    <Compile Include="Platform\Utilities\InteropHelpers.cs" />
+    <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\BufferedReadStream.cs">
+      <Link>Platform\NVorbis\BufferedReadStream.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\DataPacket.cs">
+      <Link>Platform\NVorbis\DataPacket.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Huffman.cs">
+      <Link>Platform\NVorbis\Huffman.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IContainerReader.cs">
+      <Link>Platform\NVorbis\IContainerReader.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IPacketProvider.cs">
+      <Link>Platform\NVorbis\IPacketProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IVorbisStreamStatus.cs">
+      <Link>Platform\NVorbis\IVorbisStreamStatus.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Mdct.cs">
+      <Link>Platform\NVorbis\Mdct.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\NewStreamEventArgs.cs">
+      <Link>Platform\NVorbis\NewStreamEventArgs.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\ParameterChangeEventArgs.cs">
+      <Link>Platform\NVorbis\ParameterChangeEventArgs.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\RingBuffer.cs">
+      <Link>Platform\NVorbis\RingBuffer.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\StreamReadBuffer.cs">
+      <Link>Platform\NVorbis\StreamReadBuffer.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Utils.cs">
+      <Link>Platform\NVorbis\Utils.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisCodebook.cs">
+      <Link>Platform\NVorbis\VorbisCodebook.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisFloor.cs">
+      <Link>Platform\NVorbis\VorbisFloor.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisMapping.cs">
+      <Link>Platform\NVorbis\VorbisMapping.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisMode.cs">
+      <Link>Platform\NVorbis\VorbisMode.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisReader.cs">
+      <Link>Platform\NVorbis\VorbisReader.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisResidue.cs">
+      <Link>Platform\NVorbis\VorbisResidue.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisStreamDecoder.cs">
+      <Link>Platform\NVorbis\VorbisStreamDecoder.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisTime.cs">
+      <Link>Platform\NVorbis\VorbisTime.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggContainerReader.cs">
+      <Link>Platform\NVorbis\Ogg\OggContainerReader.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggCrc.cs">
+      <Link>Platform\NVorbis\Ogg\OggCrc.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPacket.cs">
+      <Link>Platform\NVorbis\Ogg\OggPacket.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPacketReader.cs">
+      <Link>Platform\NVorbis\Ogg\OggPacketReader.cs</Link>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPageFlags.cs">
+      <Link>Platform\NVorbis\Ogg\OggPageFlags.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="MonoGame.bmp">
+      <LogicalName>MonoGame.bmp</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\ThirdParty\SDL_GameControllerDB\gamecontrollerdb.txt">
+      <LogicalName>gamecontrollerdb.txt</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\ThirdParty\Dependencies\openal-soft\MacOS\Universal\libopenal.1.dylib" PackagePath="runtimes\osx\native" Visible="false" />
+    <Content Include="..\ThirdParty\Dependencies\SDL\MacOS\Universal\libSDL2-2.0.0.dylib" PackagePath="runtimes\osx\native" Visible="false" />
+
+    <Content Include="MonoGame.Framework.DesktopGL.MacOS.targets" PackagePath="build" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\ThirdParty\Dependencies\SDL\MacOS\Universal\libSDL2-2.0.0.dylib">
+      <Link>libSDL2-2.0.0.dylib</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ThirdParty\Dependencies\openal-soft\MacOS\Universal\libopenal.1.dylib">
+      <Link>libopenal.1.dylib</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <Import Project="Platform\OpenGL.targets" />
+  <Import Project="Platform\OpenAL.targets" />
+</Project>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.MacOS.targets
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.MacOS.targets
@@ -1,0 +1,15 @@
+<Project>
+
+  <PropertyGroup>
+    <MonoGamePlatform>DesktopGL</MonoGamePlatform>
+  </PropertyGroup>
+
+  <Target Name="CopyDesktopGLNative" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <_lib_osx Include="$(MSBuildThisFileDirectory)\..\runtimes\osx\native\*.*" />
+    </ItemGroup>
+  
+    <Copy SourceFiles="@(_lib_osx)" DestinationFolder="$(OutDir)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
This adds a csproj for the macOS project. I did not yet test this because I don't own a Mac.
The project needs to be explicitly restored and built with MSBuild.
I did not yet add the build to the CAKE script.