### PR TITLE
Fix for 6825. Catch ArgumentException when trying to get encoding upon PipelineController.DoBuild

### DIFF
--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -501,7 +501,7 @@ namespace MonoGame.Tools.Pipeline
             Encoding encoding;
             try {
                 encoding = Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
-            } catch (NotSupportedException) {
+            } catch (Exception ex) when (ex is NotSupportedException || ex is ArgumentException) {
                 encoding = Encoding.UTF8;
             }
             var currentDir = Environment.CurrentDirectory;

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -501,9 +501,12 @@ namespace MonoGame.Tools.Pipeline
             Encoding encoding;
             try {
                 encoding = Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
-            } catch (Exception ex) when (ex is NotSupportedException || ex is ArgumentException) {
+            } catch (NotSupportedException) {
+                encoding = Encoding.UTF8;
+            } catch (ArgumentException) {
                 encoding = Encoding.UTF8;
             }
+            
             var currentDir = Environment.CurrentDirectory;
             try
             {


### PR DESCRIPTION
Related to issue #6825 