### PR TITLE
Further garbage optimizations to Joystick

### DIFF
--- a/MonoGame.Framework/Input/Joystick.cs
+++ b/MonoGame.Framework/Input/Joystick.cs
@@ -10,6 +10,17 @@ namespace Microsoft.Xna.Framework.Input
     public static partial class Joystick
     {
         /// <summary>
+        /// A default <see cref="JoystickState"/>.
+        /// </summary>
+        private static JoystickState _defaultJoystickState = new JoystickState
+        {
+            IsConnected = false,
+            Axes = new int[0],
+            Buttons = new ButtonState[0],
+            Hats = new JoystickHat[0]
+        };
+
+        /// <summary>
         /// Gets a value indicating whether the current platform supports reading raw joystick data.
         /// </summary>
         /// <value><c>true</c> if the current platform supports reading raw joystick data; otherwise, <c>false</c>.</value>
@@ -36,6 +47,16 @@ namespace Microsoft.Xna.Framework.Input
         public static JoystickState GetState(int index)
         {
             return PlatformGetState(index);
+        }
+
+        /// <summary>
+        /// Gets the current state of the joystick by updating an existing <see cref="JoystickState"/>.
+        /// </summary>
+        /// <param name="joystickState">The <see cref="JoystickState"/> to update.</param>
+        /// <param name="index">Index of the joystick you want to access.</param>
+        public static void GetState(ref JoystickState joystickState, int index)
+        {
+            PlatformGetState(ref joystickState, index);
         }
     }
 }

--- a/MonoGame.Framework/Platform/Input/Joystick.Default.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.Default.cs
@@ -24,13 +24,12 @@ namespace Microsoft.Xna.Framework.Input
 
         private static JoystickState PlatformGetState(int index)
         {
-            return new JoystickState()
-            {
-                IsConnected = false,
-                Axes = new int[0],
-                Buttons = new ButtonState[0],
-                Hats = new JoystickHat[0]
-            };
+            return _defaultJoystickState;
+        }
+
+        private static void PlatformGetState(ref JoystickState joystickState, int index)
+        {
+
         }
     }
 }

--- a/MonoGame.Framework/Platform/Input/Joystick.Web.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.Web.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Xna.Framework.Input
             };
         }
 
-        private static JoystickState PlatformGetState(ref JoystickState joystickState, int index)
+        private static void PlatformGetState(ref JoystickState joystickState, int index)
         {
             joystickState.IsConnected = false;
 

--- a/MonoGame.Framework/Platform/Input/Joystick.Web.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.Web.cs
@@ -47,8 +47,8 @@ namespace Microsoft.Xna.Framework.Input
         private static JoystickState PlatformGetState(int index)
         {
             var connected = false;
-            var axes = new int[0];
-            var buttons = new ButtonState[0];
+            var axes = _defaultJoystickState.Axes;
+            var buttons = _defaultJoystickState.Buttons;
 
             var navigator = Builtins.Global["navigator"];
             var gamepads = navigator.getGamepads ? navigator.getGamepads() : navigator.webkitGetGamepads();
@@ -83,8 +83,52 @@ namespace Microsoft.Xna.Framework.Input
                 IsConnected = connected,
                 Axes = axes,
                 Buttons = buttons,
-                Hats = new JoystickHat[0]
+                Hats = _defaultJoystickState.Hats
             };
+        }
+
+        private static JoystickState PlatformGetState(ref JoystickState joystickState, int index)
+        {
+            joystickState.IsConnected = false;
+
+            var navigator = Builtins.Global["navigator"];
+            var gamepads = navigator.getGamepads ? navigator.getGamepads() : navigator.webkitGetGamepads();
+
+            if (gamepads.length > index)
+            {
+                if (gamepads[index])
+                {
+                    joystickState.IsConnected = true;
+
+                    var axescount = gamepads[index].axes.length;
+                    if (joystickState.Axes.Length < axescount)
+                    {
+                        joystickState.Axes = new int[axescount];
+                    }
+
+                    for (int i = 0; i < axescount; i++)
+                        joystickState.Axes[i] = gamepads[index].axes[i];
+
+                    var buttoncount = gamepads[index].buttons.length;
+                    if (joystickState.Buttons.Length < buttoncount)
+                    {
+                        joystickState.Buttons = new ButtonState[buttoncount];
+                    }
+                    
+                    for (int i = 0; i < buttoncount; i++)
+                    {
+                        if (gamepads[index].buttons[i].pressed)
+                            joystickState.Buttons[i] = ButtonState.Pressed;
+                        else
+                            joystickState.Buttons[i] = ButtonState.Released;
+                    }
+                }
+            }
+
+            if (joystickState.Hats == null)
+            {
+                joystickState.Hats = _defaultJoystickState.Hats;
+            }
         }
     }
 }


### PR DESCRIPTION
Relevant issue: https://github.com/MonoGame/MonoGame/issues/6820

Summary of changes:

- Added a Joystick.GetState overload taking in a `ref JoystickState` that is updated, and implemented the overload on all publicly accessible platforms
- Moved `_defaultJoystickState` to the shared file so all platforms can use it
- Made `Joystick.Web` use the default joystick's zero-length arrays in several instances to avoid allocations

I do not see a project for Web, so I'm not sure if the changes to Web compiles.