### PR TITLE
Fix path to ExternalTool for content pipeline on .NET Core

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 
             try
             {
-                var p = Process.Start("chmod", "u+x '" + path + "'");
+                var p = Process.Start("chmod", "u+x \"" + path + "\"");
                 p.WaitForExit();
             }
             catch


### PR DESCRIPTION
From what I understand, single quotes in command arguments are escaped on Unix in .NET Core to be consistent with Windows.
See https://github.com/dotnet/corefx/issues/38483 and mono issue referred to in there.

@cra0zy 