### PR TITLE
Replaced PngWriter with StbImageWriteSharp

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -817,6 +817,9 @@
     <Compile Include="Platform\Graphics\Texture2D.OpenGL.cs">
       <Services>OpenGLGraphics</Services>
     </Compile>
+    <Compile Include="Platform\Graphics\Texture2D.StbSharp.cs">
+      <Services>OpenGLGraphics,DirectXGraphics</Services>
+    </Compile>
     <Compile Include="Platform\Graphics\Texture2D.Web.cs">
       <Services>WebGraphics</Services>
     </Compile>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -35,6 +35,7 @@ This package provides you with MonoGame Framework that uses OpenGL for rendering
     <Compile Include="Platform\TitleContainer.Desktop.cs" />
     <Compile Include="Platform\Audio\OggStream.cs" />
     <Compile Include="Platform\Graphics\OpenGL.Common.cs" />
+    <Compile Include="Platform\Graphics\Texture2D.StbSharp.cs" />    
     <Compile Include="Platform\SDL\SDL2.cs" />
     <Compile Include="Platform\SDL\SDLGamePlatform.cs" />
     <Compile Include="Platform\SDL\SDLGameWindow.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -25,6 +25,7 @@ This package provides you with MonoGame Framework that uses DirectX for renderin
   <ItemGroup>
     <Compile Include="Platform\GamePlatform.Desktop.cs" />
     <Compile Include="Platform\Graphics\SwapChainRenderTarget.cs" />
+    <Compile Include="Platform\Graphics\Texture2D.StbSharp.cs" />
     <Compile Include="Platform\Input\GamePad.XInput.cs" />
     <Compile Include="Platform\Input\InputKeyEventArgs.cs" />
     <Compile Include="Platform\Input\Joystick.Default.cs" />
@@ -55,6 +56,7 @@ This package provides you with MonoGame Framework that uses DirectX for renderin
 
   <ItemGroup>
     <Compile Include="..\ThirdParty\StbImageSharp\src\StbImageSharp\**\*.cs" LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageWriteSharp\src\StbImageWriteSharp\**\*.cs" LinkBase="Utilities\StbImageWriteSharp"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
@@ -39,6 +39,7 @@ This package provides you with MonoGame Framework that works on Windows 10, Wind
   <ItemGroup>
     <Compile Include="Platform\GamePlatform.Desktop.cs" />
     <Compile Include="Platform\GraphicsDeviceManager.WinRT.cs" />
+    <Compile Include="Platform\Graphics\Texture2D.StbSharp.cs" />
     <Compile Include="Platform\Input\GamePad.UWP.cs" />
     <Compile Include="Platform\Input\InputKeyEventArgs.cs" />
     <Compile Include="Platform\Input\Joystick.Default.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
@@ -65,7 +65,6 @@ This package provides you with MonoGame Framework that works on Windows 10, Wind
     <Compile Include="Platform\WindowsUniversal\InputEvents.cs" />
 
     <Compile Include="..\ThirdParty\StbImageSharp\src\StbImageSharp\**\*.cs" LinkBase="Utilities\StbImageSharp"/>
-    <Compile Include="..\ThirdParty\StbImageWriteSharp\src\StbImageWriteSharp\**\*.cs" LinkBase="Utilities\StbImageWriteSharp"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
@@ -65,6 +65,7 @@ This package provides you with MonoGame Framework that works on Windows 10, Wind
     <Compile Include="Platform\WindowsUniversal\InputEvents.cs" />
 
     <Compile Include="..\ThirdParty\StbImageSharp\src\StbImageSharp\**\*.cs" LinkBase="Utilities\StbImageSharp"/>
+    <Compile Include="..\ThirdParty\StbImageWriteSharp\src\StbImageWriteSharp\**\*.cs" LinkBase="Utilities\StbImageWriteSharp"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
@@ -213,20 +213,6 @@ namespace Microsoft.Xna.Framework.Graphics
             return arraySlice * _levelCount + level;
         }
 
-        private void PlatformSaveAsJpeg(Stream stream, int width, int height)
-        {
-#if WINDOWS_UAP
-            SaveAsImage(Windows.Graphics.Imaging.BitmapEncoder.JpegEncoderId, stream, width, height);
-#else
-            SaveAsImage(stream, width, height, ImageWriterFormat.Jpg);
-#endif
-        }
-
-        private void PlatformSaveAsPng(Stream stream, int width, int height)
-        {
-            SaveAsImage(stream, width, height, ImageWriterFormat.Png);
-        }
-
 #if WINDOWS_UAP
         private void SaveAsImage(Guid encoderId, Stream stream, int width, int height)
         {

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
@@ -213,33 +213,6 @@ namespace Microsoft.Xna.Framework.Graphics
             return arraySlice * _levelCount + level;
         }
 
-#if WINDOWS_UAP
-        private void SaveAsImage(Guid encoderId, Stream stream, int width, int height)
-        {
-            var pixelData = new byte[Width * Height * GraphicsExtensions.GetSize(Format)];
-            GetData(pixelData);
-
-            // TODO: We need to convert from Format to R8G8B8A8!
-
-            // TODO: We should implement async SaveAsPng() for WinRT.
-            Task.Run(async () =>
-            {
-                // Create a temporary memory stream for writing the png.
-                var memstream = new InMemoryRandomAccessStream();
-
-                // Write the png.
-                var encoder = await Windows.Graphics.Imaging.BitmapEncoder.CreateAsync(encoderId, memstream);
-                encoder.SetPixelData(BitmapPixelFormat.Rgba8, BitmapAlphaMode.Ignore, (uint)width, (uint)height, 96, 96, pixelData);
-                await encoder.FlushAsync();
-
-                // Copy the memory stream into the real output stream.
-                memstream.Seek(0);
-                memstream.AsStreamForRead().CopyTo(stream);
-
-            }).Wait();
-        }
-#endif
-
         protected internal virtual Texture2DDescription GetTexture2DDescription()
         {
             var desc = new Texture2DDescription();

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
@@ -6,12 +6,9 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using MonoGame.Utilities;
-using MonoGame.Utilities.Png;
 using SharpDX;
 using SharpDX.Direct3D11;
 using SharpDX.DXGI;
-using SharpDX.WIC;
-using StbImageSharp;
 using MapFlags = SharpDX.Direct3D11.MapFlags;
 using Resource = SharpDX.Direct3D11.Resource;
 
@@ -216,82 +213,18 @@ namespace Microsoft.Xna.Framework.Graphics
             return arraySlice * _levelCount + level;
         }
 
-        private unsafe static Texture2D PlatformFromStream(GraphicsDevice graphicsDevice, Stream stream)
-        {
-            byte[] bytes;
-
-            // Rewind stream if it is at end
-            if (stream.CanSeek && stream.Length == stream.Position)
-            {
-                stream.Seek(0, SeekOrigin.Begin);
-            }
-
-            // Copy it's data to memory
-            // As some platforms dont provide full stream functionality and thus streams can't be read as it is
-            using (var ms = new MemoryStream())
-            {
-                stream.CopyTo(ms);
-                bytes = ms.ToArray();
-            }
-
-            // The data returned is always four channel BGRA
-            var result = ImageResult.FromMemory(bytes, ColorComponents.RedGreenBlueAlpha);
-
-            // XNA blacks out any pixels with an alpha of zero.
-            fixed (byte* b = &result.Data[0])
-            {
-                for (var i = 0; i < result.Data.Length; i += 4)
-                {
-                    if (b[i + 3] == 0)
-                    {
-                        b[i + 0] = 0;
-                        b[i + 1] = 0;
-                        b[i + 2] = 0;
-                    }
-                }
-            }
-
-            Texture2D texture = null;
-            texture = new Texture2D(graphicsDevice, result.Width, result.Height);
-            texture.SetData(result.Data);
-
-            return texture;
-        }
-
         private void PlatformSaveAsJpeg(Stream stream, int width, int height)
         {
 #if WINDOWS_UAP
             SaveAsImage(Windows.Graphics.Imaging.BitmapEncoder.JpegEncoderId, stream, width, height);
 #else
-            throw new NotImplementedException();
+            SaveAsImage(stream, width, height, ImageWriterFormat.Jpg);
 #endif
-        }
-
-        //Converts Pixel Data from BGRA to RGBA
-        private static void ConvertToRGBA(int pixelHeight, int pixelWidth, byte[] pixels)
-        {
-            int offset = 0;
-
-            for (int row = 0; row < (uint)pixelHeight; row++)
-            {
-                int rowxPixelWidth = row * pixelWidth * 4;
-                for (int col = 0; col < (uint)pixelWidth; col++)
-                {
-                    offset = rowxPixelWidth + (col * 4);
-
-                    byte B = pixels[offset];
-                    byte R = pixels[offset + 2];
-
-                    pixels[offset] = R;
-                    pixels[offset + 2] = B;
-                }
-            }
         }
 
         private void PlatformSaveAsPng(Stream stream, int width, int height)
         {
-            var pngWriter = new PngWriter();
-            pngWriter.Write(this, stream);
+            SaveAsImage(stream, width, height, ImageWriterFormat.Png);
         }
 
 #if WINDOWS_UAP
@@ -320,72 +253,6 @@ namespace Microsoft.Xna.Framework.Graphics
             }).Wait();
         }
 #endif
-
-        static unsafe SharpDX.Direct3D11.Texture2D CreateTex2DFromBitmap(BitmapSource bsource, GraphicsDevice device)
-        {
-            Texture2DDescription desc;
-            desc.Width = bsource.Size.Width;
-            desc.Height = bsource.Size.Height;
-            desc.ArraySize = 1;
-            desc.BindFlags = BindFlags.ShaderResource;
-            desc.Usage = ResourceUsage.Default;
-            desc.CpuAccessFlags = CpuAccessFlags.None;
-            desc.Format = SharpDX.DXGI.Format.R8G8B8A8_UNorm;
-            desc.MipLevels = 1;
-            desc.OptionFlags = ResourceOptionFlags.None;
-            desc.SampleDescription.Count = 1;
-            desc.SampleDescription.Quality = 0;
-
-            using (DataStream s = new DataStream(bsource.Size.Height * bsource.Size.Width * 4, true, true))
-            {
-                bsource.CopyPixels(bsource.Size.Width * 4, s);
-
-                // XNA blacks out any pixels with an alpha of zero.
-                var data = (byte*)s.DataPointer;
-                for (var i = 0; i < s.Length; i+=4)
-                {
-                    if (data[i + 3] == 0)
-                    {
-                        data[i + 0] = 0;
-                        data[i + 1] = 0;
-                        data[i + 2] = 0;
-                    }
-                }
-
-                DataRectangle rect = new DataRectangle(s.DataPointer, bsource.Size.Width * 4);
-
-                return new SharpDX.Direct3D11.Texture2D(device._d3dDevice, desc, rect);
-            }
-        }
-
-        static ImagingFactory imgfactory;
-        private static BitmapSource LoadBitmap(Stream stream, out SharpDX.WIC.BitmapDecoder decoder)
-        {
-            if (imgfactory == null)
-            {
-                imgfactory = new ImagingFactory();
-            }
-
-            decoder = new SharpDX.WIC.BitmapDecoder(
-                imgfactory,
-                stream,
-                DecodeOptions.CacheOnDemand
-                );
-
-            var fconv = new FormatConverter(imgfactory);
-
-            using (var frame = decoder.GetFrame(0))
-            {
-                fconv.Initialize(
-                    frame,
-                    PixelFormat.Format32bppRGBA,
-                    BitmapDitherType.None,
-                    null,
-                    0.0,
-                    BitmapPaletteType.Custom);
-            }
-            return fconv;
-        }
 
         protected internal virtual Texture2DDescription GetTexture2DDescription()
         {

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
@@ -6,8 +6,6 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using MonoGame.Utilities;
-using MonoGame.Utilities.Png;
-using StbImageSharp;
 
 #if IOS
 using UIKit;
@@ -20,7 +18,6 @@ using System.Drawing;
 using MonoGame.OpenGL;
 using GLPixelFormat = MonoGame.OpenGL.PixelFormat;
 using PixelFormat = MonoGame.OpenGL.PixelFormat;
-using StbImageWriteSharp;
 
 #if ANDROID
 using Android.Graphics;
@@ -257,48 +254,6 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
         }
 
-        private unsafe static Texture2D PlatformFromStream(GraphicsDevice graphicsDevice, Stream stream)
-        {
-            byte[] bytes;
-
-            // Rewind stream if it is at end
-            if (stream.CanSeek && stream.Length == stream.Position)
-            {
-                stream.Seek(0, SeekOrigin.Begin);
-            }
-
-            // Copy it's data to memory
-            // As some platforms dont provide full stream functionality and thus streams can't be read as it is
-            using (var ms = new MemoryStream())
-            {
-                stream.CopyTo(ms);
-                bytes = ms.ToArray();
-            }
-
-            // The data returned is always four channel BGRA
-            var result = ImageResult.FromMemory(bytes, StbImageSharp.ColorComponents.RedGreenBlueAlpha);
-
-            // XNA blacks out any pixels with an alpha of zero.
-            fixed (byte* b = &result.Data[0])
-            {
-                for (var i = 0; i < result.Data.Length; i += 4)
-                {
-                    if (b[i + 3] == 0)
-                    {
-                        b[i + 0] = 0;
-                        b[i + 1] = 0;
-                        b[i + 2] = 0;
-                    }
-                }
-            }
-
-            Texture2D texture = null;
-            texture = new Texture2D(graphicsDevice, result.Width, result.Height);
-            texture.SetData(result.Data);
-
-            return texture;
-        }
-
 #if IOS
         [CLSCompliant(false)]
         public static Texture2D FromStream(GraphicsDevice graphicsDevice, UIImage uiImage)
@@ -429,81 +384,25 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
         }
 
-#if DESKTOPGL
-        internal enum ImageWriterFormat
-        {
-            Jpg,
-            Png
-        }
-#endif
-
         private void PlatformSaveAsJpeg(Stream stream, int width, int height)
         {
-#if DESKTOPGL
+#if !ANDROID
             SaveAsImage(stream, width, height, ImageWriterFormat.Jpg);
-#elif ANDROID
-            SaveAsImage(stream, width, height, Bitmap.CompressFormat.Jpeg);
 #else
-            throw new NotImplementedException();
+            SaveAsImage(stream, width, height, Bitmap.CompressFormat.Jpeg);
 #endif
         }
 
         private void PlatformSaveAsPng(Stream stream, int width, int height)
         {
-#if DESKTOPGL
+#if !ANDROID
             SaveAsImage(stream, width, height, ImageWriterFormat.Png);
-#elif ANDROID
-            SaveAsImage(stream, width, height, Bitmap.CompressFormat.Png);
 #else
-            var pngWriter = new PngWriter();
-            pngWriter.Write(this, stream);
+            SaveAsImage(stream, width, height, Bitmap.CompressFormat.Png);
 #endif
         }
 
-#if DESKTOPGL
-        internal unsafe void SaveAsImage(Stream stream, int width, int height, ImageWriterFormat format)
-        {
-	        if (stream == null)
-	        {
-		        throw new ArgumentNullException("stream", "'stream' cannot be null (Nothing in Visual Basic)");
-	        }
-	        if (width <= 0)
-	        {
-		        throw new ArgumentOutOfRangeException("width", width, "'width' cannot be less than or equal to zero");
-	        }
-	        if (height <= 0)
-	        {
-		        throw new ArgumentOutOfRangeException("height", height, "'height' cannot be less than or equal to zero");
-	        }
-	        Color[] data = null;
-	        try
-	        {
-                data = GetColorData();
-
-                // Write
-                fixed (Color* ptr = &data[0])
-                {
-                    var writer = new ImageWriter();
-                    switch (format)
-                    {
-                        case ImageWriterFormat.Jpg:
-                            writer.WriteJpg(ptr, width, height, StbImageWriteSharp.ColorComponents.RedGreenBlueAlpha, stream, 90);
-                            break;
-                        case ImageWriterFormat.Png:
-                            writer.WritePng(ptr, width, height, StbImageWriteSharp.ColorComponents.RedGreenBlueAlpha, stream);
-                            break;
-                    }
-                }
-            }
-            finally
-	        {
-		        if (data != null)
-		        {
-			        data = null;
-		        }
-	        }
-        }
-#elif ANDROID
+#if ANDROID
         private void SaveAsImage(Stream stream, int width, int height, Bitmap.CompressFormat format)
         {
             int[] data = new int[width * height];

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
@@ -384,26 +384,6 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
         }
 
-#if ANDROID
-        private void SaveAsImage(Stream stream, int width, int height, Bitmap.CompressFormat format)
-        {
-            int[] data = new int[width * height];
-            GetData(data);
-            // internal structure is BGR while bitmap expects RGB
-            for (int i = 0; i < data.Length; ++i)
-            {
-                uint pixel = (uint)data[i];
-                data[i] = (int)((pixel & 0xFF00FF00) | ((pixel & 0x00FF0000) >> 16) | ((pixel & 0x000000FF) << 16));
-            }
-            using (Bitmap bitmap = Bitmap.CreateBitmap(width, height, Bitmap.Config.Argb8888))
-            {
-                bitmap.SetPixels(data, 0, width, 0, 0, width, height);
-                bitmap.Compress(format, 100, stream);
-                bitmap.Recycle();
-            }
-        }
-#endif
-
         // This method allows games that use Texture2D.FromStream
         // to reload their textures after the GL context is lost.
         private void PlatformReload(Stream textureStream)

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
@@ -384,24 +384,6 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
         }
 
-        private void PlatformSaveAsJpeg(Stream stream, int width, int height)
-        {
-#if !ANDROID
-            SaveAsImage(stream, width, height, ImageWriterFormat.Jpg);
-#else
-            SaveAsImage(stream, width, height, Bitmap.CompressFormat.Jpeg);
-#endif
-        }
-
-        private void PlatformSaveAsPng(Stream stream, int width, int height)
-        {
-#if !ANDROID
-            SaveAsImage(stream, width, height, ImageWriterFormat.Png);
-#else
-            SaveAsImage(stream, width, height, Bitmap.CompressFormat.Png);
-#endif
-        }
-
 #if ANDROID
         private void SaveAsImage(Stream stream, int width, int height, Bitmap.CompressFormat format)
         {

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
@@ -1,0 +1,105 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using StbImageSharp;
+using StbImageWriteSharp;
+using System;
+using System.IO;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public partial class Texture2D
+    {
+        private unsafe static Texture2D PlatformFromStream(GraphicsDevice graphicsDevice, Stream stream)
+        {
+            byte[] bytes;
+
+            // Rewind stream if it is at end
+            if (stream.CanSeek && stream.Length == stream.Position)
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+            }
+
+            // Copy it's data to memory
+            // As some platforms dont provide full stream functionality and thus streams can't be read as it is
+            using (var ms = new MemoryStream())
+            {
+                stream.CopyTo(ms);
+                bytes = ms.ToArray();
+            }
+
+            // The data returned is always four channel BGRA
+            var result = ImageResult.FromMemory(bytes, StbImageSharp.ColorComponents.RedGreenBlueAlpha);
+
+            // XNA blacks out any pixels with an alpha of zero.
+            fixed (byte* b = &result.Data[0])
+            {
+                for (var i = 0; i < result.Data.Length; i += 4)
+                {
+                    if (b[i + 3] == 0)
+                    {
+                        b[i + 0] = 0;
+                        b[i + 1] = 0;
+                        b[i + 2] = 0;
+                    }
+                }
+            }
+
+            Texture2D texture = null;
+            texture = new Texture2D(graphicsDevice, result.Width, result.Height);
+            texture.SetData(result.Data);
+
+            return texture;
+        }
+
+        internal enum ImageWriterFormat
+        {
+            Jpg,
+            Png
+        }
+
+        internal unsafe void SaveAsImage(Stream stream, int width, int height, ImageWriterFormat format)
+        {
+            if (stream == null)
+            {
+                throw new ArgumentNullException("stream", "'stream' cannot be null (Nothing in Visual Basic)");
+            }
+            if (width <= 0)
+            {
+                throw new ArgumentOutOfRangeException("width", width, "'width' cannot be less than or equal to zero");
+            }
+            if (height <= 0)
+            {
+                throw new ArgumentOutOfRangeException("height", height, "'height' cannot be less than or equal to zero");
+            }
+            Color[] data = null;
+            try
+            {
+                data = GetColorData();
+
+                // Write
+                fixed (Color* ptr = &data[0])
+                {
+                    var writer = new ImageWriter();
+                    switch (format)
+                    {
+                        case ImageWriterFormat.Jpg:
+                            writer.WriteJpg(ptr, width, height, StbImageWriteSharp.ColorComponents.RedGreenBlueAlpha, stream, 90);
+                            break;
+                        case ImageWriterFormat.Png:
+                            writer.WritePng(ptr, width, height, StbImageWriteSharp.ColorComponents.RedGreenBlueAlpha, stream);
+                            break;
+                    }
+                }
+            }
+            finally
+            {
+                if (data != null)
+                {
+                    data = null;
+                }
+            }
+        }
+    }
+}

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
@@ -53,7 +53,6 @@ namespace Microsoft.Xna.Framework.Graphics
             return texture;
         }
 
-#if !WINDOWS_UAP
         internal enum ImageWriterFormat
         {
             Jpg,
@@ -102,6 +101,5 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
             }
         }
-#endif
     }
 }

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
@@ -53,13 +53,23 @@ namespace Microsoft.Xna.Framework.Graphics
             return texture;
         }
 
-        internal enum ImageWriterFormat
+        private void PlatformSaveAsJpeg(Stream stream, int width, int height)
+        {
+            SaveAsImage(stream, width, height, ImageWriterFormat.Jpg);
+        }
+
+        private void PlatformSaveAsPng(Stream stream, int width, int height)
+        {
+            SaveAsImage(stream, width, height, ImageWriterFormat.Png);
+        }
+
+        private enum ImageWriterFormat
         {
             Jpg,
             Png
         }
 
-        internal unsafe void SaveAsImage(Stream stream, int width, int height, ImageWriterFormat format)
+        private unsafe void SaveAsImage(Stream stream, int width, int height, ImageWriterFormat format)
         {
             if (stream == null)
             {

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Xna.Framework.Graphics
             return texture;
         }
 
+#if !WINDOWS_UAP
         internal enum ImageWriterFormat
         {
             Jpg,
@@ -101,5 +102,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
This is follow up to #6703 
I did some refactoring and moved all StbSharp stuff to Texture2D.StbSharp.cs and removed code that seems to be obsolete.
Also I've made it so StbImageWriteSharp is used instead of NotImplementedException.
Some platform specific image writers are still used: for Android and UWP.