### PR TITLE
Fix issue #6453 - SwapChain is null in GraphicsDevice.PlatformDispose

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
@@ -945,7 +945,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformDispose()
         {
             // make sure to release full screen or this might cause issues on exit
-            if (_swapChain.IsFullScreen)
+            if (_swapChain != null && _swapChain.IsFullScreen)
                 _swapChain.SetFullscreenState(false, null);
 
             SharpDX.Utilities.Dispose(ref _renderTargetView);


### PR DESCRIPTION
This is a very small fix to resolve issue #6453 and prevent `GraphicsDevice.PlatformDispose` throwing `NullReferenceException` in WPF applications.