### PR TITLE
iOS core build with Keyboard.GetState method

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.iOSCore.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOSCore.csproj
@@ -32,7 +32,6 @@ This package provides you with MonoGame Framework that works on iOS.</Descriptio
     <Compile Remove="GraphicsDeviceManager.cs" />
     <Compile Remove="Graphics\GraphicsAdapter.cs" />
     <Compile Remove="Graphics\OcclusionQuery.cs" />
-    <Compile Remove="Input\Keyboard.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,13 +44,14 @@ This package provides you with MonoGame Framework that works on iOS.</Descriptio
     <Compile Include="Platform\iOS\iOSGameView_Touch.cs" />
     <Compile Include="Platform\iOS\iOSGameWindow.cs" />
     <Compile Include="Platform\iOS\OrientationConverter.cs" />
- 
+
     <Compile Include="Platform\GamePlatform.Mobile.cs" />
     <Compile Include="Platform\Graphics\GraphicsAdapter.Legacy.cs" />
     <Compile Include="Platform\Graphics\OpenGL.iOS.cs" />
     <Compile Include="Platform\GraphicsDeviceManager.Legacy.cs" />
     <Compile Include="Platform\Input\GamePad.iOS.cs" />
     <Compile Include="Platform\Input\Joystick.Default.cs" />
+    <Compile Include="Platform\Input\Keyboard.Default.cs" />
     <Compile Include="Platform\Input\KeyboardInput.iOS.cs" />
     <Compile Include="Platform\Input\MessageBox.iOS.cs" />
     <Compile Include="Platform\Input\Mouse.Default.cs" />
@@ -65,7 +65,7 @@ This package provides you with MonoGame Framework that works on iOS.</Descriptio
     <Compile Include="Platform\Utilities\FuncLoader.iOS.cs" />
     <Compile Include="Platform\Utilities\InteropHelpers.cs" />
     <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
-    
+
     <Compile Include="..\ThirdParty\StbImageSharp\src\StbImageSharp\**\*.cs" LinkBase="Utilities\StbImageSharp"/>
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\StbImageWriteSharp\**\*.cs" LinkBase="Utilities\StbImageWriteSharp"/>
   </ItemGroup>


### PR DESCRIPTION
Currently, nuget package of iOS core build with cake has no `Keyboard.GetState` method. And this break thirdparty librarie that are platform agnostic and depend on that method, which stops project depending on these libraries compiling(Keyboard.GetState method not found).

Here is a instance: https://github.com/craftworkgames/MonoGame.Extended/blob/develop/Source/MonoGame.Extended.Input/InputListeners/KeyboardListener.cs#L40

The keyboard class was intentionally removed. I don't why. It could sit there and wouldn't affect anything.