### PR TITLE
Fix WindowsDX Test output type

### DIFF
--- a/Test/MonoGame.Tests.WindowsDX.csproj
+++ b/Test/MonoGame.Tests.WindowsDX.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <ProjectType>Exe</ProjectType>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net471</TargetFramework>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
I messed this up when I created the project in #6824.
I wanted to run the tests, but for some reason GraphicsDevice creation failed when I tried. I'll look into it later.