### PR TITLE
[iOS][Android] Fix Texture2D reference

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.AndroidCore.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.AndroidCore.csproj
@@ -52,6 +52,7 @@ This package provides you with MonoGame Framework that works on Android.</Descri
     <Compile Include="Platform\Graphics\GraphicsAdapter.Legacy.cs" />
     <Compile Include="Platform\Graphics\OpenGL.Android.cs" />
     <Compile Include="Platform\Graphics\OpenGL.Common.cs" />
+    <Compile Include="Platform\Graphics\Texture2D.StbSharp.cs" />
     <Compile Include="Platform\GraphicsDeviceManager.Legacy.cs" />
     <Compile Include="Platform\Input\GamePad.Android.cs" />
     <Compile Include="Platform\Input\Joystick.Default.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.iOSCore.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOSCore.csproj
@@ -49,6 +49,7 @@ This package provides you with MonoGame Framework that works on iOS.</Descriptio
     <Compile Include="Platform\GamePlatform.Mobile.cs" />
     <Compile Include="Platform\Graphics\GraphicsAdapter.Legacy.cs" />
     <Compile Include="Platform\Graphics\OpenGL.iOS.cs" />
+    <Compile Include="Platform\Graphics\Texture2D.StbSharp.cs" />
     <Compile Include="Platform\GraphicsDeviceManager.Legacy.cs" />
     <Compile Include="Platform\Input\GamePad.iOS.cs" />
     <Compile Include="Platform\Input\Joystick.Default.cs" />


### PR DESCRIPTION
#### Description
Add `Texture2D.StbSharp.cs` to iOSCore and AndroidCore.


#### Explanation
The cake builds for iOSCore and AndroidCore are failing for me on macOS-10.14 with the following errors:
```
Graphics/Texture2D.cs(328,13): error CS0103: The name 'PlatformSaveAsJpeg' does not exist in the current context
Graphics/Texture2D.cs(339,13): error CS0103: The name 'PlatformSaveAsPng' does not exist in the current context
```

- It looks like #6867 intended to add `Texture2D.StbSharp.cs` to all platforms, but only modified desktop platforms
- In develop right now, iOSCore and AndroidCore only use `Texture2D.OpenGL.cs`, but #6867 removed `PlatformSaveAsJpeg` and `PlatformSaveAsPng` from that

After these changes, iOSCore and AndroidCore build fine for me.