### PR TITLE
Add MonoGame.Content.Builder package

### DIFF
--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="MonoGame.Content.Builder.targets" PackagePath="build" />
+  </ItemGroup>
+
+</Project>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -6,7 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="MonoGame.Content.Builder.props" PackagePath="build" />
     <Content Include="MonoGame.Content.Builder.targets" PackagePath="build" />
+    <Content Include="version\Version.props" PackagePath="build\version\$(Version)" />
   </ItemGroup>
 
 </Project>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <NoWarn>NU5128</NoWarn>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <Content Include="MonoGame.Content.Builder.props" PackagePath="build" />
     <Content Include="MonoGame.Content.Builder.targets" PackagePath="build" />
-    <Content Include="version\Version.props" PackagePath="build\version\$(Version)" />
+    <Content Include="version\Version.props" PackagePath="build\version\$(PackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoWarn>NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.props
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.props
@@ -1,0 +1,12 @@
+﻿<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)/version/**/Version.props" />
+  
+  <PropertyGroup>
+    <DotnetCommand Condition="'$(DotnetCommand)' == ''">dotnet</DotnetCommand>
+    <MGCBCommand Condition="'$(MGCBCommand)' == ''">$(DotnetCommand) tool run dotnet-mgcb</MGCBCommand>
+    <MGCBVersion Condition="'$(MGCBVersion)' == ''">$(MonoGameContentBuilderVersion)</MGCBVersion>
+    <MGCBArguments>/platform:$(MonoGamePlatform) /quiet</MGCBArguments>
+  </PropertyGroup>
+
+</Project>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.props
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.props
@@ -4,9 +4,8 @@
   
   <PropertyGroup>
     <DotnetCommand Condition="'$(DotnetCommand)' == ''">dotnet</DotnetCommand>
-    <MGCBCommand Condition="'$(MGCBCommand)' == ''">$(DotnetCommand) tool run dotnet-mgcb</MGCBCommand>
+    <MGCBPackageId Condition="'$(MGCBPackageId)' == ''">dotnet-mgcb</MGCBPackageId>
     <MGCBVersion Condition="'$(MGCBVersion)' == ''">$(MonoGameContentBuilderVersion)</MGCBVersion>
-    <MGCBArguments>/platform:$(MonoGamePlatform) /quiet</MGCBArguments>
   </PropertyGroup>
 
 </Project>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.props
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.props
@@ -6,6 +6,7 @@
     <DotnetCommand Condition="'$(DotnetCommand)' == ''">dotnet</DotnetCommand>
     <MGCBPackageId Condition="'$(MGCBPackageId)' == ''">dotnet-mgcb</MGCBPackageId>
     <MGCBVersion Condition="'$(MGCBVersion)' == ''">$(MonoGameContentBuilderVersion)</MGCBVersion>
+    <EnableMGCBItems Condition="'$(EnableMGCBItems)' == ''">true</EnableMGCBItems>
   </PropertyGroup>
 
 </Project>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
@@ -1,7 +1,5 @@
 ﻿<Project>
 
-  <UsingTask TaskName="MonoGame.Build.Tasks.CollectContentReferences" AssemblyFile="MonoGame.Build.Tasks.dll" />
-
   <!-- Add MonoGameContentReference to item type selection in Visual Studio -->
   <ItemGroup>
     <AvailableItemName Include="MonoGameContentReference" />
@@ -12,18 +10,196 @@
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
 
+  <!--
+    Target flow diagram
+    * - only run if necessary
+
+                                      InstallMGCB*
+                                           ^
+                                           |
+         GetInstalledMGCB*     ->     UpdateMGCB*
+                                                        \
+                                                          -> RunContentBuilder -> IncludeContent
+                                                        /
+      CollectContentReferences -> PrepareContentBuilder
+  -->
   <PropertyGroup>
     <BuildDependsOn>
-      BuildContent;
+      IncludeContent;
       $(BuildDependsOn);
     </BuildDependsOn>
   </PropertyGroup>
 
-  <Target Name="UpdateMGCB">
+  <!--
+    Calls 'dotnet tool' commands to parse information about any locally installed MGCB tools.
+
+    Outputs:
+      - MGCBInstalledVersion: the version of an installed MGCB tool, or empty string
+      - MGCBInstalledFolder: the folder with a locally installed MGCB tool, or empty string
+
+    Example:
+      - Given the following output from 'dotnet tool list -local':
+          Package Id       Version      Commands      Manifest
+          - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+          dotnet-mgcb      2.0.0        mgcb          C:\Game\Game.DesktopGL\.config\dotnet-tools.json
+      - Output
+        - MGCBInstalledVersion: 2.0.0
+        - MGCBInstalledFolder: C:\Game\Game.DesktopGL
+  -->
+  <Target Name="GetInstalledMGCB">
+
+    <!-- List dotnet tools. -->
+    <Exec
+      WorkingDirectory="$(MSBuildProjectDirectory)"
+      Command="$(DotnetCommand) tool list --local"
+      ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="ConsoleOutput" />
+    </Exec>
+
+    <!-- Get header indices, because the Manifest path may contain spaces or semicolons, which means we cannot simply split. -->
+    <PropertyGroup>
+      <DotnetToolHeader>$(ConsoleOutput.Split(';')[0])</DotnetToolHeader>
+
+      <DotnetToolPackageIdIndex>$(DotnetToolHeader.IndexOf('Package Id'))</DotnetToolPackageIdIndex>
+      <DotnetToolVersionIndex>$(DotnetToolHeader.IndexOf('Version'))</DotnetToolVersionIndex>
+      <DotnetToolCommandsIndex>$(DotnetToolHeader.IndexOf('Commands'))</DotnetToolCommandsIndex>
+      <DotnetToolManifestIndex>$(DotnetToolHeader.IndexOf('Manifest'))</DotnetToolManifestIndex>
+
+      <DotnetToolPackageIdLength>$([MSBuild]::Subtract($(DotnetToolVersionIndex), $(DotnetToolPackageIdIndex)))</DotnetToolPackageIdLength>
+      <DotnetToolVersionLength>$([MSBuild]::Subtract($(DotnetToolCommandsIndex), $(DotnetToolVersionIndex)))</DotnetToolVersionLength>
+      <DotnetToolCommandsLength>$([MSBuild]::Subtract($(DotnetToolManifestIndex), $(DotnetToolCommandsIndex)))</DotnetToolCommandsLength>
+    </PropertyGroup>
+
+    <!-- Get metadata from output. Note: the header and horizontal line will be present here too, but they should not interfere with anything. -->
+    <ItemGroup>
+      <ConsoleLine Include="$(ConsoleOutput.Split(';'))" />
+      <DotnetTool Include="%(ConsoleLine.Identity)" Condition="'%(Identity)' != ''">
+        <PackageId>$([System.String]::Copy(%(Identity)).Substring($(DotnetToolPackageIdIndex), $(DotnetToolPackageIdLength)).Trim())</PackageId>
+        <Version>$([System.String]::Copy(%(Identity)).Substring($(DotnetToolVersionIndex), $(DotnetToolVersionLength)).Trim())</Version>
+        <Commands>$([System.String]::Copy(%(Identity)).Substring($(DotnetToolCommandsIndex), $(DotnetToolCommandsLength)).Trim())</Commands>
+        <Manifest>$([System.String]::Copy(%(Identity)).Substring($(DotnetToolManifestIndex)).Trim())</Manifest>
+      </DotnetTool>
+    </ItemGroup>
+
+    <!-- Get metadata for the MGCB tool, if present. -->
+    <PropertyGroup>
+      <MGCBInstalledVersion Condition="'%(PackageId)' == '$(MGCBPackageId)'">%(DotnetTool.Version)</MGCBInstalledVersion>
+      <MGCBInstalledFolder Condition="'%(PackageId)' == '$(MGCBPackageId)'">$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName(%(DotnetTool.Manifest)))))</MGCBInstalledFolder>
+    </PropertyGroup>
 
   </Target>
 
-  <Target Name="PrepareMGCB">
+  <!--
+    Ensures a tools manifest exists in the project directory with the correct version of the MGCB tool installed.
+  -->
+  <Target Name="InstallMGCB">
+
+    <!-- Ensure there is a manifest for the project. -->
+    <Exec
+      WorkingDirectory="$(MSBuildProjectDirectory)"
+      Command="$(DotnetCommand) new tool-manifest"
+      ContinueOnError="true" />
+
+    <!-- If there is a version of MGCB installed in the project directory, uninstall it. -->
+    <Exec
+      Condition="'$(MGCBInstalledFolder)' == '$(MSBuildProjectDirectory)'"
+      WorkingDirectory="$(MSBuildProjectDirectory)"
+      Command="$(DotnetCommand) tool uninstall $(MGCBPackageId)" />
+
+    <!-- Install the correct version of MGCB. -->
+    <Exec
+      WorkingDirectory="$(MSBuildProjectDirectory)"
+      Command="$(DotnetCommand) tool install $(MGCBPackageId) --version $(MGCBVersion)" />
+
+  </Target>
+
+  <!--
+    Restores or installs the correct version of the MGCB tool if MGCBCommand is not already defined
+
+    Outputs:
+      - MGCBCommand: the command to run the MGCB tool without any arguments
+  -->
+  <Target Name="UpdateMGCB" Condition="'$(MGCBCommand)' == ''" DependsOnTargets="GetInstalledMGCB">
+
+    <!-- If the correct version is in the manifest, restore to ensure it's installed -->
+    <Exec
+      Condition="$(MGCBInstalledVersion) == $(MGCBVersion)"
+      Command="$(DotnetCommand) tool restore" />
+
+    <!-- If the correct version is not in the manifest, install the correct version -->
+    <CallTarget
+      Condition="$(MGCBInstalledVersion) != $(MGCBVersion)"
+      Targets="InstallMGCB" />
+
+    <PropertyGroup>
+      <MGCBCommand>$(DotnetCommand) tool run mgcb</MGCBCommand>
+    </PropertyGroup>
+    
+  </Target>
+
+  <!--
+    Converts MonoGameContentReference items to ContentReference items, deriving the necessary metadata
+
+    Outputs:
+      - ContentReference: references to .mgcb files that can be built with MGCB
+        - FullDir: the absolute path of the folder containing the .mgcb file
+        - ContentDir: the relative path of the resource folder to contain the content files
+        - ContentOutputDir: the absolute path of the bin folder containing final built content
+        - ContentIntermediateOutputDir: the absolute path of the obj folder containing intermediate content
+
+    Example:
+      - Given the following file setup:
+        - C:\Game\Game.Shared\Content.mgcb
+        - C:\Game\Game.DesktopGL\Game.DesktopGL.csproj
+          - MonoGameContentReference: ..\Content\Content.mgcb
+      - Output:
+        - ContentReference
+          - FullDir: C:/Game/Game.Shared/
+          - ContentDir: Game.Shared/
+          - ContentOutputDir: C:/Game/Game.Shared/bin/DesktopGL/Content
+          - ContentIntermediateOutputDir: C:/Game/Game.Shared/obj/DesktopGL/Content
+  -->
+  <Target Name="CollectContentReferences">
+
+    <ItemGroup>
+
+      <!-- Start with existing metadata. -->
+      <ContentReference Include="@(MonoGameContentReference)">
+        <Link>%(MonoGameContentReference.Link)</Link>
+        <FullDir>%(MonoGameContentReference.RootDir)%(MonoGameContentReference.Directory)</FullDir>
+        <OutputFolder>%(MonoGameContentReference.Filename)</OutputFolder>
+      </ContentReference>
+
+      <!--
+        Process intermediate metadata.
+        Switch all back-slashes to forward-slashes so the MGCB command doesn't think it's trying to escape characters or quotes.
+        ContentFolder will be the name of the containing folder (using the Link if it exists) so the directory structure of the included content mimics that of the source content.
+      -->
+      <ContentReference>
+        <FullDir>$([System.String]::Copy(%(FullDir)).Replace('\','/'))</FullDir>
+        <ContentFolder Condition="'%(Link)' == ''">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(FullPath)))))</ContentFolder>
+        <ContentFolder Condition="'%(Link)' != ''">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetFullPath(%(Link)))))))</ContentFolder>
+      </ContentReference>
+
+      <!-- Assemble final metadata. -->
+      <ContentReference>
+        <ContentDir>%(ContentFolder)/</ContentDir>
+        <ContentOutputDir>%(FullDir)bin/$(MonoGamePlatform)/%(OutputFolder)</ContentOutputDir>
+        <ContentIntermediateOutputDir>%(FullDir)obj/$(MonoGamePlatform)/%(OutputFolder)</ContentIntermediateOutputDir>
+      </ContentReference>
+
+    </ItemGroup>
+
+  </Target>
+
+  <!--
+    Set and validate properties, and create folders for content output.
+
+    Outputs:
+      - PlatformResourcePrefix: the platform-specific prefix for included content paths
+      - MonoGameMGCBAdditionalArguments: extra arguments to add to the MGCB call
+  -->
+  <Target Name="PrepareContentBuilder" DependsOnTargets="CollectContentReferences">
 
     <PropertyGroup>
       <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX'">$(MonoMacResourcePrefix)</PlatformResourcePrefix>
@@ -31,13 +207,8 @@
       <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">$(MonoAndroidAssetsPrefix)</PlatformResourcePrefix>
       <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' != '' And !HasTrailingSlash('$(PlatformResourcePrefix)')">$(PlatformResourcePrefix)\</PlatformResourcePrefix>
       <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' == ''"></PlatformResourcePrefix>
+      <MonoGameMGCBAdditionalArguments Condition="'$(MonoGameMGCBAdditionalArguments)' == ''">/quiet</MonoGameMGCBAdditionalArguments>
     </PropertyGroup>
-
-    <!-- Get all Mono Game Content References and store them in a list -->
-    <!-- We do this here so we are compatible with xbuild -->
-    <CollectContentReferences ContentReferences="@(MonoGameContentReference)" MonoGamePlatform="$(MonoGamePlatform)">
-      <Output TaskParameter="Output" ItemName="ContentReferences"/>
-    </CollectContentReferences>
 
     <Error
       Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, WindowsStoreApp, WindowsPhone8, MacOSX, iOS, Linux, DesktopGL, RaspberryPi, Android, Ouya, NativeClient, PlayStation4, PSVita, XboxOne or PlayStationMobile."
@@ -59,38 +230,55 @@
 
     <Warning
       Text="No Content References Found. Please make sure your .mgcb file has a build action of MonoGameContentReference"
-      Condition=" '%(ContentReferences.FullPath)' == '' "
+      Condition=" '%(ContentReference.FullPath)' == '' "
     />
 
-    <MakeDir Directories="%(ContentReferences.ContentOutputDir)"/>
-    <MakeDir Directories="%(ContentReferences.ContentIntermediateOutputDir)"/>
+    <MakeDir Directories="%(ContentReference.ContentOutputDir)"/>
+    <MakeDir Directories="%(ContentReference.ContentIntermediateOutputDir)"/>
 
   </Target>
 
-  <Target Name="RunMGCB" DependsOnTargets="UpdateMGCB;PrepareMGCB">
+  <!--
+    Run MGCB to build content and include it as ExtraContent.
 
+    Outputs:
+      - ExtraContent: built content files
+        - ContentDir: the relative path of the embedded folder to contain the content files
+  -->
+  <Target Name="RunContentBuilder" DependsOnTargets="UpdateMGCB;PrepareContentBuilder">
+
+    <!-- Execute MGCB from the project directory so we use the correct manifest. -->
     <Exec
-      Condition=" '%(ContentReferences.FullPath)' != '' "
-      Command="$(MGCBCommand) $(MGCBArguments) /@:&quot;%(ContentReferences.FullPath)&quot; /outputDir:&quot;%(ContentReferences.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReferences.ContentIntermediateOutputDir)&quot;"
-      WorkingDirectory="%(ContentReferences.RootDir)%(ContentReferences.Directory)" />
+      Condition=" '%(ContentReference.FullPath)' != '' "
+      Command="$(MGCBCommand) $(MonoGameMGCBAdditionalArguments) /platform:$(MonoGamePlatform) /@:&quot;%(ContentReference.FullPath)&quot; /outputDir:&quot;%(ContentReference.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReference.ContentIntermediateOutputDir)&quot; /workingDir:&quot;%(ContentReference.FullDir)&quot;"
+      WorkingDirectory="$(MSBuildProjectDirectory)" />
 
-    <CreateItem
-      Include="%(ContentReferences.RelativeFullPath)%(ContentReferences.ContentOutputDir)\**\*.*"
-      AdditionalMetadata="ContentOutputDir=%(ContentReferences.ContentDirectory)">
-      <Output TaskParameter="Include" ItemName="ExtraContent" />
-    </CreateItem>
+    <ItemGroup>
+      <ExtraContent Include="%(ContentReference.ContentOutputDir)\**\*.*">
+        <ContentDir>%(ContentReference.ContentDir)</ContentDir>
+      </ExtraContent>
+    </ItemGroup>
 
   </Target>
 
+  <!--
+    Include ExtraContent as platform-specific content in the project output.
+
+    Outputs:
+      - AndroidAsset: built content files if Android
+      - BundleResource: built content files if MacOSX or iOS
+      - Content: built content files for all other platforms
+  -->
   <Target
-    Name="BuildContent"
-    DependsOnTargets="RunMGCB"
+    Name="IncludeContent"
+    DependsOnTargets="RunContentBuilder"
     Condition=" '@(MonoGameContentReference)' != '' "
     Outputs="%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension)">
 
+    <!-- Call CreateItem on each piece of ExtraContent so it's easy to switch the item type by platform -->
     <CreateItem
       Include="%(ExtraContent.FullPath)"
-      AdditionalMetadata="Link=$(PlatformResourcePrefix)%(ExtraContent.ContentOutputDir)%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension);CopyToOutputDirectory=PreserveNewest"
+      AdditionalMetadata="Link=$(PlatformResourcePrefix)%(ExtraContent.ContentDir)%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension);CopyToOutputDirectory=PreserveNewest"
       Condition="'%(ExtraContent.Filename)' != ''">
       <Output TaskParameter="Include" ItemName="Content" Condition="'$(MonoGamePlatform)' != 'Android' And '$(MonoGamePlatform)' != 'iOS' And '$(MonoGamePlatform)' != 'MacOSX'" />
       <Output TaskParameter="Include" ItemName="BundleResource" Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'" />

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
@@ -1,17 +1,102 @@
 ﻿<Project>
 
-  <Target Name="TestOutput" AfterTargets="AfterBuild">
-    <XmlPeek
-      XmlInputPath="$(MSBuildThisFileDirectory)\..\monogame.content.builder.nuspec"
-      Query="//*[name()='version']/text()">
-      <Output TaskParameter="Result" ItemName="MonoGameContentBuilderVersion" />
-    </XmlPeek>
+  <UsingTask TaskName="MonoGame.Build.Tasks.CollectContentReferences" AssemblyFile="MonoGame.Build.Tasks.dll" />
+
+  <!-- Add MonoGameContentReference to item type selection in Visual Studio -->
+  <ItemGroup>
+    <AvailableItemName Include="MonoGameContentReference" />
+  </ItemGroup>
+
+  <!-- This disables the IDE feature that skips executing msbuild in some build situations. -->
+  <PropertyGroup>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <BuildDependsOn>
+      BuildContent;
+      $(BuildDependsOn);
+    </BuildDependsOn>
+  </PropertyGroup>
+
+  <Target Name="UpdateMGCB">
+
+  </Target>
+
+  <Target Name="PrepareMGCB">
 
     <PropertyGroup>
-      <MonoGameContentBuilderVersion>@(MonoGameContentBuilderVersion)</MonoGameContentBuilderVersion>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX'">$(MonoMacResourcePrefix)</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'iOS'">$(IPhoneResourcePrefix)</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">$(MonoAndroidAssetsPrefix)</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' != '' And !HasTrailingSlash('$(PlatformResourcePrefix)')">$(PlatformResourcePrefix)\</PlatformResourcePrefix>
+      <PlatformResourcePrefix Condition="'$(PlatformResourcePrefix)' == ''"></PlatformResourcePrefix>
     </PropertyGroup>
 
-    <Message Importance="high" Text="Version: $(MonoGameContentBuilderVersion)" />
+    <!-- Get all Mono Game Content References and store them in a list -->
+    <!-- We do this here so we are compatible with xbuild -->
+    <CollectContentReferences ContentReferences="@(MonoGameContentReference)" MonoGamePlatform="$(MonoGamePlatform)">
+      <Output TaskParameter="Output" ItemName="ContentReferences"/>
+    </CollectContentReferences>
+
+    <Error
+      Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, WindowsStoreApp, WindowsPhone8, MacOSX, iOS, Linux, DesktopGL, RaspberryPi, Android, Ouya, NativeClient, PlayStation4, PSVita, XboxOne or PlayStationMobile."
+      Condition="'$(MonoGamePlatform)' != 'Windows' And
+                 '$(MonoGamePlatform)' != 'iOS' And       
+                 '$(MonoGamePlatform)' != 'Android' And       
+                 '$(MonoGamePlatform)' != 'Linux' And           
+                 '$(MonoGamePlatform)' != 'DesktopGL' And           
+                 '$(MonoGamePlatform)' != 'MacOSX' And       
+                 '$(MonoGamePlatform)' != 'WindowsStoreApp' And       
+                 '$(MonoGamePlatform)' != 'NativeClient' And       
+                 '$(MonoGamePlatform)' != 'PlayStationMobile' And       
+                 '$(MonoGamePlatform)' != 'WindowsPhone8' And       
+                 '$(MonoGamePlatform)' != 'RaspberryPi' And       
+                 '$(MonoGamePlatform)' != 'PlayStation4' And       
+                 '$(MonoGamePlatform)' != 'PSVita' And       
+                 '$(MonoGamePlatform)' != 'XboxOne' And 
+                 '$(MonoGamePlatform)' != 'WindowsGL'" />
+
+    <Warning
+      Text="No Content References Found. Please make sure your .mgcb file has a build action of MonoGameContentReference"
+      Condition=" '%(ContentReferences.FullPath)' == '' "
+    />
+
+    <MakeDir Directories="%(ContentReferences.ContentOutputDir)"/>
+    <MakeDir Directories="%(ContentReferences.ContentIntermediateOutputDir)"/>
+
+  </Target>
+
+  <Target Name="RunMGCB" DependsOnTargets="UpdateMGCB;PrepareMGCB">
+
+    <Exec
+      Condition=" '%(ContentReferences.FullPath)' != '' "
+      Command="$(MGCBCommand) $(MGCBArguments) /@:&quot;%(ContentReferences.FullPath)&quot; /outputDir:&quot;%(ContentReferences.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReferences.ContentIntermediateOutputDir)&quot;"
+      WorkingDirectory="%(ContentReferences.RootDir)%(ContentReferences.Directory)" />
+
+    <CreateItem
+      Include="%(ContentReferences.RelativeFullPath)%(ContentReferences.ContentOutputDir)\**\*.*"
+      AdditionalMetadata="ContentOutputDir=%(ContentReferences.ContentDirectory)">
+      <Output TaskParameter="Include" ItemName="ExtraContent" />
+    </CreateItem>
+
+  </Target>
+
+  <Target
+    Name="BuildContent"
+    DependsOnTargets="RunMGCB"
+    Condition=" '@(MonoGameContentReference)' != '' "
+    Outputs="%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension)">
+
+    <CreateItem
+      Include="%(ExtraContent.FullPath)"
+      AdditionalMetadata="Link=$(PlatformResourcePrefix)%(ExtraContent.ContentOutputDir)%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension);CopyToOutputDirectory=PreserveNewest"
+      Condition="'%(ExtraContent.Filename)' != ''">
+      <Output TaskParameter="Include" ItemName="Content" Condition="'$(MonoGamePlatform)' != 'Android' And '$(MonoGamePlatform)' != 'iOS' And '$(MonoGamePlatform)' != 'MacOSX'" />
+      <Output TaskParameter="Include" ItemName="BundleResource" Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'" />
+      <Output TaskParameter="Include" ItemName="AndroidAsset" Condition="'$(MonoGamePlatform)' == 'Android'" />
+    </CreateItem>
+
   </Target>
 
 </Project>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
@@ -1,0 +1,17 @@
+﻿<Project>
+
+  <Target Name="TestOutput" AfterTargets="AfterBuild">
+    <XmlPeek
+      XmlInputPath="$(MSBuildThisFileDirectory)\..\monogame.content.builder.nuspec"
+      Query="//*[name()='version']/text()">
+      <Output TaskParameter="Result" ItemName="MonoGameContentBuilderVersion" />
+    </XmlPeek>
+
+    <PropertyGroup>
+      <MonoGameContentBuilderVersion>@(MonoGameContentBuilderVersion)</MonoGameContentBuilderVersion>
+    </PropertyGroup>
+
+    <Message Importance="high" Text="Version: $(MonoGameContentBuilderVersion)" />
+  </Target>
+
+</Project>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
@@ -182,7 +182,7 @@
       <ContentReference>
         <FullDir>$([System.String]::Copy(%(FullDir)).Replace('\','/'))</FullDir>
         <ContentFolder Condition="'%(Link)' == ''">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(FullPath)))))</ContentFolder>
-        <ContentFolder Condition="'%(Link)' != ''">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetFullPath(%(Link)))))))</ContentFolder>
+        <ContentFolder Condition="'%(Link)' != ''">$([System.IO.Path]::GetDirectoryName(%(Link)))</ContentFolder>
       </ContentReference>
 
       <!-- Assemble final metadata. -->

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
@@ -171,6 +171,7 @@
       <ContentReference Include="@(MonoGameContentReference)">
         <Link>%(MonoGameContentReference.Link)</Link>
         <FullDir>%(MonoGameContentReference.RootDir)%(MonoGameContentReference.Directory)</FullDir>
+        <ContentFolder></ContentFolder>
         <OutputFolder>%(MonoGameContentReference.Filename)</OutputFolder>
       </ContentReference>
 
@@ -181,8 +182,8 @@
       -->
       <ContentReference>
         <FullDir>$([System.String]::Copy(%(FullDir)).Replace('\','/'))</FullDir>
-        <ContentFolder Condition="'%(Link)' == ''">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(FullPath)))))</ContentFolder>
         <ContentFolder Condition="'%(Link)' != ''">$([System.IO.Path]::GetDirectoryName(%(Link)))</ContentFolder>
+        <ContentFolder Condition="'%(Link)' == '' AND '%(RelativeDir)' != ''">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(RelativeDir)))))</ContentFolder>
       </ContentReference>
 
       <!-- Assemble final metadata. -->
@@ -234,7 +235,7 @@
 
     <Warning
       Text="No Content References Found. Please make sure your .mgcb file has a build action of MonoGameContentReference"
-      Condition=" '%(ContentReference.FullPath)' == '' "
+      Condition="'%(ContentReference.FullPath)' == ''"
     />
 
     <MakeDir Directories="%(ContentReference.ContentOutputDir)"/>
@@ -253,12 +254,14 @@
 
     <!-- Execute MGCB from the project directory so we use the correct manifest. -->
     <Exec
-      Condition=" '%(ContentReference.FullPath)' != '' "
+      Condition="'%(ContentReference.FullPath)' != ''"
       Command="$(MGCBCommand) $(MonoGameMGCBAdditionalArguments) /platform:$(MonoGamePlatform) /@:&quot;%(ContentReference.FullPath)&quot; /outputDir:&quot;%(ContentReference.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReference.ContentIntermediateOutputDir)&quot; /workingDir:&quot;%(ContentReference.FullDir)&quot;"
       WorkingDirectory="$(MSBuildProjectDirectory)" />
 
     <ItemGroup>
-      <ExtraContent Include="%(ContentReference.ContentOutputDir)\**\*.*">
+      <ExtraContent
+        Condition="'%(ContentReference.ContentOutputDir)' != ''"
+        Include="%(ContentReference.ContentOutputDir)\**\*.*">
         <ContentDir>%(ContentReference.ContentDir)</ContentDir>
       </ExtraContent>
     </ItemGroup>
@@ -276,7 +279,7 @@
   <Target
     Name="IncludeContent"
     DependsOnTargets="RunContentBuilder"
-    Condition=" '@(MonoGameContentReference)' != '' "
+    Condition="'$(EnableMGCBItems)' == 'true' OR '@(MonoGameContentReference)' != ''"
     Outputs="%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension)">
 
     <!-- Call CreateItem on each piece of ExtraContent so it's easy to switch the item type by platform. -->

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
@@ -161,7 +161,7 @@
   -->
   <Target Name="CollectContentReferences">
 
-    <ItemGroup Condition="'$(EnableMGCBItems)' == 'true'>
+    <ItemGroup Condition="'$(EnableMGCBItems)' == 'true'">
       <MonoGameContentReference Include="**/*.mgcb" />
     </ItemGroup>
 

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
@@ -114,19 +114,19 @@
   </Target>
 
   <!--
-    Restores or installs the correct version of the MGCB tool if MGCBCommand is not already defined
+    Restores or installs the correct version of the MGCB tool if MGCBCommand is not already defined.
 
     Outputs:
       - MGCBCommand: the command to run the MGCB tool without any arguments
   -->
   <Target Name="UpdateMGCB" Condition="'$(MGCBCommand)' == ''" DependsOnTargets="GetInstalledMGCB">
 
-    <!-- If the correct version is in the manifest, restore to ensure it's installed -->
+    <!-- If the correct version is in the manifest, restore to ensure it's installed. -->
     <Exec
       Condition="$(MGCBInstalledVersion) == $(MGCBVersion)"
       Command="$(DotnetCommand) tool restore" />
 
-    <!-- If the correct version is not in the manifest, install the correct version -->
+    <!-- If the correct version is not in the manifest, install the correct version. -->
     <CallTarget
       Condition="$(MGCBInstalledVersion) != $(MGCBVersion)"
       Targets="InstallMGCB" />
@@ -138,7 +138,7 @@
   </Target>
 
   <!--
-    Converts MonoGameContentReference items to ContentReference items, deriving the necessary metadata
+    Converts MonoGameContentReference items to ContentReference items, deriving the necessary metadata.
 
     Outputs:
       - ContentReference: references to .mgcb files that can be built with MGCB
@@ -275,7 +275,7 @@
     Condition=" '@(MonoGameContentReference)' != '' "
     Outputs="%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension)">
 
-    <!-- Call CreateItem on each piece of ExtraContent so it's easy to switch the item type by platform -->
+    <!-- Call CreateItem on each piece of ExtraContent so it's easy to switch the item type by platform. -->
     <CreateItem
       Include="%(ExtraContent.FullPath)"
       AdditionalMetadata="Link=$(PlatformResourcePrefix)%(ExtraContent.ContentDir)%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension);CopyToOutputDirectory=PreserveNewest"

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
@@ -161,6 +161,10 @@
   -->
   <Target Name="CollectContentReferences">
 
+    <ItemGroup Condition="'$(EnableMGCBItems)' == 'true'>
+      <MonoGameContentReference Include="**/*.mgcb" />
+    </ItemGroup>
+
     <ItemGroup>
 
       <!-- Start with existing metadata. -->

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.targets
@@ -134,7 +134,7 @@
     <PropertyGroup>
       <MGCBCommand>$(DotnetCommand) tool run mgcb</MGCBCommand>
     </PropertyGroup>
-    
+
   </Target>
 
   <!--
@@ -171,7 +171,7 @@
       <ContentReference Include="@(MonoGameContentReference)">
         <Link>%(MonoGameContentReference.Link)</Link>
         <FullDir>%(MonoGameContentReference.RootDir)%(MonoGameContentReference.Directory)</FullDir>
-        <ContentFolder></ContentFolder>
+        <ContentFolder>%(MonoGameContentReference.ContentFolder)</ContentFolder>
         <OutputFolder>%(MonoGameContentReference.Filename)</OutputFolder>
       </ContentReference>
 
@@ -182,8 +182,8 @@
       -->
       <ContentReference>
         <FullDir>$([System.String]::Copy(%(FullDir)).Replace('\','/'))</FullDir>
-        <ContentFolder Condition="'%(Link)' != ''">$([System.IO.Path]::GetDirectoryName(%(Link)))</ContentFolder>
-        <ContentFolder Condition="'%(Link)' == '' AND '%(RelativeDir)' != ''">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(RelativeDir)))))</ContentFolder>
+        <ContentFolder Condition="'%(ContentFolder)' == '' AND '%(Link)' != ''">$([System.IO.Path]::GetDirectoryName(%(Link)))</ContentFolder>
+        <ContentFolder Condition="'%(ContentFolder)' == '' AND '%(Link)' == '' AND '%(RelativeDir)' != ''">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName(%(RelativeDir)))))</ContentFolder>
       </ContentReference>
 
       <!-- Assemble final metadata. -->
@@ -236,6 +236,11 @@
     <Warning
       Text="No Content References Found. Please make sure your .mgcb file has a build action of MonoGameContentReference"
       Condition="'%(ContentReference.FullPath)' == ''"
+    />
+
+    <Warning
+      Text="Content Reference output directory contains '..' which may cause content to be placed outside of the output directory. Please set ContentFolder on your MonoGameContentReference '%(ContentReference.Filename)' to enforce the correct content output location."
+      Condition="$([System.String]::Copy('%(ContentReference.ContentDir)').Contains('..'))"
     />
 
     <MakeDir Directories="%(ContentReference.ContentOutputDir)"/>

--- a/Tools/MonoGame.Content.Builder/version/Version.props
+++ b/Tools/MonoGame.Content.Builder/version/Version.props
@@ -1,0 +1,5 @@
+﻿<Project>
+  <PropertyGroup>
+    <MonoGameContentBuilderVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileFullPath)))))</MonoGameContentBuilderVersion>
+  </PropertyGroup>
+</Project>

--- a/build.cake
+++ b/build.cake
@@ -148,13 +148,13 @@ Task("BuildTools")
     .Does(() =>
 {
     DotNetCoreRestore("Tools/2MGFX/2MGFX.csproj");
-    MSBuild("Tools/2MGFX/2MGFX.csproj", msPackSettings);
+    PackProject("Tools/2MGFX/2MGFX.csproj");
 
     DotNetCoreRestore("Tools/MGCB/MGCB.csproj");
-    MSBuild("Tools/MGCB/MGCB.csproj", msPackSettings);
+    PackProject("Tools/MGCB/MGCB.csproj");
 
     DotNetCoreRestore("Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj");
-    MSBuild("Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj", msPackSettings);
+    PackProject("Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj");
 });
 
 Task("PackVSTemplates")

--- a/build.cake
+++ b/build.cake
@@ -147,6 +147,14 @@ Task("BuildTools")
     .IsDependentOn("Prep")
     .Does(() =>
 {
+    DotNetCoreRestore("Tools/2MGFX/2MGFX.csproj");
+    MSBuild("Tools/2MGFX/2MGFX.csproj", msPackSettings);
+
+    DotNetCoreRestore("Tools/MGCB/MGCB.csproj");
+    MSBuild("Tools/MGCB/MGCB.csproj", msPackSettings);
+
+    DotNetCoreRestore("Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj");
+    MSBuild("Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj", msPackSettings);
 });
 
 Task("PackVSTemplates")


### PR DESCRIPTION
### Description

A single NuGet package that combines the jobs of the old `MonoGame.Content.Builder.targets` and `MonoGame.Build.Tasks` steps while using the new MGCB dotnet tool. Addresses #6898.

1. Get the package version.
    - I considered several different approaches (reading the nuspec, generating a props file post-build), but decided on using the `$(Version)` property to pack a props file that inspects its own path. This option has the fewest moving parts, and relies only on pieces that we explicitly place (unlike the nuspec).
2. Run `dotnet tool list --local` to check for a locally installed MGCB tool with the same version.
3. Restore an existing MGCB tool of the correct version, or (re-)install the MGCB tool.
4. Collect content references.
    - Translation and simplification of the same task from `MonoGame.Build.Tasks`.
    - I opted to not use the existing `MonoGame.Build.Tasks` for several reasons. `dotnet pack` doesn't support packing files from `ProjectReferences` and the workaround doesn't work with `IncludeBuildOutput` disabled, and it didn't seem worth adding extra manual steps to copy the files or publishing a separate `MonoGame.Build.Tasks` NuGet package. Additionally, I believe MonoGame.Build.Tasks was originally written to accomodate xbuild, but that's no longer necessary, so the same steps can easily be performed in targets.
5. Build content.
6. Include content.

### Extensibility

All of the following MSBuild properties can be customized.

New
- `DotnetCommand`: dotnet command. Default: `dotnet`
- `MGCBCommand` MGCB command. Default: `$(DotnetCommand) tool run mgcb`
- `MGCBPackageId`: MGCB dotnet tool package ID. Default: `dotnet-mgcb`
- `MGCBVersion`: MGCB dotnet tool version. Default: `MonoGame.Content.Builder` version

Pre-existing
- `MonoGameMGCBAdditionalArguments`: additional arguments to pass to MGCB. Default: `/quiet`
- `PlatformResourcePrefix`: platform-specific prefix for included content paths. Default: depends on platform and prefixes defined by Xamarin

### Validation

I tested the following scenarios with WindowsDX, using a local package of `dotnet-mgcb`. All were successful in running MGCB, including content, and loading content in a game.

- Having no `dotnet-mgcb` installed
    - `MonoGame.Content.Builder` creates a manifest and installs the correct version of `dotnet-mgcb`
- Having the correct version of `dotnet-mgcb` installed in the project directory or parent directory
    - `MonoGame.Content.Builder` restores the installed version of `dotnet-mgcb`
- Having an old version of `dotnet-mgcb` installed in the project directory
    - `MonoGame.Content.Builder` uninstalls and reinstalls the correct version of `dotnet-mgcb`
- Having an old version of `dotnet-mgcb` installed in the parent directory
    - `MonoGame.Content.Builder` creates a manifest and installs the correct version of `dotnet-mgcb` in the project directory