### PR TITLE
Decouple Content.Pipeline from Graphics

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -420,6 +420,7 @@
     <Compile Include="Content\ContentLoadException.cs" />
     <Compile Include="Content\ContentManager.cs" />
     <Compile Include="Content\ContentReader.cs" />
+    <Compile Include="Content\ContentReaderExtensions.cs" />
     <Compile Include="Content\ContentReaders\AlphaTestEffectReader.cs" />
     <Compile Include="Content\ContentReaders\ArrayReader.cs" />
     <Compile Include="Content\ContentReaders\BasicEffectReader.cs" />

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Xna.Framework.Content
 
 		private string _rootDirectory = string.Empty;
 		private IServiceProvider serviceProvider;
-		private IGraphicsDeviceService graphicsDeviceService;
         private Dictionary<string, object> loadedAssets = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 		private List<IDisposable> disposableAssets = new List<IDisposable>();
         private bool disposed;
@@ -314,15 +313,6 @@ namespace Microsoft.Xna.Framework.Content
 			string originalAssetName = assetName;
 			object result = null;
 
-			if (this.graphicsDeviceService == null)
-			{
-				this.graphicsDeviceService = serviceProvider.GetService(typeof(IGraphicsDeviceService)) as IGraphicsDeviceService;
-				if (this.graphicsDeviceService == null)
-				{
-					throw new InvalidOperationException("No Graphics Device Service");
-				}
-			}
-			
             // Try to load as XNB file
             var stream = OpenStream(assetName);
             using (var xnbReader = new BinaryReader(stream))
@@ -389,7 +379,7 @@ namespace Microsoft.Xna.Framework.Content
                 decompressedStream = stream;
             }
 
-            var reader = new ContentReader(this, decompressedStream, this.graphicsDeviceService.GraphicsDevice,
+            var reader = new ContentReader(this, decompressedStream,
                                                         originalAssetName, version, recordDisposableObject);
             
             return reader;
@@ -438,15 +428,6 @@ namespace Microsoft.Xna.Framework.Content
 			if (disposed)
 			{
 				throw new ObjectDisposedException("ContentManager");
-			}
-
-			if (this.graphicsDeviceService == null)
-			{
-				this.graphicsDeviceService = serviceProvider.GetService(typeof(IGraphicsDeviceService)) as IGraphicsDeviceService;
-				if (this.graphicsDeviceService == null)
-				{
-					throw new InvalidOperationException("No Graphics Device Service");
-				}
 			}
 
             var stream = OpenStream(assetName);

--- a/MonoGame.Framework/Content/ContentReader.cs
+++ b/MonoGame.Framework/Content/ContentReader.cs
@@ -29,16 +29,13 @@ namespace Microsoft.Xna.Framework.Content
             }
         }
 
-        internal GraphicsDevice GraphicsDevice
+        internal GraphicsDevice GetGraphicsDevice()
         {
-            get
-            {
-                var graphicsDeviceService = ContentManager.ServiceProvider.GetService(typeof(IGraphicsDeviceService)) as IGraphicsDeviceService;
-                if (graphicsDeviceService == null)
-                    throw new InvalidOperationException("No Graphics Device Service");
+            var graphicsDeviceService = ContentManager.ServiceProvider.GetService(typeof(IGraphicsDeviceService)) as IGraphicsDeviceService;
+            if (graphicsDeviceService == null)
+                throw new InvalidOperationException("No Graphics Device Service");
 
-                return graphicsDeviceService.GraphicsDevice;
-            }
+            return graphicsDeviceService.GraphicsDevice;
         }
 
         internal ContentReader(ContentManager manager, Stream stream, string assetName, int version, Action<IDisposable> recordDisposableObject)

--- a/MonoGame.Framework/Content/ContentReader.cs
+++ b/MonoGame.Framework/Content/ContentReader.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
@@ -27,15 +26,6 @@ namespace Microsoft.Xna.Framework.Content
             {
                 return typeReaders;
             }
-        }
-
-        internal GraphicsDevice GetGraphicsDevice()
-        {
-            var graphicsDeviceService = ContentManager.ServiceProvider.GetService(typeof(IGraphicsDeviceService)) as IGraphicsDeviceService;
-            if (graphicsDeviceService == null)
-                throw new InvalidOperationException("No Graphics Device Service");
-
-            return graphicsDeviceService.GraphicsDevice;
         }
 
         internal ContentReader(ContentManager manager, Stream stream, string assetName, int version, Action<IDisposable> recordDisposableObject)

--- a/MonoGame.Framework/Content/ContentReader.cs
+++ b/MonoGame.Framework/Content/ContentReader.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Xna.Framework.Content
         private ContentManager contentManager;
         private Action<IDisposable> recordDisposableObject;
         private ContentTypeReaderManager typeReaderManager;
-        private GraphicsDevice graphicsDevice;
         private string assetName;
         private List<KeyValuePair<int, Action<object>>> sharedResourceFixups;
         private ContentTypeReader[] typeReaders;
@@ -34,14 +33,17 @@ namespace Microsoft.Xna.Framework.Content
         {
             get
             {
-                return this.graphicsDevice;
+                var graphicsDeviceService = ContentManager.ServiceProvider.GetService(typeof(IGraphicsDeviceService)) as IGraphicsDeviceService;
+                if (graphicsDeviceService == null)
+                    throw new InvalidOperationException("No Graphics Device Service");
+
+                return graphicsDeviceService.GraphicsDevice;
             }
         }
 
-        internal ContentReader(ContentManager manager, Stream stream, GraphicsDevice graphicsDevice, string assetName, int version, Action<IDisposable> recordDisposableObject)
+        internal ContentReader(ContentManager manager, Stream stream, string assetName, int version, Action<IDisposable> recordDisposableObject)
             : base(stream)
         {
-            this.graphicsDevice = graphicsDevice;
             this.recordDisposableObject = recordDisposableObject;
             this.contentManager = manager;
             this.assetName = assetName;

--- a/MonoGame.Framework/Content/ContentReaderExtensions.cs
+++ b/MonoGame.Framework/Content/ContentReaderExtensions.cs
@@ -1,0 +1,26 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Microsoft.Xna.Framework.Content
+{
+    public static class ContentReaderExtensions
+    {
+        /// <summary>
+        /// Gets the GraphicsDevice from the ContentManager.ServiceProvider.
+        /// </summary>
+        /// <returns>The <see cref="GraphicsDevice"/>.</returns>
+        public static GraphicsDevice GetGraphicsDevice(this ContentReader contentReader)
+        {
+            var serviceProvider = contentReader.ContentManager.ServiceProvider;
+            var graphicsDeviceService = serviceProvider.GetService(typeof(IGraphicsDeviceService)) as IGraphicsDeviceService;
+            if (graphicsDeviceService == null)
+                throw new InvalidOperationException("No Graphics Device Service");
+
+            return graphicsDeviceService.GraphicsDevice;
+        }
+    }
+}

--- a/MonoGame.Framework/Content/ContentReaders/AlphaTestEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/AlphaTestEffectReader.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xna.Framework.Content
     {
         protected internal override AlphaTestEffect Read(ContentReader input, AlphaTestEffect existingInstance)
         {
-            var effect = new AlphaTestEffect(input.GraphicsDevice);
+            var effect = new AlphaTestEffect(input.GetGraphicsDevice());
 
             effect.Texture = input.ReadExternalReference<Texture>() as Texture2D;
             effect.AlphaFunction = (CompareFunction)input.ReadInt32();

--- a/MonoGame.Framework/Content/ContentReaders/BasicEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BasicEffectReader.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xna.Framework.Content
     {
         protected internal override BasicEffect Read(ContentReader input, BasicEffect existingInstance)
         {
-            var effect = new BasicEffect(input.GraphicsDevice);
+            var effect = new BasicEffect(input.GetGraphicsDevice());
             var texture = input.ReadExternalReference<Texture>() as Texture2D;
             if (texture != null)
             {

--- a/MonoGame.Framework/Content/ContentReaders/DualTextureEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DualTextureEffectReader.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Xna.Framework.Content
     {
         protected internal override DualTextureEffect Read(ContentReader input, DualTextureEffect existingInstance)
         {
-			DualTextureEffect effect = new DualTextureEffect(input.GraphicsDevice);
+			DualTextureEffect effect = new DualTextureEffect(input.GetGraphicsDevice());
 			effect.Texture = input.ReadExternalReference<Texture>() as Texture2D;
 			effect.Texture2 = input.ReadExternalReference<Texture>() as Texture2D;
 			effect.DiffuseColor = input.ReadVector3 ();

--- a/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Xna.Framework.Content
             int dataSize = input.ReadInt32();
             byte[] data = input.ContentManager.GetScratchBuffer(dataSize);
             input.Read(data, 0, dataSize);
-            var effect = new Effect(input.GraphicsDevice, data, 0, dataSize);
+            var effect = new Effect(input.GetGraphicsDevice(), data, 0, dataSize);
             effect.Name = input.AssetName;
             return effect;
         }

--- a/MonoGame.Framework/Content/ContentReaders/EnvironmentMapEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EnvironmentMapEffectReader.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Xna.Framework.Content
     {
         protected internal override EnvironmentMapEffect Read(ContentReader input, EnvironmentMapEffect existingInstance)
         {
-            var effect = new EnvironmentMapEffect(input.GraphicsDevice);
+            var effect = new EnvironmentMapEffect(input.GetGraphicsDevice());
             effect.Texture = input.ReadExternalReference<Texture>() as Texture2D;
 			effect.EnvironmentMap = input.ReadExternalReference<TextureCube>() as TextureCube;
 			effect.EnvironmentMapAmount = input.ReadSingle ();

--- a/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Xna.Framework.Content
 
             if (indexBuffer == null)
             {
-                indexBuffer = new IndexBuffer(input.GraphicsDevice,
+                indexBuffer = new IndexBuffer(input.GetGraphicsDevice(),
                     sixteenBits ? IndexElementSize.SixteenBits : IndexElementSize.ThirtyTwoBits, 
                     dataSize / (sixteenBits ? 2 : 4), BufferUsage.None);
             }

--- a/MonoGame.Framework/Content/ContentReaders/ModelReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ModelReader.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Xna.Framework.Content
                 if (existingInstance != null)
                     continue;
 
-				ModelMesh mesh = new ModelMesh(reader.GraphicsDevice, parts);
+				ModelMesh mesh = new ModelMesh(reader.GetGraphicsDevice(), parts);
 
                 // Tag reassignment
                 mesh.Tag = meshTag;
@@ -183,7 +183,7 @@ namespace Microsoft.Xna.Framework.Content
             // Read the final pieces of model data.
             var rootBoneIndex = ReadBoneReference(reader, boneCount);
 
-            Model model = new Model(reader.GraphicsDevice, bones, meshes);
+            Model model = new Model(reader.GetGraphicsDevice(), bones, meshes);
 
             model.Root = bones[rootBoneIndex];
 		

--- a/MonoGame.Framework/Content/ContentReaders/SkinnedEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SkinnedEffectReader.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Xna.Framework.Content
     {
         protected internal override SkinnedEffect Read(ContentReader input, SkinnedEffect existingInstance)
         {
-            var effect = new SkinnedEffect(input.GraphicsDevice);
+            var effect = new SkinnedEffect(input.GetGraphicsDevice());
 			effect.Texture = input.ReadExternalReference<Texture> () as Texture2D;
 			effect.WeightsPerVertex = input.ReadInt32 ();
 			effect.DiffuseColor = input.ReadVector3 ();

--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Xna.Framework.Content
 
             // If the system does not fully support Power of Two textures,
             // skip any mip maps supplied with any non PoT textures.
-            if (levelCount > 1 && !reader.GraphicsDevice.GraphicsCapabilities.SupportsNonPowerOfTwo &&
+            if (levelCount > 1 && !reader.GetGraphicsDevice().GraphicsCapabilities.SupportsNonPowerOfTwo &&
                 (!MathHelper.IsPowerOfTwo(width) || !MathHelper.IsPowerOfTwo(height)))
             {
                 levelCountOutput = 1;
@@ -42,21 +42,21 @@ namespace Microsoft.Xna.Framework.Content
 			{
 				case SurfaceFormat.Dxt1:
 				case SurfaceFormat.Dxt1a:
-					if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsDxt1)
+					if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsDxt1)
 						convertedFormat = SurfaceFormat.Color;
 					break;
 				case SurfaceFormat.Dxt1SRgb:
-					if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsDxt1)
+					if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsDxt1)
 						convertedFormat = SurfaceFormat.ColorSRgb;
 					break;
 				case SurfaceFormat.Dxt3:
 				case SurfaceFormat.Dxt5:
-					if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
+					if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc)
 						convertedFormat = SurfaceFormat.Color;
 					break;
 				case SurfaceFormat.Dxt3SRgb:
 				case SurfaceFormat.Dxt5SRgb:
-					if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
+					if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc)
 						convertedFormat = SurfaceFormat.ColorSRgb;
 					break;
 				case SurfaceFormat.NormalizedByte4:
@@ -64,7 +64,7 @@ namespace Microsoft.Xna.Framework.Content
 					break;
 			}
 			
-            texture = existingInstance ?? new Texture2D(reader.GraphicsDevice, width, height, levelCountOutput > 1, convertedFormat);
+            texture = existingInstance ?? new Texture2D(reader.GetGraphicsDevice(), width, height, levelCountOutput > 1, convertedFormat);
 #if OPENGL
             Threading.BlockOnUIThread(() =>
             {
@@ -86,7 +86,7 @@ namespace Microsoft.Xna.Framework.Content
 					    case SurfaceFormat.Dxt1:
                         case SurfaceFormat.Dxt1SRgb:
                         case SurfaceFormat.Dxt1a:
-				            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsDxt1 && convertedFormat == SurfaceFormat.Color)
+				            if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsDxt1 && convertedFormat == SurfaceFormat.Color)
 				            {
 				                levelData = DxtUtil.DecompressDxt1(levelData, levelWidth, levelHeight);
 				                levelDataSizeInBytes = levelData.Length;
@@ -94,8 +94,8 @@ namespace Microsoft.Xna.Framework.Content
 				            break;
 					    case SurfaceFormat.Dxt3:
 					    case SurfaceFormat.Dxt3SRgb:
-                            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
-				                if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc &&
+                            if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc)
+				                if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc &&
 				                    convertedFormat == SurfaceFormat.Color)
 				                {
 				                    levelData = DxtUtil.DecompressDxt3(levelData, levelWidth, levelHeight);
@@ -104,8 +104,8 @@ namespace Microsoft.Xna.Framework.Content
 				            break;
 					    case SurfaceFormat.Dxt5:
 					    case SurfaceFormat.Dxt5SRgb:
-                            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
-				                if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc &&
+                            if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc)
+				                if (!reader.GetGraphicsDevice().GraphicsCapabilities.SupportsS3tc &&
 				                    convertedFormat == SurfaceFormat.Color)
 				                {
 				                    levelData = DxtUtil.DecompressDxt5(levelData, levelWidth, levelHeight);

--- a/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Xna.Framework.Content
             int levelCount = reader.ReadInt32();
 
             if (existingInstance == null)
-                texture = new Texture3D(reader.GraphicsDevice, width, height, depth, levelCount > 1, format);
+                texture = new Texture3D(reader.GetGraphicsDevice(), width, height, depth, levelCount > 1, format);
             else
                 texture = existingInstance;
 

--- a/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Xna.Framework.Content
 			int levels = reader.ReadInt32();
 
             if (existingInstance == null)
-                textureCube = new TextureCube(reader.GraphicsDevice, size, levels > 1, surfaceFormat);
+                textureCube = new TextureCube(reader.GetGraphicsDevice(), size, levels > 1, surfaceFormat);
             else
                 textureCube = existingInstance;
 

--- a/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Xna.Framework.Content
             byte[] data = input.ContentManager.GetScratchBuffer(dataSize);
             input.Read(data, 0, dataSize);
 
-            var buffer = new VertexBuffer(input.GraphicsDevice, declaration, vertexCount, BufferUsage.None);
+            var buffer = new VertexBuffer(input.GetGraphicsDevice(), declaration, vertexCount, BufferUsage.None);
             buffer.SetData(data, 0, dataSize);
             return buffer;
         }


### PR DESCRIPTION
Removes the depedency of GraphicsDevice from base class ContentReader and the cached IGraphicsDeviceService from ContentManager.

Readers of GraphicsResources request the GraphicsDevice directly from the ServiceProvider.