### PR TITLE
[CAKE] Disable WindowsDX compilation on non-Windows platforms

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -82,6 +82,7 @@ Task("BuildDesktopGL")
 
 Task("BuildWindowsDX")
     .IsDependentOn("Prep")
+    .WithCriteria(() => IsRunningOnWindows())
     .Does(() =>
 {
     DotNetCoreRestore("MonoGame.Framework.WindowsDX.sln");


### PR DESCRIPTION
Since we added netcoreapp3.0 as a target framework, this can no longer be compiled from non Windows operating systems.