### PR TITLE
FileHelpers: Fix Uri getting confused by double slashes

### DIFF
--- a/MonoGame.Framework/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework/Utilities/FileHelpers.cs
@@ -42,6 +42,10 @@ namespace MonoGame.Utilities
             // Uri accepts forward slashes
             filePath = filePath.Replace(BackwardSlash, ForwardSlash);
 
+            // Sanitize the path of double slashes, they confuse Uri
+            while (filePath.Contains("//"))
+                filePath = filePath.Replace("//", "/");
+
             bool hasForwardSlash = filePath.StartsWith(ForwardSlashString);
             if (!hasForwardSlash)
                 filePath = ForwardSlashString + filePath;

--- a/Test/Framework/UtilitiesTest.cs
+++ b/Test/Framework/UtilitiesTest.cs
@@ -42,6 +42,7 @@ namespace MonoGame.Tests.Framework
         [TestCase(  @"Content/../file",                 @"../file.extension",       @"file.extension")]
         [TestCase(  @"Content/./file",                  @"file.extension",          @"Content/file.extension")]
         [TestCase(  @"Content/./file",                  @"./file.extension",        @"Content/file.extension")]
+        [TestCase(  @"Content//file",                   @"../file.extension",       @"file.extension")]
         [TestCase(  @"C:\Game\Content\fi#le",           @"fi#le.extension",         @"C:\Game\Content\fi#le.extension")]
         public void ResolveRelativePath(
                     string rootFilePath,                string relativePath,        string matchFullPath)


### PR DESCRIPTION
While working on a Proton title I ran into an issue with ReadExternalReference, where the file path and external reference path looked something like this:

```
Models//zolt
..\effects\instancerDeep
```

With the current function, you end up getting `Models/effects/instancerDeep`, which is wrong. Strangely enough, Uri is sensitive to empty directory names, so to resolve this you have to strip out the double slashes manually. It also has to be looped because you could get something really awful like `Something\\\\Or\\Other`, and Replace only does one pass per call.