### PR TITLE
Use the the newest version 2.0.54 for MSBuild.Sdk.Extras to fix building ios project

### DIFF
--- a/MonoGame.Framework/global.json
+++ b/MonoGame.Framework/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "1.6.65"
+        "MSBuild.Sdk.Extras": "2.0.54"
     }
 }


### PR DESCRIPTION
I got a error message on building ios project:
```
$ ./build.sh --build-target=BuildiOS --build-configuration=Debug --build-version=3.7.104
Feeds used:
  /Users/Ryan/.nuget/packages/
  https://api.nuget.org/v3/index.json

All packages listed in /Users/Ryan/monogame/MonoGame/Cake/packages.config are already installed.
Analyzing build script...
Processing build script...
Installing tools...
Compiling build script...

========================================
Prep
========================================
Executing task: Prep
Finished executing task: Prep

========================================
BuildiOS
========================================
Executing task: BuildiOS
  Restore completed in 22.79 ms for /Users/Ryan/monogame/MonoGame/MonoGame.Framework/MonoGame.Framework.iOSCore.csproj.
Microsoft (R) Build Engine version 16.4.0-ci for Mono
Copyright (C) Microsoft Corporation. All rights reserved.

/Users/Ryan/.nuget/packages/msbuild.sdk.extras/1.6.65/Build/LanguageTargets/CheckMissing.targets(32,3): warning MSB4011: "/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/msbuild/Current/bin/Microsoft.CSharp.targets" cannot be imported again. It was already imported at "/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.CSharp.targets (36,2)". This is most likely a build authoring error. This subsequent import will be ignored. [/Users/Ryan/monogame/MonoGame/MonoGame.Framework/MonoGame.Framework.iOSCore.csproj]
/Users/Ryan/.nuget/packages/msbuild.sdk.extras/1.6.65/Build/LanguageTargets/CheckMissing.targets(36,5): error : The specified language targets for xamarinios10 is missing. Ensure correct tooling is installed for 'xamarinios'. Missing: '/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/xbuild/Xamarin/iOS/Xamarin.iOS.CSharp.targets' [/Users/Ryan/monogame/MonoGame/MonoGame.Framework/MonoGame.Framework.iOSCore.csproj]
An error occurred when executing task 'BuildiOS'.
Error: One or more errors occurred. (MSBuild: Process returned an error (exit code 1).)
        MSBuild: Process returned an error (exit code 1).
```

This patch fixes the error.