### PR TITLE
Implements trigger vibrations on UWP and add overloads

### DIFF
--- a/MonoGame.Framework/Input/GamePad.cs
+++ b/MonoGame.Framework/Input/GamePad.cs
@@ -116,7 +116,21 @@ namespace Microsoft.Xna.Framework.Input
         /// <returns>Returns true if the vibration motors were set.</returns>
         public static bool SetVibration(PlayerIndex playerIndex, float leftMotor, float rightMotor)
         {
-            return SetVibration((int)playerIndex, leftMotor, rightMotor);
+            return SetVibration((int)playerIndex, leftMotor, rightMotor, 0.0f, 0.0f);
+        }
+
+        /// <summary>
+        /// Sets the vibration motor speeds on the controller device if supported.
+        /// </summary>
+        /// <param name="playerIndex">Player index that identifies the controller to set.</param>
+        /// <param name="leftMotor">The speed of the left motor, between 0.0 and 1.0. This motor is a low-frequency motor.</param>
+        /// <param name="rightMotor">The speed of the right motor, between 0.0 and 1.0. This motor is a high-frequency motor.</param>
+        /// <param name="leftTrigger">(Xbox One controller only) The speed of the left trigger motor, between 0.0 and 1.0. This motor is a high-frequency motor.</param>
+        /// <param name="rightTrigger">(Xbox One controller only) The speed of the right trigger motor, between 0.0 and 1.0. This motor is a high-frequency motor.</param>
+        /// <returns>Returns true if the vibration motors were set.</returns>
+        public static bool SetVibration(PlayerIndex playerIndex, float leftMotor, float rightMotor, float leftTrigger, float rightTrigger)
+        {
+            return SetVibration((int)playerIndex, leftMotor, rightMotor, leftTrigger, rightTrigger);
         }
 
         /// <summary>
@@ -127,11 +141,25 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="rightMotor">The speed of the right motor, between 0.0 and 1.0. This motor is a high-frequency motor.</param>
         /// <returns>Returns true if the vibration motors were set.</returns>
         public static bool SetVibration(int index, float leftMotor, float rightMotor)
+        {           
+            return SetVibration(index, leftMotor, rightMotor, 0.0f, 0.0f);
+        }
+
+        /// <summary>
+        /// Sets the vibration motor speeds on the controller device if supported.
+        /// </summary>
+        /// <param name="index">Index for the controller you want to query.</param>
+        /// <param name="leftMotor">The speed of the left motor, between 0.0 and 1.0. This motor is a low-frequency motor.</param>
+        /// <param name="rightMotor">The speed of the right motor, between 0.0 and 1.0. This motor is a high-frequency motor.</param>
+        /// <param name="leftTrigger">(Xbox One controller only) The speed of the left trigger motor, between 0.0 and 1.0. This motor is a high-frequency motor.</param>
+        /// <param name="rightTrigger">(Xbox One controller only) The speed of the right trigger motor, between 0.0 and 1.0. This motor is a high-frequency motor.</param>
+        /// <returns>Returns true if the vibration motors were set.</returns>
+        public static bool SetVibration(int index, float leftMotor, float rightMotor, float leftTrigger, float rightTrigger)
         {
             if (index < 0 || index >= PlatformGetMaxNumberOfGamePads())
                 return false;
-            
-            return PlatformSetVibration(index, MathHelper.Clamp(leftMotor, 0.0f, 1.0f), MathHelper.Clamp(rightMotor, 0.0f, 1.0f));
+
+            return PlatformSetVibration(index, MathHelper.Clamp(leftMotor, 0.0f, 1.0f), MathHelper.Clamp(rightMotor, 0.0f, 1.0f), MathHelper.Clamp(leftTrigger, 0.0f, 1.0f), MathHelper.Clamp(rightTrigger, 0.0f, 1.0f));
         }
 
         /// <summary>

--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Xna.Framework.Input
             return state;
         }
 
-        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)
+        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor, float leftTrigger, float rightTrigger)
         {
             var gamePad = GamePads[index];
             if (gamePad == null)

--- a/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
@@ -309,7 +309,7 @@ namespace Microsoft.Xna.Framework.Input
             return ret;
         }
 
-        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)
+        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor, float leftTrigger, float rightTrigger)
         {
             if (!Gamepads.ContainsKey(index))
                 return false;

--- a/MonoGame.Framework/Platform/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.UWP.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Xna.Framework.Input
             return result;
         }
 
-        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)
+        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor, float leftTrigger, float rightTrigger)
         {
             if (!_gamepads.ContainsKey(index))
                 return false;
@@ -159,9 +159,9 @@ namespace Microsoft.Xna.Framework.Input
             gamepad.Vibration = new WGI.GamepadVibration
             {
                 LeftMotor = leftMotor,
-                LeftTrigger = leftMotor,
+                LeftTrigger = leftTrigger,
                 RightMotor = rightMotor,
-                RightTrigger = rightMotor
+                RightTrigger = rightTrigger
             };
 
             return true;

--- a/MonoGame.Framework/Platform/Input/GamePad.Web.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Web.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Xna.Framework.Input
             return state;
         }
 
-        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)
+        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor, float leftTrigger, float rightTrigger)
         {
             return false;
         }

--- a/MonoGame.Framework/Platform/Input/GamePad.XInput.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.XInput.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Xna.Framework.Input
             return new GamePadButtons(ret);
         }
 
-        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)
+        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor, float leftTrigger, float rightTrigger)
         {
             if (!_connected[index])
             {

--- a/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Xna.Framework.Input
             return state;
         }
 
-        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)
+        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor, float leftTrigger, float rightTrigger)
         {
             return false;
         }

--- a/MonoGame.Framework/Platform/Input/GamePad.tvOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.tvOS.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Xna.Framework.Input
             return state;
         }
 
-        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)
+        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor, float leftTrigger, float rightTrigger)
         {
             return false;
         }


### PR DESCRIPTION
Hi!

This addresses #6929 by adding overloads to activate separately Xbox One controller trigger vibrations. Only implementing it for UWP for now.

@tomspilman 

Fixes #6929