### PR TITLE
Fix: CoreRT crash

### DIFF
--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -199,7 +199,8 @@ namespace MonoGame.OpenAL
 
 #if DESKTOPGL
             // Load bundled library
-            var assemblyLocation = Path.GetDirectoryName(typeof(AL).Assembly.Location);
+            var assemblyLocation = Path.GetDirectoryName(typeof(AL).Assembly.Location) ?? "./";
+
             if (CurrentPlatform.OS == OS.Windows && Environment.Is64BitProcess)
                 ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x64/soft_oal.dll"));
             else if (CurrentPlatform.OS == OS.Windows && !Environment.Is64BitProcess)

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -18,7 +18,8 @@ internal static class Sdl
         var ret = IntPtr.Zero;
 
         // Load bundled library
-        var assemblyLocation = Path.GetDirectoryName(typeof(Sdl).Assembly.Location);
+        var assemblyLocation = Path.GetDirectoryName(typeof(Sdl).Assembly.Location) ?? "./";
+        
         if (CurrentPlatform.OS == OS.Windows && Environment.Is64BitProcess)
             ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x64/SDL2.dll"));
         else if (CurrentPlatform.OS == OS.Windows && !Environment.Is64BitProcess)


### PR DESCRIPTION
The game built with Microsoft.DotNet.ILCompiler 1.0.0-alpha-28229-02 (CoreRT) was crashing on startup due to `assemblyLocation` being null.

It's expected to be working properly in the future CoreRT versions.