### PR TITLE
Make Cake script can build individual nuget packages.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -162,6 +162,7 @@ Task("BuildTools")
 });
 
 Task("PackVSTemplates")
+    .IsDependentOn("Prep")
     .Does(() =>
 {
     var vsdirs = GetDirectories("./ProjectTemplates/VisualStudio20*");

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,7 @@
 // ARGUMENTS
 //////////////////////////////////////////////////////////////////////
 
-var target = Argument("build-target", "Default");
+var target = Argument("target", "Default");
 string version = null;
 if (HasArgument("build-version"))
     version = Argument<string>("build-version");


### PR DESCRIPTION
Make cake build script be able to build individual library, such as when you only want Android part, in PowerShell:

```
.\Protobuild.exe --generate Android
.\build.ps1 --target="BuildAndroid"
```

To build project template nuget:

```
.\build.ps1 --target="PackVSTemplates"
```