### PR TITLE
[Android] fix GamePad.Back emulation

### DIFF
--- a/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
@@ -1149,6 +1149,8 @@ namespace Microsoft.Xna.Framework
 
         public override bool OnKeyUp(Keycode keyCode, KeyEvent e)
         {
+            if (keyCode == Keycode.Back)
+                GamePad.Back = false;
             if (GamePad.OnKeyUp(keyCode, e))
                 return true;
             return Keyboard.KeyUp(keyCode);

--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -151,7 +151,6 @@ namespace Microsoft.Xna.Framework.Input
                 if (index == 0 && Back)
                 {
                     // Consume state
-                    Back = false;
                     state = new GamePadState(new GamePadThumbSticks(), new GamePadTriggers(), new GamePadButtons(Buttons.Back), new GamePadDPad());
                     state.IsConnected = false;
                 }


### PR DESCRIPTION
The current implementation will report Buttons.Back as Pressed and immediately return to Released on the next frame. 
The state is changed repeatedly from frame to frame for as long as the user keeps the back button pressed.

this results is various problems:
-Reports multiple Pressed/Released for a single press.
-It's not possible to detect  a HOLD gesture.
-Writing crossplatform code is problematic, checking for both gamepad Buttons.Back and Keys.Back releases will result in registering multiple events. (Windows Store uses the Keys.Back which is also what Android is reporting natively when the back button is pressed. GamePad's Buttons.Back is used on Desktop but also on Android with bluetooth gamepads).