### PR TITLE
[Pipeline] Rethrow InvalidContentException for Importers instead of wraping it in a new PipelineException. 

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -672,6 +672,10 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 {
                     throw;
                 }
+                catch (InvalidContentException)
+                {
+                    throw;
+                }
                 catch (Exception inner)
                 {
                     throw new PipelineException(string.Format("Importer '{0}' had unexpected failure!", pipelineEvent.Importer), inner);


### PR DESCRIPTION
Similar to what we are doing for processors.

https://github.com/MonoGame/MonoGame/blob/477dbd28c5af48ca7b2c910109da4e92a5c0e7fc/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs#L715-L726

Currently an InvalidContentException from an importer will be wrapped in a new PipelineException with the error msg replaced by 'Importer '{0}' had unexpected failure!' while this should happed only for unknown errors/exceptions.