### PR TITLE
Running the tests on .Net Core and Visual 2017/2019

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -73,10 +73,20 @@ This package provides you with the content pipeline for Windows, Mac and Linux w
     </Reference>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(SolutionName)' != 'MonoGame.Framework.WindowsDX'">
     <ProjectReference Include="..\MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj">
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SolutionName)' == 'MonoGame.Framework.WindowsDX'">
+    <ProjectReference Include="..\MonoGame.Framework\MonoGame.Framework.WindowsDX.csproj">
+      <PrivateAssets>All</PrivateAssets>
+    </ProjectReference>
+  </ItemGroup>
+
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
   </ItemGroup>
 

--- a/MonoGame.Framework.DesktopGL.sln
+++ b/MonoGame.Framework.DesktopGL.sln
@@ -1,11 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29519.181
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.DesktopGL", "MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj", "{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoGame.Framework.DesktopGL", "MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj", "{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Tests.DesktopGL", "Test\MonoGame.Tests.DesktopGL.csproj", "{D80F2C27-F1E6-4395-95E2-D6EAB308C9DF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoGame.Tests.DesktopGL", "Test\MonoGame.Tests.DesktopGL.csproj", "{D80F2C27-F1E6-4395-95E2-D6EAB308C9DF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoGame.Framework.Content.Pipeline", "MonoGame.Framework.Content.Pipeline\MonoGame.Framework.Content.Pipeline.csproj", "{7A02A18D-15C4-4440-8921-D191B0F050A1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "2MGFX", "Tools\2MGFX\2MGFX.csproj", "{4381A4EF-A2B6-4162-92A8-E240A8DC562B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MGCB", "Tools\MGCB\MGCB.csproj", "{0A2C8210-21D2-450E-8647-E08954E57498}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,9 +21,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C01379FE-63B0-4DDC-AE9C-9C916CCE5F45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -44,5 +47,47 @@ Global
 		{D80F2C27-F1E6-4395-95E2-D6EAB308C9DF}.Release|x64.Build.0 = Release|Any CPU
 		{D80F2C27-F1E6-4395-95E2-D6EAB308C9DF}.Release|x86.ActiveCfg = Release|Any CPU
 		{D80F2C27-F1E6-4395-95E2-D6EAB308C9DF}.Release|x86.Build.0 = Release|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Debug|x64.Build.0 = Debug|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Debug|x86.Build.0 = Debug|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Release|x64.ActiveCfg = Release|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Release|x64.Build.0 = Release|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Release|x86.ActiveCfg = Release|Any CPU
+		{7A02A18D-15C4-4440-8921-D191B0F050A1}.Release|x86.Build.0 = Release|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Debug|x64.Build.0 = Debug|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Debug|x86.Build.0 = Debug|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Release|x64.ActiveCfg = Release|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Release|x64.Build.0 = Release|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Release|x86.ActiveCfg = Release|Any CPU
+		{4381A4EF-A2B6-4162-92A8-E240A8DC562B}.Release|x86.Build.0 = Release|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Debug|x64.Build.0 = Debug|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Debug|x86.Build.0 = Debug|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Release|x64.ActiveCfg = Release|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Release|x64.Build.0 = Release|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Release|x86.ActiveCfg = Release|Any CPU
+		{0A2C8210-21D2-450E-8647-E08954E57498}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E1E69DA8-12D1-4CB2-84DC-33EEA2316293}
 	EndGlobalSection
 EndGlobal

--- a/MonoGame.Framework.WindowsDX.sln
+++ b/MonoGame.Framework.WindowsDX.sln
@@ -1,11 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29519.181
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.WindowsDX", "MonoGame.Framework\MonoGame.Framework.WindowsDX.csproj", "{888F236E-6309-4E7A-9045-FC6AB1617565}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoGame.Framework.WindowsDX", "MonoGame.Framework\MonoGame.Framework.WindowsDX.csproj", "{888F236E-6309-4E7A-9045-FC6AB1617565}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Tests.WindowsDX", "Test\MonoGame.Tests.WindowsDX.csproj", "{E951F34F-4046-470B-B706-E6179E0F4A83}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoGame.Tests.WindowsDX", "Test\MonoGame.Tests.WindowsDX.csproj", "{E951F34F-4046-470B-B706-E6179E0F4A83}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoGame.Framework.Content.Pipeline", "MonoGame.Framework.Content.Pipeline\MonoGame.Framework.Content.Pipeline.csproj", "{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "2MGFX", "Tools\2MGFX\2MGFX.csproj", "{6AE7672E-0D05-4BB8-AC9A-785837A742CA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MGCB", "Tools\MGCB\MGCB.csproj", "{98A2930A-FC0B-4B3D-8113-A6340A550127}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,9 +21,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{888F236E-6309-4E7A-9045-FC6AB1617565}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -44,5 +47,47 @@ Global
 		{E951F34F-4046-470B-B706-E6179E0F4A83}.Release|x64.Build.0 = Release|Any CPU
 		{E951F34F-4046-470B-B706-E6179E0F4A83}.Release|x86.ActiveCfg = Release|Any CPU
 		{E951F34F-4046-470B-B706-E6179E0F4A83}.Release|x86.Build.0 = Release|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Debug|x64.Build.0 = Debug|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Debug|x86.Build.0 = Debug|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Release|x64.ActiveCfg = Release|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Release|x64.Build.0 = Release|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Release|x86.ActiveCfg = Release|Any CPU
+		{6BF31C53-0484-432B-AD7D-F7DFEB98C92F}.Release|x86.Build.0 = Release|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Debug|x64.Build.0 = Debug|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Debug|x86.Build.0 = Debug|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Release|x64.ActiveCfg = Release|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Release|x64.Build.0 = Release|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Release|x86.ActiveCfg = Release|Any CPU
+		{6AE7672E-0D05-4BB8-AC9A-785837A742CA}.Release|x86.Build.0 = Release|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Debug|x64.Build.0 = Debug|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Debug|x86.Build.0 = Debug|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Release|x64.ActiveCfg = Release|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Release|x64.Build.0 = Release|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Release|x86.ActiveCfg = Release|Any CPU
+		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DB6EDE25-DC0E-4705-93E9-73155A697921}
 	EndGlobalSection
 EndGlobal

--- a/Test/ContentPipeline/BuilderTargetsTest.cs
+++ b/Test/ContentPipeline/BuilderTargetsTest.cs
@@ -51,6 +51,8 @@ namespace MonoGame.Tests.ContentPipeline
         [TestCaseSource("BuilderTargetsBuildTools")]
 #if DESKTOPGL
         [Ignore("Fails on Mac build server with xbuild for some reason.")]
+#else
+        [Ignore("This test need to be rewritten to properly test Tools\\MonoGame.Content.Builder instead of the old builder targets.")]
 #endif
         public void BuildSimpleProject(string buildTool)
         {

--- a/Test/MonoGame.Tests.DesktopGL.csproj
+++ b/Test/MonoGame.Tests.DesktopGL.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)\bin\DesktopGL\$(Configuration)\$(TargetFramework)\</RunWorkingDirectory>
+
 
     <DefineConstants>DESKTOPGL</DefineConstants>
     <BaseOutputPath>bin\DesktopGL</BaseOutputPath>

--- a/Test/MonoGame.Tests.DesktopGL.csproj
+++ b/Test/MonoGame.Tests.DesktopGL.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
 
     <DefineConstants>DESKTOPGL</DefineConstants>
     <BaseOutputPath>bin\DesktopGL</BaseOutputPath>
@@ -12,6 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="NUnitLite" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
   </ItemGroup>
 
@@ -21,6 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="bin\**\*" />
+    <Compile Remove="obj\**\*" />
     <Compile Remove="Properties/**/*" />
     <Compile Remove="Interactive/**/*" />
     <Compile Remove="Runner/iOS/**/*" />

--- a/Test/MonoGame.Tests.WindowsDX.csproj
+++ b/Test/MonoGame.Tests.WindowsDX.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net471</TargetFramework>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateProgramFile>false</GenerateProgramFile>
 
     <DefineConstants>WINDOWS;DIRECTX</DefineConstants>
     <BaseOutputPath>bin\WindowsDX</BaseOutputPath>
@@ -23,6 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="bin\**\*" />
+    <Compile Remove="obj\**\*" />
     <Compile Remove="Properties/**/*" />
     <Compile Remove="Interactive/**/*" />
     <Compile Remove="Runner/iOS/**/*" />

--- a/Test/MonoGame.Tests.WindowsDX.csproj
+++ b/Test/MonoGame.Tests.WindowsDX.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)\bin\WindowsDX\$(Configuration)\$(TargetFramework)\</RunWorkingDirectory>
 
     <DefineConstants>WINDOWS;DIRECTX</DefineConstants>
     <BaseOutputPath>bin\WindowsDX</BaseOutputPath>


### PR DESCRIPTION
Hello there,

I'm starting to work on making the tests to run on both ```dotnet``` and Visual Studio, and also having the solution files to work (they aren't right now, and are missing MGCB, 2MGFX and Pipeline).

I'm testing on Visual 2017+2019 and .Net Core 3.1.

**What this PR does:**
- Fixes the solution files to load ```MonoGame.Framework.Content.Pipeline.csproj``` for the test to build and run
- Adds MGCB and 2MGFX to the solutions (Pipeline doesn't have a SDK-Style csproj yet to be included)
- Fixes the tests to work (WIP, see status section)

**Issue with ```MonoGame.Framework.Content.Pipeline.csproj```:**

Right now, the ```.sln``` don't work because they are missing ```MonoGame.Framework.Content.Pipeline.csproj```, which itself is an issue because it references ```DesktopGL``` (and therefore prevents the ```WindowsDX``` tests and tools to build).

We can workaround this by adding conditions to the base framework reference in ```MonoGame.Framework.Content.Pipeline.csproj```:

```
  <ItemGroup Condition="'$(SolutionName)' != 'MonoGame.Framework.WindowsDX'">
    <ProjectReference Include="..\MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj">
      <PrivateAssets>All</PrivateAssets>
    </ProjectReference>
  </ItemGroup>

  <ItemGroup Condition="'$(SolutionName)' == 'MonoGame.Framework.WindowsDX'">
    <ProjectReference Include="..\MonoGame.Framework\MonoGame.Framework.WindowsDX.csproj">
      <PrivateAssets>All</PrivateAssets>
    </ProjectReference>
  </ItemGroup>
```

This allows everything to build and work properly from the sln files for both ```WindowsDX``` and ```DesktopGL```.

However, this is kind of hacky and requires to build/run the tests from sln (e.g. ```dotnet test .\MonoGame.Framework.WindowsDX.sln``` or loading the sln in VS).
Building/running the tests directly (e.g. ```dotnet build .\Tests\MonoGame.Tests.WindowsDX.csproj```) won't work because of how the content pipeline references the base framework.

How do we want to handle this? @Jjagg @cra0zy @tomspilman 
Does working from solution files good enough when willing to run tests? Or should the test projects work on their own without solution files (and if so, how should we handle the problematic reference)?

**Remaining errors while running tests:**
- WindowsDX: stock effects are absent from the test folder
- WindowsDX: nvtt can't be loaded because it has the wrong bitness
- WindowsDX: SharpFont tries to load freetype dll with the wrong bitness
- WindowsDX: freeimage.dll has the wrong bitness and can't be loaded
- WindowsDX: Assimp32.dll can't be found (likely a bitness issue too)
- WindowsDX & DesktopGL: running the tests from Visual Studio or from ```dotnet test``` doesn't run the exact same set of tests (1282 vs 1298 on WindowsDX; 1141 vs 1246 on DesktopGL)
- WindowsDX: tests can't find assets when run from Visual Studio (they work fine from ```dotnet new```)