### PR TITLE
[Templates] Fix opening generated projects with IDEs

### DIFF
--- a/ProjectTemplates/DotNetTemplate/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
+++ b/ProjectTemplates/DotNetTemplate/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
@@ -12,6 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Icon.ico" />
+    <None Remove="Icon.bmp" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Icon.ico" />
     <EmbeddedResource Include="Icon.bmp" />
   </ItemGroup>
@@ -21,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" />
+    <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectTemplates/DotNetTemplate/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
+++ b/ProjectTemplates/DotNetTemplate/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" />
+    <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Stuff done:
- Hidden duplicate Icon items visible in Solution Explorer
- Hidden TrimmerRootAssembly item being visible in Solution Explorer