### PR TITLE
Offset should not be removed from length, length is the the length of…

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Xna.Framework.Audio
                 throw new ArgumentException("Ensure that the buffer length is non-zero.", "buffer");
 
             var blockAlign = (int)channels * 2;
-            if ((buffer.Length % blockAlign) != 0)
+            if ((count % blockAlign) != 0)
                 throw new ArgumentException("Ensure that the buffer meets the block alignment requirements for the number of channels.", "buffer");
 
             if (count <= 0)
@@ -177,7 +177,7 @@ namespace Microsoft.Xna.Framework.Audio
             if (((ulong)count + (ulong)offset) > (ulong)buffer.Length)
                 throw new ArgumentException("Ensure that the offset+count region lines within the buffer.", "offset");
 
-            var totalSamples = buffer.Length / blockAlign;
+            var totalSamples = count / blockAlign;
 
             if (loopStart < 0)
                 throw new ArgumentException("The loopStart cannot be negative.", "loopStart");

--- a/MonoGame.Framework/Platform/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffect.XAudio.cs
@@ -152,8 +152,8 @@ namespace Microsoft.Xna.Framework.Audio
         {
             // NOTE: We make a copy here because old versions of 
             // DataStream.Create didn't work correctly for offsets.
-            var data = new byte[length - offset];
-            Buffer.BlockCopy(buffer, offset, data, 0, length - offset);
+            var data = new byte[length];
+            Buffer.BlockCopy(buffer, offset, data, 0, length);
 
             return DataStream.Create(data, true, false);
         }


### PR DESCRIPTION
… data to use, which is separate from the source buffer length

fixes #6995

(cherry picked from commit 7fc6bb3758cf14b423987b7e99e93fef170598cb)