### PR TITLE
Update Pipeline Tool project files

### DIFF
--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -27,7 +27,7 @@
     <CustomDefinitions>
       <Platform Name="Windows">TRACE;WINDOWS</Platform>
       <Platform Name="MacOS">TRACE;MONOMAC;GTK2</Platform>
-      <Platform Name="Linux">TRACE;LINUX;GTK3</Platform>
+      <Platform Name="Linux">TRACE;LINUX;GTK</Platform>
     </CustomDefinitions>
     <FrameworkVersions>
       <Version>v4.7.2</Version>

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -11,6 +11,7 @@ This package provides you with the content pipeline for Windows, Mac and Linux w
     
     <AssemblyName>MonoGame.Framework.Content.Pipeline</AssemblyName>
     <RootNamespace>Microsoft.Xna.Framework.Content.Pipeline</RootNamespace>
+    <CopyContentFiles>True</CopyContentFiles>
   </PropertyGroup>
 
   <ItemGroup>
@@ -90,7 +91,7 @@ This package provides you with the content pipeline for Windows, Mac and Linux w
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(CopyContentFiles)' == 'True'">
     <Content Include="..\ThirdParty\Dependencies\SharpDX\net40\SharpDX.dll" PackagePath="lib\netstandard2.0" Visible="false" />
     <Content Include="..\ThirdParty\Dependencies\SharpDX\SharpDX.D3DCompiler.dll" PackagePath="lib\netstandard2.0" Visible="false" />
     <Content Include="..\ThirdParty\Dependencies\CppNet\CppNet.dll" PackagePath="lib\netstandard2.0" Visible="false" />

--- a/MonoGame.Framework.DesktopGL.sln
+++ b/MonoGame.Framework.DesktopGL.sln
@@ -13,6 +13,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "2MGFX", "Tools\2MGFX\2MGFX.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MGCB", "Tools\MGCB\MGCB.csproj", "{0A2C8210-21D2-450E-8647-E08954E57498}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{C9C1F3D2-48F2-4411-A7F7-608FD59861B5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PipelineTool.Gtk", "Tools\Pipeline\PipelineTool.Gtk.csproj", "{4458364B-E957-4D12-A01A-012510FE6906}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,11 +87,26 @@ Global
 		{0A2C8210-21D2-450E-8647-E08954E57498}.Release|x64.Build.0 = Release|Any CPU
 		{0A2C8210-21D2-450E-8647-E08954E57498}.Release|x86.ActiveCfg = Release|Any CPU
 		{0A2C8210-21D2-450E-8647-E08954E57498}.Release|x86.Build.0 = Release|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Debug|x64.Build.0 = Debug|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Debug|x86.Build.0 = Debug|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Release|x64.ActiveCfg = Release|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Release|x64.Build.0 = Release|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Release|x86.ActiveCfg = Release|Any CPU
+		{4458364B-E957-4D12-A01A-012510FE6906}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E1E69DA8-12D1-4CB2-84DC-33EEA2316293}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{4458364B-E957-4D12-A01A-012510FE6906} = {C9C1F3D2-48F2-4411-A7F7-608FD59861B5}
 	EndGlobalSection
 EndGlobal

--- a/MonoGame.Framework.WindowsDX.sln
+++ b/MonoGame.Framework.WindowsDX.sln
@@ -13,6 +13,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "2MGFX", "Tools\2MGFX\2MGFX.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MGCB", "Tools\MGCB\MGCB.csproj", "{98A2930A-FC0B-4B3D-8113-A6340A550127}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{9A4EC299-FA43-4773-A91E-E8E4EB0B6C33}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PipelineTool.Wpf", "Tools\Pipeline\PipelineTool.Wpf.csproj", "{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,11 +87,26 @@ Global
 		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Release|x64.Build.0 = Release|Any CPU
 		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Release|x86.ActiveCfg = Release|Any CPU
 		{98A2930A-FC0B-4B3D-8113-A6340A550127}.Release|x86.Build.0 = Release|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Debug|x64.Build.0 = Debug|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Debug|x86.Build.0 = Debug|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Release|x64.ActiveCfg = Release|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Release|x64.Build.0 = Release|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Release|x86.ActiveCfg = Release|Any CPU
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DB6EDE25-DC0E-4705-93E9-73155A697921}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{52B8CF0D-087F-4A72-AD6C-6AEEAA3F4092} = {9A4EC299-FA43-4773-A91E-E8E4EB0B6C33}
 	EndGlobalSection
 EndGlobal

--- a/Tools/2MGFX/2MGFX.csproj
+++ b/Tools/2MGFX/2MGFX.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>2mgfx</ToolCommandName>
     <PackageId>dotnet-2mgfx</PackageId>

--- a/Tools/MGCB/MGCB.csproj
+++ b/Tools/MGCB/MGCB.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>mgcb</ToolCommandName>
     <PackageId>dotnet-mgcb</PackageId>

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -37,7 +37,9 @@ namespace MonoGame.Tools.Pipeline
             "../../../../MGCB/bin/Debug/netcoreapp3.0",
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../../MGCB/bin/Debug/netcoreapp3.0"),
 #endif
-            Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../MGCB")
+            "../MGCB",
+            "../../../../MGCB/bin/Debug/netcoreapp3.0",
+            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
         };
 
         public IEnumerable<ContentItemTemplate> Templates

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -31,16 +31,13 @@ namespace MonoGame.Tools.Pipeline
         {
             "/Library/Frameworks/MonoGame.framework/Current/Tools",
 #if DEBUG
-            "../../../../../MGCB/bin/Windows/AnyCPU/Debug",
-            Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../../../MGCB/bin/Windows/AnyCPU/Debug"),
+            "../../../../MGCB/bin/Debug/netcoreapp3.0",
+            Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../../MGCB/bin/Debug/netcoreapp3.0"),
 #else
-            "../../../../../MGCB/bin/Windows/AnyCPU/Release",
-            Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../../../MGCB/bin/Windows/AnyCPU/Release"),
+            "../../../../MGCB/bin/Debug/netcoreapp3.0",
+            Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../../MGCB/bin/Debug/netcoreapp3.0"),
 #endif
-            "../MGCB",
-            Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../MGCB"),
-            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-            "",
+            Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../MGCB")
         };
 
         public IEnumerable<ContentItemTemplate> Templates
@@ -486,15 +483,22 @@ namespace MonoGame.Tools.Pipeline
         }
 
         private string FindMGCB()
-        {            
+        {
             foreach (var root in _mgcbSearchPaths)
             {
                 var mgcbPath = Path.Combine(root, "MGCB.exe");
                 if (File.Exists(mgcbPath))
                     return Path.GetFullPath(mgcbPath);
+
+                if (Global.Unix)
+                {
+                    mgcbPath = Path.Combine(root, "MGCB");
+                    if (File.Exists(mgcbPath))
+                        return Path.GetFullPath(mgcbPath);
+                }
             }
 
-            throw new FileNotFoundException("MGCB.exe is not in the search path!");
+            throw new FileNotFoundException("MGCB is not in the search path!");
         }
 
         private void DoBuild(string commands)

--- a/Tools/Pipeline/Controls/DrawInfo.cs
+++ b/Tools/Pipeline/Controls/DrawInfo.cs
@@ -19,12 +19,12 @@ namespace MonoGame.Tools.Pipeline
             HoverBackColor = SystemColors.Highlight;
             DisabledTextColor = SystemColors.ControlText;
             DisabledTextColor.A = 0.4f;
-            BorderColor = Global.Unix ? SystemColors.WindowBackground : SystemColors.Control;
+            BorderColor = Global.IsGtk ? SystemColors.WindowBackground : SystemColors.Control;
         }
 
         public static void SetPixelsPerPoint(Graphics g)
         {
-            if (!once && !Global.Unix)
+            if (!once && !Global.IsGtk)
             {
                 once = true;
                 TextHeight = (int)(SystemFonts.Default().LineHeight * g.PixelsPerPoint + 0.5);

--- a/Tools/Pipeline/Controls/Pad.eto.cs
+++ b/Tools/Pipeline/Controls/Pad.eto.cs
@@ -26,7 +26,7 @@ namespace MonoGame.Tools.Pipeline
             panelLabel = new Panel();
             panelLabel.Padding = new Padding(5);
 
-            if (!Global.Unix)
+            if (!Global.IsGtk)
                 panelLabel.Height = 25;
 
             stack = new StackLayout();

--- a/Tools/Pipeline/Controls/Pad.eto.cs
+++ b/Tools/Pipeline/Controls/Pad.eto.cs
@@ -7,7 +7,7 @@ using Eto.Forms;
 
 namespace MonoGame.Tools.Pipeline
 {
-#if LINUX
+#if GTK
     public partial class Pad : GroupBox
 #else
     public partial class Pad : Panel

--- a/Tools/Pipeline/Controls/PropertyCells/CellBase.cs
+++ b/Tools/Pipeline/Controls/PropertyCells/CellBase.cs
@@ -22,14 +22,6 @@ namespace MonoGame.Tools.Pipeline
 
     public class CellBase
     {
-        public string Category { get; set; }
-        public object Value { get; set; }
-        public string DisplayValue { get; set; }
-        public string Text { get; set; }
-        public bool Editable { get; set; }
-        public int Height { get; set; }
-        public Action OnKill;
-
         protected EventHandler _eventHandler;
         protected Rectangle _lastRec;
         protected Type _type;
@@ -48,6 +40,15 @@ namespace MonoGame.Tools.Pipeline
 
             OnCreate();
         }
+
+        public string Category { get; set; }
+        public object Value { get; set; }
+        public string DisplayValue { get; set; }
+        public string Text { get; set; }
+        public bool Editable { get; set; }
+        public int Height { get; set; }
+        public Action OnKill { get; set; }
+        public bool HasDialog { get; protected set; }
 
         public virtual void OnCreate()
         {

--- a/Tools/Pipeline/Controls/PropertyCells/CellColor.cs
+++ b/Tools/Pipeline/Controls/PropertyCells/CellColor.cs
@@ -15,6 +15,8 @@ namespace MonoGame.Tools.Pipeline
 
         public override void OnCreate()
         {
+            HasDialog = true;
+
             if (Value != null)
             {
                 var tmp = (Microsoft.Xna.Framework.Color)Value;

--- a/Tools/Pipeline/Controls/PropertyCells/CellPath.cs
+++ b/Tools/Pipeline/Controls/PropertyCells/CellPath.cs
@@ -13,6 +13,7 @@ namespace MonoGame.Tools.Pipeline
     {
         public override void OnCreate()
         {
+            HasDialog = true;
             if (Value == null)
                 Value = "";
         }

--- a/Tools/Pipeline/Controls/PropertyCells/CellRefs.cs
+++ b/Tools/Pipeline/Controls/PropertyCells/CellRefs.cs
@@ -15,6 +15,8 @@ namespace MonoGame.Tools.Pipeline
     {
         public override void OnCreate()
         {
+            HasDialog = true;
+
             if (Value == null)
                 Value = new List<string>();
 
@@ -31,6 +33,7 @@ namespace MonoGame.Tools.Pipeline
         public override void Edit(PixelLayout control)
         {
             var dialog = new ReferenceDialog(PipelineController.Instance, (Value as List<string>).ToArray());
+       
             if (dialog.ShowModal(control) && _eventHandler != null)
             {
                 _eventHandler(dialog.References, EventArgs.Empty);

--- a/Tools/Pipeline/Controls/PropertyGridTable.cs
+++ b/Tools/Pipeline/Controls/PropertyGridTable.cs
@@ -213,7 +213,23 @@ namespace MonoGame.Tools.Pipeline
 
             if (e.Location.X >= _separatorPos && _selectedCell != null && _selectedCell.Editable && !_skipEdit)
             {
-                var action = new Action(() => _selectedCell.Edit(pixel1));
+                var action = new Action(() =>
+                {
+                    if (Global.IsGtk && !_selectedCell.HasDialog)
+                    {
+                        pixel1.RemoveAll();
+                        pixel1 = new PixelLayout();
+                        pixel1.Add(drawable, 0, 0);
+                        _selectedCell.Edit(pixel1);
+                        Content = pixel1;
+
+                        pixel1.Style = "Stretch";
+                    }
+                    else
+                    {
+                        _selectedCell.Edit(pixel1);
+                    }
+                });
 
 #if WINDOWS
                 (drawable.ControlObject as System.Windows.Controls.Canvas).Dispatcher.BeginInvoke(action,

--- a/Tools/Pipeline/Controls/PropertyGridTable.cs
+++ b/Tools/Pipeline/Controls/PropertyGridTable.cs
@@ -248,7 +248,7 @@ namespace MonoGame.Tools.Pipeline
             SetWidth();
 #endif
 
-#if LINUX
+#if GTK
             // force size reallocation
             drawable.Width = pixel1.Width - 2;
 

--- a/Tools/Pipeline/Global.Linux.cs
+++ b/Tools/Pipeline/Global.Linux.cs
@@ -17,6 +17,7 @@ namespace MonoGame.Tools.Pipeline
 
         private static void PlatformInit()
         {
+            IsGtk = true;
             Linux = true;
             UseHeaderBar = true;
             _theme = IconTheme.Default;

--- a/Tools/Pipeline/Global.cs
+++ b/Tools/Pipeline/Global.cs
@@ -22,6 +22,7 @@ namespace MonoGame.Tools.Pipeline
         public static bool Linux { get; private set; }
         public static bool UseHeaderBar { get; set; }
         public static bool Unix { get; private set; }
+        public static bool IsGtk { get; private set; }
 
         private static Dictionary<string, Bitmap> _files;
         private static Image _folder;

--- a/Tools/Pipeline/Global.cs
+++ b/Tools/Pipeline/Global.cs
@@ -15,9 +15,6 @@ namespace MonoGame.Tools.Pipeline
         {
             get
             {
-                if (Unix)
-                    return Linux ? "/" : ":";
-
                 return "/?<>\\:*|\"";
             }
         }
@@ -104,7 +101,7 @@ namespace MonoGame.Tools.Pipeline
 
         public static Image GetEtoIcon(string resource)
         {
-#if LINUX
+#if GTK
             var nativeicon = PlatformGetIcon(resource);
 
             if (nativeicon != null)

--- a/Tools/Pipeline/MainWindow.cs
+++ b/Tools/Pipeline/MainWindow.cs
@@ -310,12 +310,7 @@ namespace MonoGame.Tools.Pipeline
         {
             var proc = new Process();
 
-            if (!Global.Unix)
-            {
-                proc.StartInfo.FileName = exe;
-                proc.StartInfo.Arguments = commands;
-            }
-            else
+            if (Global.Unix && exe.EndsWith(".exe"))
             {
                 string monoLoc = null;
 
@@ -352,6 +347,15 @@ namespace MonoGame.Tools.Pipeline
                 {
                     proc.StartInfo.Arguments = string.Format("\"{0}\" {1}", exe, commands);
                 }
+            }
+            else
+            {
+                proc.StartInfo.FileName = exe;
+                proc.StartInfo.Arguments = commands;
+
+                // TODO: Fix debugging .NET Core stuff from Unix
+
+                System.Console.WriteLine(exe + " " + commands);
             }
 
             return proc;

--- a/Tools/Pipeline/PipelineTool.Gtk.csproj
+++ b/Tools/Pipeline/PipelineTool.Gtk.csproj
@@ -4,7 +4,6 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <DefineConstants>GTK</DefineConstants>
-    <CopyContentFiles>False</CopyContentFiles>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,11 +11,6 @@
     <EmbeddedResource Include="**\*.glade">
       <LogicalName>%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.0-rc.5" />
-    <PackageReference Include="GtkSharp" Version="3.22.25.56" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,165 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\MGCB\CommandLineParser.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- The resources for icons and buttons -->
-    <EmbeddedResource Include="App.ico" />
-    <EmbeddedResource Include="Icons\monogame.png">
-      <LogicalName>Icons.monogame.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Settings.png">
-      <LogicalName>Icons.Settings.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\..\LICENSE.txt">
-      <Link>LICENSE.txt</Link>
-      <LogicalName>LICENSE.txt</LogicalName>
-    </EmbeddedResource>
-  
-    <!--- The resources for treeview -->
-    <EmbeddedResource Include="Icons\TreeView\Root.png">
-      <LogicalName>TreeView.Root.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\TreeView\File.png">
-      <LogicalName>TreeView.File.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\TreeView\Folder.png">
-      <LogicalName>TreeView.Folder.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\TreeView\Link.png">
-      <LogicalName>TreeView.Link.png</LogicalName>
-    </EmbeddedResource>
-    
-    <!-- The resources for output filtering -->
-    <EmbeddedResource Include="Icons\Build\EndFailed.png">
-      <LogicalName>Build.EndFailed.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\EndSucceed.png">
-      <LogicalName>Build.EndSucceed.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Fail.png">
-      <LogicalName>Build.Fail.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Information.png">
-      <LogicalName>Build.Information.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Processing.png">
-      <LogicalName>Build.Processing.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Skip.png">
-      <LogicalName>Build.Skip.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Start.png">
-      <LogicalName>Build.Start.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Succeed.png">
-      <LogicalName>Build.Succeed.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\SucceedWithWarnings.png">
-      <LogicalName>Build.SucceedWithWarnings.png</LogicalName>
-    </EmbeddedResource>
-    
-    <!-- The resources for menubar and toolbar -->
-    <EmbeddedResource Include="Icons\Commands\Build.png">
-      <LogicalName>Commands.Build.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\CancelBuild.png">
-      <LogicalName>Commands.CancelBuild.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Clean.png">
-      <LogicalName>Commands.Clean.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Close.png">
-      <LogicalName>Commands.Close.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Delete.png">
-      <LogicalName>Commands.Delete.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\ExistingFolder.png">
-      <LogicalName>Commands.ExistingFolder.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\ExistingItem.png">
-      <LogicalName>Commands.ExistingItem.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Help.png">
-      <LogicalName>Commands.Help.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\New.png">
-      <LogicalName>Commands.New.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\NewFolder.png">
-      <LogicalName>Commands.NewFolder.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\NewItem.png">
-      <LogicalName>Commands.NewItem.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Open.png">
-      <LogicalName>Commands.Open.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\OpenItem.png">
-      <LogicalName>Commands.OpenItem.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Rebuild.png">
-      <LogicalName>Commands.Rebuild.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Redo.png">
-      <LogicalName>Commands.Redo.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Rename.png">
-      <LogicalName>Commands.Rename.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Save.png">
-      <LogicalName>Commands.Save.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\SaveAs.png">
-      <LogicalName>Commands.SaveAs.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Undo.png">
-      <LogicalName>Commands.Undo.png</LogicalName>
-    </EmbeddedResource>
-
-    <!-- Copy the template resources to the output -->
-    <Content Include="Templates\Effect.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\Effect.fx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\Effect.template">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\SpriteEffect.fx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\SpriteEffect.template">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\Xml.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\XmlContent.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\XmlContent.template">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\Font.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\SpriteFont.spritefont">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\SpriteFont.template">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\LocalizedSpriteFont.spritefont">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\LocalizedSpriteFont.template">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.0-rc.5" />
+    <PackageReference Include="GtkSharp" Version="3.22.25.56" />
   </ItemGroup>
 
   <ItemGroup>
@@ -195,5 +32,7 @@
       <AdditionalProperties>CopyContentFiles=False</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>
+
+  <Import Project="PipelineTool.targets" />
 
 </Project>

--- a/Tools/Pipeline/PipelineTool.Gtk.csproj
+++ b/Tools/Pipeline/PipelineTool.Gtk.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -15,9 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.5.0-rc.4" />
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.0-rc.4" />
-    <PackageReference Include="GtkSharp" Version="3.22.25.*" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.0-rc.5" />
+    <PackageReference Include="GtkSharp" Version="3.22.25.56" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tools/Pipeline/PipelineTool.Gtk.csproj
+++ b/Tools/Pipeline/PipelineTool.Gtk.csproj
@@ -1,0 +1,200 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <DefineConstants>GTK</DefineConstants>
+    <CopyContentFiles>False</CopyContentFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="**\*.glade" />
+    <EmbeddedResource Include="**\*.glade">
+      <LogicalName>%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Eto.Forms" Version="2.5.0-rc.4" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.0-rc.4" />
+    <PackageReference Include="GtkSharp" Version="3.22.25.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Global.Mac.cs" />
+    <Compile Remove="Global.Windows.cs" />
+    <Compile Remove="Styles.Mac.cs" />
+    <Compile Remove="Styles.Windows.cs" />
+    <Compile Remove="Properties\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\MGCB\CommandLineParser.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The resources for icons and buttons -->
+    <EmbeddedResource Include="App.ico" />
+    <EmbeddedResource Include="Icons\monogame.png">
+      <LogicalName>Icons.monogame.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Settings.png">
+      <LogicalName>Icons.Settings.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\..\LICENSE.txt">
+      <Link>LICENSE.txt</Link>
+      <LogicalName>LICENSE.txt</LogicalName>
+    </EmbeddedResource>
+  
+    <!--- The resources for treeview -->
+    <EmbeddedResource Include="Icons\TreeView\Root.png">
+      <LogicalName>TreeView.Root.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\TreeView\File.png">
+      <LogicalName>TreeView.File.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\TreeView\Folder.png">
+      <LogicalName>TreeView.Folder.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\TreeView\Link.png">
+      <LogicalName>TreeView.Link.png</LogicalName>
+    </EmbeddedResource>
+    
+    <!-- The resources for output filtering -->
+    <EmbeddedResource Include="Icons\Build\EndFailed.png">
+      <LogicalName>Build.EndFailed.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\EndSucceed.png">
+      <LogicalName>Build.EndSucceed.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Fail.png">
+      <LogicalName>Build.Fail.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Information.png">
+      <LogicalName>Build.Information.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Processing.png">
+      <LogicalName>Build.Processing.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Skip.png">
+      <LogicalName>Build.Skip.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Start.png">
+      <LogicalName>Build.Start.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Succeed.png">
+      <LogicalName>Build.Succeed.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\SucceedWithWarnings.png">
+      <LogicalName>Build.SucceedWithWarnings.png</LogicalName>
+    </EmbeddedResource>
+    
+    <!-- The resources for menubar and toolbar -->
+    <EmbeddedResource Include="Icons\Commands\Build.png">
+      <LogicalName>Commands.Build.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\CancelBuild.png">
+      <LogicalName>Commands.CancelBuild.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Clean.png">
+      <LogicalName>Commands.Clean.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Close.png">
+      <LogicalName>Commands.Close.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Delete.png">
+      <LogicalName>Commands.Delete.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\ExistingFolder.png">
+      <LogicalName>Commands.ExistingFolder.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\ExistingItem.png">
+      <LogicalName>Commands.ExistingItem.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Help.png">
+      <LogicalName>Commands.Help.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\New.png">
+      <LogicalName>Commands.New.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\NewFolder.png">
+      <LogicalName>Commands.NewFolder.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\NewItem.png">
+      <LogicalName>Commands.NewItem.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Open.png">
+      <LogicalName>Commands.Open.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\OpenItem.png">
+      <LogicalName>Commands.OpenItem.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Rebuild.png">
+      <LogicalName>Commands.Rebuild.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Redo.png">
+      <LogicalName>Commands.Redo.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Rename.png">
+      <LogicalName>Commands.Rename.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Save.png">
+      <LogicalName>Commands.Save.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\SaveAs.png">
+      <LogicalName>Commands.SaveAs.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Undo.png">
+      <LogicalName>Commands.Undo.png</LogicalName>
+    </EmbeddedResource>
+
+    <!-- Copy the template resources to the output -->
+    <Content Include="Templates\Effect.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Effect.fx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Effect.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteEffect.fx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteEffect.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Xml.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\XmlContent.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\XmlContent.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Font.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteFont.spritefont">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteFont.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\LocalizedSpriteFont.spritefont">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\LocalizedSpriteFont.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj" />
+    <ProjectReference Include="..\..\MonoGame.Framework.Content.Pipeline\MonoGame.Framework.Content.Pipeline.csproj">
+      <AdditionalProperties>CopyContentFiles=False</AdditionalProperties>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/Tools/Pipeline/PipelineTool.Wpf.csproj
+++ b/Tools/Pipeline/PipelineTool.Wpf.csproj
@@ -1,0 +1,198 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <DefineConstants>WINDOWS;WPF</DefineConstants>
+    <ApplicationIcon>App.ico</ApplicationIcon>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="**\*.glade" />
+    <EmbeddedResource Include="**\*.glade">
+      <LogicalName>%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Global.Mac.cs" />
+    <Compile Remove="Global.Linux.cs" />
+    <Compile Remove="Styles.Mac.cs" />
+    <Compile Remove="Styles.Linux.cs" />
+    <Compile Remove="Properties\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\MGCB\CommandLineParser.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The resources for icons and buttons -->
+    <EmbeddedResource Include="App.ico" />
+    <EmbeddedResource Include="Icons\monogame.png">
+      <LogicalName>Icons.monogame.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Settings.png">
+      <LogicalName>Icons.Settings.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\..\LICENSE.txt">
+      <Link>LICENSE.txt</Link>
+      <LogicalName>LICENSE.txt</LogicalName>
+    </EmbeddedResource>
+  
+    <!--- The resources for treeview -->
+    <EmbeddedResource Include="Icons\TreeView\Root.png">
+      <LogicalName>TreeView.Root.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\TreeView\File.png">
+      <LogicalName>TreeView.File.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\TreeView\Folder.png">
+      <LogicalName>TreeView.Folder.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\TreeView\Link.png">
+      <LogicalName>TreeView.Link.png</LogicalName>
+    </EmbeddedResource>
+    
+    <!-- The resources for output filtering -->
+    <EmbeddedResource Include="Icons\Build\EndFailed.png">
+      <LogicalName>Build.EndFailed.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\EndSucceed.png">
+      <LogicalName>Build.EndSucceed.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Fail.png">
+      <LogicalName>Build.Fail.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Information.png">
+      <LogicalName>Build.Information.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Processing.png">
+      <LogicalName>Build.Processing.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Skip.png">
+      <LogicalName>Build.Skip.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Start.png">
+      <LogicalName>Build.Start.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Succeed.png">
+      <LogicalName>Build.Succeed.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\SucceedWithWarnings.png">
+      <LogicalName>Build.SucceedWithWarnings.png</LogicalName>
+    </EmbeddedResource>
+    
+    <!-- The resources for menubar and toolbar -->
+    <EmbeddedResource Include="Icons\Commands\Build.png">
+      <LogicalName>Commands.Build.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\CancelBuild.png">
+      <LogicalName>Commands.CancelBuild.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Clean.png">
+      <LogicalName>Commands.Clean.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Close.png">
+      <LogicalName>Commands.Close.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Delete.png">
+      <LogicalName>Commands.Delete.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\ExistingFolder.png">
+      <LogicalName>Commands.ExistingFolder.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\ExistingItem.png">
+      <LogicalName>Commands.ExistingItem.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Help.png">
+      <LogicalName>Commands.Help.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\New.png">
+      <LogicalName>Commands.New.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\NewFolder.png">
+      <LogicalName>Commands.NewFolder.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\NewItem.png">
+      <LogicalName>Commands.NewItem.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Open.png">
+      <LogicalName>Commands.Open.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\OpenItem.png">
+      <LogicalName>Commands.OpenItem.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Rebuild.png">
+      <LogicalName>Commands.Rebuild.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Redo.png">
+      <LogicalName>Commands.Redo.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Rename.png">
+      <LogicalName>Commands.Rename.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Save.png">
+      <LogicalName>Commands.Save.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\SaveAs.png">
+      <LogicalName>Commands.SaveAs.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Undo.png">
+      <LogicalName>Commands.Undo.png</LogicalName>
+    </EmbeddedResource>
+
+    <!-- Copy the template resources to the output -->
+    <Content Include="Templates\Effect.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Effect.fx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Effect.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteEffect.fx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteEffect.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Xml.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\XmlContent.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\XmlContent.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Font.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteFont.spritefont">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteFont.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\LocalizedSpriteFont.spritefont">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\LocalizedSpriteFont.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\MonoGame.Framework\MonoGame.Framework.WindowsDX.csproj" />
+    <ProjectReference Include="..\..\MonoGame.Framework.Content.Pipeline\MonoGame.Framework.Content.Pipeline.csproj">
+      <AdditionalProperties>CopyContentFiles=False</AdditionalProperties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0-rc.5" />
+  </ItemGroup>
+
+</Project>

--- a/Tools/Pipeline/PipelineTool.Wpf.csproj
+++ b/Tools/Pipeline/PipelineTool.Wpf.csproj
@@ -8,13 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="**\*.glade" />
-    <EmbeddedResource Include="**\*.glade">
-      <LogicalName>%(Filename)%(Extension)</LogicalName>
-    </EmbeddedResource>
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Remove="Global.Mac.cs" />
     <Compile Remove="Global.Linux.cs" />
     <Compile Remove="Styles.Mac.cs" />
@@ -23,165 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\MGCB\CommandLineParser.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- The resources for icons and buttons -->
-    <EmbeddedResource Include="App.ico" />
-    <EmbeddedResource Include="Icons\monogame.png">
-      <LogicalName>Icons.monogame.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Settings.png">
-      <LogicalName>Icons.Settings.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\..\LICENSE.txt">
-      <Link>LICENSE.txt</Link>
-      <LogicalName>LICENSE.txt</LogicalName>
-    </EmbeddedResource>
-  
-    <!--- The resources for treeview -->
-    <EmbeddedResource Include="Icons\TreeView\Root.png">
-      <LogicalName>TreeView.Root.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\TreeView\File.png">
-      <LogicalName>TreeView.File.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\TreeView\Folder.png">
-      <LogicalName>TreeView.Folder.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\TreeView\Link.png">
-      <LogicalName>TreeView.Link.png</LogicalName>
-    </EmbeddedResource>
-    
-    <!-- The resources for output filtering -->
-    <EmbeddedResource Include="Icons\Build\EndFailed.png">
-      <LogicalName>Build.EndFailed.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\EndSucceed.png">
-      <LogicalName>Build.EndSucceed.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Fail.png">
-      <LogicalName>Build.Fail.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Information.png">
-      <LogicalName>Build.Information.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Processing.png">
-      <LogicalName>Build.Processing.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Skip.png">
-      <LogicalName>Build.Skip.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Start.png">
-      <LogicalName>Build.Start.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\Succeed.png">
-      <LogicalName>Build.Succeed.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Build\SucceedWithWarnings.png">
-      <LogicalName>Build.SucceedWithWarnings.png</LogicalName>
-    </EmbeddedResource>
-    
-    <!-- The resources for menubar and toolbar -->
-    <EmbeddedResource Include="Icons\Commands\Build.png">
-      <LogicalName>Commands.Build.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\CancelBuild.png">
-      <LogicalName>Commands.CancelBuild.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Clean.png">
-      <LogicalName>Commands.Clean.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Close.png">
-      <LogicalName>Commands.Close.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Delete.png">
-      <LogicalName>Commands.Delete.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\ExistingFolder.png">
-      <LogicalName>Commands.ExistingFolder.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\ExistingItem.png">
-      <LogicalName>Commands.ExistingItem.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Help.png">
-      <LogicalName>Commands.Help.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\New.png">
-      <LogicalName>Commands.New.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\NewFolder.png">
-      <LogicalName>Commands.NewFolder.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\NewItem.png">
-      <LogicalName>Commands.NewItem.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Open.png">
-      <LogicalName>Commands.Open.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\OpenItem.png">
-      <LogicalName>Commands.OpenItem.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Rebuild.png">
-      <LogicalName>Commands.Rebuild.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Redo.png">
-      <LogicalName>Commands.Redo.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Rename.png">
-      <LogicalName>Commands.Rename.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Save.png">
-      <LogicalName>Commands.Save.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\SaveAs.png">
-      <LogicalName>Commands.SaveAs.png</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Icons\Commands\Undo.png">
-      <LogicalName>Commands.Undo.png</LogicalName>
-    </EmbeddedResource>
-
-    <!-- Copy the template resources to the output -->
-    <Content Include="Templates\Effect.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\Effect.fx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\Effect.template">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\SpriteEffect.fx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\SpriteEffect.template">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\Xml.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\XmlContent.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\XmlContent.template">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\Font.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\SpriteFont.spritefont">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\SpriteFont.template">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\LocalizedSpriteFont.spritefont">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Templates\LocalizedSpriteFont.template">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0-rc.5" />
   </ItemGroup>
 
   <ItemGroup>
@@ -191,8 +26,6 @@
     </ProjectReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0-rc.5" />
-  </ItemGroup>
+  <Import Project="PipelineTool.targets" />
 
 </Project>

--- a/Tools/Pipeline/PipelineTool.targets
+++ b/Tools/Pipeline/PipelineTool.targets
@@ -1,0 +1,165 @@
+<Project>
+
+  <ItemGroup>
+    <Compile Include="..\MGCB\CommandLineParser.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The resources for icons and buttons -->
+    <EmbeddedResource Include="App.ico" />
+    <EmbeddedResource Include="Icons\monogame.png">
+      <LogicalName>Icons.monogame.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Settings.png">
+      <LogicalName>Icons.Settings.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\..\LICENSE.txt">
+      <Link>LICENSE.txt</Link>
+      <LogicalName>LICENSE.txt</LogicalName>
+    </EmbeddedResource>
+  
+    <!--- The resources for treeview -->
+    <EmbeddedResource Include="Icons\TreeView\Root.png">
+      <LogicalName>TreeView.Root.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\TreeView\File.png">
+      <LogicalName>TreeView.File.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\TreeView\Folder.png">
+      <LogicalName>TreeView.Folder.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\TreeView\Link.png">
+      <LogicalName>TreeView.Link.png</LogicalName>
+    </EmbeddedResource>
+    
+    <!-- The resources for output filtering -->
+    <EmbeddedResource Include="Icons\Build\EndFailed.png">
+      <LogicalName>Build.EndFailed.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\EndSucceed.png">
+      <LogicalName>Build.EndSucceed.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Fail.png">
+      <LogicalName>Build.Fail.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Information.png">
+      <LogicalName>Build.Information.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Processing.png">
+      <LogicalName>Build.Processing.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Skip.png">
+      <LogicalName>Build.Skip.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Start.png">
+      <LogicalName>Build.Start.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\Succeed.png">
+      <LogicalName>Build.Succeed.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Build\SucceedWithWarnings.png">
+      <LogicalName>Build.SucceedWithWarnings.png</LogicalName>
+    </EmbeddedResource>
+    
+    <!-- The resources for menubar and toolbar -->
+    <EmbeddedResource Include="Icons\Commands\Build.png">
+      <LogicalName>Commands.Build.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\CancelBuild.png">
+      <LogicalName>Commands.CancelBuild.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Clean.png">
+      <LogicalName>Commands.Clean.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Close.png">
+      <LogicalName>Commands.Close.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Delete.png">
+      <LogicalName>Commands.Delete.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\ExistingFolder.png">
+      <LogicalName>Commands.ExistingFolder.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\ExistingItem.png">
+      <LogicalName>Commands.ExistingItem.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Help.png">
+      <LogicalName>Commands.Help.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\New.png">
+      <LogicalName>Commands.New.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\NewFolder.png">
+      <LogicalName>Commands.NewFolder.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\NewItem.png">
+      <LogicalName>Commands.NewItem.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Open.png">
+      <LogicalName>Commands.Open.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\OpenItem.png">
+      <LogicalName>Commands.OpenItem.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Rebuild.png">
+      <LogicalName>Commands.Rebuild.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Redo.png">
+      <LogicalName>Commands.Redo.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Rename.png">
+      <LogicalName>Commands.Rename.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Save.png">
+      <LogicalName>Commands.Save.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\SaveAs.png">
+      <LogicalName>Commands.SaveAs.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icons\Commands\Undo.png">
+      <LogicalName>Commands.Undo.png</LogicalName>
+    </EmbeddedResource>
+
+    <!-- Copy the template resources to the output -->
+    <Content Include="Templates\Effect.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Effect.fx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Effect.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteEffect.fx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteEffect.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Xml.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\XmlContent.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\XmlContent.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\Font.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteFont.spritefont">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\SpriteFont.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\LocalizedSpriteFont.spritefont">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Templates\LocalizedSpriteFont.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/Tools/Pipeline/Program.cs
+++ b/Tools/Pipeline/Program.cs
@@ -38,11 +38,11 @@ namespace MonoGame.Tools.Pipeline
                 var win = new MainWindow();
                 var controller = PipelineController.Create(win);
 
-#if LINUX
+#if GTK
                 Global.Application.AddWindow(win.ToNative() as Gtk.Window);
 #endif
 
-#if LINUX && !DEBUG
+#if GTK && !DEBUG
 
                 GLib.ExceptionManager.UnhandledException += (e) =>
                 {

--- a/Tools/Pipeline/Program.cs
+++ b/Tools/Pipeline/Program.cs
@@ -18,7 +18,14 @@ namespace MonoGame.Tools.Pipeline
         {
             Styles.Load();
 
+#if GTK
+            var app = new Application(Platforms.Gtk);
+#elif WPF
+            var app = new Application(Platforms.Wpf);
+#else
             var app = new Application(Platform.Detect);
+#endif
+
             app.Style = "PipelineTool";
 
             PipelineSettings.Default.Load();
@@ -73,7 +80,7 @@ namespace MonoGame.Tools.Pipeline
                 PipelineSettings.Default.Save();
                 app.Restart();
             }
-# endif
+#endif
         }
     }
 }

--- a/Tools/Pipeline/Styles.Linux.cs
+++ b/Tools/Pipeline/Styles.Linux.cs
@@ -38,20 +38,6 @@ namespace MonoGame.Tools.Pipeline
             Global.Application.AddAction(a);
         }
 
-        private static void Connect(Command cmd, Gdk.Key key, Gdk.ModifierType modifier = Gdk.ModifierType.None)
-        {
-            var cclosure = g_cclosure_new(Marshal.GetFunctionPointerForDelegate(
-                (Action<IntPtr, IntPtr, IntPtr, IntPtr, IntPtr>)((IntPtr a, IntPtr b, IntPtr c, IntPtr d, IntPtr data) =>
-            {
-                var command = ((GCHandle)data).Target as Command;
-
-                if (command.Enabled)
-                    command.Execute();
-            })), (IntPtr)GCHandle.Alloc(cmd), IntPtr.Zero);
-
-            _accelGroup.Connect((uint)key, modifier, Gtk.AccelFlags.Mask, cclosure);
-        }
-
         private static void ReloadBuildbox()
         {
             var b = MainWindow.Instance.cmdBuild.Enabled;
@@ -124,15 +110,15 @@ namespace MonoGame.Tools.Pipeline
                 };
 
                 _accelGroup = new Gtk.AccelGroup();
-
-                Connect(MainWindow.Instance.cmdNew, Gdk.Key.N, Gdk.ModifierType.ControlMask);
+                
+                /*Connect(MainWindow.Instance.cmdNew, Gdk.Key.N, Gdk.ModifierType.ControlMask);
                 Connect(MainWindow.Instance.cmdOpen, Gdk.Key.O, Gdk.ModifierType.ControlMask);
                 Connect(MainWindow.Instance.cmdSave, Gdk.Key.S, Gdk.ModifierType.ControlMask);
                 Connect(MainWindow.Instance.cmdExit, Gdk.Key.Q, Gdk.ModifierType.ControlMask);
                 Connect(MainWindow.Instance.cmdUndo, Gdk.Key.Z, Gdk.ModifierType.ControlMask);
                 Connect(MainWindow.Instance.cmdRedo, Gdk.Key.Y, Gdk.ModifierType.ControlMask);
                 Connect(MainWindow.Instance.cmdBuild, Gdk.Key.F6);
-                Connect(MainWindow.Instance.cmdHelp, Gdk.Key.F1);
+                Connect(MainWindow.Instance.cmdHelp, Gdk.Key.F1);*/
 
                 h.Control.AddAccelGroup(_accelGroup);
 

--- a/Tools/Pipeline/nuget.config
+++ b/Tools/Pipeline/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="eto-myget" value="https://www.myget.org/F/eto/api/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Notes:
- Pipeline Tool no longer copies all the MGCB stuff and Content Pipeline native deps as it does not need them to be operational, it just needs to find them in specified paths, this should make packaging Pipeline Tool for dotnet a bit easier
  - MGCB will no longer be built automatically when running the Pipeline Tool because of the above
- Versions are marked with Gtk and Wpf, Gtk version is connected to the DesktopGL project and can be run from any system, including Windows, Wpf version is connected to the WindowsDX project and only works on Windows 
- Keyboard shortcuts are disabled for the Gtk version