### PR TITLE
Fix #6732 - Support base index for instancing

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -122,6 +122,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal bool SupportsInstancing { get; private set; }
 
+        internal bool SupportsBaseIndexInstancing { get; private set; }
+
         internal bool SupportsSeparateBlendStates { get; private set; }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1310,12 +1310,13 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="startIndex">The index within the index buffer to start drawing from.</param>
         /// <param name="primitiveCount">The number of primitives in a single instance.</param>
         /// <param name="instanceCount">The number of instances to render.</param>
+        /// <param name="baseInstance">Used to offset the instance range indexed from the instance buffer.</param>
         /// <remarks>Note that minVertexIndex and numVertices are unused in MonoGame and will be ignored.</remarks>
         [Obsolete("Use DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount) instead. In future versions this method can be removed.")]
         public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int minVertexIndex,
-                                            int numVertices, int startIndex, int primitiveCount, int instanceCount)
+                                            int numVertices, int startIndex, int primitiveCount, int instanceCount, int baseInstance = 0)
         {
-            DrawInstancedPrimitives(primitiveType, baseVertex, startIndex, primitiveCount, instanceCount);
+            DrawInstancedPrimitives(primitiveType, baseVertex, startIndex, primitiveCount, instanceCount, baseInstance);
         }
 
         /// <summary>
@@ -1326,8 +1327,9 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="startIndex">The index within the index buffer to start drawing from.</param>
         /// <param name="primitiveCount">The number of primitives in a single instance.</param>
         /// <param name="instanceCount">The number of instances to render.</param>
+        /// <param name="baseInstance">Used to offset the instance range indexed from the instance buffer.</param>
         /// <remarks>Draw geometry with data from multiple bound vertex streams at different frequencies.</remarks>
-        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount)
+        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount, int baseInstance)
         {
             if (_vertexShader == null)
                 throw new InvalidOperationException("Vertex shader must be set before calling DrawInstancedPrimitives.");
@@ -1341,7 +1343,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (primitiveCount <= 0)
                 throw new ArgumentOutOfRangeException("primitiveCount");
 
-            PlatformDrawInstancedPrimitives(primitiveType, baseVertex, startIndex, primitiveCount, instanceCount);
+            PlatformDrawInstancedPrimitives(primitiveType, baseVertex, startIndex, primitiveCount, instanceCount, baseInstance);
 
             unchecked
             {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1329,7 +1329,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="instanceCount">The number of instances to render.</param>
         /// <param name="baseInstance">Used to offset the instance range indexed from the instance buffer.</param>
         /// <remarks>Draw geometry with data from multiple bound vertex streams at different frequencies.</remarks>
-        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount, int baseInstance)
+        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount, int baseInstance = 0)
         {
             if (_vertexShader == null)
                 throw new InvalidOperationException("Vertex shader must be set before calling DrawInstancedPrimitives.");

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1329,7 +1329,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="instanceCount">The number of instances to render.</param>
         /// <param name="baseInstance">Used to offset the instance range indexed from the instance buffer.</param>
         /// <remarks>Draw geometry with data from multiple bound vertex streams at different frequencies.</remarks>
-        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount, int baseInstance=0)
+        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount, int baseInstance = 0)
         {
             if (_vertexShader == null)
                 throw new InvalidOperationException("Vertex shader must be set before calling DrawInstancedPrimitives.");

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1329,7 +1329,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="instanceCount">The number of instances to render.</param>
         /// <param name="baseInstance">Used to offset the instance range indexed from the instance buffer.</param>
         /// <remarks>Draw geometry with data from multiple bound vertex streams at different frequencies.</remarks>
-        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount, int baseInstance = 0)
+        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount, int baseInstance=0)
         {
             if (_vertexShader == null)
                 throw new InvalidOperationException("Vertex shader must be set before calling DrawInstancedPrimitives.");

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1310,11 +1310,29 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="startIndex">The index within the index buffer to start drawing from.</param>
         /// <param name="primitiveCount">The number of primitives in a single instance.</param>
         /// <param name="instanceCount">The number of instances to render.</param>
+        /// <remarks>Note that minVertexIndex and numVertices are unused in MonoGame and will be ignored.</remarks>
+        [Obsolete("Use DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount) instead. In future versions this method can be removed.")]
+        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int minVertexIndex,
+                                            int numVertices, int startIndex, int primitiveCount, int instanceCount)
+        {
+            DrawInstancedPrimitives(primitiveType, baseVertex, startIndex, primitiveCount, instanceCount, 0);
+        }
+
+        /// <summary>
+        /// Draw instanced geometry from the bound vertex buffers and index buffer.
+        /// </summary>
+        /// <param name="primitiveType">The type of primitives in the index buffer.</param>
+        /// <param name="baseVertex">Used to offset the vertex range indexed from the vertex buffer.</param>
+        /// <param name="minVertexIndex">This is unused and remains here only for XNA API compatibility.</param>
+        /// <param name="numVertices">This is unused and remains here only for XNA API compatibility.</param>
+        /// <param name="startIndex">The index within the index buffer to start drawing from.</param>
+        /// <param name="primitiveCount">The number of primitives in a single instance.</param>
+        /// <param name="instanceCount">The number of instances to render.</param>
         /// <param name="baseInstance">Used to offset the instance range indexed from the instance buffer.</param>
         /// <remarks>Note that minVertexIndex and numVertices are unused in MonoGame and will be ignored.</remarks>
         [Obsolete("Use DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount) instead. In future versions this method can be removed.")]
         public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int minVertexIndex,
-                                            int numVertices, int startIndex, int primitiveCount, int instanceCount, int baseInstance = 0)
+                                            int numVertices, int startIndex, int primitiveCount, int instanceCount, int baseInstance)
         {
             DrawInstancedPrimitives(primitiveType, baseVertex, startIndex, primitiveCount, instanceCount, baseInstance);
         }
@@ -1327,9 +1345,23 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="startIndex">The index within the index buffer to start drawing from.</param>
         /// <param name="primitiveCount">The number of primitives in a single instance.</param>
         /// <param name="instanceCount">The number of instances to render.</param>
+        /// <remarks>Draw geometry with data from multiple bound vertex streams at different frequencies.</remarks>
+        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount)
+        {
+            DrawInstancedPrimitives(primitiveType, baseVertex, startIndex, primitiveCount, instanceCount, 0);
+        }
+
+        /// <summary>
+        /// Draw instanced geometry from the bound vertex buffers and index buffer.
+        /// </summary>
+        /// <param name="primitiveType">The type of primitives in the index buffer.</param>
+        /// <param name="baseVertex">Used to offset the vertex range indexed from the vertex buffer.</param>
+        /// <param name="startIndex">The index within the index buffer to start drawing from.</param>
+        /// <param name="primitiveCount">The number of primitives in a single instance.</param>
+        /// <param name="instanceCount">The number of instances to render.</param>
         /// <param name="baseInstance">Used to offset the instance range indexed from the instance buffer.</param>
         /// <remarks>Draw geometry with data from multiple bound vertex streams at different frequencies.</remarks>
-        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount, int baseInstance = 0)
+        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount, int baseInstance)
         {
             if (_vertexShader == null)
                 throw new InvalidOperationException("Vertex shader must be set before calling DrawInstancedPrimitives.");

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1323,25 +1323,6 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         /// <param name="primitiveType">The type of primitives in the index buffer.</param>
         /// <param name="baseVertex">Used to offset the vertex range indexed from the vertex buffer.</param>
-        /// <param name="minVertexIndex">This is unused and remains here only for XNA API compatibility.</param>
-        /// <param name="numVertices">This is unused and remains here only for XNA API compatibility.</param>
-        /// <param name="startIndex">The index within the index buffer to start drawing from.</param>
-        /// <param name="primitiveCount">The number of primitives in a single instance.</param>
-        /// <param name="instanceCount">The number of instances to render.</param>
-        /// <param name="baseInstance">Used to offset the instance range indexed from the instance buffer.</param>
-        /// <remarks>Note that minVertexIndex and numVertices are unused in MonoGame and will be ignored.</remarks>
-        [Obsolete("Use DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount) instead. In future versions this method can be removed.")]
-        public void DrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int minVertexIndex,
-                                            int numVertices, int startIndex, int primitiveCount, int instanceCount, int baseInstance)
-        {
-            DrawInstancedPrimitives(primitiveType, baseVertex, startIndex, primitiveCount, instanceCount, baseInstance);
-        }
-
-        /// <summary>
-        /// Draw instanced geometry from the bound vertex buffers and index buffer.
-        /// </summary>
-        /// <param name="primitiveType">The type of primitives in the index buffer.</param>
-        /// <param name="baseVertex">Used to offset the vertex range indexed from the vertex buffer.</param>
         /// <param name="startIndex">The index within the index buffer to start drawing from.</param>
         /// <param name="primitiveCount">The number of primitives in a single instance.</param>
         /// <param name="instanceCount">The number of instances to render.</param>

--- a/MonoGame.Framework/Platform/Graphics/GraphicsCapabilities.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsCapabilities.DirectX.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
             SupportsNormalized = true;
 
             SupportsInstancing = true;
+            SupportsBaseIndexInstancing = true;
             SupportsSeparateBlendStates = true;
 
             MaxTextureAnisotropy = (device.GraphicsProfile == GraphicsProfile.Reach) ? 2 : 16;

--- a/MonoGame.Framework/Platform/Graphics/GraphicsCapabilities.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsCapabilities.OpenGL.cs
@@ -121,6 +121,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
             SupportsInstancing = GL.VertexAttribDivisor != null;
 
+            SupportsBaseIndexInstancing = GL.DrawElementsInstancedBaseInstance != null;
+
 #if GLES
             SupportsSeparateBlendStates = false;
 #else

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
@@ -1482,7 +1482,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         private void PlatformDrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex,
-            int primitiveCount, int instanceCount)
+            int primitiveCount, int instanceCount, int baseInstance = 0)
         {
             lock (_d3dContext)
             {
@@ -1490,7 +1490,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 _d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
                 int indexCount = GetElementCountArray(primitiveType, primitiveCount);
-                _d3dContext.DrawIndexedInstanced(indexCount, instanceCount, startIndex, baseVertex, 0);
+                _d3dContext.DrawIndexedInstanced(indexCount, instanceCount, startIndex, baseVertex, baseInstance);
             }
         }
 

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -1191,19 +1191,25 @@ namespace Microsoft.Xna.Framework.Graphics
 
             ApplyAttribs(_vertexShader, baseVertex);
 
-            if (GraphicsCapabilities.SupportsBaseIndexInstancing && baseInstance > 0)
+            if (baseInstance > 0)
+            {
+                if (!GraphicsCapabilities.SupportsBaseIndexInstancing)
+                    throw new PlatformNotSupportedException("Instanced geometry drawing with base index requires at least OpenGL 4.2. Try upgrading your graphics card drivers.");
+
                 GL.DrawElementsInstancedBaseInstance(target,
-                                     indexElementCount,
-                                     indexElementType,
-                                     indexOffsetInBytes,
-                                     instanceCount,
-                                     baseInstance);
+                                          indexElementCount,
+                                          indexElementType,
+                                          indexOffsetInBytes,
+                                          instanceCount,
+                                          baseInstance);
+            }
             else
                 GL.DrawElementsInstanced(target,
                                      indexElementCount,
                                      indexElementType,
                                      indexOffsetInBytes,
                                      instanceCount);
+
             GraphicsExtensions.CheckGLError();
         }
 

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -1194,7 +1194,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (baseInstance > 0)
             {
                 if (!GraphicsCapabilities.SupportsBaseIndexInstancing)
-                    throw new PlatformNotSupportedException("Instanced geometry drawing with base index requires at least OpenGL 4.2. Try upgrading your graphics card drivers.");
+                    throw new PlatformNotSupportedException("Instanced geometry drawing with base instance requires at least OpenGL 4.2. Try upgrading your graphics card drivers.");
 
                 GL.DrawElementsInstancedBaseInstance(target,
                                           indexElementCount,

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -1175,7 +1175,7 @@ namespace Microsoft.Xna.Framework.Graphics
             vbHandle.Free();
         }
 
-        private void PlatformDrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount)
+        private void PlatformDrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount, int baseInstance = 0)
         {
             if (!GraphicsCapabilities.SupportsInstancing)
                 throw new PlatformNotSupportedException("Instanced geometry drawing requires at least OpenGL 3.2 or GLES 3.2. Try upgrading your graphics card drivers.");
@@ -1191,7 +1191,15 @@ namespace Microsoft.Xna.Framework.Graphics
 
             ApplyAttribs(_vertexShader, baseVertex);
 
-            GL.DrawElementsInstanced(target,
+            if (GraphicsCapabilities.SupportsBaseIndexInstancing && baseInstance > 0)
+                GL.DrawElementsInstancedBaseInstance(target,
+                                     indexElementCount,
+                                     indexElementType,
+                                     indexOffsetInBytes,
+                                     instanceCount,
+                                     baseInstance);
+            else
+                GL.DrawElementsInstanced(target,
                                      indexElementCount,
                                      indexElementType,
                                      indexOffsetInBytes,

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.Web.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.Web.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
         }
 
-        private void PlatformDrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount)
+        private void PlatformDrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount, int baseInstance = 0)
         {
         }
 

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -1221,6 +1221,13 @@ namespace MonoGame.OpenGL
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [UnmanagedFunctionPointer(callingConvention)]
         [MonoNativeFunctionWrapper]
+        internal delegate void DrawElementsInstancedBaseInstanceDelegate(GLPrimitiveType primitiveType, int count, DrawElementsType elementType,
+            IntPtr offset, int instanceCount, int baseInstance);
+        internal static DrawElementsInstancedBaseInstanceDelegate DrawElementsInstancedBaseInstance;
+
+        [System.Security.SuppressUnmanagedCodeSecurity()]
+        [UnmanagedFunctionPointer(callingConvention)]
+        [MonoNativeFunctionWrapper]
         internal delegate void VertexAttribDivisorDelegate(int location, int frequency);
         internal static VertexAttribDivisorDelegate VertexAttribDivisor;
 
@@ -1385,7 +1392,9 @@ namespace MonoGame.OpenGL
             try {
                 DrawElementsInstanced = LoadFunction<DrawElementsInstancedDelegate> ("glDrawElementsInstanced");
                 VertexAttribDivisor = LoadFunction<VertexAttribDivisorDelegate> ("glVertexAttribDivisor");
-            } catch (EntryPointNotFoundException) {
+                DrawElementsInstancedBaseInstance = LoadFunction<DrawElementsInstancedBaseInstanceDelegate>("glDrawElementsInstancedBaseInstance");
+            }
+            catch (EntryPointNotFoundException) {
                 // this will be detected in the initialization of GraphicsCapabilities
             }
 


### PR DESCRIPTION
Per #6732 ... This change exposes the option to set the instance base index for instancing. This works perfectly on DirectX, and somewhat works on OpenGL. On OpenGL, this is still impacted by the instancing bug #6293.

Note: For OpenGL, if not setting the base instance index (which is the default behavior), it will continue using the original OpenGL API. If setting the base, this will use the OpenGL API glDrawElementsInstancedBaseInstance which is only available in OpenGL 4.2 and higher.

Also added a capabilities check to GraphicsCapabilities.cs. If the glDrawElementsInstancedBaseInstance is not available (i.e. < OpenGL 4.2), this defaults to the default behavior and calls the original method without attempting to set the base index.

FYI @Jjagg  Let me know if this looks good.