### PR TITLE
Added LastJoystickIndex to the Joystick API

### DIFF
--- a/MonoGame.Framework/Input/Joystick.cs
+++ b/MonoGame.Framework/Input/Joystick.cs
@@ -30,6 +30,14 @@ namespace Microsoft.Xna.Framework.Input
         }
 
         /// <summary>
+        /// Gets a value indicating how many joysticks are connected to the system.
+        /// </summary>
+        public static int JoystickCount
+        {
+            get { return PlatformJoystickCount; }
+        }
+
+        /// <summary>
         /// Gets the capabilites of the joystick.
         /// </summary>
         /// <param name="index">Index of the joystick you want to access.</param>

--- a/MonoGame.Framework/Input/Joystick.cs
+++ b/MonoGame.Framework/Input/Joystick.cs
@@ -35,9 +35,9 @@ namespace Microsoft.Xna.Framework.Input
         /// As such, this value may be larger than 0 even if only one joystick is connected.
         /// </para>
         /// </summary>
-        public static int LastJoystickIndex
+        public static int LastConnectedIndex
         {
-            get { return PlatformLastJoystickIndex; }
+            get { return PlatformLastConnectedIndex; }
         }
 
         /// <summary>

--- a/MonoGame.Framework/Input/Joystick.cs
+++ b/MonoGame.Framework/Input/Joystick.cs
@@ -30,11 +30,14 @@ namespace Microsoft.Xna.Framework.Input
         }
 
         /// <summary>
-        /// Gets a value indicating how many joysticks are connected to the system.
+        /// Gets a value indicating the last joystick index connected to the system. If this value is less than 0, no joysticks are connected.
+        /// <para>The order joysticks are connected and disconnected determines their index.
+        /// As such, this value may be larger than 0 even if only one joystick is connected.
+        /// </para>
         /// </summary>
-        public static int JoystickCount
+        public static int LastJoystickIndex
         {
-            get { return PlatformJoystickCount; }
+            get { return PlatformLastJoystickIndex; }
         }
 
         /// <summary>

--- a/MonoGame.Framework/Platform/Input/Joystick.Default.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.Default.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Xna.Framework.Input
             return _defaultJoystickState;
         }
 
-        private static int PlatformJoystickCount
+        private static int PlatformLastJoystickIndex
         {
             get
             {

--- a/MonoGame.Framework/Platform/Input/Joystick.Default.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.Default.cs
@@ -27,6 +27,14 @@ namespace Microsoft.Xna.Framework.Input
             return _defaultJoystickState;
         }
 
+        private static int PlatformJoystickCount
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
         private static void PlatformGetState(ref JoystickState joystickState, int index)
         {
 

--- a/MonoGame.Framework/Platform/Input/Joystick.Default.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.Default.cs
@@ -27,11 +27,11 @@ namespace Microsoft.Xna.Framework.Input
             return _defaultJoystickState;
         }
 
-        private static int PlatformLastJoystickIndex
+        private static int PlatformLastConnectedIndex
         {
             get
             {
-                return 0;
+                return -1;
             }
         }
 

--- a/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xna.Framework.Input
     static partial class Joystick
     {
         internal static Dictionary<int, IntPtr> Joysticks = new Dictionary<int, IntPtr>();
-        private static int _lastJoystickIndex = -1;
+        private static int _lastConnectedIndex = -1;
 
         internal static void AddDevice(int deviceId)
         {
@@ -20,8 +20,8 @@ namespace Microsoft.Xna.Framework.Input
             while (Joysticks.ContainsKey(id))
                 id++;
 
-            if (id > _lastJoystickIndex)
-                _lastJoystickIndex = id;
+            if (id > _lastConnectedIndex)
+                _lastConnectedIndex = id;
 
             Joysticks.Add(id, jdevice);
 
@@ -40,8 +40,8 @@ namespace Microsoft.Xna.Framework.Input
                     Sdl.Joystick.Close(Joysticks[entry.Key]);
                     Joysticks.Remove(entry.Key);
 
-                    if (key == _lastJoystickIndex)
-                        RecalculateLastJoystickIndex();
+                    if (key == _lastConnectedIndex)
+                        RecalculateLastConnectedIndex();
 
                     break;
                 }
@@ -58,19 +58,19 @@ namespace Microsoft.Xna.Framework.Input
             Joysticks.Clear ();
         }
 
-        private static void RecalculateLastJoystickIndex()
+        private static void RecalculateLastConnectedIndex()
         {
-            _lastJoystickIndex = -1;
+            _lastConnectedIndex = -1;
             foreach (var entry in Joysticks)
             {
-                if (entry.Key > _lastJoystickIndex)
-                    _lastJoystickIndex = entry.Key;
+                if (entry.Key > _lastConnectedIndex)
+                    _lastConnectedIndex = entry.Key;
             }
         }
 
-        private static int PlatformLastJoystickIndex
+        private static int PlatformLastConnectedIndex
         {
-            get { return _lastJoystickIndex; }
+            get { return _lastConnectedIndex; }
         }
 
         private const bool PlatformIsSupported = true;

--- a/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
@@ -48,6 +48,14 @@ namespace Microsoft.Xna.Framework.Input
             Joysticks.Clear ();
         }
 
+        private static int PlatformJoystickCount
+        {
+            get
+            {
+                return Joysticks.Count;
+            }
+        }
+
         private const bool PlatformIsSupported = true;
 
         private static JoystickCapabilities PlatformGetCapabilities(int index)

--- a/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
@@ -52,7 +52,17 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return Joysticks.Count;
+                if (Joysticks.Count == 0) return 0;
+
+                //Joysticks retain their indices, so fetch the highest index out of the ones plugged in
+                int highestIndex = 0;
+                foreach (var entry in Joysticks)
+                {
+                    if (entry.Key > highestIndex)
+                        highestIndex = entry.Key;
+                }
+
+                return highestIndex + 1;
             }
         }
 

--- a/MonoGame.Framework/Platform/Input/Joystick.Web.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.Web.cs
@@ -44,6 +44,28 @@ namespace Microsoft.Xna.Framework.Input
             };
         }
 
+        private static int PlatformJoystickCount
+        {
+            get
+            {
+                var navigator = Builtins.Global["navigator"];
+                var gamepads = navigator.getGamepads ? navigator.getGamepads() : navigator.webkitGetGamepads();
+                
+                int count = 0;
+                
+                for (int i = 0; i < gamepads.length; i++)
+                {
+                    //WebKit gamepad elements may be null if the gamepad disconnects during a session in order to preserve index
+                    if (gamepads[i])
+                    {
+                        count++;
+                    }
+                }
+                
+                return count;
+            }
+        }
+
         private static JoystickState PlatformGetState(int index)
         {
             var connected = false;

--- a/MonoGame.Framework/Platform/Input/Joystick.Web.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.Web.cs
@@ -44,12 +44,12 @@ namespace Microsoft.Xna.Framework.Input
             };
         }
 
-        private static int PlatformLastJoystickIndex
+        private static int PlatformLastConnectedIndex
         {
             get
             {
                 //Stubbed so it compiles
-                return 0;
+                return -1;
             }
         }
 

--- a/MonoGame.Framework/Platform/Input/Joystick.Web.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.Web.cs
@@ -44,25 +44,12 @@ namespace Microsoft.Xna.Framework.Input
             };
         }
 
-        private static int PlatformJoystickCount
+        private static int PlatformLastJoystickIndex
         {
             get
             {
-                var navigator = Builtins.Global["navigator"];
-                var gamepads = navigator.getGamepads ? navigator.getGamepads() : navigator.webkitGetGamepads();
-                
-                int count = 0;
-                
-                for (int i = 0; i < gamepads.length; i++)
-                {
-                    //WebKit gamepad elements may be null if the gamepad disconnects during a session in order to preserve index
-                    if (gamepads[i])
-                    {
-                        count++;
-                    }
-                }
-                
-                return count;
+                //Stubbed so it compiles
+                return 0;
             }
         }
 


### PR DESCRIPTION
This PR adds a `JoystickCount` property to query the number of joysticks connected to the system.

There was previously no direct way of knowing how many joysticks were connected. The only way to truly find out is call `Joystick.GetCapabilities` on an increasing index until `IsConnected` is false for an index. This is not very effective nor performant because on some platforms each `GetCapabilities` call generates unavoidable garbage to obtain the GUID string of the joystick.

This PR improves things by supplying a concrete number developers can reference with minimal overhead.

@harry-cpp @Jjagg 