### PR TITLE
Fixed memory leak in SDL_GameControllerMapping by freeing the returned string

### DIFF
--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -944,6 +944,10 @@ internal static class Sdl
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void d_sdl_free(IntPtr ptr);
+        public static d_sdl_free SDL_Free = FuncLoader.LoadFunction<d_sdl_free>(NativeLibrary, "SDL_free");
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int d_sdl_gamecontrolleraddmapping(string mappingString);
         public static d_sdl_gamecontrolleraddmapping AddMapping = FuncLoader.LoadFunction<d_sdl_gamecontrolleraddmapping>(NativeLibrary, "SDL_GameControllerAddMapping");
 
@@ -991,7 +995,16 @@ internal static class Sdl
 
         public static string GetMapping(IntPtr gamecontroller)
         {
-            return InteropHelpers.Utf8ToString(SDL_GameControllerMapping(gamecontroller));
+            IntPtr nativeStr = SDL_GameControllerMapping(gamecontroller);
+            if (nativeStr == IntPtr.Zero)
+                return string.Empty;
+
+            string mappingStr = InteropHelpers.Utf8ToString(nativeStr);
+
+            //The mapping string returned by SDL is owned by us and thus must be freed
+            SDL_Free(nativeStr);
+
+            return mappingStr;
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]


### PR DESCRIPTION
As discussed in https://github.com/MonoGame/MonoGame/issues/7018, a memory leak occurs whenever obtaining a `GamePad`'s mapping from SDL, which is retrieved whenever `GamePad.GetCapabilities` is called.

This PR fixes the memory leak by freeing the unmanaged string SDL allocates when obtaining the mapping before returning the managed mapping string.

@harry-cpp 