### PR TITLE
Look for native libraries in Frameworks folder for macOS .app bundles

### DIFF
--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -210,7 +210,13 @@ namespace MonoGame.OpenAL
             else if (CurrentPlatform.OS == OS.Linux && !Environment.Is64BitProcess)
                 ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x86/libopenal.so.1"));
             else if (CurrentPlatform.OS == OS.MacOSX)
+            {
                 ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "libopenal.1.dylib"));
+
+                //Look in Frameworks for .app bundles
+                if (ret == IntPtr.Zero)
+                    ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "..", "Frameworks", "libopenal.1.dylib"));
+            }
 
             // Load system library
             if (ret == IntPtr.Zero)

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -29,7 +29,13 @@ internal static class Sdl
         else if (CurrentPlatform.OS == OS.Linux && !Environment.Is64BitProcess)
             ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x86/libSDL2-2.0.so.0"));
         else if (CurrentPlatform.OS == OS.MacOSX)
+        {
             ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "libSDL2-2.0.0.dylib"));
+
+            //Look in Frameworks for .app bundles
+            if (ret == IntPtr.Zero)
+                ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "..", "Frameworks", "libSDL2-2.0.0.dylib"));
+        }
 
         // Load system library
         if (ret == IntPtr.Zero)


### PR DESCRIPTION
This PR makes macOS also look in the "Frameworks" folder of a .app bundle when loading native libraries. The "Frameworks" folder is the preferred location for libraries of .app bundles based on official documentation.

Related issue: https://github.com/MonoGame/MonoGame/issues/7012