### PR TITLE
Reduced garbage in Direct X-specific SetRenderTargets methods

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
@@ -1077,7 +1077,10 @@ namespace Microsoft.Xna.Framework.Graphics
             if (renderTarget == null)
                 SetRenderTarget(null);
             else
-                SetRenderTargets(new RenderTargetBinding(renderTarget, arraySlice));
+            {
+                _tempRenderTargetBinding[0] = new RenderTargetBinding(renderTarget, arraySlice);
+                SetRenderTargets(_tempRenderTargetBinding);
+            }
         }
 
         // Only implemented for DirectX right now, so not in GraphicsDevice.cs
@@ -1086,7 +1089,10 @@ namespace Microsoft.Xna.Framework.Graphics
             if (renderTarget == null)
                 SetRenderTarget(null);
             else
-                SetRenderTargets(new RenderTargetBinding(renderTarget, arraySlice));
+            {
+                _tempRenderTargetBinding[0] = new RenderTargetBinding(renderTarget, arraySlice);
+                SetRenderTargets(_tempRenderTargetBinding);
+            }
         }
 
         private void PlatformApplyDefaultRenderTarget()


### PR DESCRIPTION
This resolves https://github.com/MonoGame/MonoGame/issues/7005 by applying the same fix in https://github.com/MonoGame/MonoGame/pull/4853 to a few `SetRenderTargets` methods specific to Direct X projects.