### PR TITLE
fixing csproj template for dotnetcore

### DIFF
--- a/ProjectTemplates/DotNetTemplate/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
+++ b/ProjectTemplates/DotNetTemplate/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
@@ -31,8 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
-    <PackageReference Include="MonoGame.Content.Builder" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.*" />
+    <PackageReference Include="MonoGame.Content.Builder" Version="3.7.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi,

I had some problems using dotnet core template for Mac using dotnet core sdk.

The csproj file in the path below seems to be wrong.

ProjectTemplates/DotNetTemplate/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj

MonoGame.Content.Builder has not 3.8.* version in nuget.
MonoGame.Framework.DesktopGL has not version 3.8.* in nuget.
MonoGame.Framework.DesktopGL.Core is needed.

Thanks.

http://community.monogame.net/t/dotnetemplate-not-working-on-mac-os-x/12194