### PR TITLE
Fix initialization crash on iOS GLES 2.0 devices

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/OpenGL.iOS.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.iOS.cs
@@ -35,12 +35,15 @@ namespace MonoGame.OpenGL
     {
         public GraphicsContext ()
         {
-            var ios7OrAbove = UIKit.UIDevice.CurrentDevice.CheckSystemVersion(7, 0);
-
-            if (ios7OrAbove)
+            try
+            {
                 Context = new EAGLContext(EAGLRenderingAPI.OpenGLES3);
-            else
+            }
+            catch
+            {
+                // Fall back to GLES 2.0
                 Context = new EAGLContext(EAGLRenderingAPI.OpenGLES2);
+            }
         }
 
         public bool IsCurrent {


### PR DESCRIPTION
Fall back to GLES 2.0 after first attempting to initialize GLES 3.0 rather than assuming the GLES version based on the iOS version as per the [Apple developer documentation](https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/OpenGLES_ProgrammingGuide/WorkingwithOpenGLESContexts/WorkingwithOpenGLESContexts.html) (see Listing 2-1).

Tested on an iPad 4 running iOS 9.3.5 (GLES 2.0) and an iPad 6 running iOS 13.3.1 (GLES 3.0).