### PR TITLE
Added missing STBSHARP_INTERNAL definitions

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -14,6 +14,7 @@ This package provides you with the content pipeline for Windows, Mac and Linux w
     <RootNamespace>Microsoft.Xna.Framework.Content.Pipeline</RootNamespace>
     <CopyContentFiles>True</CopyContentFiles>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
+    <DefineConstants>STBSHARP_INTERNAL</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>monoandroid90</TargetFramework>
-    <DefineConstants>ANDROID;GLES</DefineConstants>
+    <DefineConstants>ANDROID;GLES;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MGOpenGL>GLES</MGOpenGL>
     <Description>MonoGame is an open source implementation of the Microsoft XNA 4.x Framework. The goal is to make it easy for XNA developers to create cross-platform games with extremely high code reuse.

--- a/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>uap10.0</TargetFramework>
     <!-- TODO: NET45 is here for reflection API (Utilities\ReflectionHelpers), but does not make sense semantically -->
-    <DefineConstants>WINDOWS_UAP;DIRECTX11_1;NET45</DefineConstants>
+    <DefineConstants>WINDOWS_UAP;DIRECTX11_1;NET45;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>xamarinios10</TargetFramework>
-    <DefineConstants>IOS;GLES</DefineConstants>
+    <DefineConstants>IOS;GLES;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MGOpenGL>GLES</MGOpenGL>
 


### PR DESCRIPTION
STBSHARP_INTERNAL definition makes StbSharp classes(which are included in the MG as source code) internal. 
Lack of this definition keeps them public.