### PR TITLE
Improve native library loading

### DIFF
--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -195,53 +195,17 @@ namespace MonoGame.OpenAL
 
         private static IntPtr GetNativeLibrary()
         {
-            var ret = IntPtr.Zero;
-
 #if DESKTOPGL
-            // Load bundled library
-            var assemblyLocation = Path.GetDirectoryName(typeof(AL).Assembly.Location) ?? "./";
-
-            if (CurrentPlatform.OS == OS.Windows && Environment.Is64BitProcess)
-                ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x64/soft_oal.dll"));
-            else if (CurrentPlatform.OS == OS.Windows && !Environment.Is64BitProcess)
-                ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x86/soft_oal.dll"));
-            else if (CurrentPlatform.OS == OS.Linux && Environment.Is64BitProcess)
-                ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x64/libopenal.so.1"));
-            else if (CurrentPlatform.OS == OS.Linux && !Environment.Is64BitProcess)
-                ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x86/libopenal.so.1"));
-            else if (CurrentPlatform.OS == OS.MacOSX)
-            {
-                ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "libopenal.1.dylib"));
-
-                //Look in Frameworks for .app bundles
-                if (ret == IntPtr.Zero)
-                    ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "..", "Frameworks", "libopenal.1.dylib"));
-            }
-
-            // Load system library
-            if (ret == IntPtr.Zero)
-            {
-                if (CurrentPlatform.OS == OS.Windows)
-                    ret = FuncLoader.LoadLibrary("soft_oal.dll");
-                else if (CurrentPlatform.OS == OS.Linux)
-                    ret = FuncLoader.LoadLibrary("libopenal.so.1");
-                else
-                    ret = FuncLoader.LoadLibrary("libopenal.1.dylib");
-            }
-
-            // Try extra locations for Windows because of .NET Core rids
             if (CurrentPlatform.OS == OS.Windows)
-            {
-                var rid = Environment.Is64BitProcess ? "win-x64" : "win-x86";
-
-                if (ret == IntPtr.Zero)
-                    ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "../../runtimes", rid, "native/soft_oal.dll"));
-
-                if (ret == IntPtr.Zero)
-                    ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "runtimes", rid, "native/soft_oal.dll"));
-            }
+                return FuncLoader.LoadLibraryExt("soft_oal.dll");
+            else if (CurrentPlatform.OS == OS.Linux)
+                return FuncLoader.LoadLibraryExt("libopenal.so.1");
+            else if (CurrentPlatform.OS == OS.MacOSX)
+                return FuncLoader.LoadLibraryExt("libopenal.1.dylib");
+            else
+                return FuncLoader.LoadLibraryExt("openal");
 #elif ANDROID
-            ret = FuncLoader.LoadLibrary("libopenal32.so");
+            var ret = FuncLoader.LoadLibrary("libopenal32.so");
 
             if (ret == IntPtr.Zero)
             {
@@ -251,11 +215,11 @@ namespace MonoGame.OpenAL
 
                 ret = FuncLoader.LoadLibrary(lib);
             }
-#else
-            ret = FuncLoader.LoadLibrary("/System/Library/Frameworks/OpenAL.framework/OpenAL");
-#endif
 
             return ret;
+#else
+            return FuncLoader.LoadLibrary("/System/Library/Frameworks/OpenAL.framework/OpenAL");
+#endif
         }
 
         [CLSCompliant(false)]

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -15,56 +15,14 @@ internal static class Sdl
 
     private static IntPtr GetNativeLibrary()
     {
-        var ret = IntPtr.Zero;
-
-        // Load bundled library
-        var assemblyLocation = Path.GetDirectoryName(typeof(Sdl).Assembly.Location) ?? "./";
-        
-        if (CurrentPlatform.OS == OS.Windows && Environment.Is64BitProcess)
-            ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x64/SDL2.dll"));
-        else if (CurrentPlatform.OS == OS.Windows && !Environment.Is64BitProcess)
-            ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x86/SDL2.dll"));
-        else if (CurrentPlatform.OS == OS.Linux && Environment.Is64BitProcess)
-            ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x64/libSDL2-2.0.so.0"));
-        else if (CurrentPlatform.OS == OS.Linux && !Environment.Is64BitProcess)
-            ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "x86/libSDL2-2.0.so.0"));
-        else if (CurrentPlatform.OS == OS.MacOSX)
-        {
-            ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "libSDL2-2.0.0.dylib"));
-
-            //Look in Frameworks for .app bundles
-            if (ret == IntPtr.Zero)
-                ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "..", "Frameworks", "libSDL2-2.0.0.dylib"));
-        }
-
-        // Load system library
-        if (ret == IntPtr.Zero)
-        {
-            if (CurrentPlatform.OS == OS.Windows)
-                ret = FuncLoader.LoadLibrary("SDL2.dll");
-            else if (CurrentPlatform.OS == OS.Linux)
-                ret = FuncLoader.LoadLibrary("libSDL2-2.0.so.0");
-            else
-                ret = FuncLoader.LoadLibrary("libSDL2-2.0.0.dylib");
-        }
-
-        // Try extra locations for Windows because of .NET Core rids
         if (CurrentPlatform.OS == OS.Windows)
-        {
-            var rid = Environment.Is64BitProcess ? "win-x64" : "win-x86";
-
-            if (ret == IntPtr.Zero)
-                ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "../../runtimes", rid, "native/SDL2.dll"));
-
-            if (ret == IntPtr.Zero)
-                ret = FuncLoader.LoadLibrary(Path.Combine(assemblyLocation, "runtimes", rid, "native/SDL2.dll"));
-        }
-
-        // Welp, all failed, PANIC!!!
-        if (ret == IntPtr.Zero)
-            throw new Exception("Failed to load SDL library.");
-
-        return ret;
+            return FuncLoader.LoadLibraryExt("SDL2.dll");
+        else if (CurrentPlatform.OS == OS.Linux)
+            return FuncLoader.LoadLibraryExt("libSDL2-2.0.so.0");
+        else if (CurrentPlatform.OS == OS.MacOSX)
+            return FuncLoader.LoadLibraryExt("libSDL2-2.0.0.dylib");
+        else
+            return FuncLoader.LoadLibraryExt("sdl2");
     }
 
     public static int Major;

--- a/MonoGame.Framework/Platform/Utilities/CurrentPlatform.cs
+++ b/MonoGame.Framework/Platform/Utilities/CurrentPlatform.cs
@@ -81,6 +81,23 @@ namespace MonoGame.Utilities
                 return os;
             }
         }
+
+        public static string Rid
+        {
+            get
+            {
+                if (CurrentPlatform.OS == OS.Windows && Environment.Is64BitProcess)
+                    return "win-x64";
+                else if (CurrentPlatform.OS == OS.Windows && !Environment.Is64BitProcess)
+                    return "win-x86";
+                else if (CurrentPlatform.OS == OS.Linux)
+                    return "linux-x64";
+                else if (CurrentPlatform.OS == OS.MacOSX)
+                    return "osx";
+                else
+                    return "unknown";
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Stuff done:
- Added rid to the `CurrentPlatform` helper class
- Moved the library handling logic to `FuncLoader`
- Fixed library search locations for .NET Core
- Better explained each search location
- Inform the user about library that failed to load in the exception itself