### PR TITLE
Enable executable generation for macOS by default

### DIFF
--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -6,6 +6,7 @@
     <BaseIntermediateOutputPath>obj\$(MonoGamePlatform)</BaseIntermediateOutputPath>
     <BaseOutputPath>..\Artifacts\Tests\$(MonoGamePlatform)</BaseOutputPath>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
+    <UseAppHost>true</UseAppHost>
   </PropertyGroup>
 
 </Project>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -9,6 +9,7 @@
     <PackageId>dotnet-mgcb</PackageId>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <AssemblyName>mgcb</AssemblyName>
+    <UseAppHost>true</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
+++ b/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
@@ -9,6 +9,7 @@
     <PackageId>dotnet-mgfxc</PackageId>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <AssemblyName>mgfxc</AssemblyName>
+    <UseAppHost>true</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
+++ b/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
@@ -9,6 +9,7 @@
     <DefineConstants>DESKTOPGL</DefineConstants>
     <BaseOutputPath>..\..\Artifacts\Tests\Tools</BaseOutputPath>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
+    <UseAppHost>true</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
UseAppHost is enabled by default on Windows / Linux, and disabled by default on macOS.