### PR TITLE
Update SpriteFont.cs

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -222,8 +222,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 if (c == '\n')
                 {
-                    finalLineHeight = LineSpacing;
-
                     offset.X = 0;
                     offset.Y += LineSpacing;
                     firstGlyphOfLine = true;


### PR DESCRIPTION
removed redundant lines 
finalLineHeight is pre-calculated and doesn't need to be set inside the loop.