### PR TITLE
Update SpriteFont.cs

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -222,8 +222,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 if (c == '\n')
                 {
-                    finalLineHeight = LineSpacing;
-
                     offset.X = 0;
                     offset.Y += LineSpacing;
                     firstGlyphOfLine = true;
@@ -251,9 +249,6 @@ namespace Microsoft.Xna.Framework.Graphics
                     width = proposedWidth;
 
                 offset.X += pCurrentGlyph->RightSideBearing;
-
-                if (pCurrentGlyph->Cropping.Height > finalLineHeight)
-                    finalLineHeight = pCurrentGlyph->Cropping.Height;
             }
 
             size.X = width;


### PR DESCRIPTION
Removed inconsistency's with drawstring. The lines removed account for height cropping that spritebatch doesn't account for which would result in, a accumulating error between what is drawn and what measure string would report for the total height of the measured text. 
Im doubtful if it is correct to second guess the line height returned by a font if spritebatch did account for it.