### PR TITLE
Discovery of MGCB language agnostic.

### DIFF
--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -61,10 +61,10 @@
          is formatted as a `PrintableTable` (https://github.com/dotnet/cli/blob/master/src/dotnet/PrintableTable.cs).
          `PrintableTable` defines six consecutive spaces as its column delimiter (public const string ColumnDelimiter = "      ";)  -->
     <PropertyGroup>
-      <DotnetToolHeaderPackageIDColumnName>$(ConsoleOutput.Split("      ")[0])</DotnetToolHeaderPackageIDColumnName>
-      <DotnetToolHeaderVersionColumnName>$(ConsoleOutput.Split("      ")[1])</DotnetToolHeaderVersionColumnName>
-      <DotnetToolHeaderCommandsColumnName>$(ConsoleOutput.Split("      ")[2])</DotnetToolHeaderCommandsColumnName>
-      <DotnetToolHeaderManifestColumnName>$(ConsoleOutput.Split("      ")[3])</DotnetToolHeaderManifestColumnName>
+      <DotnetToolHeaderPackageIDColumnName>$(ConsoleOutput.Split("      ", StringSplitOptions.RemoveEmptyEntries)[0])</DotnetToolHeaderPackageIDColumnName>
+      <DotnetToolHeaderVersionColumnName>$(ConsoleOutput.Split("      ", StringSplitOptions.RemoveEmptyEntries)[1])</DotnetToolHeaderVersionColumnName>
+      <DotnetToolHeaderCommandsColumnName>$(ConsoleOutput.Split("      ", StringSplitOptions.RemoveEmptyEntries)[2])</DotnetToolHeaderCommandsColumnName>
+      <DotnetToolHeaderManifestColumnName>$(ConsoleOutput.Split("      ", StringSplitOptions.RemoveEmptyEntries)[3])</DotnetToolHeaderManifestColumnName>
 
       <DotnetToolPackageIdIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderPackageIDColumnName)))</DotnetToolPackageIdIndex>
       <DotnetToolVersionIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderVersionColumnName)))</DotnetToolVersionIndex>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -59,11 +59,15 @@
     <!-- Get header indices, because the Manifest path may contain spaces or semicolons, which means we cannot simply split. -->
     <PropertyGroup>
       <DotnetToolHeader>$(ConsoleOutput.Split(';')[0])</DotnetToolHeader>
+      <DotnetToolHeaderPackageIDColumnName>$(DotnetToolHeader.Split(' ', StringSplitOptions.RemoveEmptyEntries)[0])</DotnetToolHeaderPackageIDColumnName>
+      <DotnetToolHeaderVersionColumnName>$(DotnetToolHeader.Split(' ', StringSplitOptions.RemoveEmptyEntries)[1])</DotnetToolHeaderVersionColumnName>
+      <DotnetToolHeaderCommandsColumnName>$(DotnetToolHeader.Split(' ', StringSplitOptions.RemoveEmptyEntries)[2])</DotnetToolHeaderCommandsColumnName>
+      <DotnetToolHeaderManifestColumnName>$(DotnetToolHeader.Split(' ', StringSplitOptions.RemoveEmptyEntries)[3])</DotnetToolHeaderManifestColumnName>
 
-      <DotnetToolPackageIdIndex>$(DotnetToolHeader.IndexOf('Package Id'))</DotnetToolPackageIdIndex>
-      <DotnetToolVersionIndex>$(DotnetToolHeader.IndexOf('Version'))</DotnetToolVersionIndex>
-      <DotnetToolCommandsIndex>$(DotnetToolHeader.IndexOf('Commands'))</DotnetToolCommandsIndex>
-      <DotnetToolManifestIndex>$(DotnetToolHeader.IndexOf('Manifest'))</DotnetToolManifestIndex>
+      <DotnetToolPackageIdIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderPackageIDColumnName)))</DotnetToolPackageIdIndex>
+      <DotnetToolVersionIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderVersionColumnName)))</DotnetToolVersionIndex>
+      <DotnetToolCommandsIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderCommandsColumnName)))</DotnetToolCommandsIndex>
+      <DotnetToolManifestIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderManifestColumnName)))</DotnetToolManifestIndex>
 
       <DotnetToolPackageIdLength>$([MSBuild]::Subtract($(DotnetToolVersionIndex), $(DotnetToolPackageIdIndex)))</DotnetToolPackageIdLength>
       <DotnetToolVersionLength>$([MSBuild]::Subtract($(DotnetToolCommandsIndex), $(DotnetToolVersionIndex)))</DotnetToolVersionLength>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -66,10 +66,10 @@
       <DotnetToolHeaderCommandsColumnName>$(ConsoleOutput.Split("      ", StringSplitOptions.RemoveEmptyEntries)[2])</DotnetToolHeaderCommandsColumnName>
       <DotnetToolHeaderManifestColumnName>$(ConsoleOutput.Split("      ", StringSplitOptions.RemoveEmptyEntries)[3])</DotnetToolHeaderManifestColumnName>
 
-      <DotnetToolPackageIdIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderPackageIDColumnName)))</DotnetToolPackageIdIndex>
-      <DotnetToolVersionIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderVersionColumnName)))</DotnetToolVersionIndex>
-      <DotnetToolCommandsIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderCommandsColumnName)))</DotnetToolCommandsIndex>
-      <DotnetToolManifestIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderManifestColumnName)))</DotnetToolManifestIndex>
+      <DotnetToolPackageIdIndex>$(ConsoleOutput.IndexOf($(DotnetToolHeaderPackageIDColumnName)))</DotnetToolPackageIdIndex>
+      <DotnetToolVersionIndex>$(ConsoleOutput.IndexOf($(DotnetToolHeaderVersionColumnName)))</DotnetToolVersionIndex>
+      <DotnetToolCommandsIndex>$(ConsoleOutput.IndexOf($(DotnetToolHeaderCommandsColumnName)))</DotnetToolCommandsIndex>
+      <DotnetToolManifestIndex>$(ConsoleOutput.IndexOf($(DotnetToolHeaderManifestColumnName)))</DotnetToolManifestIndex>
 
       <DotnetToolPackageIdLength>$([MSBuild]::Subtract($(DotnetToolVersionIndex), $(DotnetToolPackageIdIndex)))</DotnetToolPackageIdLength>
       <DotnetToolVersionLength>$([MSBuild]::Subtract($(DotnetToolCommandsIndex), $(DotnetToolVersionIndex)))</DotnetToolVersionLength>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -56,13 +56,15 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="ConsoleOutput" />
     </Exec>
 
-    <!-- Get header indices, because the Manifest path may contain spaces or semicolons, which means we cannot simply split. -->
+    <!-- Get header indices.
+         The output of `dotnet tool list` (https://github.com/dotnet/cli/blob/master/src/dotnet/commands/dotnet-tool/list/ToolListGlobalOrToolPathCommand.cs) 
+         is formatted as a `PrintableTable` (https://github.com/dotnet/cli/blob/master/src/dotnet/PrintableTable.cs).
+         `PrintableTable` defines six consecutive spaces as its column delimiter (public const string ColumnDelimiter = "      ";)  -->
     <PropertyGroup>
-      <DotnetToolHeader>$(ConsoleOutput.Split(';')[0])</DotnetToolHeader>
-      <DotnetToolHeaderPackageIDColumnName>$(DotnetToolHeader.Split(' ', StringSplitOptions.RemoveEmptyEntries)[0])</DotnetToolHeaderPackageIDColumnName>
-      <DotnetToolHeaderVersionColumnName>$(DotnetToolHeader.Split(' ', StringSplitOptions.RemoveEmptyEntries)[1])</DotnetToolHeaderVersionColumnName>
-      <DotnetToolHeaderCommandsColumnName>$(DotnetToolHeader.Split(' ', StringSplitOptions.RemoveEmptyEntries)[2])</DotnetToolHeaderCommandsColumnName>
-      <DotnetToolHeaderManifestColumnName>$(DotnetToolHeader.Split(' ', StringSplitOptions.RemoveEmptyEntries)[3])</DotnetToolHeaderManifestColumnName>
+      <DotnetToolHeaderPackageIDColumnName>$(ConsoleOutput.Split("      ")[0])</DotnetToolHeaderPackageIDColumnName>
+      <DotnetToolHeaderVersionColumnName>$(ConsoleOutput.Split("      ")[1])</DotnetToolHeaderVersionColumnName>
+      <DotnetToolHeaderCommandsColumnName>$(ConsoleOutput.Split("      ")[2])</DotnetToolHeaderCommandsColumnName>
+      <DotnetToolHeaderManifestColumnName>$(ConsoleOutput.Split("      ")[3])</DotnetToolHeaderManifestColumnName>
 
       <DotnetToolPackageIdIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderPackageIDColumnName)))</DotnetToolPackageIdIndex>
       <DotnetToolVersionIndex>$(DotnetToolHeader.IndexOf($(DotnetToolHeaderVersionColumnName)))</DotnetToolVersionIndex>


### PR DESCRIPTION
Fixes #7084 

Changed parsing of `dotnet tool list -local` to depend on column order instead off on column titles. Column titles are language specific, so that the code threw on non-english systems.
Tested new version on english and german systems.