### PR TITLE
MouseState.ToString

### DIFF
--- a/MonoGame.Framework/Input/MouseState.cs
+++ b/MonoGame.Framework/Input/MouseState.cs
@@ -149,6 +149,62 @@ namespace Microsoft.Xna.Framework.Input
         }
 
         /// <summary>
+        /// Returns a string describing the mouse state.
+        /// </summary>
+        public override string ToString()
+        {
+            string buttons;
+            if (_buttons == 0)
+                buttons = "None";
+            else
+            {
+                buttons = string.Empty;
+                if ((_buttons & LeftButtonFlag) == LeftButtonFlag)
+                {
+                    if (buttons.Length > 0)
+                        buttons += " Left";
+                    else
+                        buttons += "Left";
+                }
+                if ((_buttons & RightButtonFlag) == RightButtonFlag)
+                {
+                    if (buttons.Length > 0)
+                        buttons += " Right";
+                    else
+                        buttons += "Right";
+                }
+                if ((_buttons & MiddleButtonFlag) == MiddleButtonFlag)
+                {
+                    if (buttons.Length > 0)
+                        buttons += " Middle";
+                    else
+                        buttons += "Middle";
+                }
+                if ((_buttons & XButton1Flag) == XButton1Flag)
+                {
+                    if (buttons.Length > 0)
+                        buttons += " XButton1";
+                    else
+                        buttons += "XButton1";
+                }
+                if ((_buttons & XButton2Flag) == XButton2Flag)
+                {
+                    if (buttons.Length > 0)
+                        buttons += " XButton2";
+                    else
+                        buttons += "XButton2";
+                }
+            }
+
+            return  "[MouseState X=" + _x +
+                    ", Y=" + _y +
+                    ", Buttons=" + buttons +
+                    ", Wheel=" + _scrollWheelValue +
+                    ", HWheel=" + _horizontalScrollWheelValue +
+                    "]";
+        }
+
+        /// <summary>
         /// Gets horizontal position of the cursor in relation to the window.
         /// </summary>
         public int X


### PR DESCRIPTION
This PR added `MouseState.ToString()` to match XNA and MonoGame formatting in other types.

MonoGame (the fuzzy text is because this is from a video stream):
![image](https://user-images.githubusercontent.com/103522/78467836-9d28d800-76d6-11ea-96d9-deda1183819b.png)

XNA:
![image](https://user-images.githubusercontent.com/103522/78467854-e416cd80-76d6-11ea-9803-5f745fc72229.png)


I am matching the formatting used in other input types like GamePad:  https://github.com/MonoGame/MonoGame/blob/develop/MonoGame.Framework/Input/GamePadState.cs#L213

