### PR TITLE
Fixing openal audio duplicating sourceids

### DIFF
--- a/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.OpenAL.cs
@@ -106,12 +106,12 @@ namespace Microsoft.Xna.Framework.Audio
         {
             // Stop the source and bind null buffer so that it can be recycled
             AL.GetError();
-            if (AL.IsSource(SourceId))
+            if (HasSourceId && AL.IsSource(SourceId))
             {
                 AL.SourceStop(SourceId);
                 AL.Source(SourceId, ALSourcei.Buffer, 0);
                 ALHelper.CheckError("Failed to stop the source.");
-                controller.RecycleSource(SourceId);
+                controller.FreeSource(this);
             }
             
             if (disposing)

--- a/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.OpenAL.cs
@@ -106,14 +106,18 @@ namespace Microsoft.Xna.Framework.Audio
         {
             // Stop the source and bind null buffer so that it can be recycled
             AL.GetError();
-            if (HasSourceId && AL.IsSource(SourceId))
+
+            lock (sourceMutex)
             {
-                AL.SourceStop(SourceId);
-                AL.Source(SourceId, ALSourcei.Buffer, 0);
-                ALHelper.CheckError("Failed to stop the source.");
-                controller.FreeSource(this);
+                if (HasSourceId && AL.IsSource(SourceId))
+                {
+                    AL.SourceStop(SourceId);
+                    AL.Source(SourceId, ALSourcei.Buffer, 0);
+                    ALHelper.CheckError("Failed to stop the source.");
+                    controller.FreeSource(this);
+                }
             }
-            
+
             if (disposing)
             {
                 while (_queuedBuffers.Count > 0)

--- a/MonoGame.Framework/Platform/Media/Song.NVorbis.cs
+++ b/MonoGame.Framework/Platform/Media/Song.NVorbis.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Xna.Framework.Media
     {
         private OggStream stream;
         private float _volume = 1f;
+        private readonly object _sourceMutex = new object();
 
         private void PlatformInitialize(string fileName)
         {
@@ -34,11 +35,14 @@ namespace Microsoft.Xna.Framework.Media
 		
         void PlatformDispose(bool disposing)
         {
-            if (stream == null)
-                return;
+            lock (_sourceMutex)
+            {
+                if (stream == null)
+                    return;
 
-            stream.Dispose();
-            stream = null;
+                stream.Dispose();
+                stream = null;
+            }
         }
 
         internal void Play(TimeSpan? startPosition)


### PR DESCRIPTION
Resolves #7094.

Ensures that no two threads try to release openal source ids at the same time.

Ensures that openal source id aren't released twice by making sure HasSourceId is true beforehand.