### PR TITLE
[WinDx && DesktopGL] Method to prevent closing of Monogame Window

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Xna.Framework
 
         private bool _shouldExit;
         private bool _suppressDraw;
-        private bool _exitAborted = true;
+        private bool _processExit;
 
         partial void PlatformConstruct();       
 
@@ -397,10 +397,10 @@ namespace Microsoft.Xna.Framework
                 break;
             case GameRunBehavior.Synchronous:
                 //True by default, we don't want to exit on launch
-                while (_exitAborted)
+                while (!_processExit)
                 {
-                    //We don't want to continue looping unless (on desktop platforms) the exit is terminated
-                    _exitAborted = false;
+                    //Next time an exit is requested we want to break out of this loop unless we're on a desktop platform and the exit is aborted in the OnBeforeExit event.
+                    _processExit = true;
 
                     // XNA runs one Update even before showing the window
                     DoUpdate(new GameTime());
@@ -726,7 +726,7 @@ namespace Microsoft.Xna.Framework
 
 #if (WINDOWS && DIRECTX) || DESKTOPGL
             //Only allow aborting of the exit process on desktop platforms where it is supported.
-            _exitAborted = args.Cancel;
+            _processExit = !args.Cancel;
 #endif
         }
 

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -396,21 +396,22 @@ namespace Microsoft.Xna.Framework
                 Platform.StartRunLoop();
                 break;
             case GameRunBehavior.Synchronous:
+                // XNA runs one Update even before showing the window
+                DoUpdate(new GameTime());
+
                 //True by default, we don't want to exit on launch
                 while (!_processExit)
                 {
                     //Next time an exit is requested we want to break out of this loop unless we're on a desktop platform and the exit is aborted in the OnBeforeExit event.
                     _processExit = true;
 
-                    // XNA runs one Update even before showing the window
-                    DoUpdate(new GameTime());
-
                     Platform.RunLoop();
-                    EndRun();
 
                     //Raise the before exiting event and provide an opportunity for the exit to be prevented
                     DoBeforeExit();
                 }
+
+                EndRun();
 
                 DoExiting();
                 break;


### PR DESCRIPTION
PR for issue #6415 

This edit creates a new Game.cs event that will fire before the application would exit on all platforms. The BeforeExit() event arguments contains a .Cancel property that, when set to true on WindowsDX and DesktopGL platforms will keep running the Platform.RunLoop() code effectively keeping players in-game.

In our use case this will be great to inform players online that they are about to exit while in combat, and that their character will remain in-game until they are deemed safe or die.

Tested and working. 

If you all would like this to be done differently I'm happy to discuss and revise in order to get this merged in. Thanks!