### PR TITLE
Clean up OpenAL SFX disposal

### DIFF
--- a/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.OpenAL.cs
@@ -104,19 +104,8 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformDispose(bool disposing)
         {
-            // Stop the source and bind null buffer so that it can be recycled
-            AL.GetError();
-
-            lock (sourceMutex)
-            {
-                if (HasSourceId && AL.IsSource(SourceId))
-                {
-                    AL.SourceStop(SourceId);
-                    AL.Source(SourceId, ALSourcei.Buffer, 0);
-                    ALHelper.CheckError("Failed to stop the source.");
-                    controller.FreeSource(this);
-                }
-            }
+            // SFXI disposal handles buffer detachment and source recycling
+            base.Dispose(disposing);
 
             if (disposing)
             {

--- a/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
@@ -428,13 +428,16 @@ namespace Microsoft.Xna.Framework.Audio
 		}
 
         public void RecycleSource(int sourceId)
-		{
+        {
+            AL.Source(sourceId, ALSourcei.Buffer, 0);
+            ALHelper.CheckError("Failed to free source from buffers.");
+
             lock (availableSourcesCollection)
             {
-                inUseSourcesCollection.Remove(sourceId);
-                availableSourcesCollection.Add(sourceId);
+                if (inUseSourcesCollection.Remove(sourceId))
+                    availableSourcesCollection.Add(sourceId);
             }
-		}
+        }
 
         public void FreeSource(SoundEffectInstance inst)
         {

--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.OpenAL.cs
@@ -175,14 +175,17 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void FreeSource()
         {
+            if (!HasSourceId)
+                return;
+
             lock (sourceMutex)
             {
-                if (HasSourceId)
+                if (HasSourceId && AL.IsSource(SourceId))
                 {
                     AL.SourceStop(SourceId);
                     ALHelper.CheckError("Failed to stop source.");
 
-                    // Reset the SendFilter to 0 if we are NOT using reverb since 
+                    // Reset the SendFilter to 0 if we are NOT using reverb since
                     // sources are recycled
                     if (OpenALSoundController.Instance.SupportsEfx)
                     {
@@ -191,9 +194,6 @@ namespace Microsoft.Xna.Framework.Audio
                         AL.Source(SourceId, ALSourcei.EfxDirectFilter, 0);
                         ALHelper.CheckError("Failed to unset filter.");
                     }
-
-                    AL.Source(SourceId, ALSourcei.Buffer, 0);
-                    ALHelper.CheckError("Failed to free source from buffer.");
 
                     controller.FreeSource(this);
                 }


### PR DESCRIPTION
Follow up on #7095. 
Deduplicates some code so it's easier to follow.
Also removes the low pass filter from `OggStream` since we don't use it.