### PR TITLE
Support canceling game exit

### DIFF
--- a/MonoGame.Framework/ExitingEventArgs.cs
+++ b/MonoGame.Framework/ExitingEventArgs.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Microsoft.Xna.Framework
+{
+    /// <summary>
+    /// Event arguments for <see cref="Game.Exiting"/>.
+    /// </summary>
+    public class ExitingEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Set to <c>true</c> to cancel closing the game.
+        /// </summary>
+        public bool Cancel { get; set; }
+    }
+}

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -362,6 +362,8 @@ namespace Microsoft.Xna.Framework
 
         #region Events
 
+        private readonly ExitingEventArgs _exitingEventArgs = new ExitingEventArgs();
+
         /// <summary>
         /// Raised when the game gains focus.
         /// </summary>
@@ -380,7 +382,7 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Raised when this game is exiting.
         /// </summary>
-        public event EventHandler<EventArgs> Exiting;
+        public event EventHandler<ExitingEventArgs> Exiting;
 
 #if WINDOWS_UAP
         [CLSCompliant(false)]
@@ -495,8 +497,6 @@ namespace Microsoft.Xna.Framework
                 DoUpdate(new GameTime());
 
                 Platform.RunLoop();
-                EndRun();
-				DoExiting();
                 break;
             default:
                 throw new ArgumentException(string.Format(
@@ -631,8 +631,17 @@ namespace Microsoft.Xna.Framework
 
             if (_shouldExit)
             {
-                Platform.Exit();
-                _shouldExit = false; //prevents perpetual exiting on platforms supporting resume.
+                _exitingEventArgs.Cancel = false;
+                OnExiting(this, _exitingEventArgs);
+
+                if (!_exitingEventArgs.Cancel)
+                {
+                    Platform.Exit();
+                    EndRun();
+                    UnloadContent();
+                }
+
+                _shouldExit = false;
             }
         }
 
@@ -743,7 +752,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="sender">This <see cref="Game"/>.</param>
         /// <param name="args">The arguments to the <see cref="Exiting"/> event.</param>
-        protected virtual void OnExiting(object sender, EventArgs args)
+        protected virtual void OnExiting(object sender, ExitingEventArgs args)
         {
             EventHelpers.Raise(sender, Exiting, args);
         }
@@ -795,8 +804,6 @@ namespace Microsoft.Xna.Framework
 
             var platform = (GamePlatform)sender;
             platform.AsyncRunLoopEnded -= Platform_AsyncRunLoopEnded;
-            EndRun();
-			DoExiting();
         }
 
         #endregion Event Handlers
@@ -870,12 +877,6 @@ namespace Microsoft.Xna.Framework
             _components.ComponentAdded += Components_ComponentAdded;
             _components.ComponentRemoved += Components_ComponentRemoved;
         }
-
-		internal void DoExiting()
-		{
-			OnExiting(this, EventArgs.Empty);
-			UnloadContent();
-		}
 
         #endregion Internal Methods
 

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -362,8 +362,6 @@ namespace Microsoft.Xna.Framework
 
         #region Events
 
-        private readonly ExitingEventArgs _exitingEventArgs = new ExitingEventArgs();
-
         /// <summary>
         /// Raised when the game gains focus.
         /// </summary>
@@ -631,10 +629,11 @@ namespace Microsoft.Xna.Framework
 
             if (_shouldExit)
             {
-                _exitingEventArgs.Cancel = false;
-                OnExiting(this, _exitingEventArgs);
+                var exitingEventArgs = new ExitingEventArgs();
 
-                if (!_exitingEventArgs.Cancel)
+                OnExiting(this, exitingEventArgs);
+
+                if (!exitingEventArgs.Cancel)
                 {
                     Platform.Exit();
                     EndRun();

--- a/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Xna.Framework
                 switch (ev.Type)
                 {
                     case Sdl.EventType.Quit:
-                        _isExiting++;
+                        Game.Exit();
                         break;
                     case Sdl.EventType.JoyDeviceAdded:
                         Joystick.AddDevices();
@@ -241,7 +241,7 @@ namespace Microsoft.Xna.Framework
                                 _view.Moved();
                                 break;
                             case Sdl.Window.EventId.Close:
-                                _isExiting++;
+                                Game.Exit();
                                 break;
                         }
                         break;

--- a/MonoGame.Framework/Platform/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Platform/Windows/WinFormsGameWindow.cs
@@ -162,6 +162,7 @@ namespace MonoGame.Framework
             _resizeTickTimer = new System.Timers.Timer(1) { SynchronizingObject = Form, AutoReset = false };
             _resizeTickTimer.Elapsed += OnResizeTick;
 
+            Form.FormClosing += OnFormClosing;
             Form.Activated += OnActivated;
             Form.Deactivate += OnDeactivate;
             Form.Resize += OnResize;
@@ -235,6 +236,12 @@ namespace MonoGame.Framework
             {
                 _allWindowsReaderWriterLockSlim.ExitWriteLock();
             }
+        }
+
+        private void OnFormClosing(object sender, FormClosingEventArgs e)
+        {
+            e.Cancel = true;
+            _platform.Game.Exit();
         }
 
         private void OnActivated(object sender, EventArgs eventArgs)

--- a/Tests/Framework/GameTest.cs
+++ b/Tests/Framework/GameTest.cs
@@ -279,7 +279,7 @@ namespace MonoGame.Tests {
 
                 protected override void OnActivated(object sender, EventArgs args) { ActivatedCount++; base.OnActivated(sender, args); }
                 protected override void OnDeactivated(object sender, EventArgs args) { DeactivatedCount++; base.OnDeactivated(sender, args); }
-                protected override void OnExiting(object sender, EventArgs args) { ExitingCount++; base.OnExiting(sender, args); }
+                protected override void OnExiting(object sender, ExitingEventArgs args) { ExitingCount++; base.OnExiting(sender, args); }
                 protected override void Dispose(bool disposing) { DisposeCount++; base.Dispose(disposing); }
             }
 


### PR DESCRIPTION
Felt inspired by #7096. Fixes #6415.

Note that this breaks user code that overrides `OnExiting` because the signature changed. I think however that that's very minor and this is better than cluttering the API with another way to do it.

@tomspilman @mrhelmut @harry-cpp I made the assumption that all platforms use `Tick` to run their game loop. Note that invocation of the `Exiting` event, the `EndRun` call and the `UnloadContent` call now only happen from `Tick`. So if closed platforms have another way to run the game loop they need to call those methods where they exit the game. If so the whole [`_shouldExit` block](https://github.com/MonoGame/MonoGame/compare/develop...Jjagg:exit-cancel?expand=1#diff-c9a47e02910a8951188f9eb0ac3615e8R522-R534) should be extracted into a separate method.

@jcsnider Please try this if you're interested :) 