### PR TITLE
Always use Release configuration with mgfxc reference

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -269,13 +269,13 @@ This package provides you with the content pipeline for Windows, Mac and Linux w
 
   <!-- Build and copy MFFXC, just don't reference it! -->
   <ItemGroup>
-    <Content Include="..\Artifacts\MonoGame.Effect.Compiler\$(Configuration)\*" Visible="false">
+    <Content Include="..\Artifacts\MonoGame.Effect.Compiler\Release\*" Visible="false">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <Target Name="BuildMFGXC" BeforeTargets="Restore">
-    <MSBuild Projects="..\Tools\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=$(Configuration);UseAppHost=False" Targets="Restore" />
-    <MSBuild Projects="..\Tools\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=$(Configuration);UseAppHost=False" Targets="Build" />
+    <MSBuild Projects="..\Tools\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=Release;UseAppHost=False" Targets="Restore" />
+    <MSBuild Projects="..\Tools\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=Release;UseAppHost=False" Targets="Build" />
   </Target>
   
   <Import Project="..\Stadia\MonoGame.Framework.Content.Pipeline.targets" Condition="exists('..\Stadia\MonoGame.Framework.Content.Pipeline.targets')" />

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -19,13 +19,13 @@
 
   <!-- Build and copy MFFXC, just don't reference it! -->
   <ItemGroup>
-    <Content Include="..\..\Artifacts\MonoGame.Effect.Compiler\$(Configuration)\*" Visible="false">
+    <Content Include="..\..\Artifacts\MonoGame.Effect.Compiler\Release\*" Visible="false">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <Target Name="BuildMFGXC" BeforeTargets="Restore">
-    <MSBuild Projects="..\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=$(Configuration);UseAppHost=False" Targets="Restore" />
-    <MSBuild Projects="..\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=$(Configuration);UseAppHost=False" Targets="Build" />
+    <MSBuild Projects="..\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=Release;UseAppHost=False" Targets="Restore" />
+    <MSBuild Projects="..\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=Release;UseAppHost=False" Targets="Build" />
   </Target>
 
 </Project>


### PR DESCRIPTION
So fun note, $(Configuration) is set after the Restore target, so we can't pass it.