### PR TITLE
Fix incompatibility in cake script when multiple versions of .Net Core are installed on Windows 10

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -164,6 +164,7 @@ Task("BuildContentPipeline")
 
 Task("BuildTools")
     .IsDependentOn("Prep")
+    .WithCriteria(() => GetMSBuildWith("Microsoft.VisualStudio.Component.Windows10SDK.18362"))
     .Does(() =>
 {
     DotNetCoreRestore("Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj");


### PR DESCRIPTION
When both .Net Core 3.1 & 2.1 are both installed, cake script aborts during BuildTools portion with the following message:

```
C:\Program Files\dotnet\sdk\2.1.512\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(137,5): error NETSDK1045: The current .NET SDK does not support targeting .NET Core 3.1.  Either target .NET Core 2.1 or lower, or use a version of the .NET SDK that supports .NET Core 3.1. [\MonoGame\Tools\MonoGame.Content.Builder\MonoGame.Content.Builder.csproj]
An error occurred when executing task 'BuildTools'.
Error: One or more errors occurred. (MSBuild: Process returned an error (exit code 1).)
        MSBuild: Process returned an error (exit code 1).
```

Closes #7092 

Tested locally on Windows 10 64Bit