### PR TITLE
Fixed deconstruction of color for bytes and floats

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1879,10 +1879,10 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Deconstruction method for <see cref="Color"/>.
         /// </summary>
-        /// <param name="r"></param>
-        /// <param name="g"></param>
-        /// <param name="b"></param>
-        public void Deconstruct(out float r, out float g, out float b)
+        /// <param name="r">Red component value from 0 to 255.</param>
+        /// <param name="g">Green component value from 0 to 255.</param>
+        /// <param name="b">Blue component value from 0 to 255.</param>
+        public void Deconstruct(out byte r, out byte g, out byte b)
         {
             r = R;
             g = G;
@@ -1890,18 +1890,46 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Deconstruction method for <see cref="Color"/>.
+        /// </summary>
+        /// <param name="r">Red component value from 0.0f to 1.0f.</param>
+        /// <param name="g">Green component value from 0.0f to 1.0f.</param>
+        /// <param name="b">Blue component value from 0.0f to 1.0f.</param>
+        public void Deconstruct(out float r, out float g, out float b)
+        {
+            r = R / 255f;
+            g = G / 255f;
+            b = B / 255f;
+        }
+
+        /// <summary>
         /// Deconstruction method for <see cref="Color"/> with Alpha.
         /// </summary>
-        /// <param name="r"></param>
-        /// <param name="g"></param>
-        /// <param name="b"></param>
-        /// <param name="a"></param>
-        public void Deconstruct(out float r, out float g, out float b, out float a)
+        /// <param name="r">Red component value from 0 to 255.</param>
+        /// <param name="g">Green component value from 0 to 255.</param>
+        /// <param name="b">Blue component value from 0 to 255.</param>
+        /// <param name="a">Alpha component value from 0 to 255.</param>
+        public void Deconstruct(out byte r, out byte g, out byte b, out byte a)
         {
             r = R;
             g = G;
             b = B;
             a = A;
+        }
+
+        /// <summary>
+        /// Deconstruction method for <see cref="Color"/> with Alpha.
+        /// </summary>
+        /// <param name="r">Red component value from 0.0f to 1.0f.</param>
+        /// <param name="g">Green component value from 0.0f to 1.0f.</param>
+        /// <param name="b">Blue component value from 0.0f to 1.0f.</param>
+        /// <param name="a">Alpha component value from 0.0f to 1.0f.</param>
+        public void Deconstruct(out float r, out float g, out float b, out float a)
+        {
+            r = R / 255f;
+            g = G / 255f;
+            b = B / 255f;
+            a = A / 255f;
         }
     }
 }

--- a/Tests/Framework/ColorTest.cs
+++ b/Tests/Framework/ColorTest.cs
@@ -195,11 +195,10 @@ namespace MonoGame.Tests.Framework
 
 #if !XNA
         [Test]
-        public void Deconstruct()
+        public void DeconstructBytes()
         {
             Color color = new Color(255, 255, 255);
-
-            float r, g, b;
+            byte r, g, b;
 
             color.Deconstruct(out r, out g, out b);
 
@@ -209,7 +208,7 @@ namespace MonoGame.Tests.Framework
 
             Color color2 = new Color(255, 255, 255, 255);
 
-            float r2, g2, b2, a2;
+            byte r2, g2, b2, a2;
 
             color2.Deconstruct(out r2, out g2, out b2, out a2);
 
@@ -217,6 +216,30 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(g2, color2.G);
             Assert.AreEqual(b2, color2.B);
             Assert.AreEqual(a2, color2.A);
+        }
+
+        [Test]
+        public void DeconstructFloats()
+        {
+            Color color = new Color(255, 255, 255);
+            float r, g, b;
+
+            color.Deconstruct(out r, out g, out b);
+
+            Assert.AreEqual(r, color.R / 255f);
+            Assert.AreEqual(g, color.G / 255f);
+            Assert.AreEqual(b, color.B / 255f);
+
+            Color color2 = new Color(255, 255, 255, 255);
+
+            float r2, g2, b2, a2;
+
+            color2.Deconstruct(out r2, out g2, out b2, out a2);
+
+            Assert.AreEqual(r2, color2.R / 255f);
+            Assert.AreEqual(g2, color2.G / 255f);
+            Assert.AreEqual(b2, color2.B / 255f);
+            Assert.AreEqual(a2, color2.A / 255f);
         }
 #endif
     }


### PR DESCRIPTION
Deconstruction of color class returned floats instead of bytes with range of 0-255,
If tried to pass them to constructor of color class it would create white color because of the mismatch with the float/byte constructor.

I modified the class so not it will have 2 deconstructors, one for floats and one for bytes (included with and without alpha channel).