### PR TITLE
Set cake tools path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,5 +86,5 @@ Installers/MacOS/Scripts/Framework/postinstall
 IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/MonoGame.Framework.dll.config
 
 # CAKE
-Cake/**
-!Cake/packages.config
+.cake/**
+

--- a/cake.config
+++ b/cake.config
@@ -1,0 +1,3 @@
+[Paths]
+Tools=./.cake
+


### PR DESCRIPTION
Sets the cake tools path to `./.cake`.
Fixes #7110.