### PR TITLE
Use dotnet CLI in Cake to support building without Mono

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -267,13 +267,19 @@ This package provides you with the content pipeline for Windows, Mac and Linux w
     </Compile>
   </ItemGroup>
 
-  <!-- Build and copy MFFXC, just don't reference it! -->
+  <!-- Build and copy MGFXC, just don't reference it! -->
+  <PropertyGroup>
+    <!-- NuGet warns if we copy assemblies, but don't reference them; we suppress those warning. -->
+    <NoWarn>NU5100</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
-    <Content Include="..\Artifacts\MonoGame.Effect.Compiler\Release\*" Visible="false">
+    <Content Include="..\Artifacts\MonoGame.Effect.Compiler\Release\*"
+             Exclude="..\Artifacts\MonoGame.Effect.Compiler\Release\*.nupkg"
+             Visible="false">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <Target Name="BuildMFGXC" BeforeTargets="Restore">
+  <Target Name="BuildMGFXC" BeforeTargets="Restore">
     <MSBuild Projects="..\Tools\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=Release;UseAppHost=False" Targets="Restore" />
     <MSBuild Projects="..\Tools\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=Release;UseAppHost=False" Targets="Build" />
   </Target>

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -269,7 +269,7 @@ This package provides you with the content pipeline for Windows, Mac and Linux w
 
   <!-- Build and copy MGFXC, just don't reference it! -->
   <PropertyGroup>
-    <!-- NuGet warns if we copy assemblies, but don't reference them; we suppress those warning. -->
+    <!-- NuGet warns if we copy assemblies but don't reference them; we suppress those warnings. -->
     <NoWarn>NU5100</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -11,6 +11,14 @@ This package provides you with MonoGame Framework that uses OpenGL for rendering
     <PackageId>MonoGame.Framework.DesktopGL</PackageId>
   </PropertyGroup>
 
+  <!-- NETFX reference assemblies let us target .NET Framework on Mac/Linux without Mono -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Remove="bin\**\*" />
     <Compile Remove="obj\**\*" />

--- a/Templates/MonoGame.Templates.CSharp/MonoGame.Templates.CSharp.csproj
+++ b/Templates/MonoGame.Templates.CSharp/MonoGame.Templates.CSharp.csproj
@@ -12,6 +12,8 @@
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>
+
+    <NoWarn>NU5128</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="content\**\*" Exclude="content\**\.DS_Store;content\**\bin;content\**\obj" />

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.csproj
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.csproj
@@ -13,4 +13,11 @@
     <Content Include="version\Version.props" PackagePath="build\version\$(PackageVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -19,7 +19,7 @@
 
   <!-- Build and copy MGFXC, just don't reference it! -->
   <PropertyGroup>
-    <!-- NuGet warns if we copy assemblies, but don't reference them; we suppress those warning. -->
+    <!-- NuGet warns if we copy assemblies but don't reference them; we suppress those warnings. -->
     <NoWarn>NU5100</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -17,9 +17,15 @@
     <ProjectReference Include="..\..\MonoGame.Framework.Content.Pipeline\MonoGame.Framework.Content.Pipeline.csproj" />
   </ItemGroup>
 
-  <!-- Build and copy MFFXC, just don't reference it! -->
+  <!-- Build and copy MGFXC, just don't reference it! -->
+  <PropertyGroup>
+    <!-- NuGet warns if we copy assemblies, but don't reference them; we suppress those warning. -->
+    <NoWarn>NU5100</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
-    <Content Include="..\..\Artifacts\MonoGame.Effect.Compiler\Release\*" Visible="false">
+    <Content Include="..\..\Artifacts\MonoGame.Effect.Compiler\Release\*"
+             Exclude="..\..\Artifacts\MonoGame.Effect.Compiler\Release\*.nupkg"
+             Visible="false">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Tools/MonoGame.Packaging.Flatpak/MonoGame.Packaging.Flatpak.csproj
+++ b/Tools/MonoGame.Packaging.Flatpak/MonoGame.Packaging.Flatpak.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <BaseOutputPath>..\..\Artifacts\MonoGame.Packaging.Flatpak</BaseOutputPath>
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
     <PackageIconUrl>https://pbs.twimg.com/profile_images/487954549441691649/O3KsHAsb_400x400.png</PackageIconUrl>
@@ -21,8 +21,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" />
-    
+
     <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
+
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Tools/MonoGame.Packaging.Flatpak/MonoGame.Packaging.Flatpak.csproj
+++ b/Tools/MonoGame.Packaging.Flatpak/MonoGame.Packaging.Flatpak.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <BaseOutputPath>..\..\Artifacts\MonoGame.Packaging.Flatpak</BaseOutputPath>
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
     <PackageIconUrl>https://pbs.twimg.com/profile_images/487954549441691649/O3KsHAsb_400x400.png</PackageIconUrl>

--- a/build.cake
+++ b/build.cake
@@ -17,9 +17,14 @@ MSBuildSettings msPackSettings, mdPackSettings;
 DotNetCoreMSBuildSettings dnBuildSettings;
 DotNetCorePackSettings dnPackSettings;
 
-private void PackProject(string filePath)
+private void PackMSBuild(string filePath)
 {
     MSBuild(filePath, msPackSettings);
+}
+
+private void PackDotnet(string filePath)
+{
+    DotNetCorePack(filePath, dnPackSettings);
 }
 
 private bool GetMSBuildWith(string requires)
@@ -60,6 +65,7 @@ Task("Prep")
     msPackSettings = new MSBuildSettings();
     msPackSettings.Verbosity = Verbosity.Minimal;
     msPackSettings.Configuration = configuration;
+    msPackSettings.Restore = true;
     msPackSettings.WithProperty("Version", version);
     msPackSettings.WithTarget("Pack");
 
@@ -83,7 +89,7 @@ Task("BuildDesktopGL")
     .Does(() =>
 {
     DotNetCoreRestore("MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj");
-    PackProject("MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj");
+    PackDotnet("MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj");
 });
 
 Task("TestDesktopGL")
@@ -104,7 +110,7 @@ Task("BuildWindowsDX")
     .Does(() =>
 {
     DotNetCoreRestore("MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj");
-    PackProject("MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj");
+    PackDotnet("MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj");
 });
 
 Task("TestWindowsDX")
@@ -130,8 +136,7 @@ Task("BuildAndroid")
     return DirectoryExists("/Library/Frameworks/Xamarin.Android.framework");
 }).Does(() =>
 {
-    DotNetCoreRestore("MonoGame.Framework/MonoGame.Framework.Android.csproj");
-    PackProject("MonoGame.Framework/MonoGame.Framework.Android.csproj");
+    PackMSBuild("MonoGame.Framework/MonoGame.Framework.Android.csproj");
 });
 
 Task("BuildiOS")
@@ -141,8 +146,7 @@ Task("BuildiOS")
     return DirectoryExists("/Library/Frameworks/Xamarin.iOS.framework");
 }).Does(() =>
 {
-    DotNetCoreRestore("MonoGame.Framework/MonoGame.Framework.iOS.csproj");
-    PackProject("MonoGame.Framework/MonoGame.Framework.iOS.csproj");
+    PackMSBuild("MonoGame.Framework/MonoGame.Framework.iOS.csproj");
 });
 
 Task("BuildUWP")
@@ -150,36 +154,29 @@ Task("BuildUWP")
     .WithCriteria(() => GetMSBuildWith("Microsoft.VisualStudio.Component.Windows10SDK.17763"))
     .Does(() =>
 {
-    DotNetCoreRestore("MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj");
-    PackProject("MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj");
+    PackMSBuild("MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj");
 });
 
 Task("BuildContentPipeline")
     .IsDependentOn("Prep")
     .Does(() =>
 {
-    DotNetCoreRestore("MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj");
-    PackProject("MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj");
+    PackDotnet("MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj");
 });
 
 Task("BuildTools")
     .IsDependentOn("Prep")
     .Does(() =>
 {
-    DotNetCoreRestore("Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj");
-    PackProject("Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj");
+    PackDotnet("Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj");
     
-    DotNetCoreRestore("Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj");
-    PackProject("Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj");
+    PackDotnet("Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj");
     
-    DotNetCoreRestore("Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.csproj");
-    PackProject("Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.csproj");
+    PackDotnet("Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.csproj");
 
-    DotNetCoreRestore("Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.csproj");
-    PackProject("Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.csproj");
+    PackDotnet("Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.csproj");
 
-    DotNetCoreRestore("Tools/MonoGame.Packaging.Flatpak/MonoGame.Packaging.Flatpak.csproj");
-    PackProject("Tools/MonoGame.Packaging.Flatpak/MonoGame.Packaging.Flatpak.csproj");
+    PackDotnet("Tools/MonoGame.Packaging.Flatpak/MonoGame.Packaging.Flatpak.csproj");
 });
 
 Task("TestTools")
@@ -198,8 +195,7 @@ Task("PackDotNetTemplates")
     .IsDependentOn("Prep")
     .Does(() =>
 {
-    DotNetCoreRestore("Templates/MonoGame.Templates.CSharp/MonoGame.Templates.CSharp.csproj");
-    PackProject("Templates/MonoGame.Templates.CSharp/MonoGame.Templates.CSharp.csproj");
+    PackDotnet("Templates/MonoGame.Templates.CSharp/MonoGame.Templates.CSharp.csproj");
 });
 
 Task("PackVSTemplates")


### PR DESCRIPTION
This lets Cake use .NET CLI for projects that support it and adds .NET Framework reference assemblies to the projects that target .NET Framework. That way Linux/Mac can run the build script without having Mono installed.
I also fixed most build warnings.

This solves the issue from #7108. ~However this makes Cake use .NET CLI on windows as well. I think Cake requires the dotnet host to be in PATH to use it, so having Visual Studio with .NET Core workload installed is not sufficient (unless you're running Cake from a VS console or have added .NET CLI to PATH manually).~ Apparently installing the .NET Core SDK with VS adds `dotnet` to PATH as well.