### PR TITLE
Set MG nuget versions in templates to match template build version

### DIFF
--- a/Templates/MonoGame.Templates.CSharp/MonoGame.Templates.CSharp.csproj
+++ b/Templates/MonoGame.Templates.CSharp/MonoGame.Templates.CSharp.csproj
@@ -23,8 +23,14 @@
       <MGProjects Include="**\*.csproj" />
     </ItemGroup>
 
+    <!-- For SDK-style project files -->
     <XmlPoke XmlInputPath="%(MGProjects.Identity)"
         Query="Project/ItemGroup/PackageReference[starts-with(@Include, &quot;MonoGame&quot;)]/@Version"
+        Value="$(Version)" />
+    <!-- For old-style project files that set the xml namespace -->
+    <XmlPoke XmlInputPath="%(MGProjects.Identity)"
+        Namespaces="&lt;Namespace Prefix='n' Uri='http://schemas.microsoft.com/developer/msbuild/2003' /&gt;"
+        Query="n:Project/n:ItemGroup/n:PackageReference[starts-with(@Include, &quot;MonoGame&quot;)]/@Version"
         Value="$(Version)" />
   </Target>
 </Project>

--- a/Templates/MonoGame.Templates.CSharp/MonoGame.Templates.CSharp.csproj
+++ b/Templates/MonoGame.Templates.CSharp/MonoGame.Templates.CSharp.csproj
@@ -17,4 +17,14 @@
     <Content Include="content\**\*" Exclude="content\**\.DS_Store;content\**\bin;content\**\obj" />
     <Compile Remove="**\*" />
   </ItemGroup>
+
+  <Target Name="SetMGPackageReferenceVersions" BeforeTargets="CoreBuild">
+    <ItemGroup>
+      <MGProjects Include="**\*.csproj" />
+    </ItemGroup>
+
+    <XmlPoke XmlInputPath="%(MGProjects.Identity)"
+        Query="Project/ItemGroup/PackageReference[starts-with(@Include, &quot;MonoGame&quot;)]/@Version"
+        Value="$(Version)" />
+  </Target>
 </Project>


### PR DESCRIPTION
This adds a task that sets the `PackageReference` version for the MonoGame NuGet references in the template projects. 