### PR TITLE
Add SourceLink support to MonoGame.Framework

### DIFF
--- a/MonoGame.Framework/Directory.Build.props
+++ b/MonoGame.Framework/Directory.Build.props
@@ -14,5 +14,13 @@
     <LangVersion>5</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+  </ItemGroup>
 </Project>
 


### PR DESCRIPTION
Requested in #7115. 

I have not yet tested this. I think it'll only work for DesktopGL and WindowsDX because by default non-SDK-style projects generate full PDB symbols which is not compatible with SourceLink.

This includes the pdb in the NuGet packages.
Builds for NuGet should NOT include the pdb, instead a seperate snupkg should be built and published to the NuGet symbol server to distribute the symbols.
See https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg.

A snupkg can be generated by setting
```
<IncludeSymbols>true</IncludeSymbols>
<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 ```

How do we best handle this? I think it'd be nice to let the build script take an argument that indicates if the build should be published to the develop feed or to nuget.org. It can then set an MSBuild property based on that and we can conditionally choose to include symbols or to build a .snukpg.