### PR TITLE
Move content building before PrepareForBuild so it works for iOS

### DIFF
--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -23,12 +23,6 @@
                                                         /
       CollectContentReferences -> PrepareContentBuilder
   -->
-  <PropertyGroup>
-    <BuildDependsOn>
-      IncludeContent;
-      $(BuildDependsOn);
-    </BuildDependsOn>
-  </PropertyGroup>
 
   <!--
     Calls 'dotnet tool' commands to parse information about any locally installed MGCB tools.
@@ -299,7 +293,8 @@
     Name="IncludeContent"
     DependsOnTargets="RunContentBuilder"
     Condition="'$(EnableMGCBItems)' == 'true' OR '@(MonoGameContentReference)' != ''"
-    Outputs="%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension)">
+    Outputs="%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension)"
+    BeforeTargets="PrepareForBuild">
 
     <!-- Call CreateItem on each piece of ExtraContent so it's easy to switch the item type by platform. -->
     <CreateItem


### PR DESCRIPTION
iOS uses BundleResource action which is calculated before the BuildDependsOn action (like our targets is), it worked by sheer luck before...