### PR TITLE
Revert "Can't hide mouse cursor #6180 (#6908)" because of win32 threading crash

### DIFF
--- a/MonoGame.Framework/Platform/WindowsUniversal/InputEvents.cs
+++ b/MonoGame.Framework/Platform/WindowsUniversal/InputEvents.cs
@@ -35,22 +35,6 @@ namespace Microsoft.Xna.Framework
         // To convert from DIPs (device independent pixels) to actual screen resolution pixels.
         private static float _currentDipFactor;
 
-        private CoreIndependentInputSource _coreIndependentInputSource;
-
-        /// <summary>
-        /// Sets the cursor of <see cref="CoreIndependentInputSource"/> thread
-        /// </summary>
-        public CoreCursor CoreCursor
-        {
-            set
-            {
-                _coreIndependentInputSource.Dispatcher.TryRunAsync(
-                    CoreDispatcherPriority.Normal,
-                    () => _coreIndependentInputSource.PointerCursor = value)
-                    .GetAwaiter().GetResult();
-            }
-        }
-
         public InputEvents(CoreWindow window, UIElement inputElement, TouchQueue touchQueue)
         {
             _touchQueue = touchQueue;
@@ -74,17 +58,18 @@ namespace Microsoft.Xna.Framework
                 {
                     var inputDevices = CoreInputDeviceTypes.Mouse | CoreInputDeviceTypes.Pen | CoreInputDeviceTypes.Touch;
 
+                    CoreIndependentInputSource coreIndependentInputSource;
                     if (inputElement is SwapChainBackgroundPanel)
-                        _coreIndependentInputSource = ((SwapChainBackgroundPanel)inputElement).CreateCoreIndependentInputSource(inputDevices);
+                        coreIndependentInputSource = ((SwapChainBackgroundPanel)inputElement).CreateCoreIndependentInputSource(inputDevices);
                     else
-                        _coreIndependentInputSource = ((SwapChainPanel)inputElement).CreateCoreIndependentInputSource(inputDevices);
+                        coreIndependentInputSource = ((SwapChainPanel)inputElement).CreateCoreIndependentInputSource(inputDevices);
 
-                    _coreIndependentInputSource.PointerPressed += CoreWindow_PointerPressed;
-                    _coreIndependentInputSource.PointerMoved += CoreWindow_PointerMoved;
-                    _coreIndependentInputSource.PointerReleased += CoreWindow_PointerReleased;
-                    _coreIndependentInputSource.PointerWheelChanged += CoreWindow_PointerWheelChanged;
+                    coreIndependentInputSource.PointerPressed += CoreWindow_PointerPressed;
+                    coreIndependentInputSource.PointerMoved += CoreWindow_PointerMoved;
+                    coreIndependentInputSource.PointerReleased += CoreWindow_PointerReleased;
+                    coreIndependentInputSource.PointerWheelChanged += CoreWindow_PointerWheelChanged;
 
-                    _coreIndependentInputSource.Dispatcher.ProcessEvents(CoreProcessEventsOption.ProcessUntilQuit);
+                    coreIndependentInputSource.Dispatcher.ProcessEvents(CoreProcessEventsOption.ProcessUntilQuit);
                 });
                 var inputWorker = ThreadPool.RunAsync(workItemHandler, WorkItemPriority.High, WorkItemOptions.TimeSliced);
             }

--- a/MonoGame.Framework/Platform/WindowsUniversal/InputEvents.cs
+++ b/MonoGame.Framework/Platform/WindowsUniversal/InputEvents.cs
@@ -35,6 +35,23 @@ namespace Microsoft.Xna.Framework
         // To convert from DIPs (device independent pixels) to actual screen resolution pixels.
         private static float _currentDipFactor;
 
+        private CoreIndependentInputSource _coreIndependentInputSource;
+
+        /// <summary>
+        /// Sets the cursor of <see cref="CoreIndependentInputSource"/> thread
+        /// </summary>
+        public CoreCursor CoreCursor
+        {
+            set
+            {
+                if (_coreIndependentInputSource != null)
+                    _coreIndependentInputSource.Dispatcher.TryRunAsync(
+                          CoreDispatcherPriority.Normal,
+                        () => _coreIndependentInputSource.PointerCursor = value)
+                        .GetAwaiter().GetResult();
+            }
+        }
+
         public InputEvents(CoreWindow window, UIElement inputElement, TouchQueue touchQueue)
         {
             _touchQueue = touchQueue;
@@ -58,18 +75,17 @@ namespace Microsoft.Xna.Framework
                 {
                     var inputDevices = CoreInputDeviceTypes.Mouse | CoreInputDeviceTypes.Pen | CoreInputDeviceTypes.Touch;
 
-                    CoreIndependentInputSource coreIndependentInputSource;
                     if (inputElement is SwapChainBackgroundPanel)
-                        coreIndependentInputSource = ((SwapChainBackgroundPanel)inputElement).CreateCoreIndependentInputSource(inputDevices);
+                        _coreIndependentInputSource = ((SwapChainBackgroundPanel)inputElement).CreateCoreIndependentInputSource(inputDevices);
                     else
-                        coreIndependentInputSource = ((SwapChainPanel)inputElement).CreateCoreIndependentInputSource(inputDevices);
+                        _coreIndependentInputSource = ((SwapChainPanel)inputElement).CreateCoreIndependentInputSource(inputDevices);
 
-                    coreIndependentInputSource.PointerPressed += CoreWindow_PointerPressed;
-                    coreIndependentInputSource.PointerMoved += CoreWindow_PointerMoved;
-                    coreIndependentInputSource.PointerReleased += CoreWindow_PointerReleased;
-                    coreIndependentInputSource.PointerWheelChanged += CoreWindow_PointerWheelChanged;
+                    _coreIndependentInputSource.PointerPressed += CoreWindow_PointerPressed;
+                    _coreIndependentInputSource.PointerMoved += CoreWindow_PointerMoved;
+                    _coreIndependentInputSource.PointerReleased += CoreWindow_PointerReleased;
+                    _coreIndependentInputSource.PointerWheelChanged += CoreWindow_PointerWheelChanged;
 
-                    coreIndependentInputSource.Dispatcher.ProcessEvents(CoreProcessEventsOption.ProcessUntilQuit);
+                    _coreIndependentInputSource.Dispatcher.ProcessEvents(CoreProcessEventsOption.ProcessUntilQuit);
                 });
                 var inputWorker = ThreadPool.RunAsync(workItemHandler, WorkItemPriority.High, WorkItemOptions.TimeSliced);
             }

--- a/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Xna.Framework
                 return;
 
             var asyncResult = _coreWindow.Dispatcher.RunIdleAsync( (e) =>
- {
+            {
                 if (visible)
                     _coreWindow.PointerCursor = new CoreCursor(CoreCursorType.Arrow, 0);
                 else

--- a/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
@@ -334,15 +334,12 @@ namespace Microsoft.Xna.Framework
                 return;
 
             var asyncResult = _coreWindow.Dispatcher.RunIdleAsync( (e) =>
-            {
-                if (visible)
-                    _coreWindow.PointerCursor = new CoreCursor(CoreCursorType.Arrow, 0);
-                else
-                    _coreWindow.PointerCursor = null;
-
-                // On UAP platform it is also necessary to set the cursor of CoreIndependentInputSource in InputEvents
-                _inputEvents.CoreCursor = _coreWindow.PointerCursor;
-            });
+           {
+               if (visible)
+                   _coreWindow.PointerCursor = new CoreCursor(CoreCursorType.Arrow, 0);
+               else
+                   _coreWindow.PointerCursor = null;
+           });
         }
 
         internal void RunLoop()

--- a/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
@@ -334,12 +334,15 @@ namespace Microsoft.Xna.Framework
                 return;
 
             var asyncResult = _coreWindow.Dispatcher.RunIdleAsync( (e) =>
-           {
-               if (visible)
-                   _coreWindow.PointerCursor = new CoreCursor(CoreCursorType.Arrow, 0);
-               else
-                   _coreWindow.PointerCursor = null;
-           });
+ {
+                if (visible)
+                    _coreWindow.PointerCursor = new CoreCursor(CoreCursorType.Arrow, 0);
+                else
+                    _coreWindow.PointerCursor = null;
+
+                // On UAP platform it is also necessary to set the cursor of CoreIndependentInputSource in InputEvents
+                _inputEvents.CoreCursor = _coreWindow.PointerCursor;
+            });
         }
 
         internal void RunLoop()


### PR DESCRIPTION
Hello :)

#6908 introduced a threading race condition that makes win32 API calls to crash (e.g. loading assets).

Also, ```IsMouseVisible = false;``` is working without this PR as of Windows 10 SDK 1903 (and targeting Fall Creator Update at minimum), which is the intended baseline of MonoGame.

So I guess that we're good as-is and this issue doesn't need to be addressed for older targets.

Cheers!