### PR TITLE
Fixed a bug where The "New Item" dialogue would have no templates listed

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
@@ -112,13 +112,9 @@ namespace MonoGame.Tools.Pipeline
             {
                 LoadTemplates(macPath);
             }
-            else if (Directory.Exists(windowsAndLinuxPath))
-            {
-                LoadTemplates(windowsAndLinuxPath);
-            }
             else
             {
-                throw new DirectoryNotFoundException("'Templates' or 'Resources' folder not found");
+                LoadTemplates(windowsAndLinuxPath);
             }
 
             UpdateMenu();

--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
@@ -105,19 +105,22 @@ namespace MonoGame.Tools.Pipeline
 
             _templateItems = new List<ContentItemTemplate>();
             var root = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var macPath = Path.Combine(root, "..", "Resources");
+            var windowsAndLinuxPath = Path.Combine(root, "Templates");
 
-            // I do not understand why this piece of code is here. Is there a possibility where the "Templates" folder is actually called "Resources"?
-            // What I do know is that I don't have a folder called "Resources" in this commit, so to prevent the path to be renamed to "Resources" I commented it out instead of removing it
-            //if (Directory.Exists(Path.Combine (root, "..", "Resources", "Templates")))
-            //{
-            //    root = Path.Combine(root, "..", "Resources");
-            //}
+            if (Directory.Exists(macPath))
+            {
+                LoadTemplates(macPath);
+            }
+            else if (Directory.Exists(windowsAndLinuxPath))
+            {
+                LoadTemplates(windowsAndLinuxPath);
+            }
+            else
+            {
+                throw new DirectoryNotFoundException("'Templates' or 'Resources' folder not found");
+            }
 
-            // It seems obvious what this is supposed to do, but the resulting path, provided as parameter, does not exist in my case
-            //LoadTemplates(Path.Combine(root, "../../../Templates"));
-
-            // This way the templates folder can be found in my case
-            LoadTemplates(Path.Combine(root, "Templates"));
             UpdateMenu();
 
             view.UpdateRecentList(PipelineSettings.Default.ProjectHistory);

--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
@@ -105,11 +105,19 @@ namespace MonoGame.Tools.Pipeline
 
             _templateItems = new List<ContentItemTemplate>();
             var root = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            if (Directory.Exists(Path.Combine (root, "..", "Resources", "Templates")))
-            {
-                root = Path.Combine(root, "..", "Resources");
-            }
-            LoadTemplates(Path.Combine(root, "../../../Templates"));
+
+            // I do not understand why this piece of code is here. Is there a possibility where the "Templates" folder is actually called "Resources"?
+            // What I do know is that I don't have a folder called "Resources" in this commit, so to prevent the path to be renamed to "Resources" I commented it out instead of removing it
+            //if (Directory.Exists(Path.Combine (root, "..", "Resources", "Templates")))
+            //{
+            //    root = Path.Combine(root, "..", "Resources");
+            //}
+
+            // It seems obvious what this is supposed to do, but the resulting path, provided as parameter, does not exist in my case
+            //LoadTemplates(Path.Combine(root, "../../../Templates"));
+
+            // This way the templates folder can be found in my case
+            LoadTemplates(Path.Combine(root, "Templates"));
             UpdateMenu();
 
             view.UpdateRecentList(PipelineSettings.Default.ProjectHistory);


### PR DESCRIPTION
When I pull the latest commits from the develop branch and run or debug the MonoGame.Content.Builder.Editor.Windows project, I was not able to add new items to my content file using the NewItemDialogue dialogue as the templates could not be found. This resulted in a NullReferenceException when I tried closing the dialogue without having anything selected.

I am not certain what the original piece of code is supposed to do, hence I commented it out instead of removing it. Any comments on that matter would be highly appreciated.