### PR TITLE
Add Web platform information to the content builder

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioHelper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
     class AudioHelper
     {
         // This array must remain in sync with the ConversionFormat enum.
-        static string[] conversionFormatExtensions = new[] { "wav", "wav", "wma", "xma", "wav", "m4a", "ogg" };
+        static string[] conversionFormatExtensions = new[] { "wav", "wav", "wma", "xma", "wav", "m4a", "ogg", "mp3" };
 
         /// <summary>
         /// Gets the file extension for an audio format.

--- a/MonoGame.Framework.Content.Pipeline/Audio/ConversionFormat.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/ConversionFormat.cs
@@ -43,5 +43,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
         /// Vorbis open, patent-free audio encoding
         /// </summary>
         Vorbis,
+
+        /// <summary>
+        /// mp3 audio format
+        /// </summary>
+        Mp3
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                     platform == TargetPlatform.Windows ||
                     platform == TargetPlatform.WindowsPhone8 ||
                     platform == TargetPlatform.WindowsStoreApp ||
-                    platform == TargetPlatform.iOS;
+                    platform == TargetPlatform.iOS ||
+                    platform == TargetPlatform.Web;
         }
 
         public override ConversionQuality ConvertAudio(TargetPlatform platform, ConversionQuality quality, AudioContent content)
@@ -52,6 +53,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
 
             else if (platform == TargetPlatform.DesktopGL)
                 targetFormat = ConversionFormat.Vorbis;
+            else if (platform == TargetPlatform.Web)
+                targetFormat = ConversionFormat.Mp3;
 
             // Get the song output path with the target format extension.
             outputFileName = Path.ChangeExtension(outputFileName, AudioHelper.GetExtension(targetFormat));
@@ -346,6 +349,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                         // Vorbis
                         ffmpegCodecName = "libvorbis";
                         ffmpegMuxerName = "ogg";
+                        //format = 0x0000; /* WAVE_FORMAT_UNKNOWN */
+                        break;
+                    case ConversionFormat.Mp3:
+                        // Vorbis
+                        ffmpegCodecName = "libmp3lame";
+                        ffmpegMuxerName = "mp3";
                         //format = 0x0000; /* WAVE_FORMAT_UNKNOWN */
                         break;
                     default:

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     platform == TargetPlatform.Windows ||
                     platform == TargetPlatform.WindowsPhone8 ||
                     platform == TargetPlatform.WindowsStoreApp ||
-                    platform == TargetPlatform.iOS;
+                    platform == TargetPlatform.iOS ||
+                    platform == TargetPlatform.Web;
         }
 
         private static bool IsCompressedTextureFormat(TextureProcessorOutputFormat format)
@@ -63,7 +64,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                             platform == TargetPlatform.WindowsStoreApp ||
                             platform == TargetPlatform.DesktopGL ||
                             platform == TargetPlatform.MacOSX ||
-                            platform == TargetPlatform.NativeClient)
+                            platform == TargetPlatform.NativeClient ||
+                            platform == TargetPlatform.Web)
                 {
                     if (format != TextureProcessorOutputFormat.DxtCompressed)
                         throw new PlatformNotSupportedException(format + " platform only supports DXT texture compression");

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
             'O', // XboxOne
             'S', // Nintendo Switch
             'G', // Google Stadia
+            'b', // WebAssembly and Bridge.NET
         };
 
         /// <summary>

--- a/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
+++ b/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
@@ -105,6 +105,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// Google Stadia
         /// </summary>
         Stadia,
+
+        /// <summary>
+        /// WebAssembly and Bridge.NET
+        /// </summary>
+        Web
     }
 
 

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Xna.Framework.Content
             'O', // XboxOne
             'S', // Nintendo Switch
             'G', // Google Stadia
+            'b', // WebAssembly and Bridge.NET
 
             // NOTE: There are additional idenfiers for consoles that 
             // are not defined in this repository.  Be sure to ask the

--- a/Tools/MonoGame.Tools.Tests/TestCompiler.cs
+++ b/Tools/MonoGame.Tools.Tests/TestCompiler.cs
@@ -67,7 +67,8 @@ namespace MonoGame.Tests.ContentPipeline
             TargetPlatform.PlayStation4,
             TargetPlatform.PSVita,
             TargetPlatform.XboxOne,
-            TargetPlatform.Switch
+            TargetPlatform.Switch,
+            TargetPlatform.Web
         };
         static readonly IReadOnlyCollection<GraphicsProfile> GraphicsProfiles = new[]
         {


### PR DESCRIPTION
Both my WebAssembly and Bridge.NET versions can use all the content DesktopGL spits out, except for music, which needs to be in mp3 format for the most wide range support. This just adds the needed bits for the content part.