### PR TITLE
Reduce top margin for documentation content

### DIFF
--- a/Documentation/theme/monogame/styles/monogame.css
+++ b/Documentation/theme/monogame/styles/monogame.css
@@ -22,7 +22,7 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .mg-link-block {
     display: none;
   }

--- a/Documentation/theme/monogame/styles/monogame.css
+++ b/Documentation/theme/monogame/styles/monogame.css
@@ -1,3 +1,7 @@
+.article {
+  margin-top: 80px;
+}
+
 .mg-link {
   display: block;
   padding: 15px 15px 0 15px;


### PR DESCRIPTION
With docfx all set up, the whole design of the docs site is checked in as well, making it easy to change things like this 🙌

Before:

![image](https://user-images.githubusercontent.com/14875382/82201520-cd33df80-9900-11ea-9560-291cc0254441.png)

After:

![image](https://user-images.githubusercontent.com/14875382/82201546-d91fa180-9900-11ea-9d3b-c45a42f2f597.png)
