### PR TITLE
Effect Compiler Fixes

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
@@ -50,45 +50,107 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         public override CompiledEffectContent Process(EffectContent input, ContentProcessorContext context)
         {
             var mgfxc = Path.Combine(Path.GetDirectoryName(typeof(EffectProcessor).Assembly.Location), "mgfxc.dll");
-            var sourceFile = Path.GetTempFileName();
+            var sourceFile = input.Identity.SourceFilename;
             var destFile = Path.GetTempFileName();
-            var target = context.TargetPlatform.ToString().Contains("Windows");
-            
-            File.WriteAllText(sourceFile, input.EffectCode);
-
-            var proc = new Process();
-            proc.StartInfo.FileName = "dotnet";
-            proc.StartInfo.Arguments = "\"" + mgfxc + "\" \"" + sourceFile + "\" \"" + destFile + "\" /Profile:" + GetProfileForPlatform(context.TargetPlatform.ToString());
+            var arguments = "\"" + mgfxc + "\" \"" + sourceFile + "\" \"" + destFile + "\" /Profile:" + GetProfileForPlatform(context.TargetPlatform);
 
             if (debugMode == EffectProcessorDebugMode.Debug)
-                proc.StartInfo.Arguments += " /Debug";
+                arguments += " /Debug";
 
             if (!string.IsNullOrWhiteSpace(defines))
-                proc.StartInfo.Arguments += " \"/Defines:" + defines + "\"";
+                arguments += " \"/Defines:" + defines + "\"";
 
-            proc.Start();
-            proc.WaitForExit();
+            string stdout, stderr;
 
-            var success = proc.ExitCode == 0;
+            var success = ExternalTool.Run("dotnet", arguments, out stdout, out stderr) == 0;
             var ret = success ? new CompiledEffectContent(File.ReadAllBytes(destFile)) : null;
 
-            File.Delete(sourceFile);
             File.Delete(destFile);
 
-            if (!success)
-                throw new Exception("mgfxc exited with non 0 exit code.");
+            ProcessErrorsAndWarnings(!success, stderr, input, context);
 
             return ret;
         }
 
-        private string GetProfileForPlatform(string platform)
+        private string GetProfileForPlatform(TargetPlatform platform)
         {
-            if (platform == "Windows" ||
-                platform == "WindowsPhone8" ||
-                platform == "WindowsStoreApp")
-                return "DirectX_11";
+            switch (platform)
+            {
+                case TargetPlatform.Windows:
+                case TargetPlatform.WindowsPhone8:
+                case TargetPlatform.WindowsStoreApp:
+                    return "DirectX_11";
+                case TargetPlatform.iOS:
+                case TargetPlatform.Android:
+                case TargetPlatform.DesktopGL:
+                case TargetPlatform.MacOSX:
+                case TargetPlatform.RaspberryPi:
+                case TargetPlatform.Web:
+                    return "OpenGL";
+            }
 
-            return "OpenGL";
+            return platform.ToString();
+        }
+
+        private static void ProcessErrorsAndWarnings(bool buildFailed, string shaderErrorsAndWarnings, EffectContent input, ContentProcessorContext context)
+        {
+            // Split the errors and warnings into individual lines.
+            var errorsAndWarningArray = shaderErrorsAndWarnings.Split(new[] { "\n", "\r", Environment.NewLine },
+                                                                      StringSplitOptions.RemoveEmptyEntries);
+
+            var errorOrWarning = new Regex(@"(.*)\(([0-9]*(,[0-9]+(-[0-9]+)?)?)\)\s*:\s*(.*)", RegexOptions.Compiled);
+            ContentIdentity identity = null;
+            var allErrorsAndWarnings = string.Empty;
+
+            // Process all the lines.
+            for (var i = 0; i < errorsAndWarningArray.Length; i++)
+            {
+                var match = errorOrWarning.Match(errorsAndWarningArray[i]);
+                if (!match.Success || match.Groups.Count != 4)
+                {
+                    // Just log anything we don't recognize as a warning.
+                    if (buildFailed)
+                        allErrorsAndWarnings += errorsAndWarningArray[i] + Environment.NewLine;
+                    else
+                        context.Logger.LogWarning(string.Empty, input.Identity, errorsAndWarningArray[i]);
+
+                    continue;
+                }
+
+                var fileName = match.Groups[1].Value;
+                var lineAndColumn = match.Groups[2].Value;
+                var message = match.Groups[3].Value;
+
+                // Try to ensure a good file name for the error message.
+                if (string.IsNullOrEmpty(fileName))
+                    fileName = input.Identity.SourceFilename;
+                else if (!File.Exists(fileName))
+                {
+                    var folder = Path.GetDirectoryName(input.Identity.SourceFilename);
+                    fileName = Path.Combine(folder, fileName);
+                }
+
+                // If we got an exception then we'll be throwing an exception 
+                // below, so just gather the lines to throw later.
+                if (buildFailed)
+                {
+                    if (identity == null)
+                    {
+                        identity = new ContentIdentity(fileName, input.Identity.SourceTool, lineAndColumn);
+                        allErrorsAndWarnings = errorsAndWarningArray[i] + Environment.NewLine;
+                    }
+                    else
+                        allErrorsAndWarnings += errorsAndWarningArray[i] + Environment.NewLine;
+                }
+                else
+                {
+                    identity = new ContentIdentity(fileName, input.Identity.SourceTool, lineAndColumn);
+                    context.Logger.LogWarning(string.Empty, identity, message, string.Empty);
+                }
+            }
+
+            if (buildFailed)
+                throw new InvalidContentException(allErrorsAndWarnings, identity ?? input.Identity);
         }
     }
 }

--- a/Tools/MonoGame.Tools.Tests/EffectProcessorTests.cs
+++ b/Tools/MonoGame.Tools.Tests/EffectProcessorTests.cs
@@ -10,9 +10,6 @@ using TwoMGFX;
 
 namespace MonoGame.Tests.ContentPipeline
 {
-#if DESKTOPGL
-    [Ignore("Building effects is only supported on Windows.")]
-#endif
     class EffectProcessorTests
     {
         class ImporterContext : ContentImporterContext

--- a/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
+++ b/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
@@ -34,6 +34,12 @@
     <Content Include="../../Tests/Assets/**/*" CopyToOutputDirectory="PreserveNewest">
       <Link>Assets/%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
+    <Content Include="../../MonoGame.Framework/Platform/Graphics/Effect/Resources/*.fx" CopyToOutputDirectory="PreserveNewest">
+      <Link>Assets/Effects/Stock/%(Filename)%(Extension)</Link>
+    </Content>
+    <Content Include="../../MonoGame.Framework/Platform/Graphics/Effect/Resources/*.fxh" CopyToOutputDirectory="PreserveNewest">
+      <Link>Assets/Effects/Stock/%(Filename)%(Extension)</Link>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/build.cake
+++ b/build.cake
@@ -54,6 +54,9 @@ private bool GetMSBuildWith(string requires)
 Task("Prep")
     .Does(() =>
 {
+    // Set MGFXC_WINE_PATH for building shaders on macOS and Linux
+    System.Environment.SetEnvironmentVariable("MGFXC_WINE_PATH", EnvironmentVariable("HOME") + "/.winemonogame");
+
     // We tag the version with the build branch to make it
     // easier to spot special builds in NuGet feeds.
     var branch = EnvironmentVariable("GIT_BRANCH") ?? string.Empty;


### PR DESCRIPTION
- Shader build tests enabled for both Windows and macOS
- EffectProcessor is now using source file instead of bytecode
- Restored deleted code for effect error collecting in EffectProcessor
- Fixed selecting target platform for shaders