### PR TITLE
[MGCB Task] Don't call tool restore on build

### DIFF
--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.csproj
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\MonoGame.Content.Builder\MonoGame.Content.Builder.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -128,11 +128,6 @@
   -->
   <Target Name="UpdateMGCB" Condition="'$(MGCBCommand)' == ''" DependsOnTargets="GetInstalledMGCB">
 
-    <!-- If the correct version is in the manifest, restore to ensure it's installed. -->
-    <Exec
-      Condition="$(MGCBInstalledVersion) == $(MGCBVersion)"
-      Command="$(DotnetCommand) tool restore" />
-
     <!-- If the correct version is not in the manifest, install the correct version. -->
     <CallTarget
       Condition="$(MGCBInstalledVersion) != $(MGCBVersion)"


### PR DESCRIPTION
Stuff done:
- Removed dotnet tool restoring
- Added a project reference to the mgcb, that way when the user adds a reference to MonoGame.Content.Builder.Task, they will also add a hidden reference to dotnet-mgcb of the same version