### PR TITLE
Remove Color object's (DisabledTextColor) alpha assignment

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/Controls/BuildItem.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Controls/BuildItem.cs
@@ -64,7 +64,7 @@ namespace MonoGame.Tools.Pipeline
                 if (_expanded)
                 {
                     _descriptionOffset = (_descSize - DrawInfo.TextHeight) / 2;
-                    Height = (int)(CellHeight + _descSize * _description.Count);
+                    Height = (int)(CellHeight + Margin + (_descSize * _description.Count));
 
                     foreach (var des in _description)
                     {

--- a/Tools/MonoGame.Content.Builder.Editor/Controls/BuildItem.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Controls/BuildItem.cs
@@ -108,7 +108,7 @@ namespace MonoGame.Tools.Pipeline
             if (_expanded)
             {
                 for (int i = 0; i < _description.Count; i++)
-                    g.DrawText(SystemFonts.Default(), DrawInfo.DisabledTextColor, x + Spacing, y + CellHeight + _descriptionOffset + _descSize * i, _description[i]);
+                    g.DrawText(SystemFonts.Default(), DrawInfo.TextColor, x + Spacing, y + CellHeight + _descriptionOffset + _descSize * i, _description[i]);
             }
         }
     }

--- a/Tools/MonoGame.Content.Builder.Editor/Controls/DrawInfo.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Controls/DrawInfo.cs
@@ -18,7 +18,6 @@ namespace MonoGame.Tools.Pipeline
             HoverTextColor = SystemColors.HighlightText;
             HoverBackColor = SystemColors.Highlight;
             DisabledTextColor = SystemColors.ControlText;
-            DisabledTextColor.A = 0.4f;
             BorderColor = Global.IsGtk ? SystemColors.WindowBackground : SystemColors.Control;
         }
 

--- a/Tools/MonoGame.Content.Builder.Editor/Controls/DrawInfo.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Controls/DrawInfo.cs
@@ -18,6 +18,7 @@ namespace MonoGame.Tools.Pipeline
             HoverTextColor = SystemColors.HighlightText;
             HoverBackColor = SystemColors.Highlight;
             DisabledTextColor = SystemColors.ControlText;
+            DisabledTextColor.A = 0.6f;
             BorderColor = Global.IsGtk ? SystemColors.WindowBackground : SystemColors.Control;
         }
 


### PR DESCRIPTION
#7160 Removing the alpha assignment darkens the text.

I had a thought to refactor since one value, `SystemColors.ControlText`, is getting assigned to two variables now, but I'm unsure about how much the `disabled` distinction plays into other methods.

What do you all think?