### PR TITLE
Omit mention of thrown exception in GamePad.MaximumGamePadCount

### DIFF
--- a/MonoGame.Framework/Input/GamePad.cs
+++ b/MonoGame.Framework/Input/GamePad.cs
@@ -163,9 +163,7 @@ namespace Microsoft.Xna.Framework.Input
         }
 
         /// <summary>
-        /// The maximum number of game pads supported on this system.  Attempting to
-        /// access a gamepad index higher than this number will result in an <see cref="InvalidOperationException"/>
-        /// being thrown by the API.
+        /// The maximum number of game pads supported on this system.
         /// </summary>
         public static int MaximumGamePadCount
         {


### PR DESCRIPTION
This PR improves the documentation for `GamePad.MaximumGamePadCount` by omitting the point about throwing an exception, as it doesn't do so on any public platforms. Will require confirmation if it actually does on private ones.