### PR TITLE
Fixed rebuild on project root does not rebuild MGCB Editor project.

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
@@ -408,7 +408,7 @@ namespace MonoGame.Tools.Pipeline
 
             // If the project itself was selected, just
             // rebuild the entire project
-            if (items.Contains(_project))
+            if (SelectedItems.Contains(_project))
             {
                 Build(true);
                 return;


### PR DESCRIPTION
Check if root project was selected in rebuild action was incorrectly
checking newly created items list instead of SelectedItems list.

Fixes #7158.