### PR TITLE
Decouple Builder.Task from dotnet-mgcb

### DIFF
--- a/Tools/AppReference.targets
+++ b/Tools/AppReference.targets
@@ -7,7 +7,7 @@
             See https://github.com/dotnet/sdk/issues/1675#issuecomment-346135772 -->
   <Target Name="CopyAppReferences" BeforeTargets="GetCopyToOutputDirectoryItems">
 
-    <!-- Get the output file of this AppReference. -->
+    <!-- Get the output folders of all AppReferences. -->
     <MSBuild Projects="%(ProjectReference.FullPath)"
              Targets="GetTargetPath"
              Properties="Configuration=$(Configuration)"
@@ -41,9 +41,16 @@
 
     <!-- Copy this content to the build and package output. -->
     <ItemGroup>
-      <TfmSpecificPackageFile Include="%(AppReferenceContent.FullPath)">
-        <PackagePath>tools\$(TargetFramework)\any\%(AppReferenceContent.SubDir)%(RecursiveDir)</PackagePath>
-      </TfmSpecificPackageFile>
+      <ContentWithTargetPath
+        Include="%(AppReferenceContent.FullPath)"
+        TargetPath="%(AppReferenceContent.SubDir)%(RecursiveDir)%(Filename)%(Extension)"
+        CopyToOutputDirectory="PreserveNewest" />
+
+      <!-- This is required to include the files in a nupkg if the project isn't packed as a tool. -->
+      <TfmSpecificPackageFile
+        Include="%(AppReferenceContent.FullPath)"
+        PackagePath="tools\$(TargetFramework)\any\%(AppReferenceContent.SubDir)%(RecursiveDir)"
+        Condition="'$(PackAsTool)' != 'true'"/>
     </ItemGroup>
 
   </Target>

--- a/Tools/AppReference.targets
+++ b/Tools/AppReference.targets
@@ -7,7 +7,7 @@
             See https://github.com/dotnet/sdk/issues/1675#issuecomment-346135772 -->
   <Target Name="CopyAppReferences" BeforeTargets="GetCopyToOutputDirectoryItems">
 
-    <!-- Get the output folders of all AppReferences. -->
+    <!-- Get the output file of this AppReference. -->
     <MSBuild Projects="%(ProjectReference.FullPath)"
              Targets="GetTargetPath"
              Properties="Configuration=$(Configuration)"
@@ -39,12 +39,11 @@
       </AppReferenceContent>
     </ItemGroup>
 
-    <!-- Copy this content to the build output. -->
+    <!-- Copy this content to the build and package output. -->
     <ItemGroup>
-      <ContentWithTargetPath
-        Include="%(AppReferenceContent.FullPath)"
-        TargetPath="%(SubDir)%(RecursiveDir)%(Filename)%(Extension)"
-        CopyToOutputDirectory="PreserveNewest" />
+      <TfmSpecificPackageFile Include="%(AppReferenceContent.FullPath)">
+        <PackagePath>tools\$(TargetFramework)\any\%(AppReferenceContent.SubDir)%(RecursiveDir)</PackagePath>
+      </TfmSpecificPackageFile>
     </ItemGroup>
 
   </Target>

--- a/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.csproj
+++ b/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.csproj
@@ -42,7 +42,7 @@
     <None Remove="**\*" />
     <Compile Remove="**\*" />
 
-    <None Include="Platform\Launcher\AppReference.targets" />
+    <None Include="..\AppReference.targets" />
     <Compile Include="Platform\Launcher\**\*.cs" />
     <Compile Include="Platform\Utilities\**\*.cs" />
   </ItemGroup>
@@ -73,6 +73,6 @@
     </ProjectReference>
   </ItemGroup>
 
-  <Import Project="Platform\Launcher\AppReference.targets" />
+  <Import Project="..\AppReference.targets" />
 
 </Project>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.csproj
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <BaseOutputPath>..\..\Artifacts\MonoGame.Content.Builder.Task</BaseOutputPath>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
@@ -10,7 +10,10 @@
   <ItemGroup>
     <Content Include="MonoGame.Content.Builder.Task.props" PackagePath="build" />
     <Content Include="MonoGame.Content.Builder.Task.targets" PackagePath="build" />
-    <Content Include="version\Version.props" PackagePath="build\version\$(PackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\AppReference.targets" />
   </ItemGroup>
 
   <ItemGroup>
@@ -19,5 +22,14 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MonoGame.Content.Builder\MonoGame.Content.Builder.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <AppReference>true</AppReference>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="..\AppReference.targets" />
 
 </Project>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
@@ -1,12 +1,9 @@
 ﻿<Project>
 
-  <Import Project="$(MSBuildThisFileDirectory)/version/**/Version.props" />
-  
   <PropertyGroup>
     <DotnetCommand Condition="'$(DotnetCommand)' == ''">dotnet</DotnetCommand>
-    <MGCBPackageId Condition="'$(MGCBPackageId)' == ''">dotnet-mgcb</MGCBPackageId>
-    <MGCBVersion Condition="'$(MGCBVersion)' == ''">$(MonoGameContentBuilderVersion)</MGCBVersion>
     <EnableMGCBItems Condition="'$(EnableMGCBItems)' == ''">true</EnableMGCBItems>
+    <MGCBPath Condition="'$(MGCBPath)' == ''">$(MSBuildThisFileDirectory)\..\tools\netcoreapp3.1\any\mgcb.dll</MGCBPath>
   </PropertyGroup>
 
 </Project>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -149,7 +149,7 @@
       - ExtraContent: built content files
         - ContentDir: the relative path of the embedded folder to contain the content files
   -->
-  <Target Name="RunContentBuilder" DependsOnTargets="UpdateMGCB;PrepareContentBuilder">
+  <Target Name="RunContentBuilder" DependsOnTargets="PrepareContentBuilder">
 
     <!-- Execute MGCB from the project directory so we use the correct manifest. -->
     <Exec

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -11,140 +11,18 @@
   </PropertyGroup>
 
   <!--
-    Target flow diagram
-    * - only run if necessary
-
-                                      InstallMGCB*
-                                           ^
-                                           |
-         GetInstalledMGCB*     ->     UpdateMGCB*
-                                                        \
-                                                          -> RunContentBuilder -> IncludeContent
-                                                        /
-      CollectContentReferences -> PrepareContentBuilder
+    Target flow
+      1. CollectContentReferences
+      2. PrepareContentBuilder
+      3. RunContentBuilder
+      4. IncludeContent
   -->
 
   <!--
-    Calls 'dotnet tool' commands to parse information about any locally installed MGCB tools.
+    ========================
+    CollectContentReferences
+    ========================
 
-    Outputs:
-      - MGCBInstalledVersion: the version of an installed MGCB tool, or empty string
-      - MGCBInstalledFolder: the folder with a locally installed MGCB tool, or empty string
-
-    Example:
-      - Given the following output from 'dotnet tool list -local':
-          Package Id       Version      Commands      Manifest
-          - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-          dotnet-mgcb      2.0.0        mgcb          C:\Game\Game.DesktopGL\.config\dotnet-tools.json
-      - Output
-        - MGCBInstalledVersion: 2.0.0
-        - MGCBInstalledFolder: C:\Game\Game.DesktopGL
-  -->
-  <Target Name="GetInstalledMGCB">
-
-    <!-- List dotnet tools. -->
-    <Exec
-      WorkingDirectory="$(MSBuildProjectDirectory)"
-      Command="$(DotnetCommand) tool list --local"
-      ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="ConsoleOutput" />
-    </Exec>
-
-    <!-- Get header indices.
-         The output of `dotnet tool list` (https://github.com/dotnet/cli/blob/master/src/dotnet/commands/dotnet-tool/list/ToolListGlobalOrToolPathCommand.cs) 
-         is formatted as a `PrintableTable` (https://github.com/dotnet/cli/blob/master/src/dotnet/PrintableTable.cs).
-         `PrintableTable` defines six consecutive spaces as its column delimiter (public const string ColumnDelimiter = "      ";).
-         However MSBuild will automatically convert a string to a char[] if there is an available overload,
-         so Split can only be called with multiple character delimiters and not with a string delimiter.
-         Therefore first replace the string delimiter with a single character delimiter. -->
-    <PropertyGroup>
-
-      <HeaderLine>$(ConsoleOutput.Split(';')[0].Replace("      ", ","))</HeaderLine>
-
-      <DotnetToolHeaderPackageIDColumnName>$(HeaderLine.Split(",", StringSplitOptions.RemoveEmptyEntries)[0].Trim())</DotnetToolHeaderPackageIDColumnName>
-      <DotnetToolHeaderVersionColumnName>$(HeaderLine.Split(",", StringSplitOptions.RemoveEmptyEntries)[1].Trim())</DotnetToolHeaderVersionColumnName>
-      <DotnetToolHeaderCommandsColumnName>$(HeaderLine.Split(",", StringSplitOptions.RemoveEmptyEntries)[2].Trim())</DotnetToolHeaderCommandsColumnName>
-      <DotnetToolHeaderManifestColumnName>$(HeaderLine.Split(",", StringSplitOptions.RemoveEmptyEntries)[3].Trim())</DotnetToolHeaderManifestColumnName>
-
-      <DotnetToolPackageIdIndex>$(ConsoleOutput.IndexOf($(DotnetToolHeaderPackageIDColumnName)))</DotnetToolPackageIdIndex>
-      <DotnetToolVersionIndex>$(ConsoleOutput.IndexOf($(DotnetToolHeaderVersionColumnName)))</DotnetToolVersionIndex>
-      <DotnetToolCommandsIndex>$(ConsoleOutput.IndexOf($(DotnetToolHeaderCommandsColumnName)))</DotnetToolCommandsIndex>
-      <DotnetToolManifestIndex>$(ConsoleOutput.IndexOf($(DotnetToolHeaderManifestColumnName)))</DotnetToolManifestIndex>
-
-      <DotnetToolPackageIdLength>$([MSBuild]::Subtract($(DotnetToolVersionIndex), $(DotnetToolPackageIdIndex)))</DotnetToolPackageIdLength>
-      <DotnetToolVersionLength>$([MSBuild]::Subtract($(DotnetToolCommandsIndex), $(DotnetToolVersionIndex)))</DotnetToolVersionLength>
-      <DotnetToolCommandsLength>$([MSBuild]::Subtract($(DotnetToolManifestIndex), $(DotnetToolCommandsIndex)))</DotnetToolCommandsLength>
-
-    </PropertyGroup>
-
-    <!-- Get metadata from output. Note: the header and horizontal line will be present here too, but they should not interfere with anything. -->
-    <ItemGroup>
-      <ConsoleLine Include="$(ConsoleOutput.Split(';'))" />
-      <DotnetTool Include="%(ConsoleLine.Identity)" Condition="'%(Identity)' != ''">
-        <PackageId>$([System.String]::Copy("%(Identity)").Substring($(DotnetToolPackageIdIndex), $(DotnetToolPackageIdLength)).Trim())</PackageId>
-        <Version>$([System.String]::Copy("%(Identity)").Substring($(DotnetToolVersionIndex), $(DotnetToolVersionLength)).Trim())</Version>
-        <Commands>$([System.String]::Copy("%(Identity)").Substring($(DotnetToolCommandsIndex), $(DotnetToolCommandsLength)).Trim())</Commands>
-        <Manifest>$([System.String]::Copy("%(Identity)").Substring($(DotnetToolManifestIndex)).Trim())</Manifest>
-      </DotnetTool>
-    </ItemGroup>
-
-    <!-- Get metadata for the MGCB tool, if present. -->
-    <PropertyGroup>
-      <MGCBInstalledVersion Condition="'%(PackageId)' == '$(MGCBPackageId)'">%(DotnetTool.Version)</MGCBInstalledVersion>
-      <MGCBInstalledFolder Condition="'%(PackageId)' == '$(MGCBPackageId)'">$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName(%(DotnetTool.Manifest)))))</MGCBInstalledFolder>
-    </PropertyGroup>
-
-  </Target>
-
-  <!--
-    Ensures a tools manifest exists in the project directory with the correct version of the MGCB tool installed.
-  -->
-  <Target Name="InstallMGCB">
-
-    <!-- Ensure there is a manifest for the project. -->
-    <Exec
-      WorkingDirectory="$(MSBuildProjectDirectory)"
-      Command="$(DotnetCommand) new tool-manifest"
-      ContinueOnError="true" />
-
-    <!-- If there is a version of MGCB installed in the project directory, uninstall it. -->
-    <Exec
-      Condition="'$(MGCBInstalledFolder)' == '$(MSBuildProjectDirectory)'"
-      WorkingDirectory="$(MSBuildProjectDirectory)"
-      Command="$(DotnetCommand) tool uninstall $(MGCBPackageId)" />
-
-    <!-- Install the correct version of MGCB. -->
-    <Exec
-      WorkingDirectory="$(MSBuildProjectDirectory)"
-      Command="$(DotnetCommand) tool install $(MGCBPackageId) --version $(MGCBVersion)" />
-
-  </Target>
-
-  <!--
-    Restores or installs the correct version of the MGCB tool if MGCBCommand is not already defined.
-
-    Outputs:
-      - MGCBCommand: the command to run the MGCB tool without any arguments
-  -->
-  <Target Name="UpdateMGCB" Condition="'$(MGCBCommand)' == ''" DependsOnTargets="GetInstalledMGCB">
-
-    <!-- If the correct version is in the manifest, restore to ensure it's installed. -->
-    <Exec
-      Condition="$(MGCBInstalledVersion) == $(MGCBVersion)"
-      Command="$(DotnetCommand) tool restore" />
-
-    <!-- If the correct version is not in the manifest, install the correct version. -->
-    <CallTarget
-      Condition="$(MGCBInstalledVersion) != $(MGCBVersion)"
-      Targets="InstallMGCB" />
-
-    <PropertyGroup>
-      <MGCBCommand>$(DotnetCommand) tool run mgcb</MGCBCommand>
-    </PropertyGroup>
-
-  </Target>
-
-  <!--
     Converts MonoGameContentReference items to ContentReference items, deriving the necessary metadata.
 
     Outputs:
@@ -158,7 +36,7 @@
       - Given the following file setup:
         - C:\Game\Game.Shared\Content.mgcb
         - C:\Game\Game.DesktopGL\Game.DesktopGL.csproj
-          - MonoGameContentReference: ..\Content\Content.mgcb
+          - MonoGameContentReference: ..\Game.Shared\Content.mgcb
       - Output:
         - ContentReference
           - FullDir: C:/Game/Game.Shared/
@@ -205,6 +83,10 @@
   </Target>
 
   <!--
+    =====================
+    PrepareContentBuilder
+    =====================
+
     Set and validate properties, and create folders for content output.
 
     Outputs:
@@ -257,6 +139,10 @@
   </Target>
 
   <!--
+    =================
+    RunContentBuilder
+    =================
+
     Run MGCB to build content and include it as ExtraContent.
 
     Outputs:
@@ -268,7 +154,7 @@
     <!-- Execute MGCB from the project directory so we use the correct manifest. -->
     <Exec
       Condition="'%(ContentReference.FullPath)' != ''"
-      Command="$(MGCBCommand) $(MonoGameMGCBAdditionalArguments) /@:&quot;%(ContentReference.FullPath)&quot; /platform:$(MonoGamePlatform) /outputDir:&quot;%(ContentReference.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReference.ContentIntermediateOutputDir)&quot; /workingDir:&quot;%(ContentReference.FullDir)&quot;"
+      Command="$(DotnetCommand) $(MGCBPath) $(MonoGameMGCBAdditionalArguments) /@:&quot;%(ContentReference.FullPath)&quot; /platform:$(MonoGamePlatform) /outputDir:&quot;%(ContentReference.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReference.ContentIntermediateOutputDir)&quot; /workingDir:&quot;%(ContentReference.FullDir)&quot;"
       WorkingDirectory="$(MSBuildProjectDirectory)" />
 
     <ItemGroup>
@@ -282,6 +168,10 @@
   </Target>
 
   <!--
+    ==============
+    IncludeContent
+    ==============
+
     Include ExtraContent as platform-specific content in the project output.
 
     Outputs:

--- a/Tools/MonoGame.Content.Builder.Task/version/Version.props
+++ b/Tools/MonoGame.Content.Builder.Task/version/Version.props
@@ -1,5 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <MonoGameContentBuilderVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileFullPath)))))</MonoGameContentBuilderVersion>
-  </PropertyGroup>
-</Project>

--- a/Tools/MonoGame.Content.Builder/.mgstats
+++ b/Tools/MonoGame.Content.Builder/.mgstats
@@ -1,1 +1,0 @@
-Source File,Dest File,Processor Type,Content Type,Source File Size,Dest File Size,Build Seconds

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -13,26 +13,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj" />
-    <ProjectReference Include="..\..\MonoGame.Framework.Content.Pipeline\MonoGame.Framework.Content.Pipeline.csproj" />
+    <None Include="..\AppReference.targets" />
   </ItemGroup>
 
-  <!-- Build and copy MGFXC, just don't reference it! -->
-  <PropertyGroup>
-    <!-- NuGet warns if we copy assemblies but don't reference them; we suppress those warnings. -->
-    <NoWarn>NU5100</NoWarn>
-  </PropertyGroup>
   <ItemGroup>
-    <Content Include="..\..\Artifacts\MonoGame.Effect.Compiler\Release\*"
-             Exclude="..\..\Artifacts\MonoGame.Effect.Compiler\Release\*.nupkg"
-             Visible="false">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <ProjectReference Include="..\..\MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj" />
+    <ProjectReference Include="..\..\MonoGame.Framework.Content.Pipeline\MonoGame.Framework.Content.Pipeline.csproj" />
+    <ProjectReference Include="..\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <AppReference>true</AppReference>
+    </ProjectReference>
   </ItemGroup>
-  <Target Name="BuildMFGXC" BeforeTargets="Restore">
-    <MSBuild Projects="..\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=Release;UseAppHost=False" Targets="Restore" />
-    <MSBuild Projects="..\MonoGame.Effect.Compiler\MonoGame.Effect.Compiler.csproj" Properties="Configuration=Release;UseAppHost=False" Targets="Build" />
-  </Target>
+
+  <Import Project="..\AppReference.targets" />
 
 </Project>
 


### PR DESCRIPTION
## Summary

I know this change hasn't really been discussed, but I think it should be considered. It decouples `Builder.Task` from the `dotnet-mgcb` global tool and packs a copy of `mgcb` directly into `Builder.Task` (just as `Builder.Editor` already does). Now `dotnet-mgcb`, `Builder.Editor`, and `Builder.Task` each ship with their own copy of `mgcb`.

Now the Task is much simpler, and the dotnet global tool is still there if you want it.

**Cons:**
* `Builder.Task` doesn't automatically install the `dotnet-mgcb` tool for you if you wanted to run it manually
* Two copies of `mgcb` will be saved, taking up twice as much space (~300MB extra) if a user wants to use the Task _and_ the dotnet tool.

**Pros:**
* No version issues like #7150
* No potential issues from parsing `dotnet tool` output
* No .config folders strewn across your project when you don't want them
* Easier to understand and maintain targets file (look at how much was deleted from `MonoGame.Content.Builder.Task.targets`)
* Easier to work from source without needing to first publish the dotnet tool to a local NuGet source (see [sample below](https://github.com/MonoGame/MonoGame/pull/7169#issuecomment-635205749))

## Validation

* Tested building a game with `Builder.Task` and running the output with each of the following
  * WindowsDX
  * WindowsUniversal
  * DesktopGL
  * iOS
* Tested building a .mgcb file with each of the following dotnet local tools
  * `dotnet-mgcb`
  * `dotnet-mgcb-editor`