### PR TITLE
Splitting assingment in ZlibStream that cause AoT issues

### DIFF
--- a/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
+++ b/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
@@ -3038,7 +3038,8 @@ namespace MonoGame.Utilities
                         // compute minimum size table less than or equal to l bits
                         z = g - w;
                         z = (z > l) ? l : z; // table size upper limit
-                        if ((f = 1 << (j = k - w)) > a + 1)
+                        j = k - w;
+                        if ((f = 1 << j) > a + 1)
                         {
                             // try a k-w bit table
                             // too few codes for k-w bit table

--- a/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
+++ b/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
@@ -2757,7 +2757,9 @@ namespace MonoGame.Utilities
             // two codes of non zero frequency.
             while (s.heap_len < 2)
             {
-                node = s.heap[++s.heap_len] = (max_code < 2 ? ++max_code : 0);
+                int code = (max_code < 2 ? ++max_code : 0);
+                s.heap[++s.heap_len] = code;
+                node = code;
                 tree[node * 2] = 1;
                 s.depth[node] = 0;
                 s.opt_len--;


### PR DESCRIPTION
When generating native code in some AoT compilers, this line causes the type of the expression within the if statement to get incorrectly interpreted. splitting this line into two different statements fixes this issue without changing the expected funcionality.

Existing tests should continue to exercise the portions of this code that were already tested.