### PR TITLE
[DesktopGL] Better debugging for macOS

### DIFF
--- a/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Xna.Framework
 
             _handle = Sdl.Window.Create("", 0, 0,
                 GraphicsDeviceManager.DefaultBackBufferWidth, GraphicsDeviceManager.DefaultBackBufferHeight,
-                Sdl.Window.State.Hidden);
+                Sdl.Window.State.Hidden | Sdl.Window.State.FullscreenDesktop);
         }
 
         internal void CreateWindow()


### PR DESCRIPTION
Creating a hidden window on macOS always forces it to go to desktop workspace, and then if the created window is fullscreen it would move to a new fullscreen workspace for the window, however just adding the FullscreenDesktop flag to our dummy window creation seems to resolve it.

This was tested with both a fullscreen window and a normal window, there is now just one workspace move.