### PR TITLE
[MGFXC Wine Script] Export env variable to zprofile

### DIFF
--- a/Tools/MonoGame.Effect.Compiler/mgfxc_wine_setup.sh
+++ b/Tools/MonoGame.Effect.Compiler/mgfxc_wine_setup.sh
@@ -37,6 +37,7 @@ cp -f "$SCRIPT_DIR/firefox_data/core/d3dcompiler_47.dll" "$WINEPREFIX/drive_c/wi
 
 # append MGFXC_WINE_PATH env variable
 echo "export MGFXC_WINE_PATH=$HOME/.winemonogame" >> ~/.profile
+echo "export MGFXC_WINE_PATH=$HOME/.winemonogame" >> ~/.zprofile
 
 # cleanup
 rm -rf "$SCRIPT_DIR"


### PR DESCRIPTION
On macOS zsh is the default shell now, it seems to be reading env variables from .zprofile instead of .profile.