### PR TITLE
Remember pipeline tool position, size and panel dimensions

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineSettings.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineSettings.cs
@@ -19,8 +19,8 @@ namespace MonoGame.Tools.Pipeline
 
         public List<string> ProjectHistory;
         public string StartupProject;
-        public System.Drawing.Size WindowSize;
-        public System.Drawing.Point WindowPosition;
+        public int WindowWidth, WindowHeight;
+        public int WindowPositionX, WindowPositionY;
         public bool WindowMaximized;
         public int HSeparator, VSeparator;
         public bool Maximized, DebugMode, PropertyGroupSort;
@@ -43,8 +43,10 @@ namespace MonoGame.Tools.Pipeline
             FilterShowCleaned = true;
             AutoScrollBuildOutput = true;
 
-            WindowSize = new System.Drawing.Size(900, 550);
-            WindowPosition = new System.Drawing.Point(182, 182);
+            WindowWidth = 900;
+            WindowHeight = 550;
+            WindowPositionX = 182;
+            WindowPositionY = 182;
             WindowMaximized = false;
             HSeparator = 200;
             VSeparator = 230;

--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineSettings.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineSettings.cs
@@ -20,7 +20,7 @@ namespace MonoGame.Tools.Pipeline
         public List<string> ProjectHistory;
         public string StartupProject;
         public int WindowWidth, WindowHeight;
-        public int WindowPositionX, WindowPositionY;
+        public int WindowPositionX, WindowPositionY, WindowMaximizedPositionX, WindowMaximizedPositionY;
         public bool WindowMaximized;
         public int HSeparator, VSeparator;
         public bool Maximized, DebugMode, PropertyGroupSort;
@@ -47,6 +47,8 @@ namespace MonoGame.Tools.Pipeline
             WindowHeight = 550;
             WindowPositionX = 182;
             WindowPositionY = 182;
+            WindowMaximizedPositionX = 0;
+            WindowMaximizedPositionY = 0;
             WindowMaximized = false;
             HSeparator = 200;
             VSeparator = 230;

--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineSettings.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineSettings.cs
@@ -21,6 +21,7 @@ namespace MonoGame.Tools.Pipeline
         public string StartupProject;
         public System.Drawing.Size WindowSize;
         public System.Drawing.Point WindowPosition;
+        public bool WindowMaximized;
         public int HSeparator, VSeparator;
         public bool Maximized, DebugMode, PropertyGroupSort;
         public bool FilterOutput, FilterShowSkipped, FilterShowSuccessful, FilterShowCleaned, AutoScrollBuildOutput;
@@ -44,6 +45,7 @@ namespace MonoGame.Tools.Pipeline
 
             WindowSize = new System.Drawing.Size(900, 550);
             WindowPosition = new System.Drawing.Point(182, 182);
+            WindowMaximized = false;
             HSeparator = 200;
             VSeparator = 230;
 

--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineSettings.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineSettings.cs
@@ -19,7 +19,8 @@ namespace MonoGame.Tools.Pipeline
 
         public List<string> ProjectHistory;
         public string StartupProject;
-        public Microsoft.Xna.Framework.Point Size;
+        public System.Drawing.Size WindowSize;
+        public System.Drawing.Point WindowPosition;
         public int HSeparator, VSeparator;
         public bool Maximized, DebugMode, PropertyGroupSort;
         public bool FilterOutput, FilterShowSkipped, FilterShowSuccessful, FilterShowCleaned, AutoScrollBuildOutput;
@@ -40,6 +41,11 @@ namespace MonoGame.Tools.Pipeline
             FilterShowSuccessful = true;
             FilterShowCleaned = true;
             AutoScrollBuildOutput = true;
+
+            WindowSize = new System.Drawing.Size(900, 550);
+            WindowPosition = new System.Drawing.Point(182, 182);
+            HSeparator = 200;
+            VSeparator = 230;
 
             try
             {

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -91,10 +91,15 @@ namespace MonoGame.Tools.Pipeline
                 }
                 else
                 {
+#if GTK
+                    PipelineSettings.Default.WindowWidth = ClientSize.Width;
+                    PipelineSettings.Default.WindowHeight = ClientSize.Height;
+#else
                     PipelineSettings.Default.WindowWidth = Bounds.Width;
                     PipelineSettings.Default.WindowHeight = Bounds.Height;
                     PipelineSettings.Default.WindowPositionX = Bounds.X;
                     PipelineSettings.Default.WindowPositionY = Bounds.Y;
+#endif
                     PipelineSettings.Default.WindowMaximized = false;
                 }
                 PipelineSettings.Default.VSeparator = splitterVertical.Position;
@@ -105,7 +110,7 @@ namespace MonoGame.Tools.Pipeline
             base.OnClosing(e);
         }
 
-        #region IView implements
+#region IView implements
 
         public void Attach(IController controller)
         {
@@ -467,9 +472,9 @@ namespace MonoGame.Tools.Pipeline
             _clipboard.Text = text;
         }
 
-        #endregion
+#endregion
 
-        #region Commands
+#region Commands
 
         private void CmdNew_Executed(object sender, EventArgs e)
         {
@@ -656,7 +661,7 @@ namespace MonoGame.Tools.Pipeline
             PipelineController.Instance.RebuildItems();
         }
 
-        #endregion
+#endregion
 
     }
 }

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -81,6 +81,17 @@ namespace MonoGame.Tools.Pipeline
         {
             e.Cancel = !PipelineController.Instance.Exit();
 
+            if(WindowState != WindowState.Minimized)
+            {
+                PipelineSettings.Default.WindowSize.Width = Bounds.Width;
+                PipelineSettings.Default.WindowSize.Height = Bounds.Height;
+                PipelineSettings.Default.WindowPosition.X = Bounds.X;
+                PipelineSettings.Default.WindowPosition.Y = Bounds.Y;
+                PipelineSettings.Default.VSeparator = splitterVertical.Position;
+                PipelineSettings.Default.HSeparator = splitterHorizontal.Position;
+                PipelineSettings.Default.Save();
+            }
+
             base.OnClosing(e);
         }
 

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -87,6 +87,7 @@ namespace MonoGame.Tools.Pipeline
                 PipelineSettings.Default.WindowSize.Height = Bounds.Height;
                 PipelineSettings.Default.WindowPosition.X = Bounds.X;
                 PipelineSettings.Default.WindowPosition.Y = Bounds.Y;
+                PipelineSettings.Default.WindowMaximized = WindowState == WindowState.Maximized ? true : false;
                 PipelineSettings.Default.VSeparator = splitterVertical.Position;
                 PipelineSettings.Default.HSeparator = splitterHorizontal.Position;
                 PipelineSettings.Default.Save();

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -91,15 +91,18 @@ namespace MonoGame.Tools.Pipeline
                 }
                 else
                 {
-#if GTK
-                    PipelineSettings.Default.WindowWidth = ClientSize.Width;
-                    PipelineSettings.Default.WindowHeight = ClientSize.Height;
-#else
-                    PipelineSettings.Default.WindowWidth = Bounds.Width;
-                    PipelineSettings.Default.WindowHeight = Bounds.Height;
-                    PipelineSettings.Default.WindowPositionX = Bounds.X;
-                    PipelineSettings.Default.WindowPositionY = Bounds.Y;
-#endif
+                    if(Global.Linux)
+                    {
+                        PipelineSettings.Default.WindowWidth = ClientSize.Width;
+                        PipelineSettings.Default.WindowHeight = ClientSize.Height;
+                    }
+                    else
+                    {
+                        PipelineSettings.Default.WindowWidth = Bounds.Width;
+                        PipelineSettings.Default.WindowHeight = Bounds.Height;
+                        PipelineSettings.Default.WindowPositionX = Bounds.X;
+                        PipelineSettings.Default.WindowPositionY = Bounds.Y;
+                    }
                     PipelineSettings.Default.WindowMaximized = false;
                 }
                 PipelineSettings.Default.VSeparator = splitterVertical.Position;
@@ -110,7 +113,7 @@ namespace MonoGame.Tools.Pipeline
             base.OnClosing(e);
         }
 
-#region IView implements
+        #region IView implements
 
         public void Attach(IController controller)
         {
@@ -472,9 +475,9 @@ namespace MonoGame.Tools.Pipeline
             _clipboard.Text = text;
         }
 
-#endregion
+        #endregion
 
-#region Commands
+        #region Commands
 
         private void CmdNew_Executed(object sender, EventArgs e)
         {
@@ -661,7 +664,7 @@ namespace MonoGame.Tools.Pipeline
             PipelineController.Instance.RebuildItems();
         }
 
-#endregion
+        #endregion
 
     }
 }

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -83,10 +83,10 @@ namespace MonoGame.Tools.Pipeline
 
             if(WindowState != WindowState.Minimized)
             {
-                PipelineSettings.Default.WindowSize.Width = Bounds.Width;
-                PipelineSettings.Default.WindowSize.Height = Bounds.Height;
-                PipelineSettings.Default.WindowPosition.X = Bounds.X;
-                PipelineSettings.Default.WindowPosition.Y = Bounds.Y;
+                PipelineSettings.Default.WindowWidth = Bounds.Width;
+                PipelineSettings.Default.WindowHeight = Bounds.Height;
+                PipelineSettings.Default.WindowPositionX = Bounds.X;
+                PipelineSettings.Default.WindowPositionY = Bounds.Y;
                 PipelineSettings.Default.WindowMaximized = WindowState == WindowState.Maximized ? true : false;
                 PipelineSettings.Default.VSeparator = splitterVertical.Position;
                 PipelineSettings.Default.HSeparator = splitterHorizontal.Position;

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -83,11 +83,20 @@ namespace MonoGame.Tools.Pipeline
 
             if(WindowState != WindowState.Minimized)
             {
-                PipelineSettings.Default.WindowWidth = Bounds.Width;
-                PipelineSettings.Default.WindowHeight = Bounds.Height;
-                PipelineSettings.Default.WindowPositionX = Bounds.X;
-                PipelineSettings.Default.WindowPositionY = Bounds.Y;
-                PipelineSettings.Default.WindowMaximized = WindowState == WindowState.Maximized ? true : false;
+                if(WindowState == WindowState.Maximized)
+                {
+                    PipelineSettings.Default.WindowMaximized = true;
+                    PipelineSettings.Default.WindowMaximizedPositionX = RestoreBounds.X;
+                    PipelineSettings.Default.WindowMaximizedPositionY = RestoreBounds.Y;
+                }
+                else
+                {
+                    PipelineSettings.Default.WindowWidth = Bounds.Width;
+                    PipelineSettings.Default.WindowHeight = Bounds.Height;
+                    PipelineSettings.Default.WindowPositionX = Bounds.X;
+                    PipelineSettings.Default.WindowPositionY = Bounds.Y;
+                    PipelineSettings.Default.WindowMaximized = false;
+                }
                 PipelineSettings.Default.VSeparator = splitterVertical.Position;
                 PipelineSettings.Default.HSeparator = splitterHorizontal.Position;
                 PipelineSettings.Default.Save();

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
@@ -50,8 +50,12 @@ namespace MonoGame.Tools.Pipeline
         {
             Title = "MGCB Editor";
             Icon = Icon.FromResource("Icons.monogame.png");
-            Bounds = new Rectangle(PipelineSettings.Default.WindowPosition.X, PipelineSettings.Default.WindowPosition.Y,
+
+            if(!PipelineSettings.Default.WindowMaximized)
+                Bounds = new Rectangle(PipelineSettings.Default.WindowPosition.X, PipelineSettings.Default.WindowPosition.Y,
                                    PipelineSettings.Default.WindowSize.Width, PipelineSettings.Default.WindowSize.Height);
+            else
+                this.WindowState = WindowState.Maximized;            
 
             MinimumSize = new Size(400, 400);
 

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
@@ -51,15 +51,20 @@ namespace MonoGame.Tools.Pipeline
             Title = "MGCB Editor";
             Icon = Icon.FromResource("Icons.monogame.png");
 
-            if(!PipelineSettings.Default.WindowMaximized)
+            if (!PipelineSettings.Default.WindowMaximized)
+            {
+#if GTK
+                Size = new Size(PipelineSettings.Default.WindowWidth, PipelineSettings.Default.WindowHeight);
+#else
                 Bounds = new Rectangle(PipelineSettings.Default.WindowPositionX, PipelineSettings.Default.WindowPositionY,
                                    PipelineSettings.Default.WindowWidth, PipelineSettings.Default.WindowHeight);
+#endif
+            }
             else
             {
                 Location = new Point(PipelineSettings.Default.WindowMaximizedPositionX, PipelineSettings.Default.WindowMaximizedPositionY);
                 WindowState = WindowState.Maximized;
             }
-                
             
 
             MinimumSize = new Size(400, 400);
@@ -80,7 +85,7 @@ namespace MonoGame.Tools.Pipeline
             splitterVertical.Position = PipelineSettings.Default.VSeparator;
             splitterVertical.FixedPanel = SplitterFixedPanel.None;
             splitterVertical.Panel1MinimumSize = 100;
-            splitterVertical.Panel2MinimumSize = 100;           
+            splitterVertical.Panel2MinimumSize = 100;
 
             projectControl = new ProjectControl();
             _pads.Add(projectControl);

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
@@ -52,8 +52,8 @@ namespace MonoGame.Tools.Pipeline
             Icon = Icon.FromResource("Icons.monogame.png");
 
             if(!PipelineSettings.Default.WindowMaximized)
-                Bounds = new Rectangle(PipelineSettings.Default.WindowPosition.X, PipelineSettings.Default.WindowPosition.Y,
-                                   PipelineSettings.Default.WindowSize.Width, PipelineSettings.Default.WindowSize.Height);
+                Bounds = new Rectangle(PipelineSettings.Default.WindowPositionX, PipelineSettings.Default.WindowPositionY,
+                                   PipelineSettings.Default.WindowWidth, PipelineSettings.Default.WindowHeight);
             else
                 this.WindowState = WindowState.Maximized;            
 

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
@@ -55,7 +55,12 @@ namespace MonoGame.Tools.Pipeline
                 Bounds = new Rectangle(PipelineSettings.Default.WindowPositionX, PipelineSettings.Default.WindowPositionY,
                                    PipelineSettings.Default.WindowWidth, PipelineSettings.Default.WindowHeight);
             else
-                this.WindowState = WindowState.Maximized;            
+            {
+                Location = new Point(PipelineSettings.Default.WindowMaximizedPositionX, PipelineSettings.Default.WindowMaximizedPositionY);
+                WindowState = WindowState.Maximized;
+            }
+                
+            
 
             MinimumSize = new Size(400, 400);
 
@@ -75,7 +80,7 @@ namespace MonoGame.Tools.Pipeline
             splitterVertical.Position = PipelineSettings.Default.VSeparator;
             splitterVertical.FixedPanel = SplitterFixedPanel.None;
             splitterVertical.Panel1MinimumSize = 100;
-            splitterVertical.Panel2MinimumSize = 100;
+            splitterVertical.Panel2MinimumSize = 100;           
 
             projectControl = new ProjectControl();
             _pads.Add(projectControl);

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
@@ -53,12 +53,11 @@ namespace MonoGame.Tools.Pipeline
 
             if (!PipelineSettings.Default.WindowMaximized)
             {
-#if GTK
-                Size = new Size(PipelineSettings.Default.WindowWidth, PipelineSettings.Default.WindowHeight);
-#else
-                Bounds = new Rectangle(PipelineSettings.Default.WindowPositionX, PipelineSettings.Default.WindowPositionY,
-                                   PipelineSettings.Default.WindowWidth, PipelineSettings.Default.WindowHeight);
-#endif
+                if(Global.Linux)
+                    Size = new Size(PipelineSettings.Default.WindowWidth, PipelineSettings.Default.WindowHeight);
+                else
+                    Bounds = new Rectangle(PipelineSettings.Default.WindowPositionX, PipelineSettings.Default.WindowPositionY,
+                                           PipelineSettings.Default.WindowWidth, PipelineSettings.Default.WindowHeight);
             }
             else
             {

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
@@ -50,7 +50,9 @@ namespace MonoGame.Tools.Pipeline
         {
             Title = "MGCB Editor";
             Icon = Icon.FromResource("Icons.monogame.png");
-            Size = new Size(900, 550);
+            Bounds = new Rectangle(PipelineSettings.Default.WindowPosition.X, PipelineSettings.Default.WindowPosition.Y,
+                                   PipelineSettings.Default.WindowSize.Width, PipelineSettings.Default.WindowSize.Height);
+
             MinimumSize = new Size(400, 400);
 
             InitalizeCommands();
@@ -60,13 +62,13 @@ namespace MonoGame.Tools.Pipeline
 
             splitterHorizontal = new Splitter();
             splitterHorizontal.Orientation = Orientation.Horizontal;
-            splitterHorizontal.Position = 200;
+            splitterHorizontal.Position = PipelineSettings.Default.HSeparator;
             splitterHorizontal.Panel1MinimumSize = 100;
             splitterHorizontal.Panel2MinimumSize = 100;
 
             splitterVertical = new Splitter();
             splitterVertical.Orientation = Orientation.Vertical;
-            splitterVertical.Position = 230;
+            splitterVertical.Position = PipelineSettings.Default.VSeparator;
             splitterVertical.FixedPanel = SplitterFixedPanel.None;
             splitterVertical.Panel1MinimumSize = 100;
             splitterVertical.Panel2MinimumSize = 100;

--- a/Tools/MonoGame.Content.Builder.Editor/Platform/Windows/Styles.Windows.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Platform/Windows/Styles.Windows.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using Eto;
+using Eto.Forms;
 using Eto.Wpf.Forms;
 using Eto.Wpf.Forms.Menu;
 using Eto.Wpf.Forms.ToolBar;
@@ -23,6 +24,13 @@ namespace MonoGame.Tools.Pipeline
                     h.WindowState = Eto.Forms.WindowState.Normal;
                     h.Location = new Eto.Drawing.Point(182, 182);
                     h.Size = new Eto.Drawing.Size(900, 550);
+
+                    var splitterEnumerator = h.Widget.Children.GetEnumerator();
+                    if( splitterEnumerator.MoveNext() == true && splitterEnumerator.Current is Splitter)
+                        ((Splitter)splitterEnumerator.Current).Position = 200;
+
+                    if (splitterEnumerator.MoveNext() == true && splitterEnumerator.Current is Splitter)
+                        ((Splitter)splitterEnumerator.Current).Position = 230;
                 }
             });
 

--- a/Tools/MonoGame.Content.Builder.Editor/Platform/Windows/Styles.Windows.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Platform/Windows/Styles.Windows.cs
@@ -13,6 +13,19 @@ namespace MonoGame.Tools.Pipeline
     {
         public static void Load()
         {
+            Style.Add<FormHandler>("MainWindow", h =>
+            {
+                var displayBounds = Eto.Forms.Screen.DisplayBounds;
+
+                if(h.Location.X < displayBounds.Left || h.Location.X > displayBounds.Right ||
+                   h.Location.Y < displayBounds.Top || h.Location.Y > displayBounds.Bottom)
+                {
+                    h.WindowState = Eto.Forms.WindowState.Normal;
+                    h.Location = new Eto.Drawing.Point(182, 182);
+                    h.Size = new Eto.Drawing.Size(900, 550);
+                }
+            });
+
             Style.Add<MenuBarHandler>("MenuBar", h =>
             {
                 h.Control.Background = System.Windows.SystemColors.ControlLightLightBrush;


### PR DESCRIPTION
The Pipeline Tool remembers the size of the panels and the size, position of the window and wether it was maximized.
The information get stored in the `Settings.xml`. If this file doesn't exist the hard-coded values from the earlier version will be used. The informations will be stored when the user closes the window.

I've used some of the `PipelineSettings` members which weren't used. Of course I will change that if the members were indeed used somewhere.

Fixes #6430 