### PR TITLE
[DesktopGL] Add left and right mouse button event handlers

### DIFF
--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -117,6 +117,28 @@ namespace Microsoft.Xna.Framework {
 
 #endif
 
+#if DESKTOPGL
+        /// <summary>
+        /// Use this event to receive all left mouse button presses and releases.
+        /// This includes sub-frame events. Handlers are called at the beginning of a frame, before game updates.
+        /// <remarks>
+        /// This event is only supported on the DesktopGL platforms.
+        /// </remarks>
+        /// </summary>
+        public event EventHandler<ButtonState> LeftButtonInput;
+
+        /// <summary>
+        /// Use this event to receive all right mouse button presses and releases.
+        /// This includes sub-frame events. Handlers are called at the beginning of a frame, before game updates.
+        /// <remarks>
+        /// This event is only supported on the DesktopGL platforms.
+        /// </remarks>
+        /// </summary>
+        public event EventHandler<ButtonState> RightButtonInput;
+        internal bool IsLeftButtonInputHandled { get { return LeftButtonInput != null; } }
+        internal bool IsRightButtonInputHandled { get { return RightButtonInput != null; } }
+#endif
+
         #endregion Events
 
         public abstract void BeginScreenDeviceChange (bool willBeFullScreen);
@@ -169,6 +191,17 @@ namespace Microsoft.Xna.Framework {
 	    {
             EventHelpers.Raise(this, KeyUp, e);
 	    }
+#endif
+
+#if DESKTOPGL
+        internal void OnLeftButtonInput(ButtonState e)
+        {
+            EventHelpers.Raise(this, LeftButtonInput, e);
+        }
+        internal void OnRightButtonInput(ButtonState e)
+        {
+            EventHelpers.Raise(this, RightButtonInput, e);
+        }
 #endif
 
         protected internal abstract void SetSupportedOrientations (DisplayOrientation orientations);

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -123,6 +123,8 @@ internal static class Sdl
         public Joystick.DeviceEvent JoystickDevice;
         [FieldOffset(0)]
         public GameController.DeviceEvent ControllerDevice;
+        [FieldOffset(0)]
+        public Mouse.ButtonEvent Button;
     }
 
     public struct Rectangle
@@ -598,6 +600,21 @@ internal static class Sdl
             X2Mask = 1 << 4
         }
 
+        public enum ButtonOrdinal : byte
+        {
+            Left = 1,
+            Middle = 2,
+            Right = 3,
+            X1 = 4,
+            X2 = 5,
+        }
+
+        public enum ButtonState : byte
+        {
+            Released = 0,
+            Pressed = 1,
+        }
+
         public enum SystemCursor
         {
             Arrow,
@@ -629,6 +646,20 @@ internal static class Sdl
             public int Y;
             public int Xrel;
             public int Yrel;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct ButtonEvent
+        {
+            public EventType Type;
+            public uint TimeStamp;
+            public uint WindowId;
+            public uint Which;
+            public ButtonOrdinal Button;
+            public ButtonState State;
+            public byte Clicks;
+            public int X;
+            public int Y;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
@@ -132,6 +132,22 @@ namespace Microsoft.Xna.Framework
                         Window.MouseState.X = ev.Motion.X;
                         Window.MouseState.Y = ev.Motion.Y;
                         break;
+                    case Sdl.EventType.MouseButtonDown:
+                        if (_view.IsLeftButtonInputHandled
+                            && ev.Button.Button == Sdl.Mouse.ButtonOrdinal.Left)
+                            _view.OnLeftButtonInput(ButtonState.Pressed);
+                        else if (_view.IsRightButtonInputHandled
+                                 && ev.Button.Button == Sdl.Mouse.ButtonOrdinal.Right)
+                            _view.OnRightButtonInput(ButtonState.Pressed);
+                        break;
+                    case Sdl.EventType.MouseButtonup:
+                        if (_view.IsLeftButtonInputHandled
+                            && ev.Button.Button == Sdl.Mouse.ButtonOrdinal.Left)
+                            _view.OnLeftButtonInput(ButtonState.Released);
+                        else if (_view.IsRightButtonInputHandled
+                                 && ev.Button.Button == Sdl.Mouse.ButtonOrdinal.Right)
+                            _view.OnRightButtonInput(ButtonState.Released);
+                        break;
                     case Sdl.EventType.KeyDown:
                     {
                         var key = KeyboardUtil.ToXna(ev.Key.Keysym.Sym);


### PR DESCRIPTION
[DesktopGL] Add left and right mouse button event handlers and trigger them from the event polling.

This allows client applications to handle sub-frame mouse events.
Addresses issue MonoGame#5988 [Mac OS X] Tap on trackpad not works correctly
This is only for the DesktopGL version as the issue has only been reported on Mac OS.
Three-finger tap for middle mouse button is not reported by SDL as a button event so no event handler has been added for the middle mouse button.