### PR TITLE
[Android] Fixed surface recreation when resuming from sleep mode on FireTV

### DIFF
--- a/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Xna.Framework
         volatile InternalState _internalState = InternalState.Exited_GameThread;
 
         bool androidSurfaceAvailable = false;
+        bool needToForceRecreateSurface = false;
 
         bool glSurfaceAvailable;
         bool glContextAvailable;
@@ -111,6 +112,10 @@ namespace Microsoft.Xna.Framework
                 if (_internalState == InternalState.Running_GameThread)
                 {
                     _internalState = InternalState.ForceRecreateSurface;
+                }
+                else
+                {
+                    needToForceRecreateSurface = true;
                 }
 
             }
@@ -574,6 +579,11 @@ namespace Microsoft.Xna.Framework
 
             lock (_lockObject)
             {
+                if (needToForceRecreateSurface && _internalState == InternalState.Running_GameThread)
+                {
+                    _internalState = InternalState.ForceRecreateSurface;
+                    needToForceRecreateSurface = false;
+                }
                 currentState = _internalState;
             }
 


### PR DESCRIPTION
Fixes  #7209 

There are more details about what this fixes in the issue I opened. Essentially, the timing at which certain calls occur make it so [SurfaceChanged()](https://github.com/MonoGame/MonoGame/blob/3fde2bf96888ca7e21dc090389e59260a999401a/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs#L104-L117) gets called while _internalState is still set to Resuming_UIThread. The result is a black screen when resuming from sleep mode on FireTV.