### PR TITLE
Fix for #7195 - Add FromNativeHandle() to RenderTarget2D

### DIFF
--- a/MonoGame.Framework/Graphics/RenderTarget2D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.cs
@@ -23,7 +23,20 @@ namespace Microsoft.Xna.Framework.Graphics
             return ContentLost != null;
         }
 
-	    public RenderTarget2D(GraphicsDevice graphicsDevice, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared, int arraySize)
+        public static RenderTarget2D FromNativeHandle(GraphicsDevice graphicsDevice, IntPtr handle, int width, int height)
+        {
+            return FromNativeHandle(graphicsDevice, handle, width, height, false, SurfaceFormat.Color, DepthFormat.Depth24, 0, RenderTargetUsage.DiscardContents);
+        }
+
+        public static RenderTarget2D FromNativeHandle(GraphicsDevice graphicsDevice, IntPtr handle, int width, int height, bool mipMap, SurfaceFormat surfaceFormat, DepthFormat depthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
+        {
+            RenderTarget2D rt = new RenderTarget2D(graphicsDevice, width, height, mipMap, surfaceFormat, depthFormat, preferredMultiSampleCount, usage, SurfaceType.SwapChainRenderTarget);
+            rt.PlatformFromNativeHandle(graphicsDevice, handle, surfaceFormat, depthFormat, preferredMultiSampleCount);
+
+            return rt;
+        }
+
+        public RenderTarget2D(GraphicsDevice graphicsDevice, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared, int arraySize)
 	        : this(graphicsDevice, width, height, mipMap, preferredFormat, preferredDepthFormat, preferredMultiSampleCount, usage, SurfaceType.RenderTarget, shared, arraySize)
 	    {
 	    }

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -112,10 +112,6 @@ namespace Microsoft.Xna.Framework.Graphics
             this._levelCount = mipmap ? CalculateMipLevels(width, height) : 1;
             this.ArraySize = arraySize;
 
-            // Texture will be assigned by the swap chain.
-		    if (type == SurfaceType.SwapChainRenderTarget)
-		        return;
-
             PlatformConstruct(width, height, mipmap, format, type, shared);
         }
 

--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.DirectX.cs
@@ -206,9 +206,6 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             var desc = GetTexture2DDescription();
 
-            // override sample description with ours
-            desc.SampleDescription = _sampleDescription;
-
             desc.BindFlags |= BindFlags.RenderTarget;
             if (Mipmap)
                 desc.OptionFlags |= ResourceOptionFlags.GenerateMipMaps;

--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.OpenGL.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Xna.Framework.Graphics
             
         }
 
+        private void PlatformFromNativeHandle(GraphicsDevice graphicsDevice, IntPtr handle, SurfaceFormat surfaceFormat, DepthFormat depthFormat, int preferredMultiSampleCount)
+        {
+            throw new NotImplementedException();
+        }
+
         private void PlatformGraphicsDeviceResetting()
         {
         }

--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.Web.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.Web.cs
@@ -18,9 +18,13 @@ namespace Microsoft.Xna.Framework.Graphics
             RenderTargetUsage usage, 
             bool shared)
         {
+        }	
+		
+        private void PlatformFromNativeHandle(GraphicsDevice graphicsDevice, IntPtr handle, SurfaceFormat surfaceFormat, DepthFormat depthFormat, int preferredMultiSampleCount)
+        {
             throw new NotImplementedException();
         }
-
+		
         private void PlatformGraphicsDeviceResetting()
         {
             throw new NotImplementedException();

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
@@ -34,9 +34,13 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformConstruct(int width, int height, bool mipmap, SurfaceFormat format, SurfaceType type, bool shared)
         {
+            _sampleDescription = new SampleDescription(1, 0);
+
+            if (type == SurfaceType.SwapChainRenderTarget)
+                return;
+
             _shared = shared;
             _mipmap = mipmap;
-            _sampleDescription = new SampleDescription(1, 0);
         }
 
         private void PlatformSetData<T>(int level, T[] data, int startIndex, int elementCount) where T : struct


### PR DESCRIPTION
@Jjagg @tomspilman Let me know if this works.

Adding support for creating RenderTarget2D from native ID3D11Texture2D handle. I modeled this from the original SwapChainRenderTarget code, and it was working fine for me. However, the original code I had broke with change #5838 (and I am guessing SwapChainRenderTarget is also broken).

@Jjagg  I believe there was an error that was introduced in #5838 

You created a new SampleDescription, however, the original SampleDescription in Texture2D.DirectX wasn't being set / updated when the SurfaceType was SwapChainRenderTarget, which was causing an error when calling out to SharpDX (I believe this error will only surface when the SurfaceType is SwapChainRenderTarget, so probably would not happen otherwise).

In order to fix this, I made the change in line 210 of RenderTarget2D.DirectX.

I could be wrong.... please double check this!

@Jjagg  Update: Looks like I might have broken something with that SampleDescription change (line 210). One of the MSAA tests is failing. Would appreciate if you could give this PR a look-over and let me know how to fix the SampleDescription problem without breaking anything. This code is fairly complex, so it's hard to determine what the correct fix should be.