### PR TITLE
Fix a race condition when playing sound in worker threads

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -158,8 +158,6 @@ namespace Microsoft.Xna.Framework.Audio
             {
                 if (!SoundEffectInstancePool.SoundsAvailable)
                     throw new InstancePlayLimitException();
-
-                SoundEffectInstancePool.Remove(this);
             }
             
             // For non-XAct sounds we need to be sure the latest
@@ -168,6 +166,7 @@ namespace Microsoft.Xna.Framework.Audio
                 PlatformSetVolume(_volume * SoundEffect.MasterVolume);
 
             PlatformPlay();
+            SoundEffectInstancePool.Remove(this);
         }
 
         /// <summary>Resumes playback for a SoundEffectInstance.</summary>


### PR DESCRIPTION
When playing sounds in worker threads
(It seems `Al.SourcePlay` is blocking. So I want to put the `SoundEffect.Play()` call into worker threads), `SoundEffectInstance.Play()` will generate a race condition on: 

https://github.com/MonoGame/MonoGame/blob/develop/MonoGame.Framework/Audio/SoundEffectInstance.cs#L162  
and 
https://github.com/MonoGame/MonoGame/blob/develop/MonoGame.Framework/Audio/SoundEffectInstancePool.cs#L139 

Which will result a null `SoundEffectInstance._effect` while calling `SoundEffectInstance.PlatformPlay()`.