### PR TITLE
Fix issues with RenderTexture2D and SwapChainRenderTarget 

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/Texture.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture.DirectX.cs
@@ -26,12 +26,12 @@ namespace Microsoft.Xna.Framework.Graphics
                 return resource.SharedHandle;
         }
 
-        internal abstract void CreateTexture();
+        internal abstract Resource CreateTexture();
 
         internal Resource GetTexture()
         {
             if (_texture == null)
-                CreateTexture();
+                _texture = CreateTexture();
 
             return _texture;
         }

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private bool _shared;
         private bool _mipmap;
-        protected SampleDescription _sampleDescription;
+        private SampleDescription _sampleDescription;
 
         private SharpDX.Direct3D11.Texture2D _cachedStagingTexture;
 
@@ -130,9 +130,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 desc.Format = SharpDXHelper.ToFormat(_format);
                 desc.BindFlags = BindFlags.None;
                 desc.CpuAccessFlags = CpuAccessFlags.Read;
-                desc.SampleDescription = new SampleDescription(1, 0);
+                desc.SampleDescription = SampleDescription;
                 desc.Usage = ResourceUsage.Staging;
                 desc.OptionFlags = ResourceOptionFlags.None;
+
 
                 _cachedStagingTexture = new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc);
             }
@@ -230,12 +231,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
             return desc;
         }
-
-        internal override void CreateTexture()
+        internal override Resource CreateTexture()
         {
             // TODO: Move this to SetData() if we want to make Immutable textures!
             var desc = GetTexture2DDescription();
-            _texture = new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc);
+            return new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc);
         }
 
         private void PlatformReload(Stream textureStream)

--- a/MonoGame.Framework/Platform/Graphics/Texture3D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture3D.DirectX.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
 
-        internal override void CreateTexture()
+        internal override Resource CreateTexture()
         {
             var description = new Texture3DDescription
             {
@@ -57,7 +57,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
             }
 
-            _texture = new SharpDX.Direct3D11.Texture3D(GraphicsDevice._d3dDevice, description);
+            return new SharpDX.Direct3D11.Texture3D(GraphicsDevice._d3dDevice, description);
         }
 
 	    private void PlatformSetData<T>(int level,

--- a/MonoGame.Framework/Platform/Graphics/TextureCube.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/TextureCube.DirectX.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Xna.Framework.Graphics
             GetTexture();
         }
 
-        internal override void CreateTexture()
+        internal override SharpDX.Direct3D11.Resource CreateTexture()
         {
             var description = new Texture2DDescription
             {
@@ -50,7 +50,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     description.OptionFlags |= ResourceOptionFlags.GenerateMipMaps;
             }
 
-            _texture = new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, description);
+            return new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, description);
         }
 
         private void PlatformGetData<T>(CubeMapFace cubeMapFace, int level, Rectangle rect, T[] data, int startIndex, int elementCount) where T : struct

--- a/MonoGame.Framework/Platform/Media/VideoPlayer.WME.cs
+++ b/MonoGame.Framework/Platform/Media/VideoPlayer.WME.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Xna.Framework.Media
                                         Texture2D.SurfaceType.RenderTarget);
 
 			var region = new SharpDX.Mathematics.Interop.RawRectangle(0, 0, _currentVideo.Width, _currentVideo.Height);
-            _mediaEngine.TransferVideoFrame(_lastFrame._texture, null, region, null);
+            _mediaEngine.TransferVideoFrame(_lastFrame.GetTexture(), null, region, null);
 
             return _lastFrame;
         }


### PR DESCRIPTION
In this i tried to start from the beginning and recreate the fix for GetData() with MSAA.

RenderTarget2D.cs, Texture3D.DirectX.cs  and TextureCube.DirectX.cs are restored as they were before #5838, I found no need to change anything.

FYI, @Jjagg , @YTN0