### PR TITLE
Fix for #7195 - Add FromNativeHandle() to RenderTarget2D

### DIFF
--- a/MonoGame.Framework/Graphics/RenderTarget2D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.cs
@@ -23,7 +23,21 @@ namespace Microsoft.Xna.Framework.Graphics
             return ContentLost != null;
         }
 
-	    public RenderTarget2D(GraphicsDevice graphicsDevice, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared, int arraySize)
+
+        public static RenderTarget2D FromNativeHandle(GraphicsDevice graphicsDevice, IntPtr handle, int width, int height)
+        {
+            return FromNativeHandle(graphicsDevice, handle, width, height, false, SurfaceFormat.Color, DepthFormat.Depth24, 0, RenderTargetUsage.DiscardContents);
+        }
+
+        public static RenderTarget2D FromNativeHandle(GraphicsDevice graphicsDevice, IntPtr handle, int width, int height, bool mipMap, SurfaceFormat surfaceFormat, DepthFormat depthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
+        {
+            RenderTarget2D renderTarget = new RenderTarget2D(graphicsDevice, width, height, mipMap, surfaceFormat, depthFormat, preferredMultiSampleCount, usage, SurfaceType.SwapChainRenderTarget);
+            renderTarget.PlatformFromNativeHandle(handle);
+
+            return renderTarget;
+        }
+
+        public RenderTarget2D(GraphicsDevice graphicsDevice, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared, int arraySize)
 	        : base(graphicsDevice, width, height, mipMap, QuerySelectedFormat(graphicsDevice, preferredFormat), SurfaceType.RenderTarget, shared, arraySize)
 	    {
             DepthStencilFormat = preferredDepthFormat;

--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.OpenGL.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Xna.Framework.Graphics
             return glTarget;
         }
 
+        private void PlatformFromNativeHandle(IntPtr handle)
+        {
+            throw new NotImplementedException();
+        }
+
         private void PlatformConstruct(GraphicsDevice graphicsDevice, int width, int height, bool mipMap,
             DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared)
         {

--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.Web.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.Web.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class RenderTarget2D
     {
+        private void PlatformFromNativeHandle(IntPtr handle)
+        {
+            throw new NotImplementedException();
+        }
+		
         private void PlatformConstruct(
             GraphicsDevice graphicsDevice, 
             int width, 


### PR DESCRIPTION
@Jjagg This is an updated fix for #7195 to add support for wrapping a native ID3D11Texture2D handle. This is useful for anyone who wants to support OpenXR, since OpenXR handles the creation of the ID3D11Texture2D textures in the OpenXR runtime.

I updated this based on the new code that @nkast submitted that got merged into develop. 

Note: I tested these changes with my OpenXR code and it works without any issues.

CC: @tomspilman 