### PR TITLE
Renamed all instances of MonoGame.Utilities to MonoGame.Framework.Utilities

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -6,7 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline
 {

--- a/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
@@ -11,7 +11,7 @@ using System.Reflection;
 using Assimp;
 using Assimp.Unmanaged;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline
 {

--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 {

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -9,7 +9,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Win32;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 using Glyph = Microsoft.Xna.Framework.Content.Pipeline.Graphics.Glyph;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Processors

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ReflectiveWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ReflectiveWriter.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
 {

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Xml;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 {

--- a/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
@@ -7,7 +7,7 @@ using System.IO;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
 using FreeImageAPI;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 using StbImageSharp;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline

--- a/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPI.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/FreeImageAPI.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace FreeImageAPI
 {

--- a/MonoGame.Framework/Audio/Xact/SoundBank.cs
+++ b/MonoGame.Framework/Audio/Xact/SoundBank.cs
@@ -3,10 +3,9 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.IO;
-using System.Diagnostics;
 using System.Collections.Generic;
-using MonoGame.Utilities;
+using System.Diagnostics;
+using System.IO;
 
 namespace Microsoft.Xna.Framework.Audio
 {

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 using Microsoft.Xna.Framework.Graphics;
 using System.Globalization;
 

--- a/MonoGame.Framework/Content/ContentReader.cs
+++ b/MonoGame.Framework/Content/ContentReader.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {

--- a/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
@@ -3,7 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {

--- a/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {

--- a/MonoGame.Framework/Content/ContentReaders/EffectMaterialReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectMaterialReader.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {

--- a/MonoGame.Framework/Content/ContentReaders/ListReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ListReader.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework.Content;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {

--- a/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
@@ -3,7 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {

--- a/MonoGame.Framework/Content/ContentReaders/SongReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SongReader.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 using Microsoft.Xna.Framework.Media;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -7,7 +7,7 @@ using System.Collections;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -446,7 +446,7 @@ namespace Microsoft.Xna.Framework
                 var sleepTime = (TargetElapsedTime - _accumulatedElapsedTime).TotalMilliseconds;
                 // We only have a precision timer on Windows, so other platforms may still overshoot
 #if WINDOWS && !DESKTOPGL
-                MonoGame.Utilities.TimerHelper.SleepForNoMoreThan(sleepTime);
+                MonoGame.Framework.Utilities.TimerHelper.SleepForNoMoreThan(sleepTime);
 #elif WINDOWS_UAP
                 lock (_locker)
                     if (sleepTime >= 2.0)

--- a/MonoGame.Framework/GameServiceContainer.cs
+++ b/MonoGame.Framework/GameServiceContainer.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework
 {

--- a/MonoGame.Framework/Graphics/Effect/EffectResource.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectResource.cs
@@ -3,7 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System.IO;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Graphics
 {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 using System.Runtime.InteropServices;
 
 

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -6,7 +6,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Graphics
 {

--- a/MonoGame.Framework/Graphics/Texture3D.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Graphics
 {

--- a/MonoGame.Framework/Graphics/TextureCube.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Graphics
 {

--- a/MonoGame.Framework/Graphics/Vertices/DynamicVertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/DynamicVertexBuffer.cs
@@ -3,7 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Graphics
 {

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.cs
@@ -3,7 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Graphics
 {

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
@@ -3,7 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Graphics
 {

--- a/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Graphics
 {

--- a/MonoGame.Framework/Platform/Audio/Microphone.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/Microphone.OpenAL.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 #if OPENAL
 using MonoGame.OpenAL;

--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework.Audio;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 using System.IO;
 
 namespace MonoGame.OpenAL

--- a/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 using System.Runtime.InteropServices;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 using MonoGame.OpenAL;
 using MonoGame.OpenGL;
 

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Diagnostics;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 #if __IOS__ || __TVOS__ || MONOMAC
 using ObjCRuntime;

--- a/MonoGame.Framework/Platform/Graphics/Shader/ConstantBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Shader/ConstantBuffer.OpenGL.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
             }
 
-            HashKey = MonoGame.Utilities.Hash.ComputeHash(data);
+            HashKey = MonoGame.Framework.Utilities.Hash.ComputeHash(data);
         }
 
         private void PlatformClear()

--- a/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             _glslCode = System.Text.Encoding.ASCII.GetString(shaderBytecode);
 
-            HashKey = MonoGame.Utilities.Hash.ComputeHash(shaderBytecode);
+            HashKey = MonoGame.Framework.Utilities.Hash.ComputeHash(shaderBytecode);
         }
 
         internal int GetShaderHandle()

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 #if IOS
 using UIKit;

--- a/MonoGame.Framework/Platform/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/TextureCube.OpenGL.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 using MonoGame.OpenGL;
 using GLPixelFormat = MonoGame.OpenGL.PixelFormat;
 using PixelFormat = MonoGame.OpenGL.PixelFormat;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Graphics
 {

--- a/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Input
 {

--- a/MonoGame.Framework/Platform/Input/MouseCursor.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/MouseCursor.SDL.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Input
 {

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Text;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 internal static class Sdl
 {

--- a/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework
 {

--- a/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Reflection;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework
 {

--- a/MonoGame.Framework/Platform/TitleContainer.Desktop.cs
+++ b/MonoGame.Framework/Platform/TitleContainer.Desktop.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework
 {

--- a/MonoGame.Framework/Platform/Utilities/AssemblyHelper.cs
+++ b/MonoGame.Framework/Platform/Utilities/AssemblyHelper.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Reflection;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
     internal static class AssemblyHelper
     {

--- a/MonoGame.Framework/Platform/Utilities/CurrentPlatform.cs
+++ b/MonoGame.Framework/Platform/Utilities/CurrentPlatform.cs
@@ -5,7 +5,7 @@
 using System.Runtime.InteropServices;
 using System;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
     internal enum OS
     {

--- a/MonoGame.Framework/Platform/Utilities/FuncLoader.Desktop.cs
+++ b/MonoGame.Framework/Platform/Utilities/FuncLoader.Desktop.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
     internal class FuncLoader
     {

--- a/MonoGame.Framework/Platform/Utilities/InteropHelpers.cs
+++ b/MonoGame.Framework/Platform/Utilities/InteropHelpers.cs
@@ -6,7 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
     internal static class InteropHelpers
     {

--- a/MonoGame.Framework/Platform/Utilities/ReflectionHelpers.Default.cs
+++ b/MonoGame.Framework/Platform/Utilities/ReflectionHelpers.Default.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
     internal static partial class ReflectionHelpers
     {

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using MonoGame.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework
 {

--- a/MonoGame.Framework/Utilities/ByteBufferPool.cs
+++ b/MonoGame.Framework/Utilities/ByteBufferPool.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
     internal class ByteBufferPool
     {

--- a/MonoGame.Framework/Utilities/Deflate/CRC32.cs
+++ b/MonoGame.Framework/Utilities/Deflate/CRC32.cs
@@ -28,7 +28,7 @@
 
 using System;
 
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
     /// <summary>
     ///   Computes a CRC-32. The CRC-32 algorithm is parameterized - you

--- a/MonoGame.Framework/Utilities/Deflate/Deflate.cs
+++ b/MonoGame.Framework/Utilities/Deflate/Deflate.cs
@@ -69,7 +69,7 @@
 
 using System;
 
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
 
     internal enum BlockState

--- a/MonoGame.Framework/Utilities/Deflate/DeflateStream.cs
+++ b/MonoGame.Framework/Utilities/Deflate/DeflateStream.cs
@@ -27,7 +27,7 @@
 
 using System;
 
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
     /// <summary>
     /// A class for compressing and decompressing streams using the Deflate algorithm.
@@ -520,9 +520,9 @@ namespace MonoGame.Utilities.Deflate
         {
             get
             {
-                if (this._baseStream._streamMode == MonoGame.Utilities.Deflate.ZlibBaseStream.StreamMode.Writer)
+                if (this._baseStream._streamMode == MonoGame.Framework.Utilities.Deflate.ZlibBaseStream.StreamMode.Writer)
                     return this._baseStream._z.TotalBytesOut;
-                if (this._baseStream._streamMode == MonoGame.Utilities.Deflate.ZlibBaseStream.StreamMode.Reader)
+                if (this._baseStream._streamMode == MonoGame.Framework.Utilities.Deflate.ZlibBaseStream.StreamMode.Reader)
                     return this._baseStream._z.TotalBytesIn;
                 return 0;
             }

--- a/MonoGame.Framework/Utilities/Deflate/GZipStream.cs
+++ b/MonoGame.Framework/Utilities/Deflate/GZipStream.cs
@@ -30,7 +30,7 @@
 using System;
 using System.IO;
 
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
     /// <summary>
     ///   A class for compressing and decompressing GZIP streams.
@@ -46,7 +46,7 @@ namespace MonoGame.Utilities.Deflate
     ///
     /// <para>
     ///   Like the <c>System.IO.Compression.GZipStream</c> in the .NET Base Class Library, the
-    ///   <c>MonoGame.Utilities.Deflate.GZipStream</c> can compress while writing, or decompress while
+    ///   <c>MonoGame.Framework.Utilities.Deflate.GZipStream</c> can compress while writing, or decompress while
     ///   reading, but not vice versa.  The compression method used is GZIP, which is
     ///   documented in <see href="http://www.ietf.org/rfc/rfc1952.txt">IETF RFC
     ///   1952</see>, "GZIP file format specification version 4.3".</para>
@@ -298,7 +298,7 @@ namespace MonoGame.Utilities.Deflate
         ///     int n= 1;
         ///     using (System.IO.Stream input = System.IO.File.OpenRead(filename))
         ///     {
-        ///         using (Stream decompressor= new MonoGame.Utilities.Deflate.GZipStream(input, CompressionMode.Decompress, true))
+        ///         using (Stream decompressor= new MonoGame.Framework.Utilities.Deflate.GZipStream(input, CompressionMode.Decompress, true))
         ///         {
         ///             using (var output = System.IO.File.Create(DecompressedFile))
         ///             {
@@ -325,7 +325,7 @@ namespace MonoGame.Utilities.Deflate
         ///     Dim working(WORKING_BUFFER_SIZE) as Byte
         ///     Dim n As Integer = 1
         ///     Using input As Stream = File.OpenRead(filename)
-        ///         Using decompressor As Stream = new MonoGame.Utilities.Deflate.GZipStream(input, CompressionMode.Decompress, True)
+        ///         Using decompressor As Stream = new MonoGame.Framework.Utilities.Deflate.GZipStream(input, CompressionMode.Decompress, True)
         ///             Using output As Stream = File.Create(UncompressedFile)
         ///                 Do
         ///                     n= decompressor.Read(working, 0, working.Length)
@@ -728,9 +728,9 @@ namespace MonoGame.Utilities.Deflate
         {
             get
             {
-                if (this._baseStream._streamMode == MonoGame.Utilities.Deflate.ZlibBaseStream.StreamMode.Writer)
+                if (this._baseStream._streamMode == MonoGame.Framework.Utilities.Deflate.ZlibBaseStream.StreamMode.Writer)
                     return this._baseStream._z.TotalBytesOut + _headerByteCount;
-                if (this._baseStream._streamMode == MonoGame.Utilities.Deflate.ZlibBaseStream.StreamMode.Reader)
+                if (this._baseStream._streamMode == MonoGame.Framework.Utilities.Deflate.ZlibBaseStream.StreamMode.Reader)
                     return this._baseStream._z.TotalBytesIn + this._baseStream._gzipHeaderByteCount;
                 return 0;
             }
@@ -751,7 +751,7 @@ namespace MonoGame.Utilities.Deflate
         /// byte[] working = new byte[WORKING_BUFFER_SIZE];
         /// using (System.IO.Stream input = System.IO.File.OpenRead(_CompressedFile))
         /// {
-        ///     using (Stream decompressor= new MonoGame.Utilities.Deflate.GZipStream(input, CompressionMode.Decompress, true))
+        ///     using (Stream decompressor= new MonoGame.Framework.Utilities.Deflate.GZipStream(input, CompressionMode.Decompress, true))
         ///     {
         ///         using (var output = System.IO.File.Create(_DecompressedFile))
         ///         {
@@ -833,7 +833,7 @@ namespace MonoGame.Utilities.Deflate
         public override void Write(byte[] buffer, int offset, int count)
         {
             if (_disposed) throw new ObjectDisposedException("GZipStream");
-            if (_baseStream._streamMode == MonoGame.Utilities.Deflate.ZlibBaseStream.StreamMode.Undefined)
+            if (_baseStream._streamMode == MonoGame.Framework.Utilities.Deflate.ZlibBaseStream.StreamMode.Undefined)
             {
                 //Console.WriteLine("GZipStream: First write");
                 if (_baseStream._wantCompress)

--- a/MonoGame.Framework/Utilities/Deflate/InfTree.cs
+++ b/MonoGame.Framework/Utilities/Deflate/InfTree.cs
@@ -62,7 +62,7 @@
 
 
 using System;
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
         
         sealed class InfTree

--- a/MonoGame.Framework/Utilities/Deflate/Inflate.cs
+++ b/MonoGame.Framework/Utilities/Deflate/Inflate.cs
@@ -63,7 +63,7 @@
 
 
 using System;
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
     sealed class InflateBlocks
     {

--- a/MonoGame.Framework/Utilities/Deflate/Tree.cs
+++ b/MonoGame.Framework/Utilities/Deflate/Tree.cs
@@ -63,7 +63,7 @@
 
 using System;
 
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
     sealed class Tree
     {

--- a/MonoGame.Framework/Utilities/Deflate/Zlib.cs
+++ b/MonoGame.Framework/Utilities/Deflate/Zlib.cs
@@ -91,7 +91,7 @@
 using System;
 using Interop=System.Runtime.InteropServices;
 
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
 
     /// <summary>

--- a/MonoGame.Framework/Utilities/Deflate/ZlibBaseStream.cs
+++ b/MonoGame.Framework/Utilities/Deflate/ZlibBaseStream.cs
@@ -27,7 +27,7 @@
 using System;
 using System.IO;
 
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
 
     internal enum ZlibStreamFlavor { ZLIB = 1950, DEFLATE = 1951, GZIP = 1952 }

--- a/MonoGame.Framework/Utilities/Deflate/ZlibCodec.cs
+++ b/MonoGame.Framework/Utilities/Deflate/ZlibCodec.cs
@@ -66,7 +66,7 @@
 
 using System;
 
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
     /// <summary>
     /// Encoder and Decoder for ZLIB and DEFLATE (IETF RFC1950 and RFC1951).

--- a/MonoGame.Framework/Utilities/Deflate/ZlibConstants.cs
+++ b/MonoGame.Framework/Utilities/Deflate/ZlibConstants.cs
@@ -63,7 +63,7 @@
 
 using System;
 
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
     /// <summary>
     /// A bunch of constants used in the Zlib interface.

--- a/MonoGame.Framework/Utilities/Deflate/ZlibStream.cs
+++ b/MonoGame.Framework/Utilities/Deflate/ZlibStream.cs
@@ -28,7 +28,7 @@
 using System;
 using System.IO;
 
-namespace MonoGame.Utilities.Deflate
+namespace MonoGame.Framework.Utilities.Deflate
 {
 
     /// <summary>
@@ -500,9 +500,9 @@ namespace MonoGame.Utilities.Deflate
         {
             get
             {
-                if (this._baseStream._streamMode == MonoGame.Utilities.Deflate.ZlibBaseStream.StreamMode.Writer)
+                if (this._baseStream._streamMode == MonoGame.Framework.Utilities.Deflate.ZlibBaseStream.StreamMode.Writer)
                     return this._baseStream._z.TotalBytesOut;
-                if (this._baseStream._streamMode == MonoGame.Utilities.Deflate.ZlibBaseStream.StreamMode.Reader)
+                if (this._baseStream._streamMode == MonoGame.Framework.Utilities.Deflate.ZlibBaseStream.StreamMode.Reader)
                     return this._baseStream._z.TotalBytesIn;
                 return 0;
             }

--- a/MonoGame.Framework/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework/Utilities/FileHelpers.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
     internal static class FileHelpers
     {

--- a/MonoGame.Framework/Utilities/Hash.cs
+++ b/MonoGame.Framework/Utilities/Hash.cs
@@ -4,7 +4,7 @@
 
 using System.IO;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
     internal static class Hash
     {

--- a/MonoGame.Framework/Utilities/Lz4Stream/Lz4DecoderStream.cs
+++ b/MonoGame.Framework/Utilities/Lz4Stream/Lz4DecoderStream.cs
@@ -9,7 +9,7 @@
 using System;
 using System.IO;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
 	internal class Lz4DecoderStream : Stream
 	{

--- a/MonoGame.Framework/Utilities/LzxStream/LzxDecoderStream.cs
+++ b/MonoGame.Framework/Utilities/LzxStream/LzxDecoderStream.cs
@@ -6,7 +6,7 @@ using System;
 using System.IO;
 using Microsoft.Xna.Framework.Content;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
     internal class LzxDecoderStream : Stream
     {

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Reflection;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
     internal static partial class ReflectionHelpers
     {

--- a/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
+++ b/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
@@ -91,7 +91,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-namespace MonoGame.Utilities
+namespace MonoGame.Framework.Utilities
 {
 
     /// <summary>

--- a/Tools/MonoGame.Effect.Compiler/Effect/EffectObject.writer.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/EffectObject.writer.cs
@@ -131,7 +131,7 @@ namespace MonoGame.Effect
 
                 // Calculate a hash code from memory stream
                 // and write it to the header.
-                var effectKey = MonoGame.Utilities.Hash.ComputeHash(memStream);
+                var effectKey = MonoGame.Framework.Utilities.Hash.ComputeHash(memStream);
                 writer.Write((Int32)effectKey);
 
                 //write content from memory stream to final stream.


### PR DESCRIPTION
As identified in the docs review, there were multiple instances of a Utilities namespace within the MonoGame framework.

To that end, all MonoGame utilities instances have been renamed to:

- MonoGame.Framework.Utilities

Resolves #7254

P.S. unclear why git has picked up other file changes, but the ONLY change in this PR is to rename the namespace and it's use.