### PR TITLE
[MGCB Editor] PropertyGrid fixes

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/Controls/PropertyGridTable.eto.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Controls/PropertyGridTable.eto.cs
@@ -15,6 +15,7 @@ namespace MonoGame.Tools.Pipeline
         private void InitializeComponent()
         {
             BackgroundColor = DrawInfo.BackColor;
+            ExpandContentWidth = true;
 
             pixel1 = new PixelLayout();
             pixel1.BackgroundColor = DrawInfo.BackColor;
@@ -25,13 +26,6 @@ namespace MonoGame.Tools.Pipeline
 
             Content = pixel1;
 
-            pixel1.Style = "Stretch";
-            drawable.Style = "Stretch";
-
-#if MONOMAC
-            drawable.Width = 10;
-#endif
-
             drawable.Paint += Drawable_Paint;
             drawable.MouseDown += Drawable_MouseDown;
             drawable.MouseUp += Drawable_MouseUp;
@@ -41,4 +35,3 @@ namespace MonoGame.Tools.Pipeline
         }
     }
 }
-

--- a/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Linux.csproj
+++ b/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Linux.csproj
@@ -30,9 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.5.0" />
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.0" />
-    <PackageReference Include="GtkSharp" Version="3.22.25.56" />
+    <PackageReference Include="Eto.Forms" Version="2.5.2" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.2" />
+    <PackageReference Include="GtkSharp" Version="3.22.25.98" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20158.1" />
   </ItemGroup>
 

--- a/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj
+++ b/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.5.0" />
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.0" />
+    <PackageReference Include="Eto.Forms" Version="2.5.2" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20158.1" />
   </ItemGroup>
 

--- a/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Windows.csproj
+++ b/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Windows.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.5.0" />
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0" />
+    <PackageReference Include="Eto.Forms" Version="2.5.2" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20158.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Newer Eto.Forms version fixed some stuff so a lot of per platform hacks have been removed.

This fixes a lot of issues on the macOS side like propertygrid being incorrect size or the cursor getting stuck on the resize cursor.