### PR TITLE
Fix loading of content with special characters in a file name

### DIFF
--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using MonoGame.Framework.Utilities;
+using  MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework
 {

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Xna.Framework
     {
         static partial void PlatformInit();
 
-        static TitleContainer() 
+        static TitleContainer()
         {
             Location = string.Empty;
             PlatformInit();

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Xna.Framework
     {
         static partial void PlatformInit();
 
-        static TitleContainer() 
+        static TitleContainer()
         {
             Location = string.Empty;
             PlatformInit();
@@ -68,7 +68,7 @@ namespace Microsoft.Xna.Framework
 
         internal static string NormalizeRelativePath(string name)
         {
-            var uri = new Uri("file:///" + name);
+            var uri = new Uri("file:///" + FileHelpers.UrlEncode(name));
             var path = uri.LocalPath;
             path = path.Substring(1);
             return path.Replace(FileHelpers.NotSeparator, FileHelpers.Separator);

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using  MonoGame.Framework.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework
 {

--- a/MonoGame.Framework/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework/Utilities/FileHelpers.cs
@@ -56,19 +56,19 @@ namespace MonoGame.Framework.Utilities
             var src = new Uri("file://" + UrlEncode(filePath));
 
             var dst = new Uri(src, UrlEncode(relativeFile));
-            // The uri now contains the path to the relativeFile with 
+            // The uri now contains the path to the relativeFile with
             // relative addresses resolved... get the local path.
             var localPath = dst.LocalPath;
 
             if (!hasForwardSlash && localPath.StartsWith("/"))
                 localPath = localPath.Substring(1);
 
-            // Convert the directory separator characters to the 
+            // Convert the directory separator characters to the
             // correct platform specific separator.
             return TrimPath(NormalizeFilePathSeparators(localPath));
         }
-		
-		internal static string UrlEncode(string url)
+
+        internal static string UrlEncode(string url)
         {
             var encoder = new UTF8Encoding();
             var safeline = new StringBuilder(encoder.GetByteCount(url) * 3);

--- a/MonoGame.Framework/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework/Utilities/FileHelpers.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 using System.Text;
-using System.Text.RegularExpressions;
+using  System.Text.RegularExpressions;
 
 namespace MonoGame.Framework.Utilities
 {

--- a/MonoGame.Framework/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework/Utilities/FileHelpers.cs
@@ -56,38 +56,19 @@ namespace MonoGame.Framework.Utilities
             var src = new Uri("file://" + UrlEncode(filePath));
 
             var dst = new Uri(src, UrlEncode(relativeFile));
-            // The uri now contains the path to the relativeFile with 
+            // The uri now contains the path to the relativeFile with
             // relative addresses resolved... get the local path.
             var localPath = dst.LocalPath;
 
             if (!hasForwardSlash && localPath.StartsWith("/"))
                 localPath = localPath.Substring(1);
 
-            // Convert the directory separator characters to the 
+            // Convert the directory separator characters to the
             // correct platform specific separator.
             return TrimPath(NormalizeFilePathSeparators(localPath));
         }
 
-        private static string TrimPath(string filePath)
-        {
-            // Remove . in filePath
-
-            while (filePath.Contains("/./"))
-                filePath = filePath.Replace("/./", "/");
-
-            while (filePath.Contains(@"\.\"))
-                filePath = filePath.Replace(@"\.\", @"\");
-
-            filePath = Regex.Replace(filePath, @"^\.(\/|\\)", string.Empty);
-
-            // Remove .. in filePath
-
-            filePath = Regex.Replace(filePath, @"[^\/\\]+(\/|\\)\.\.(\/|\\)", string.Empty);
-
-            return filePath;
-        }
-
-        private static string UrlEncode(string url)
+        internal static string UrlEncode(string url)
         {
             var encoder = new UTF8Encoding();
             var safeline = new StringBuilder(encoder.GetByteCount(url) * 3);
@@ -109,6 +90,25 @@ namespace MonoGame.Framework.Utilities
             }
 
             return safeline.ToString();
+        }
+
+        private static string TrimPath(string filePath)
+        {
+            // Remove . in filePath
+
+            while (filePath.Contains("/./"))
+                filePath = filePath.Replace("/./", "/");
+
+            while (filePath.Contains(@"\.\"))
+                filePath = filePath.Replace(@"\.\", @"\");
+
+            filePath = Regex.Replace(filePath, @"^\.(\/|\\)", string.Empty);
+
+            // Remove .. in filePath
+
+            filePath = Regex.Replace(filePath, @"[^\/\\]+(\/|\\)\.\.(\/|\\)", string.Empty);
+
+            return filePath;
         }
     }
 }

--- a/MonoGame.Framework/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework/Utilities/FileHelpers.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 using System.Text;
-using  System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 
 namespace MonoGame.Framework.Utilities
 {


### PR DESCRIPTION
Fix content loading when there are special characters like '#' or %20 in the file name/path.

Fixes #7167