### PR TITLE
WindowsDX project file needs additional paramerters for netcore style project.

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -4,8 +4,7 @@
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <DefineConstants>WINDOWS;XNADESIGNPROVIDED;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	  <UseWPF>true</UseWPF>
-	  <UseWindowsForms>true</UseWindowsForms>
+    <UseWindowsForms>true</UseWindowsForms>
     <Description>MonoGame is an open source implementation of the Microsoft XNA 4.x Framework. The goal is to make it easy for XNA developers to create cross-platform games with extremely high code reuse.
 
 This package provides you with MonoGame Framework that uses DirectX for rendering and works on Windows.</Description>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <DefineConstants>WINDOWS;XNADESIGNPROVIDED;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	  <UseWPF>true</UseWPF>
+	  <UseWindowsForms>true</UseWindowsForms>
     <Description>MonoGame is an open source implementation of the Microsoft XNA 4.x Framework. The goal is to make it easy for XNA developers to create cross-platform games with extremely high code reuse.
 
 This package provides you with MonoGame Framework that uses DirectX for rendering and works on Windows.</Description>


### PR DESCRIPTION
Following the netcore upgrade guide, a netCore csproj definition should have the following two properties set to true

```xml
<UseWPF>true</UseWPF>
<UseWindowsForms>true</UseWindowsForms>
```

Resolves #7238