### PR TITLE
Fix loading of content with special characters in a file name v2

### DIFF
--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Xna.Framework
 
         internal static string NormalizeRelativePath(string name)
         {
-            var uri = new Uri("file:///" + name);
+            var uri = new Uri("file:///" + FileHelpers.UrlEncode(name));
             var path = uri.LocalPath;
             path = path.Substring(1);
             return path.Replace(FileHelpers.NotSeparator, FileHelpers.Separator);

--- a/MonoGame.Framework/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework/Utilities/FileHelpers.cs
@@ -67,27 +67,8 @@ namespace MonoGame.Framework.Utilities
             // correct platform specific separator.
             return TrimPath(NormalizeFilePathSeparators(localPath));
         }
-
-        private static string TrimPath(string filePath)
-        {
-            // Remove . in filePath
-
-            while (filePath.Contains("/./"))
-                filePath = filePath.Replace("/./", "/");
-
-            while (filePath.Contains(@"\.\"))
-                filePath = filePath.Replace(@"\.\", @"\");
-
-            filePath = Regex.Replace(filePath, @"^\.(\/|\\)", string.Empty);
-
-            // Remove .. in filePath
-
-            filePath = Regex.Replace(filePath, @"[^\/\\]+(\/|\\)\.\.(\/|\\)", string.Empty);
-
-            return filePath;
-        }
-
-        private static string UrlEncode(string url)
+		
+		internal static string UrlEncode(string url)
         {
             var encoder = new UTF8Encoding();
             var safeline = new StringBuilder(encoder.GetByteCount(url) * 3);
@@ -109,6 +90,25 @@ namespace MonoGame.Framework.Utilities
             }
 
             return safeline.ToString();
+        }
+
+        private static string TrimPath(string filePath)
+        {
+            // Remove . in filePath
+
+            while (filePath.Contains("/./"))
+                filePath = filePath.Replace("/./", "/");
+
+            while (filePath.Contains(@"\.\"))
+                filePath = filePath.Replace(@"\.\", @"\");
+
+            filePath = Regex.Replace(filePath, @"^\.(\/|\\)", string.Empty);
+
+            // Remove .. in filePath
+
+            filePath = Regex.Replace(filePath, @"[^\/\\]+(\/|\\)\.\.(\/|\\)", string.Empty);
+
+            return filePath;
         }
     }
 }

--- a/MonoGame.Framework/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework/Utilities/FileHelpers.cs
@@ -67,8 +67,8 @@ namespace MonoGame.Framework.Utilities
             // correct platform specific separator.
             return TrimPath(NormalizeFilePathSeparators(localPath));
         }
-		
-		internal static string UrlEncode(string url)
+
+        internal static string UrlEncode(string url)
         {
             var encoder = new UTF8Encoding();
             var safeline = new StringBuilder(encoder.GetByteCount(url) * 3);


### PR DESCRIPTION
Fix content loading when there are special characters like '#' or %20 in the file name/path.

Fixes #7167

@harry-cpp I've created new PR as previous one was causing too much trouble. Mixed line endings and VS Code don't play well together.