### PR TITLE
Replace symbols for assembly references, see #7232

### DIFF
--- a/Tools/MonoGame.Content.Builder/BuildContent.cs
+++ b/Tools/MonoGame.Content.Builder/BuildContent.cs
@@ -306,7 +306,7 @@ namespace MonoGame.Content.Builder
             // so it can resolve importers, processors, writers, and types.
             foreach (var r in References)
             {
-                var assembly = r;
+                var assembly = ReplaceSymbols(r);
                 if (!Path.IsPathRooted(assembly))
                     assembly = Path.GetFullPath(Path.Combine(projectDirectory, assembly));
                 _manager.AddAssembly(assembly);


### PR DESCRIPTION
I added a call to ReplaceSymbols when the references are processed. Hope that was all to fix this.