### PR TITLE
Update documentation structure

### DIFF
--- a/Documentation/articles/getting_started/getting_started.md
+++ b/Documentation/articles/getting_started/getting_started.md
@@ -21,3 +21,7 @@ By the end of this tutorial set, you will have a working project to start buildi
 ## Migrating from MonoGame 3.7 to 3.8
 
 If you currently have a MonoGame 3.7 project and wish to upgrade it to MonoGame 3.8, please check our handy [Upgrade Guide](~/articles/migrate38.md).
+
+## Migrating from XNA to MonoGame
+
+If you currently have an XNA project or sample and wish to upgrade it to MonoGame, please check our handy [Porting guide for XNA](~/articles/porting_xna.md)

--- a/Documentation/articles/getting_started/getting_started.md
+++ b/Documentation/articles/getting_started/getting_started.md
@@ -18,10 +18,10 @@ By the end of this tutorial set, you will have a working project to start buildi
 - [Adding Content](3_adding_content.md)
 - [Adding Basic Code](4_adding_basic_code.md)
 
-## Migrating from MonoGame 3.7 to 3.8
+## Migrating from 3.7
 
 If you currently have a MonoGame 3.7 project and wish to upgrade it to MonoGame 3.8, please check our handy [Upgrade Guide](~/articles/migrate38.md).
 
-## Migrating from XNA to MonoGame
+## Migrating from XNA
 
 If you currently have an XNA project or sample and wish to upgrade it to MonoGame, please check our handy [Porting guide for XNA](~/articles/porting_xna.md)

--- a/Documentation/articles/getting_started/getting_started.md
+++ b/Documentation/articles/getting_started/getting_started.md
@@ -24,4 +24,4 @@ If you currently have a MonoGame 3.7 project and wish to upgrade it to MonoGame 
 
 ## Migrating from XNA
 
-If you currently have an XNA project or sample and wish to upgrade it to MonoGame, please check our handy [Porting guide for XNA](~/articles/porting_xna.md)
+If you currently have an XNA project or sample and wish to upgrade it to MonoGame, please check our handy [Migration guide for XNA](~/articles/migrate_xna.md)

--- a/Documentation/articles/getting_started/migrate_37.md
+++ b/Documentation/articles/getting_started/migrate_37.md
@@ -1,4 +1,4 @@
-# Migrating from MonoGame 3.7
+# Migrating from 3.7
 
 Previously MonoGame installed on your machine through an installer, but from 3.8 onwards everything is installed through NuGet packages and Visual Studio Extensions.
 

--- a/Documentation/articles/getting_started/migrate_37.md
+++ b/Documentation/articles/getting_started/migrate_37.md
@@ -1,4 +1,4 @@
-# Migrating to MonoGame 3.8
+# Migrating from MonoGame 3.7
 
 Previously MonoGame installed on your machine through an installer, but from 3.8 onwards everything is installed through NuGet packages and Visual Studio Extensions.
 

--- a/Documentation/articles/getting_started/migrate_xna.md
+++ b/Documentation/articles/getting_started/migrate_xna.md
@@ -1,4 +1,4 @@
-# Migrating from XNA to MonoGame
+# Migrating from XNA
 
 MonoGame implements the same [API](https://en.wikipedia.org/wiki/Application_programming_interface)
 as [XNA 4.0](https://docs.microsoft.com/en-us/previous-versions/windows/xna/bb200104(v=xnagamestudio.41)). That means you usually do not have to change your game code to port from XNA to

--- a/Documentation/articles/getting_started/migrate_xna.md
+++ b/Documentation/articles/getting_started/migrate_xna.md
@@ -1,4 +1,4 @@
-# Porting from XNA to MonoGame
+# Migrating from XNA to MonoGame
 
 MonoGame implements the same [API](https://en.wikipedia.org/wiki/Application_programming_interface)
 as [XNA 4.0](https://docs.microsoft.com/en-us/previous-versions/windows/xna/bb200104(v=xnagamestudio.41)). That means you usually do not have to change your game code to port from XNA to

--- a/Documentation/articles/getting_started/toc.yml
+++ b/Documentation/articles/getting_started/toc.yml
@@ -4,7 +4,7 @@
     href: 1_creating_a_new_project_vs.md
   - name: Visual Studio for Mac
     href: 1_creating_a_new_project_vsm.md
-  - name: DotNet core CLI
+  - name: .Net core CLI
     href: 1_creating_a_new_project_netcore.md    
 - name: Understanding the Code
   href: 2_understanding_the_code.md

--- a/Documentation/articles/getting_started/toc.yml
+++ b/Documentation/articles/getting_started/toc.yml
@@ -4,7 +4,7 @@
     href: 1_creating_a_new_project_vs.md
   - name: Visual Studio for Mac
     href: 1_creating_a_new_project_vsm.md
-  - name: .NET Core CLI
+  - name: .NET CLI
     href: 1_creating_a_new_project_netcore.md    
 - name: Understanding the Code
   href: 2_understanding_the_code.md

--- a/Documentation/articles/getting_started/toc.yml
+++ b/Documentation/articles/getting_started/toc.yml
@@ -12,3 +12,7 @@
   href: 3_adding_content.md
 - name: Adding Basic Code
   href: 4_adding_basic_code.md
+- name: Migrating from 3.7
+  href: migrate_37.md
+- name: Migrating from XNA
+  href: migrate_xna.md

--- a/Documentation/articles/getting_started/toc.yml
+++ b/Documentation/articles/getting_started/toc.yml
@@ -4,7 +4,7 @@
     href: 1_creating_a_new_project_vs.md
   - name: Visual Studio for Mac
     href: 1_creating_a_new_project_vsm.md
-  - name: .Net core CLI
+  - name: .NET Core CLI
     href: 1_creating_a_new_project_netcore.md    
 - name: Understanding the Code
   href: 2_understanding_the_code.md

--- a/Documentation/articles/getting_started/toc.yml
+++ b/Documentation/articles/getting_started/toc.yml
@@ -12,7 +12,3 @@
   href: 3_adding_content.md
 - name: Adding Basic Code
   href: 4_adding_basic_code.md
-- name: Migrating from 3.7
-  href: migrate_37.md
-- name: Migrating from XNA
-  href: migrate_xna.md

--- a/Documentation/articles/toc.yml
+++ b/Documentation/articles/toc.yml
@@ -15,8 +15,6 @@
   topicHref: platform_specific/platform_specific.md
 - name: Package games for distribution
   href: packaging_games.md
-- name: Porting from XNA to MonoGame
-  href: porting_xna.md
 - name: Samples and Demos
   href: samples.md
 - name: Community Tutorials

--- a/Documentation/articles/toc.yml
+++ b/Documentation/articles/toc.yml
@@ -13,6 +13,10 @@
 - name: Platform Notes
   href: platform_specific/toc.yml
   topicHref: platform_specific/platform_specific.md
+- name: Migrating from 3.7
+  href: getting_started/migrate_37.md
+- name: Migrating from XNA
+  href: getting_started/migrate_xna.md
 - name: Package games for distribution
   href: packaging_games.md
 - name: Samples and Demos


### PR DESCRIPTION
- Move 3.7 and XNA migration to Getting Started content
- Updated toc for Getting Started pages to include the migration guides
- Removed old links from header toc
- Renamed DotNet to .NET in Getting Started TOC