### PR TITLE
Template fix for DX platform, adds "UseWindowsForms" to the DX csproj

### DIFF
--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PublishReadyToRun>false</PublishReadyToRun>
     <TieredCompilation>false</TieredCompilation>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Updated DX template to include the "UseWindowsForms" tag, else this causes the error reported in #7238 

Although this (maybe others) template needs checking against any other changes made to the csproj in the Framework.

Template
```
  <PropertyGroup>
    <OutputType>WinExe</OutputType>
    <TargetFramework>netcoreapp3.1</TargetFramework>
    <PublishReadyToRun>false</PublishReadyToRun>
    <TieredCompilation>false</TieredCompilation>
    <UseWindowsForms>true</UseWindowsForms>
  </PropertyGroup>
```

Framework csproj
```
  <PropertyGroup>
    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
    <DefineConstants>WINDOWS;XNADESIGNPROVIDED;STBSHARP_INTERNAL</DefineConstants>
    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
    <UseWindowsForms>true</UseWindowsForms>
    <Description>The MonoGame runtime for Windows using DirectX API's.</Description>
    <PackageTags>monogame;.net core;core;.net standard;standard;windowsdx</PackageTags>
    <PackageId>MonoGame.Framework.WindowsDX</PackageId>
  </PropertyGroup>
```

Granted some tags are only added for NuGet package reference.