### PR TITLE
Explicitly document BackToFront and FrontToBack use an unstable sort.

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteSortMode.cs
+++ b/MonoGame.Framework/Graphics/SpriteSortMode.cs
@@ -23,10 +23,12 @@ namespace Microsoft.Xna.Framework.Graphics
         Texture,
         /// <summary>
         /// Same as <see cref="SpriteSortMode.Deferred"/>, except sprites are sorted by depth in back-to-front order prior to drawing.
+        /// An unstable sort is used, which means sprites with equal depth may not have their order preserved.
         /// </summary>
         BackToFront,
         /// <summary>
         /// Same as <see cref="SpriteSortMode.Deferred"/>, except sprites are sorted by depth in front-to-back order prior to drawing.
+        /// An unstable sort is used, which means sprites with equal depth may not have their order preserved.
         /// </summary>
         FrontToBack
     }


### PR DESCRIPTION
#3856

If two sprites have the same depth, their draw order isn't guaranteed to be preserved when sorting with `SpriteSortMode.BackToFront` or `SpriteSortMode.FrontToBack`. Using a stable sort is expensive, but as @Jjagg mentioned, wanted to document this for easier reference.

(Side note that I'm relatively new to contributing to OSS, please let me know if I'm missing anything.)