### PR TITLE
Fix multisampling in DesktopGL

### DIFF
--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Xna.Framework
         private GraphicsProfile _graphicsProfile;
         // dirty flag for ApplyChanges
         private bool _shouldApplyChanges;
-        private int? _initMultiSampleCount;
 
         /// <summary>
         /// The default back buffer width.
@@ -97,12 +96,6 @@ namespace Microsoft.Xna.Framework
             _game.Services.AddService(typeof(IGraphicsDeviceService), this);
         }
 
-        public GraphicsDeviceManager(Game game, int multiSampleCount) : this(game)
-        {
-            _initMultiSampleCount = multiSampleCount;
-            PreferMultiSampling = true;
-        }
-
         ~GraphicsDeviceManager()
         {
             Dispose(false);
@@ -115,10 +108,11 @@ namespace Microsoft.Xna.Framework
 
             try
             {
-                if (!_initialized)
-                    Initialize();
-
                 var gdi = DoPreparingDeviceSettings();
+
+                if (!_initialized)
+                    Initialize(gdi);
+
                 CreateDevice(gdi);
             }
             catch (NoSuitableGraphicsDeviceException)
@@ -375,18 +369,12 @@ namespace Microsoft.Xna.Framework
 
         partial void PlatformInitialize(PresentationParameters presentationParameters);
 
-        private void Initialize()
+        private void Initialize(GraphicsDeviceInformation gdi)
         {
             _game.Window.SetSupportedOrientations(_supportedOrientations);
 
-            var presentationParameters = new PresentationParameters();
-            PreparePresentationParameters(presentationParameters);
-
-            if (_initMultiSampleCount.HasValue)
-                presentationParameters.MultiSampleCount = _initMultiSampleCount.Value;
-
             // Allow for any per-platform changes to the presentation.
-            PlatformInitialize(presentationParameters);
+            PlatformInitialize(gdi.PresentationParameters);
 
             _initialized = true;
         }

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Xna.Framework
         private GraphicsProfile _graphicsProfile;
         // dirty flag for ApplyChanges
         private bool _shouldApplyChanges;
+        private int? _initMultiSampleCount;
 
         /// <summary>
         /// The default back buffer width.
@@ -94,6 +95,12 @@ namespace Microsoft.Xna.Framework
 
             _game.Services.AddService(typeof(IGraphicsDeviceManager), this);
             _game.Services.AddService(typeof(IGraphicsDeviceService), this);
+        }
+
+        public GraphicsDeviceManager(Game game, int multiSampleCount) : this(game)
+        {
+            _initMultiSampleCount = multiSampleCount;
+            PreferMultiSampling = true;
         }
 
         ~GraphicsDeviceManager()
@@ -375,15 +382,14 @@ namespace Microsoft.Xna.Framework
             var presentationParameters = new PresentationParameters();
             PreparePresentationParameters(presentationParameters);
 
-            EventHelpers.Raise(this, BeforeDeviceCreated, presentationParameters);
+            if (_initMultiSampleCount.HasValue)
+                presentationParameters.MultiSampleCount = _initMultiSampleCount.Value;
 
             // Allow for any per-platform changes to the presentation.
             PlatformInitialize(presentationParameters);
 
             _initialized = true;
         }
-
-        public event EventHandler<PresentationParameters> BeforeDeviceCreated;
 
         private void UpdateTouchPanel(object sender, EventArgs eventArgs)
         {

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -375,11 +375,15 @@ namespace Microsoft.Xna.Framework
             var presentationParameters = new PresentationParameters();
             PreparePresentationParameters(presentationParameters);
 
+            EventHelpers.Raise(this, BeforeDeviceCreated, presentationParameters);
+
             // Allow for any per-platform changes to the presentation.
             PlatformInitialize(presentationParameters);
 
             _initialized = true;
         }
+
+        public event EventHandler<PresentationParameters> BeforeDeviceCreated;
 
         private void UpdateTouchPanel(object sender, EventArgs eventArgs)
         {

--- a/MonoGame.Framework/Platform/GraphicsDeviceManager.SDL.cs
+++ b/MonoGame.Framework/Platform/GraphicsDeviceManager.SDL.cs
@@ -43,6 +43,12 @@ namespace Microsoft.Xna.Framework
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.ContextMajorVersion, 2);
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.ContextMinorVersion, 1);
 
+            if (presentationParameters.MultiSampleCount > 0)
+            {
+                Sdl.GL.SetAttribute(Sdl.GL.Attribute.MultiSampleBuffers, 1);
+                Sdl.GL.SetAttribute(Sdl.GL.Attribute.MultiSampleSamples, presentationParameters.MultiSampleCount);
+            }
+
             ((SdlGameWindow)SdlGameWindow.Instance).CreateWindow();
         }
     }


### PR DESCRIPTION
This is a quick and dirty fix to make multisampling work in DesktopGL.

The problem seems to be that OpenGL doesn't let you change the multisampling params after the window has been created, so they need to be passed to SDL before that point, in `PlatformInitialize()`. There was no way for the user to do that though because setting params via `graphics.GraphicsDevice` or through the `PreparingDeviceSettings` event are too late since `PlatformInitialize()` has already run. To deal with this, I added another event that is raised right before `PlatformInitialize()` so the user can pass the multisample count at that point.

The game code for enabling multisampling would look like this:

```csharp
        public Game1()
        {
            graphics = new GraphicsDeviceManager(this);
            graphics.PreferMultiSampling = true;
            graphics.BeforeDeviceCreated += Graphics_BeforeDeviceCreated;
            Content.RootDirectory = "Content";
        }

        private void Graphics_BeforeDeviceCreated(object sender, PresentationParameters e)
        {
            e.MultiSampleCount = 16;
        }
```