### PR TITLE
Added IEffectBones interface, implemented by SkinnedEffect.

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/IEffectBones.cs
+++ b/MonoGame.Framework/Graphics/Effect/IEffectBones.cs
@@ -1,51 +1,14 @@
-﻿// #region License
-// /*
-// Microsoft Public License (Ms-PL)
-// MonoGame - Copyright © 2009 The MonoGame Team
-// 
-// All rights reserved.
-// 
-// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-// accept the license, do not use the software.
-// 
-// 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-// U.S. copyright law.
-// 
-// A "contribution" is the original software, or any additions or changes to the software.
-// A "contributor" is any person that distributes its contribution under this license.
-// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-// 
-// 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-// 
-// 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-// your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-// notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-// code form, you may only do so under a license that complies with this license.
-// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-// purpose and non-infringement.
-// */
-// #endregion License
-// 
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
-    /// The common effect bones transforms parameters.
+    /// Interface for Effects that support bone transforms.
     /// </summary>
-	public interface IEffectBones
+    public interface IEffectBones
     {
         /// <summary>
         /// Sets an array of skinning bone transform matrices.

--- a/MonoGame.Framework/Graphics/Effect/IEffectBones.cs
+++ b/MonoGame.Framework/Graphics/Effect/IEffectBones.cs
@@ -1,0 +1,56 @@
+﻿// #region License
+// /*
+// Microsoft Public License (Ms-PL)
+// MonoGame - Copyright © 2009 The MonoGame Team
+// 
+// All rights reserved.
+// 
+// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+// accept the license, do not use the software.
+// 
+// 1. Definitions
+// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+// U.S. copyright law.
+// 
+// A "contribution" is the original software, or any additions or changes to the software.
+// A "contributor" is any person that distributes its contribution under this license.
+// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
+// 
+// 2. Grant of Rights
+// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+// 
+// 3. Conditions and Limitations
+// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+// your patent license from such contributor to the software ends automatically.
+// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+// notices that are present in the software.
+// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+// code form, you may only do so under a license that complies with this license.
+// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+// purpose and non-infringement.
+// */
+// #endregion License
+// 
+using System;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    /// <summary>
+    /// The common effect bones transforms parameters.
+    /// </summary>
+	public interface IEffectBones
+    {
+        /// <summary>
+        /// Sets an array of skinning bone transform matrices.
+        /// </summary>
+        void SetBoneTransforms(Matrix[] boneTransforms);
+    }
+}
+

--- a/MonoGame.Framework/Graphics/Effect/SkinnedEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/SkinnedEffect.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Xna.Framework.Graphics
     /// <summary>
     /// Built-in effect for rendering skinned character models.
     /// </summary>
-    public class SkinnedEffect : Effect, IEffectMatrices, IEffectLights, IEffectFog
+    public class SkinnedEffect : Effect, IEffectMatrices, IEffectLights, IEffectFog, IEffectBones
     {
         public const int MaxBones = 72;
         


### PR DESCRIPTION
This PR adds a convenience interface IEffectBones, which must be implemented by all shaders supporting skinning.

For years, MonoGame has relied on the good old SkinnedEffect, but as new skinned effects are on the way, a generic way of setting the bone matrices is required, in the same way as IEffectTransform, IEffectLights, etc.