### PR TITLE
Updated Matrix.CreatePerspective* to support infinite far planes.

### DIFF
--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -914,7 +914,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="width">Width of the viewing volume.</param>
         /// <param name="height">Height of the viewing volume.</param>
         /// <param name="nearPlaneDistance">Distance to the near plane.</param>
-        /// <param name="farPlaneDistance">Distance to the far plane.</param>
+        /// <param name="farPlaneDistance">Distance to the far plane, or <see cref="float.PositiveInfinity"/>.</param>
         /// <param name="result">The new projection <see cref="Matrix"/> for perspective view as an output parameter.</param>
         public static void CreatePerspective(float width, float height, float nearPlaneDistance, float farPlaneDistance, out Matrix result)
         {
@@ -930,15 +930,18 @@ namespace Microsoft.Xna.Framework
 		    {
 		        throw new ArgumentException("nearPlaneDistance >= farPlaneDistance");
 		    }
-		    result.M11 = (2f * nearPlaneDistance) / width;
-		    result.M12 = result.M13 = result.M14 = 0f;
-		    result.M22 = (2f * nearPlaneDistance) / height;
-		    result.M21 = result.M23 = result.M24 = 0f;
-		    result.M33 = farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
-		    result.M31 = result.M32 = 0f;
-		    result.M34 = -1f;
-		    result.M41 = result.M42 = result.M44 = 0f;
-		    result.M43 = (nearPlaneDistance * farPlaneDistance) / (nearPlaneDistance - farPlaneDistance);
+
+            var negFarRange = float.IsPositiveInfinity(farPlaneDistance) ? -1.0f : farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
+
+            result.M11 = (2.0f * nearPlaneDistance) / width;
+            result.M12 = result.M13 = result.M14 = 0.0f;
+            result.M22 = (2.0f * nearPlaneDistance) / height;
+            result.M21 = result.M23 = result.M24 = 0.0f;            
+            result.M33 = negFarRange;
+            result.M31 = result.M32 = 0.0f;
+            result.M34 = -1.0f;
+            result.M41 = result.M42 = result.M44 = 0.0f;
+            result.M43 = nearPlaneDistance * negFarRange;
         }
 
         /// <summary>
@@ -947,7 +950,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="fieldOfView">Field of view in the y direction in radians.</param>
         /// <param name="aspectRatio">Width divided by height of the viewing volume.</param>
         /// <param name="nearPlaneDistance">Distance to the near plane.</param>
-        /// <param name="farPlaneDistance">Distance to the far plane.</param>
+        /// <param name="farPlaneDistance">Distance to the far plane, or <see cref="float.PositiveInfinity"/>.</param>
         /// <returns>The new projection <see cref="Matrix"/> for perspective view with FOV.</returns>
         public static Matrix CreatePerspectiveFieldOfView(float fieldOfView, float aspectRatio, float nearPlaneDistance, float farPlaneDistance)
         {
@@ -962,7 +965,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="fieldOfView">Field of view in the y direction in radians.</param>
         /// <param name="aspectRatio">Width divided by height of the viewing volume.</param>
         /// <param name="nearPlaneDistance">Distance of the near plane.</param>
-        /// <param name="farPlaneDistance">Distance of the far plane.</param>
+        /// <param name="farPlaneDistance">Distance of the far plane, or <see cref="float.PositiveInfinity"/>.</param>
         /// <param name="result">The new projection <see cref="Matrix"/> for perspective view with FOV as an output parameter.</param>
         public static void CreatePerspectiveFieldOfView(float fieldOfView, float aspectRatio, float nearPlaneDistance, float farPlaneDistance, out Matrix result)
         {
@@ -982,17 +985,20 @@ namespace Microsoft.Xna.Framework
 		    {
 		        throw new ArgumentException("nearPlaneDistance >= farPlaneDistance");
 		    }
-		    float num = 1f / ((float) Math.Tan((double) (fieldOfView * 0.5f)));
-		    float num9 = num / aspectRatio;
-		    result.M11 = num9;
-		    result.M12 = result.M13 = result.M14 = 0;
-		    result.M22 = num;
-		    result.M21 = result.M23 = result.M24 = 0;
-		    result.M31 = result.M32 = 0f;
-		    result.M33 = farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
-		    result.M34 = -1;
-		    result.M41 = result.M42 = result.M44 = 0;
-		    result.M43 = (nearPlaneDistance * farPlaneDistance) / (nearPlaneDistance - farPlaneDistance);
+
+            var yScale = 1.0f / (float)Math.Tan((double)fieldOfView * 0.5f);
+            var xScale = yScale / aspectRatio;
+            var negFarRange = float.IsPositiveInfinity(farPlaneDistance) ? -1.0f : farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
+
+            result.M11 = xScale;
+            result.M12 = result.M13 = result.M14 = 0.0f;
+            result.M22 = yScale;
+            result.M21 = result.M23 = result.M24 = 0.0f;
+            result.M31 = result.M32 = 0.0f;            
+            result.M33 = negFarRange;
+            result.M34 = -1.0f;
+            result.M41 = result.M42 = result.M44 = 0.0f;
+            result.M43 = nearPlaneDistance * negFarRange;
         }
 
         /// <summary>


### PR DESCRIPTION
As many of you are aware, `System.Numerics.Vectors` was originally designed using XNA vectors and matrices as a template, this means there's a great similarity between both APIs.

Recently, I've noticed that Microsoft updated the `System.Numerics.Vectors` `Matrix4x4.CreatePerspective` and `Matrix4x4.CreatePerspectiveFieldOfView` so they can handle positive infinity far planes.

So it felt natural to keep these methods functionality as close as possible.

The System.Numerics.Vectors code, with the new infinity functionality can be found here:

- [CreatePerspective](https://github.com/dotnet/runtime/blob/e64bc548c609455652fcd4107f1f4a2ac3084ff3/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs#L824)
- [CreatePerspectiveFieldOfView](https://github.com/dotnet/runtime/blob/e64bc548c609455652fcd4107f1f4a2ac3084ff3/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs#L860)

The funcionality of these methods has not changed for usual ranges, but now it's possible to pass `float.PositiveInfinity` as the far plane.

