### PR TITLE
Edited the Getting Started parts of the documentation for grammar, clarity, and style

### DIFF
--- a/Documentation/articles/getting_started/0_getting_started.md
+++ b/Documentation/articles/getting_started/0_getting_started.md
@@ -2,9 +2,9 @@
 
 This section walks you through the basics of MonoGame and helps you create your first game.
 
-First, select the toolset and operating system you will be working with to create your first MonoGame project and then continue your journey to understand the basic layout of a MonoGame project.
+First, select the toolset and operating system you will be working with to create your first MonoGame project, then continue reading to understand the basic layout of a MonoGame project.
 
-By the end of this tutorial set, you will have a working project to start building from for your target platform and be ready to tackle your next steps.
+By the end of this tutorial set, you will have a working project to build off of for your target platform and will be ready to tackle your next steps.
 
 ## Setting up your development environment
 

--- a/Documentation/articles/getting_started/1_setting_up_your_development_environment_macos.md
+++ b/Documentation/articles/getting_started/1_setting_up_your_development_environment_macos.md
@@ -1,6 +1,5 @@
 # Setting up your development environment for macOS
-
-In this section we will go over setting up your development environment for macOS.
+This section provides a step-by-step guide for setting up your development environment for macOS.
 
 ## Install Visual Studio for Mac
 
@@ -18,11 +17,11 @@ In the menu bar, click on **Visual Studio**, and then click on the **Extensions.
 
 ![Launch Extensions manager](~/images/getting_started/vsmac-mg-install-2.png)
 
-Next, click on the **Install from file...** button in the bottom left and select the extension file we downloaded in the previous step.
+Next, click on the **Install from file...** button in the bottom left and select the extension file you downloaded in the previous step.
 
 ![Import VSM extension](~/images/getting_started/vsmac-mg-install-3.png)
 
-And finally click on the Install button once again.
+Finally, click on the Install button once again.
 
 ![Install VSM extension](~/images/getting_started/vsmac-mg-install-4.png)
 
@@ -34,9 +33,9 @@ dotnet new --install MonoGame.Templates.CSharp
 
 ## [Optional] Install MGCB Editor
 
-MGCB Editor is a tool for editing the .mgcb files, which are used for building the content.
+MGCB Editor is a tool for editing .mgcb files, which are used for building content.
 
-If you plan on using Visual Studio for Mac, the extension we installed already contains an integrated version of this tool so you can skip this step.
+If you plan on using Visual Studio for Mac, the extension you installed already contains an integrated version of this tool, so you can skip this step.
 
 ```sh
 dotnet tool install --global dotnet-mgcb-editor
@@ -45,7 +44,7 @@ mgcb-editor --register
 
 ## [Optional] Set up Wine for effect compilation
 
-Effect compilation requires access to some DirectX compiler stuff so it can't natively work on macOS systems, however we can use it through Wine.
+Effect compilation requires access to DirectX, so it won't work natively on macOS systems, but it can be used through Wine.
 
 Install brew
 

--- a/Documentation/articles/getting_started/1_setting_up_your_development_environment_ubuntu.md
+++ b/Documentation/articles/getting_started/1_setting_up_your_development_environment_ubuntu.md
@@ -1,6 +1,6 @@
 # Setting up your development environment for Ubuntu 20.04
 
-In this section we will go over setting up your development environment for Ubuntu 20.04.
+This section provides a step-by-step guide for setting up your development environment for Ubuntu 20.04.
 
 ## Install .NET Core SDK
 
@@ -21,7 +21,7 @@ sudo apt-get install -y dotnet-sdk-3.1
 
 ## [Optional] Install mono
 
-Mono is a C# runtime, just like .NET Core, and it is not necessary to install it if you are just targeting Linux, however if you want to target some other platforms, like Android, it will be required.
+Mono is a C# runtime, just like .NET Core. If you're targeting Linux only, it's unnecessary, but if you're targeting some other platforms like Android, it's required.
 
 Add repository:
 
@@ -63,7 +63,7 @@ code --install-extension ms-dotnettools.csharp
 
 ## Install MonoGame templates
 
-This will install templates for .NET Core CLI and Rider IDE. There is no template support for MonoDevelop.
+This will install templates for .NET Core CLI and the Rider IDE. There is no template support for MonoDevelop.
 
 ```sh
 dotnet new --install MonoGame.Templates.CSharp
@@ -71,7 +71,7 @@ dotnet new --install MonoGame.Templates.CSharp
 
 ## Install MGCB Editor
 
-MGCB Editor is a tool for editing the .mgcb files, which are used for building the content.
+MGCB Editor is a tool for editing .mgcb files, which are used for building content.
 
 ```sh
 dotnet tool install --global dotnet-mgcb-editor
@@ -80,7 +80,7 @@ mgcb-editor --register
 
 ## [Optional] Set up Wine for effect compilation
 
-Effect compilation requires access to some DirectX compiler stuff so it can't natively work on Linux systems, however we can use it through Wine.
+Effect compilation requires access to DirectX, so it won't work natively on Linux systems, but it can be used through Wine.
 
 Install wine64:
 

--- a/Documentation/articles/getting_started/1_setting_up_your_development_environment_windows.md
+++ b/Documentation/articles/getting_started/1_setting_up_your_development_environment_windows.md
@@ -1,10 +1,10 @@
 # Setting up your development environment for Windows
 
-In this section we will go over setting up your development environment for Windows.
+This section provides a step-by-step guide for setting up your development environment for Windows.
 
 ## Install Visual Studio 2019
 
-You will need a copy of [Visual Studio 2019](https://visualstudio.microsoft.com/vs/) or later installed (any edition, including Community) before installing MonoGame, with the following components (depending on your target platform):
+Before installing Monogame, you'll need to install [Visual Studio 2019](https://visualstudio.microsoft.com/vs/) or later (any edition, including Community) with the following components, depending on your target platform:
 
 * .NET Core cross-platform development - For Desktop OpenGL and DirectX platforms
 * Mobile Development with .NET - For Android and iOS platforms
@@ -15,21 +15,21 @@ You will need a copy of [Visual Studio 2019](https://visualstudio.microsoft.com/
 
 ![.NET Desktop component](~/images/getting_started/1_netdesktopcomponet.png)
 
-If you are targeting standard Windows DirectX backend, you are also going to need [the DirectX June 2010 runtime](https://www.microsoft.com/en-us/download/details.aspx?id=8109) for audio and gamepads to work properly.
+If you are targeting the standard Windows DirectX backend, you'll also need [the DirectX June 2010 runtime](https://www.microsoft.com/en-us/download/details.aspx?id=8109) for audio and gamepads to work properly.
 
 ## Install MonoGame extension for Visual Studio 2019
 
-To create new projects from within Visual Studio, you will need to install the Visual Studio 2019 extension which can be found in "*Extensions -> Manage Extensions*" in the Visual Studio menu bar.
+To create new projects from within Visual Studio, you will need to install the Visual Studio 2019 extension, which can be installed from "*Extensions -> Manage Extensions*" in the Visual Studio menu bar.
 
 ![Visual Studio Extension Manager](~/images/getting_started/1_VisualStudioExtensionManager.png)
 
-Once open, simply search for **MonoGame** in the top right search window (as shown above) and install the "MonoGame project templates".  You now have the MonoGame templates installed ready to create new projects.
+Once it's open, simply search for **MonoGame** in the top right search window, as shown above, and install the "MonoGame project templates".  You now have the MonoGame templates installed, ready to create new projects.
 
 ## Install MGCB Editor
 
-MGCB Editor is a tool for editing the .mgcb files, which are used for building the content.
+MGCB Editor is a tool for editing .mgcb files, which are used for building content.
 
-To register the MGCB Editor tool with Windows and Visual Studio 2019, run the following from the Command-Prompt.
+To register the MGCB Editor tool with Windows and Visual Studio 2019, run the following from the Command Prompt.
 
 ```sh
 dotnet tool install --global dotnet-mgcb-editor

--- a/Documentation/articles/getting_started/2_creating_a_new_project_netcore.md
+++ b/Documentation/articles/getting_started/2_creating_a_new_project_netcore.md
@@ -1,6 +1,6 @@
 # .NET Core CLI
 
-This guide will walk you through building a starter game with MonoGame using only the command line/terminal on your operating system and lightweight coding tool of choice (such as [Visual Studio Code](https://code.visualstudio.com/).
+This guide will walk you through building a starter game with MonoGame using only the command line/terminal on your operating system and a lightweight coding tool of your choice (such as [Visual Studio Code](https://code.visualstudio.com/).
 
 ## Create a MonoGame Project
 
@@ -18,7 +18,7 @@ For example:
 dotnet new mgdesktopgl -o MyGame
 ```
 
-> To know which platform identifier (short name) to use for your project, please refer to [Target Platforms](~/articles/platforms/0_platforms.md) or type the following command to the command prompt to list the installed templates and their corresponding short names:
+> To know which platform identifier (short name) to use for your project, please refer to [Target Platforms](~/articles/platforms/0_platforms.md), or type the following command into the command prompt to list the installed templates and their corresponding short names:
 > 
 > ```
 > dotnet new -l

--- a/Documentation/articles/getting_started/2_creating_a_new_project_vs.md
+++ b/Documentation/articles/getting_started/2_creating_a_new_project_vs.md
@@ -10,11 +10,11 @@ You should see the "Create a new project" dialog pop up. From here, select the *
 
 ![New Template](~/images/getting_started/vswin-mg-new-2.png)
 
-Next, type in a name for your project. For this tutorial, **Pong** will be used (note: project names cannot contain spaces). After you've entered the name, click on the **...** button next to the Location text field and choose a directory to contain your project. Finally, click **OK** to create the project.
+Next, type in a name for your project. For this tutorial, **Pong** will be used (note: project names cannot contain spaces). After you've entered the name, click on the **...** button next to the Location text field and choose the folder you want to save the project in. Finally, click **OK** to create the project.
 
 ![Project Name](~/images/getting_started/vswin-mg-new-3.png)
 
-If everything went correctly, you should see a project named **Pong** (or whatever name you decided on) open up like in the picture below. To run your game, simply press the big **Play Button** in the toolbar, or press **F5**.
+If everything went correctly, you should see a project named **Pong** open up like in the picture below. To run your game, simply press the big **Play Button** in the toolbar, or press **F5**.
 
 ![Project Start](~/images/getting_started/vswin-mg-new-4.png)
 

--- a/Documentation/articles/getting_started/2_creating_a_new_project_vs.md
+++ b/Documentation/articles/getting_started/2_creating_a_new_project_vs.md
@@ -10,7 +10,7 @@ You should see the "Create a new project" dialog pop up. From here, select the *
 
 ![New Template](~/images/getting_started/vswin-mg-new-2.png)
 
-Next, type in a name for your project. For this tutorial, **Pong** will be used (*note*  project names cannot contain spaces). After you've entered the name, click on the **...** button next to the Location text field and choose a directory to contain your project. Finally, click **OK** to create the project.
+Next, type in a name for your project. For this tutorial, **Pong** will be used (note: project names cannot contain spaces). After you've entered the name, click on the **...** button next to the Location text field and choose a directory to contain your project. Finally, click **OK** to create the project.
 
 ![Project Name](~/images/getting_started/vswin-mg-new-3.png)
 

--- a/Documentation/articles/getting_started/2_creating_a_new_project_vs.md
+++ b/Documentation/articles/getting_started/2_creating_a_new_project_vs.md
@@ -1,20 +1,20 @@
 # Creating a Project with Visual Studio 2019
 
-This guide will walk you through building a starter game with MonoGame using a Windows and Visual Studio 2019.
+This guide will walk you through building a starter game with MonoGame using Windows and Visual Studio 2019.
 
 Start Visual Studio and select **New Project...** in the upper left corner.
 
 ![New Solution](~/images/getting_started/vswin-mg-new-1.png)
 
-Now you should see a "New Project" dialog pop up, from here select **Templates > Visual C# > MonoGame** category, and then select **MonoGame Cross Platform Desktop Project**.
+You should see the "Create a new project" dialog pop up. From here, select the **Templates > Visual C# > MonoGame** category, and then select **MonoGame Cross Platform Desktop Project**.
 
 ![New Template](~/images/getting_started/vswin-mg-new-2.png)
 
-Next type in the name that you wish to give your project, for this tutorial let's just use **Pong** (*note* you should not use spaces when naming the project). After you've entered the name, click on the **...** button next to the location text field, and select where you wish to save your project. Finally click **OK** to create a new project.
+Next, type in a name for your project. For this tutorial, **Pong** will be used (*note*  project names cannot contain spaces). After you've entered the name, click on the **...** button next to the Location text field and choose a directory to contain your project. Finally, click **OK** to create the project.
 
 ![Project Name](~/images/getting_started/vswin-mg-new-3.png)
 
-If everything went correctly, you should see an **Pong** project open up like in the picture below. To run your game simply press the big **Play Button** in the toolbar or press **F5**.
+If everything went correctly, you should see a project named **Pong** (or whatever name you decided on) open up like in the picture below. To run your game, simply press the big **Play Button** in the toolbar, or press **F5**.
 
 ![Project Start](~/images/getting_started/vswin-mg-new-4.png)
 

--- a/Documentation/articles/getting_started/2_creating_a_new_project_vsm.md
+++ b/Documentation/articles/getting_started/2_creating_a_new_project_vsm.md
@@ -10,11 +10,11 @@ Now you should see a "New Project" dialog pop up. From here, select the **MonoGa
 
 ![New Template](~/images/getting_started/vsmac-mg-new-2.png)
 
-On the following dialog, type in a name for your project. For this tutorial, **Pong** will be used (note: project names cannot contain spaces). After you've entered the name, click on the **Browse** button next to the Location text field and choose a directory to contain your project. Finally, click **Create** to create a new project.
+On the following dialog, type in a name for your project. For this tutorial, **Pong** will be used (note: project names cannot contain spaces). After you've entered the name, click on the **Browse** button next to the Location text field and choose the folder you want to save the project in. Finally, click **Create** to create a new project.
 
 ![Project Name](~/images/getting_started/vsmac-mg-new-3.png)
 
-If everything went correctly, you should see a project named **Pong** (or whatever name you decided on) open up like in the picture below. To run your game, simply press the big **Play Button** in the upper left corner, or press **F5**.
+If everything went correctly, you should see a project named **Pong** open up like in the picture below. To run your game, simply press the big **Play Button** in the upper left corner, or press **F5**.
 
 ![Project Start](~/images/getting_started/vsmac-mg-new-4.png)
 

--- a/Documentation/articles/getting_started/2_creating_a_new_project_vsm.md
+++ b/Documentation/articles/getting_started/2_creating_a_new_project_vsm.md
@@ -6,15 +6,15 @@ Start Visual Studio for Mac and select **New** on the right side.
 
 ![New Solution](~/images/getting_started/vsmac-mg-new-1.png)
 
-Now you should see a "New Project" dialog pop up. From here select **MonoGame > App** category, then select **MonoGame Cross Platform Desktop Project** and click **Next**.
+Now you should see a "New Project" dialog pop up. From here, select the **MonoGame > App** category, then select **MonoGame Cross Platform Desktop Project** and click **Next**.
 
 ![New Template](~/images/getting_started/vsmac-mg-new-2.png)
 
-On the following dialog, type in the name that you wish to give your project, for this tutorial let's just use **Pong** (*note* you should not use spaces when naming the project). After you've entered the name, click on the **Browse** button next to the location text field, and select where you wish to save your project. Finally, click **Create** to create a new project.
+On the following dialog, type in a name for your project. For this tutorial, **Pong** will be used (note: project names cannot contain spaces). After you've entered the name, click on the **Browse** button next to the Location text field and choose a directory to contain your project. Finally, click **Create** to create a new project.
 
 ![Project Name](~/images/getting_started/vsmac-mg-new-3.png)
 
-If everything went correctly, you should see a **Pong** project open up like in the picture below. To run your game simply press the big **Play Button** in the upper left corner or press **F5**.
+If everything went correctly, you should see a project named **Pong** (or whatever name you decided on) open up like in the picture below. To run your game, simply press the big **Play Button** in the upper left corner, or press **F5**.
 
 ![Project Start](~/images/getting_started/vsmac-mg-new-4.png)
 

--- a/Documentation/articles/getting_started/3_understanding_the_code.md
+++ b/Documentation/articles/getting_started/3_understanding_the_code.md
@@ -1,22 +1,22 @@
 # Understanding the Code
 
-This tutorial will go over the code that is getting created when you start a blank project.
+This tutorial will go over the code that is generated when you start a blank project.
 
-> For help on creating a project please look at the Creating a New Project of the [Getting Started guide](0_getting_started.md).
+> For help with creating a project, please look at the Creating a New Project section of the [Getting Started guide](0_getting_started.md).
 
-Within the Game.cs class file, which is the core of any MonoGame project, you will find several critical sections necessary for your game to run, namely:
+Within the Game.cs class file, which is the core of any MonoGame project, you will find several critical sections necessary for your game to run:
 
-* Using Statements - which add references to the various components of MonoGame.
+* Using statements - which provide easy access to the various components of MonoGame.
 
 * The Game Class definition - the heart of any MonoGame project.
 
 * The Game constructor and key variables - which tell the project how to start.
 
-* The Initialize method - to define the starting point when the game runs.
+* The Initialize method - to initialize the game upon its startup.
 
 * The Load and Unload Content methods - which are used to add and remove assets from the running game from the [Content project](4_adding_content.md).
 
-* The Update method - which is called on a regular interval to update your game state, e.g. take player input, move ships or animate entities.
+* The Update method - which is called on a regular interval to update your game state, e.g. take player input, move ships, or animate entities.
 
 * The Draw method - which is called on a regular interval to take the current game state and draw your game entities to the screen.
 
@@ -33,9 +33,9 @@ using Microsoft.Xna.Framework.Storage;
 using Microsoft.Xna.Framework.Input;
 ```
 
-These using statements are required in order to use the code that MonoGame has to offer.
+These using statements make it easier to use the code that MonoGame has to offer.
 
-The reason why they start with Microsoft.Xna.Framework is because MonoGame is an open source implementation of Microsoft Xna framework, and in order to maintain compatibility with the XNA code, it is using the same namespaces.
+They are prefixed with Microsoft.Xna.Framework because MonoGame is an open source implementation of Microsoft's XNA framework, and in order to maintain compatibility with the XNA code, it is using the same namespaces.
 
 ## The Game1 Class
 
@@ -43,16 +43,16 @@ The reason why they start with Microsoft.Xna.Framework is because MonoGame is an
 public class Game1 : Game
 ```
 
-The main Game1 class is inheriting from the Game class, which provides all the core methods for your game (ie. Load/Unload Content, Update, Draw etc.). You usually have only one Game class per game so its name isn't that important.
+The main Game1 class inherits from the Game class, which provides all the core methods for your game (ie. Load/Unload Content, Update, Draw etc.). You usually only have one Game class per game, so its name isn't that important.
 
-## Instanced Variables
+## Instance Variables
 
 ```csharp
 GraphicsDeviceManager graphics;
 SpriteBatch spriteBatch;
 ```
 
-The two default variables that the blank template starts with are GraphicsDeviceManager and SpriteBatch. Both of these variables are used for drawing stuff as you will see in a later tutorial.
+The two default variables that the blank template starts with are GraphicsDeviceManager and SpriteBatch. Both of these variables are used for drawing to the screen, as you will see in a later tutorial.
 
 ## Constructor
 
@@ -64,7 +64,7 @@ public Game1()
 }
 ```
 
-The main game constructor is used to initialize the starting variables. In this case we are creating a new GraphicsDeviceManager from our game, and are setting the folder which the game will search for content.
+The main game constructor is used to initialize the starting variables. In this case, a new GraphicsDeviceManager is created, and the root directory containing the game's content files is set.
 
 ## Initialize Method
 
@@ -77,7 +77,7 @@ protected override void Initialize()
 }
 ```
 
-This method is called after the constructor, but before the main game loop(Update/Draw). This is where you can query any required services and load any non-graphic related content.
+This method is called after the constructor but before the main game loop (Update/Draw). This is where you can query any required services and load any non-graphic related content.
 
 ## LoadContent Method
 
@@ -91,7 +91,7 @@ protected override void LoadContent()
 }
 ```
 
-This method is used to load your game content. It is called only once per game, after Initialize method, but before the main game loop methods.
+This method is used to load your game content. It is called only once per game, within the Initialize method, before the main game loop starts.
 
 ## Update Method
 
@@ -122,6 +122,6 @@ protected override void Draw(GameTime gameTime)
 }
 ```
 
-Similar to the Update method, it is also called multiple times per second.
+Similar to the Update method, this method is also called multiple times per second.
 
 **Next up:** [Adding Content](4_adding_content.md)

--- a/Documentation/articles/getting_started/3_understanding_the_code.md
+++ b/Documentation/articles/getting_started/3_understanding_the_code.md
@@ -20,7 +20,7 @@ Within the Game.cs class file, which is the core of any MonoGame project, you wi
 
 * The Draw method - which is called on a regular interval to take the current game state and draw your game entities to the screen.
 
-Read further for more detail and examples while looking through the code of your new project.
+Read further for more details and examples while looking through the code of your new project.
 
 ---
 
@@ -35,7 +35,7 @@ using Microsoft.Xna.Framework.Input;
 
 These using statements make it easier to use the code that MonoGame has to offer.
 
-They are prefixed with Microsoft.Xna.Framework because MonoGame is an open source implementation of Microsoft's XNA framework, and in order to maintain compatibility with the XNA code, it is using the same namespaces.
+They are prefixed with Microsoft.Xna.Framework because MonoGame is an open source implementation of Microsoft's XNA framework, and in order to maintain compatibility with the XNA code, it uses the same namespaces.
 
 ## The Game1 Class
 

--- a/Documentation/articles/getting_started/4_adding_content.md
+++ b/Documentation/articles/getting_started/4_adding_content.md
@@ -6,7 +6,7 @@ This tutorial will go over adding content to your game.
 
 ## MonoGame Content Builder Tool (MGCB Editor)
 
-If you haven't already, you'll need to install the MGCB-Editor for managing your content. For details on getting access to this tool, see the [installation instructions here](~/articles/tools/mgcb_editor.md).
+If you haven't already, you'll need to install the MGCB Editor for managing your content. For details on getting access to this tool, see the [installation instructions here](~/articles/tools/mgcb_editor.md).
 
 > This is technically optional, since you can edit the .mgcb files manually if you wish, but the editor is highly recommended for ease of use.
 
@@ -24,7 +24,7 @@ Now open up your game project and look at the Solution Explorer window. Expand t
 
 You should now see the MGCB Editor window open up. If a text file opens instead, then right-click on **Content.mgcb** and select **Open With**, then select **mgcb-editor-wpf** in the list, click **Set as Default** and then click **OK**, then try again.
 
-> If you do not see the **mgcb-editor-wpf** option when you right-click and select **Open With**, then please review the [Tools documentation](~/articles/tools/tools.md) for installing the MGCB Editor tool for your operating system. If you do see the option, but setting it as default still results in a text file being opened when **Content.mgcb** is clicked, try right-clicking it instead and selecting **Open Containing Folder**. This will open File Explorer, and from there you should be able to double click the MGCB file to open up the editor.
+> If you do not see the **mgcb-editor-wpf** option when you right-click and select **Open With**, then please review the [Tools documentation](~/articles/tools/tools.md) for installing the MGCB Editor tool for your operating system.
 
 ![MGCB Editor](~/images/getting_started/3_mgcb_editor_tool.png)
 

--- a/Documentation/articles/getting_started/4_adding_content.md
+++ b/Documentation/articles/getting_started/4_adding_content.md
@@ -61,7 +61,7 @@ public class Game1 : Game
     private SpriteBatch _spriteBatch;
 ```
 
-Next, find the LoadContent method. Here, retrieve the "ball" sprite from the Content project and store it in the **ballTexture** private variable using the **Content.Load()** method, with the type of content you're loading specified in the angle brackets—in this case, a Texture2D image:
+Next, find the LoadContent method. Here, use **Content.Load()** to load the "ball" sprite and store it in **ballTexture**. **Content.Load()** requires you to specify what type of content you're trying to load in, and in this case it's a Texture2D.
 
 ```csharp
 protected override void LoadContent()

--- a/Documentation/articles/getting_started/4_adding_content.md
+++ b/Documentation/articles/getting_started/4_adding_content.md
@@ -2,29 +2,29 @@
 
 This tutorial will go over adding content to your game.
 
-> For help on creating a project please look at the [Creating a New Project](0_getting_started.md) of the Getting Started guide.
+> For help with creating a project, please look at the [Creating a New Project](0_getting_started.md) section of the Getting Started guide.
 
 ## MonoGame Content Builder Tool (MGCB Editor)
 
-If you have not already, you will need to install the MGCB-Editor for managing your content, for details on getting access to the tool, see the [installation instructions here](~/articles/tools/mgcb_editor.md).
+If you haven't already, you'll need to install the MGCB-Editor for managing your content. For details on getting access to this tool, see the [installation instructions here](~/articles/tools/mgcb_editor.md).
 
-> This is optional, as you can edit the .mgcb files manually if you wish, however, it is recommended to use the tool for the extra features it gives.
+> This is technically optional, since you can edit the .mgcb files manually if you wish, but the editor is highly recommended for ease of use.
 
 ## Adding content
 
-First, you are going to need some content for your game. For this tutorial use the following image of a ball:
+First, you'll need some content for your game. For this tutorial, use the following image of a ball:
 
 ![Open Content](~/images/getting_started/ball.png)
 
 Do **right-click > Save Image As** and save it somewhere locally with the name “ball.png”.
 
-Now open up your game project and look at the Solution explorer window. Expand the **Content** folder and open up **Content.mgcb** file by double-clicking on it.
+Now open up your game project and look at the Solution Explorer window. Expand the **Content** folder and open up **Content.mgcb** file by double-clicking on it.
 
 ![Open Content](~/images/getting_started/3_open_content.png)
 
-You should now see the MGCB Editor window open up. If it does not open up (you see a text file open), then you can right-click on **Content.mgcb** and select **Open With**, then select **mgcb-editor-wpf** in the list, click **Set as Default** and then click **OK**.
+You should now see the MGCB Editor window open up. If a text file opens instead, then right-click on **Content.mgcb** and select **Open With**, then select **mgcb-editor-wpf** in the list, click **Set as Default** and then click **OK**, then try again.
 
-> If you do not see the **mgcb-editor-wpf** option when you right-click and select **Open With**, then please review the [Tools documentation](~/articles/tools/tools.md) for installing the MGCB Editor tool for your operating system.
+> If you do not see the **mgcb-editor-wpf** option when you right-click and select **Open With**, then please review the [Tools documentation](~/articles/tools/tools.md) for installing the MGCB Editor tool for your operating system. If you do see the option, but setting it as default still results in a text file being opened when **Content.mgcb** is clicked, try right-clicking it instead and selecting **Open Containing Folder**. This will open File Explorer, and from there you should be able to double click the MGCB file to open up the editor.
 
 ![MGCB Editor](~/images/getting_started/3_mgcb_editor_tool.png)
 
@@ -34,15 +34,15 @@ Your game content is managed from this external tool. You can add content to you
 - **Edit > Add > Existing Item...** menu button
 - **right-click > Add > Existing Item...** context menu
 
-In this case let us use the **Add Existing Item** toolbar button.
+Make sure the "Content" MGCB file is selected to the left, then click the **Add Existing Item** toolbar button.
 
 ![Add Content](~/images/getting_started/3_add_content.png)
 
-You should now be prompted to select a file. Select the “ball.png” image that you downloaded a moment ago, once selected you will be asked "what action you want to do when adding the file?", just leave it as the default and click **OK**.
+You should now be prompted to select a file. Select the “ball.png” image that you downloaded a moment ago. Once you've confirmed your selection, you will be asked whether to copy the file, add a link to it, or skip it. Make sure "Copy the file to the directory" is selected and click **Add**.
 
 ![Copy Content](~/images/getting_started/3_copy_content.png)
 
-Now click **Save** toolbar button and close the MGCB Editor tool.
+Now click the **Save** toolbar button and close the MGCB Editor tool.
 
 ![Save Content](~/images/getting_started/3_save_content.png)
 
@@ -50,7 +50,7 @@ Now click **Save** toolbar button and close the MGCB Editor tool.
 
 ## Adding the content in your game
 
-Now that we have added the assets to the Content project, it is time to load it in your game. First open up the **Game1.cs** class file and declare a new **ballTexture** variable of type **Texture2D** in the **Game1** class, so we can store the ball image into memory.
+Now that you have added the asset to the Content project, it's time to load it into your game. First, open up the **Game1.cs** class file and declare a new **ballTexture** variable of type **Texture2D** in the **Game1** class, so you can store the ball image into memory.
 
 ```csharp
 public class Game1 : Game
@@ -61,7 +61,7 @@ public class Game1 : Game
     private SpriteBatch _spriteBatch;
 ```
 
-Next find the LoadContent method and use it to retrieve the "ball" sprite from the Content project into the **ballTexture** private variable using the **Content.Load()** method and specifying the type of data we are requesting, in this case a Texture2D image:
+Next, find the LoadContent method. Here, retrieve the "ball" sprite from the Content project and store it in the **ballTexture** private variable using the **Content.Load()** method, with the type of content you're loading specified in the angle brackets—in this case, a Texture2D image:
 
 ```csharp
 protected override void LoadContent()
@@ -74,15 +74,15 @@ protected override void LoadContent()
 }
 ```
 
-Finally, find the Draw method, and let us draw the ball onto the screen. This is done by:
+Finally, find the Draw method and draw the ball onto the screen. This is done by:
 
 - Opening a SpriteBatch (an image drawing collection function).
 
-- Adding the images we want to draw and where we want them drawn to.
+- Adding the images you want to draw and specifying where you want to draw them.
 
-- Then finally closing the SpriteBatch to commit the textures we want drawn to the screen.
+- Then finally closing the SpriteBatch to commit the textures you want drawn to the screen.
 
-> **Note**, if you add multiple images, they will be drawn in the order you place them from back to front (each drawn on top of each other).
+> **Note**: if you add multiple images, they will be drawn in the order you place them from back to front (each drawn on top of each other).
 
 As shown below:
 
@@ -100,7 +100,7 @@ protected override void Draw(GameTime gameTime)
 }
 ```
 
-Now run the game and you should get the following:
+Now run the game. You should get the following:
 
 ![Game](~/images/getting_started/3_game.png)
 

--- a/Documentation/articles/getting_started/5_adding_basic_code.md
+++ b/Documentation/articles/getting_started/5_adding_basic_code.md
@@ -1,12 +1,12 @@
 # Adding Basic Code
 
-This tutorial will go over adding basic logic to your game. This tutorial continues where [Adding Content](4_adding_content.md) left off.
+This tutorial will go over adding basic logic to your game, continuing where [Adding Content](4_adding_content.md) left off.
 
 ---
 
 ## Positioning the content
 
-First, we need to add few new variables in the Game1.cs class file, one for position and one for speed.
+First, you need to add few new variables in the Game1.cs class file: one for position and one for speed.
 
 ```csharp
 public class Game1 : Game
@@ -16,7 +16,7 @@ public class Game1 : Game
     float ballSpeed;
 ```
 
-Next let us initialize them. Find the **Initialize** method and add the following lines.
+Next, initialize them. Find the **Initialize** method and add the following lines.
 
 ```csharp
 // TODO: Add your initialization logic here
@@ -27,9 +27,9 @@ ballSpeed = 100f;
 base.Initialize();
 ```
 
-With this, we are setting the ball starting position to the center of the screen based off the dimensions of the screen determined by the current **BackBufferWidth** and **BackBufferHeight**.
+With this, you are setting the ball's starting position to the center of the screen based off the dimensions of the screen determined by the current **BackBufferWidth** and **BackBufferHeight**.
 
-The last thing we need to do is modify the position the ball is getting drawn to.
+Last, change the Draw method to draw the ball at the correct position.
 
 Find the **Draw** method and update the **spriteBatch.Draw** call to:
 
@@ -41,7 +41,7 @@ Now run the game.
 
 ![Draw Ball 1](~/images/getting_started/4_ball_not_center.png)
 
-As you can see the ball is not quite centered yet. This is because MonoGame uses (0, 0) as the origin point of the image for drawing by default (Top Left hand corner). We can modify this by taking into account the height and width of the image when drawing, as follows:
+As you can see, the ball is not quite centered yet. That's because the default origin of a texture is its top-left corner, or (0, 0) relative to the texture, so the ball texture is drawn with its top-left corner exactly centered, rather than its center. You can specify a different origin when drawing, as shown in the following code snippet. The new origin takes into account the height and width of the image when drawing:
 
 ```csharp
 _spriteBatch.Draw(
@@ -57,7 +57,7 @@ _spriteBatch.Draw(
 );
 ```
 
-We have added a few extra parameters to the spriteBatch.Draw call, but do not worry about that for now, with this update we are setting the actual center (width / 2 and height / 2) of the image as it's origin (drawing point). 
+This change adds a few extra parameters to the spriteBatch.Draw call, but don't worry about that for now. This new code sets the actual center (width / 2 and height / 2) of the image as its origin (drawing point). 
 
 Now the image will get drawn to the center of the screen.
 
@@ -67,7 +67,7 @@ Now the image will get drawn to the center of the screen.
 
 ## Getting user input
 
-Next let's setup some movement. Find the **Update** method in the Game1.cs class file and add:
+Time to set up some movement. Find the **Update** method in the Game1.cs class file and add:
 
 ```csharp
 // TODO: Add your update logic here
@@ -88,33 +88,32 @@ if(kstate.IsKeyDown(Keys.Right))
 base.Update(gameTime);
 ```
 
-Let's discuss the code a bit.
-
-With this we are getting the current keyboard state ('Keyboard.GetState()') and storing it into a variable called **kstate**.
+The following is a line-by-line analysis of the above code.
 
 ```csharp
 var kstate = Keyboard.GetState();
 ```
+This code fetches the current keyboard state ('Keyboard.GetState()') and stores it into a variable called **kstate**.
 
-Next is just a simple check to see if the Up arrow key is pressed.
 
 ```csharp
 if (kstate.IsKeyDown(Keys.Up))
 ```
+This checks to see if the Up Arrow key is pressed.
 
-If the Up Arrow key is pressed, we move the ball by the value we set **ballSpeed**. The reason why we then multiply the **ballSpeed** by **gameTime.ElapsedGameTime.TotalSeconds** is because Update is not a fixed time and the time between update calls is not always the same, so in order to get smooth movement on the screen we multiply speed by the time since the last update method was called.
 
 ```csharp
     ballPosition.Y -= ballSpeed * (float)gameTime.ElapsedGameTime.TotalSeconds;
 ```
+If the Up Arrow key is pressed, the ball moves using the value you assigned to **ballSpeed**. The reason why **ballSpeed** is multiplied by **gameTime.ElapsedGameTime.TotalSeconds** is because, when not using fixed time step, the time between Update calls varies. To account for this, the ballSpeed is multiplied by the amount of time that has passed since the last Update call. The result is that the ball appears to move at the same speed regardless of what framerate the game happens to be running at.
 
-> Try it yourself by simply moving by the **ballSpeed** alone to see the difference and compare.
+> Try experimenting with what happens if you don't multiply the **ballSpeed** by **gameTime.ElapsedGameTime.TotalSeconds**, to see the difference it makes.
 
-The sections repeat the above for the Down, Left and Right arrow keys.
+The rest of the lines of code do the same thing but for the Down, Left and Right Arrow keys, and down, left, and right movement, respectively.
 
-If you now run the game and you should be able to move the ball with the arrow keys.
+If you run the game, you should be able to move the ball with the arrow keys.
 
-You will probably notice that you can get out of the window, so let's make it so that the ball can not escape the window. We will do this by setting bounds onto the ballPosition after it has already been moved to ensure it cannot go further than the width or height of the screen.
+You will probably notice that the ball is not confined to the window. You can fix that by setting bounds onto the ballPosition after it has already been moved to ensure it cannot go further than the width or height of the screen.
 
 ```csharp
 if(kstate.IsKeyDown(Keys.Right))
@@ -133,12 +132,12 @@ else if(ballPosition.Y < ballTexture.Height / 2)
 base.Update(gameTime);
 ```
 
-Now run the game and the ball will not be able to go beyond the window bounds anymore.
+Now run the game to test for yourself that the ball cannot go beyond the window bounds anymore.
 
 Happy Coding ^^
 
 ## Further Reading
 
-Check out the [Tutorials section](~/articles/tutorials.md) for many more helpful guides and tutorials on building games with MonoGame.  We have an expansive library of helpful content all provided by other MonoGame developers in the community.
+Check out the [Tutorials section](~/articles/tutorials.md) for many more helpful guides and tutorials on building games with MonoGame.  We have an expansive library of helpful content, all provided by other MonoGame developers in the community.
 
 Additionally, be sure to check out the official [MonoGame Samples](~/articles/samples.md) page for fully built sample projects built with MonoGame and targeting our most common platforms.

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -23,7 +23,7 @@ Based on [Microsoft's XNA Framework](https://msdn.microsoft.com/en-us/library/bb
 - Content building and optimization
 - Math library optimized for games
 
-This documentation helps you get started, providing both overviews of key features and tools and a complete API reference.
+This documentation helps you get started, providing overviews of key features and tools and a complete API reference.
 
 Please use the links at the top and left to navigate the documentation sections.
 

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -14,7 +14,7 @@ Welcome to the MonoGame documentation hub!
 
 MonoGame is a simple and powerful .NET library for creating games for desktop PCs, video game consoles, and mobile devices.
 
-Based on [Microsoft's XNA Framework](https://msdn.microsoft.com/en-us/library/bb200104.aspx) it provides the following features:
+Based on [Microsoft's XNA Framework](https://msdn.microsoft.com/en-us/library/bb200104.aspx), it provides the following features:
 
 - Game framework
 - 2D and 3D rendering
@@ -23,12 +23,12 @@ Based on [Microsoft's XNA Framework](https://msdn.microsoft.com/en-us/library/bb
 - Content building and optimization
 - Math library optimized for games
 
-This documentation helps you getting started, provides overviews of key features and tools, and the complete API reference.
+This documentation helps you get started, providing both overviews of key features and tools and a complete API reference.
 
 Please use the links at the top and left to navigate the documentation sections.
 
 ## We Need Your Help!
 
-Great open source projects require high-quality documentation.  This is a call for volunteers to continue to help us make the MonoGame documentation truly great.  If you can write tutorials, feature guides, code snippets, reference docs, video walkthroughs or just any improvement to our current documentation we could use your help!
+Great open source projects require high-quality documentation.  This is a call for volunteers to continue to help us make the MonoGame documentation truly great.  If you can create tutorials, feature guides, code snippets, reference docs, or video walkthroughs, or make any improvement to our current documentation, we could use your help!
 
 Check out the [README on GitHub](https://github.com/MonoGame/MonoGame/blob/develop/README.md) or [talk with us on the community site](http://community.monogame.net/t/lets-improve-the-monogame-documentation/916) to learn how to help!


### PR DESCRIPTION
One of the main changes I made was removing references to "we" and "let's", so as not to directly reference the author of the documentation, to maintain formality.

I also made other various edits to grammar, sentence structure, and so on.

If these changes are acceptable, I can do the same for the rest of the documentation.