### PR TITLE
Updated Existing "Getting Started" page to be the new "Downloads" page

### DIFF
--- a/Documentation/articles/getting_started/0_getting_started.md
+++ b/Documentation/articles/getting_started/0_getting_started.md
@@ -2,24 +2,57 @@
 
 This section walks you through the basics of MonoGame and helps you create your first game.
 
-First, select the toolset and operating system you will be working with to create your first MonoGame project and then continue your journey to understand the basic layout of a MonoGame project.
+## Latest Release
+
+You can find the latest stable release here:
+
+<div style="text-align: center; margin-left: 10%; width: 80%;">
+<div style="font-size: 200%;">
+<a href="https://community.monogame.net/t/monogame-3-8"><br>
+<strong>MonoGame 3.8.0.1641</strong></a></div>
+<div style="font-style: italic; color: grey; margin-top:10px;">Released August 10th, 2020</div>
+</div><br/>
+
+You can also find the latest release on [NuGet](https://www.nuget.org/profiles/MonoGame).
+
+If you are looking for old releases you can find them on our [community site](https://community.monogame.net/c/releases/30).
+
+## Installing MonoGame
+
+To get started, first, select the toolset and operating system you will be working with to create your first MonoGame project and then continue your journey to understand the basic layout of a MonoGame project.
 
 By the end of this tutorial set, you will have a working project to start building from for your target platform and be ready to tackle your next steps.
 
-## Setting up your development environment
+### Setting up your development environment
 
 - [Windows](1_setting_up_your_development_environment_windows.md)
 - [macOS](1_setting_up_your_development_environment_macos.md)
 - [Ubuntu](1_setting_up_your_development_environment_ubuntu.md)
 
-## Creating a new project
+### Creating a new project
 
 - [Visual Studio 2019](2_creating_a_new_project_vs.md)
 - [Visual Studio for Mac](2_creating_a_new_project_vsm.md)
 - [DotNet core CLI](2_creating_a_new_project_netcore.md)
 
-## Building your game
+### Building your game
 
 - [Understanding the Code](3_understanding_the_code.md)
 - [Adding Content](4_adding_content.md)
 - [Adding Basic Code](5_adding_basic_code.md)
+
+## Development Builds
+
+Add our [develop branch NuGet feed](http://teamcity.monogame.net/guestAuth/app/nuget/feed/_Root/default/v3/index.json) to your IDE for the very latest assemblies or for pre-release assemblies on NuGet.
+
+We find these releases to be generally stable, but if you do run into a bug [please report it](https://github.com/mono/MonoGame/issues) to us.
+
+## Source Code
+
+If you want to get hold of the latest source code you can get that from our [Github page](https://github.com/mono/MonoGame). The [master branch](https://github.com/mono/MonoGame/tree/master) contains the latest stable release. Finally if you want to get the latest features and fixes you can download our [develop branch](https://github.com/mono/MonoGame/tree/develop).
+
+There are [several tags](https://github.com/mono/MonoGame/tags) to get access to the snap shots of previous MonoGame releases.
+
+## Logos
+
+Looking for logos to promote the fact that your game was written using MonoGame? Get them from [GitHub](https://github.com/Mono-Game/MonoGame.Logo).

--- a/Documentation/articles/getting_started/0_getting_started.md
+++ b/Documentation/articles/getting_started/0_getting_started.md
@@ -2,40 +2,23 @@
 
 This section walks you through the basics of MonoGame and helps you create your first game.
 
-## Latest Release
-
-You can find the latest stable release here:
-
-<div style="text-align: center; margin-left: 10%; width: 80%;">
-<div style="font-size: 200%;">
-<a href="https://community.monogame.net/t/monogame-3-8"><br>
-<strong>MonoGame 3.8.0.1641</strong></a></div>
-<div style="font-style: italic; color: grey; margin-top:10px;">Released August 10th, 2020</div>
-</div><br/>
-
-You can also find the latest release on [NuGet](https://www.nuget.org/profiles/MonoGame).
-
-If you are looking for old releases you can find them on our [community site](https://community.monogame.net/c/releases/30).
-
-## Installing MonoGame
-
 To get started, first, select the toolset and operating system you will be working with to create your first MonoGame project and then continue your journey to understand the basic layout of a MonoGame project.
 
 By the end of this tutorial set, you will have a working project to start building from for your target platform and be ready to tackle your next steps.
 
-### Setting up your development environment
+## Setting up your development environment
 
 - [Windows](1_setting_up_your_development_environment_windows.md)
 - [macOS](1_setting_up_your_development_environment_macos.md)
 - [Ubuntu](1_setting_up_your_development_environment_ubuntu.md)
 
-### Creating a new project
+## Creating a new project
 
 - [Visual Studio 2019](2_creating_a_new_project_vs.md)
 - [Visual Studio for Mac](2_creating_a_new_project_vsm.md)
 - [DotNet core CLI](2_creating_a_new_project_netcore.md)
 
-### Building your game
+## Building your game
 
 - [Understanding the Code](3_understanding_the_code.md)
 - [Adding Content](4_adding_content.md)
@@ -52,6 +35,10 @@ We find these releases to be generally stable, but if you do run into a bug [ple
 If you want to get hold of the latest source code you can get that from our [Github page](https://github.com/mono/MonoGame). The [master branch](https://github.com/mono/MonoGame/tree/master) contains the latest stable release. Finally if you want to get the latest features and fixes you can download our [develop branch](https://github.com/mono/MonoGame/tree/develop).
 
 There are [several tags](https://github.com/mono/MonoGame/tags) to get access to the snap shots of previous MonoGame releases.
+
+## Previous Releases
+
+If you are looking for old MonoGame releases you can find them listed [here](https://community.monogame.net/c/releases/30).
 
 ## Logos
 

--- a/Documentation/articles/getting_started/0_getting_started.md
+++ b/Documentation/articles/getting_started/0_getting_started.md
@@ -1,7 +1,5 @@
 # Getting Started
 
-This section walks you through the basics of MonoGame and helps you create your first game.
-
 To get started, first, select the toolset and operating system you will be working with to create your first MonoGame project and then continue your journey to understand the basic layout of a MonoGame project.
 
 By the end of this tutorial set, you will have a working project to start building from for your target platform and be ready to tackle your next steps.


### PR DESCRIPTION
Updated Existing "Getting Started" page to be the new "Downloads" link target.

Recommend the Link on the main website be renamed to "Getting Started" instead of Downloads.