### PR TITLE
Fixes 3D Audio Direction Issues On Platforms Using X3DAudio

### DIFF
--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
@@ -94,9 +94,9 @@ namespace Microsoft.Xna.Framework.Audio
             //
             // Programmer Notes:         
             //  According to this description the z-axis (forward vector) is inverted between these two coordinate systems.
-            //  Therefore, we need to negate the z component of any position/velocity values, and negate any forward vectors.
+            //  Therefore, we need to negate the z component of any position/direction/velocity values.
 
-            forward *= -1.0f;
+            forward.Z *= -1.0f;
             pos.Z *= -1.0f;
             vel.Z *= -1.0f;
 
@@ -132,9 +132,9 @@ namespace Microsoft.Xna.Framework.Audio
             //
             // Programmer Notes:         
             //  According to this description the z-axis (forward vector) is inverted between these two coordinate systems.
-            //  Therefore, we need to negate the z component of any position/velocity values, and negate any forward vectors.
+            //  Therefore, we need to negate the z component of any position/direction/velocity values.
 
-            forward *= -1.0f;
+            forward.Z *= -1.0f;
             pos.Z *= -1.0f;
             vel.Z *= -1.0f;
 

--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
@@ -94,9 +94,10 @@ namespace Microsoft.Xna.Framework.Audio
             //
             // Programmer Notes:         
             //  According to this description the z-axis (forward vector) is inverted between these two coordinate systems.
-            //  Therefore, we need to negate the z component of any position/direction/velocity values.
+            //  Therefore, we need to negate the z component of any position/directions/velocity values.
 
             forward.Z *= -1.0f;
+            up.Z *= -1.0f;
             pos.Z *= -1.0f;
             vel.Z *= -1.0f;
 
@@ -132,9 +133,10 @@ namespace Microsoft.Xna.Framework.Audio
             //
             // Programmer Notes:         
             //  According to this description the z-axis (forward vector) is inverted between these two coordinate systems.
-            //  Therefore, we need to negate the z component of any position/direction/velocity values.
+            //  Therefore, we need to negate the z component of any position/directions/velocity values.
 
             forward.Z *= -1.0f;
+            up.Z *= -1.0f;
             pos.Z *= -1.0f;
             vel.Z *= -1.0f;
 


### PR DESCRIPTION
This pull request is to fix 3D audio direction issues on platforms using X3DAudio. More details on the issue can be found here: https://github.com/MonoGame/MonoGame/issues/7388

Only the Z component of the emitter/listener forward direction should be negated to swap between coordinate systems.