### PR TITLE
Don't recompile the same shader multiple times.

### DIFF
--- a/Tools/MonoGame.Effect.Compiler/Effect/EffectObject.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/EffectObject.cs
@@ -795,8 +795,15 @@ namespace MonoGame.Effect
 
         private d3dx_state CreateShader(ShaderResult shaderResult, string shaderFunction, string shaderProfile, bool isVertexShader, ref string errorsAndWarnings)
         {
-            // Compile and create the shader.
-            var shaderData = shaderResult.Profile.CreateShader(shaderResult, shaderFunction, shaderProfile, isVertexShader, this, ref errorsAndWarnings);
+            // Check if this shader has already been created.
+            var shaderData = Shaders.Find(shader => shader.ShaderFunctionName == shaderFunction && shader.ShaderProfile == shaderProfile);
+            if (shaderData == null)
+            {
+                // Compile and create the shader.
+                shaderData = shaderResult.Profile.CreateShader(shaderResult, shaderFunction, shaderProfile, isVertexShader, this, ref errorsAndWarnings);
+                shaderData.ShaderFunctionName = shaderFunction;
+                shaderData.ShaderProfile = shaderProfile;
+            }
 
             var state = new d3dx_state();
             state.index = 0;

--- a/Tools/MonoGame.Effect.Compiler/Effect/ShaderData.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ShaderData.cs
@@ -54,6 +54,10 @@ namespace MonoGame.Effect
 		// The index of the shader in the shared list.
 		public int SharedIndex { get; private set; }
 
+        public string ShaderFunctionName { get; set; }
+
+        public string ShaderProfile { get; set; }
+
 #endregion // Non-Serialized Stuff
 
 	}

--- a/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.DirectX.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.DirectX.cs
@@ -49,13 +49,6 @@ namespace MonoGame.Effect
         {
             var bytecode = EffectObject.CompileHLSL(shaderResult, shaderFunction, shaderProfile, ref errorsAndWarnings);
 
-            // First look to see if we already created this same shader.
-            foreach (var shader in effect.Shaders)
-            {
-                if (bytecode.SequenceEqual(shader.Bytecode))
-                    return shader;
-            }
-
             var shaderInfo = shaderResult.ShaderInfo;
             var shaderData = ShaderData.CreateHLSL(bytecode, isVertexShader, effect.ConstantBuffers, effect.Shaders.Count, shaderInfo.SamplerStates, shaderResult.Debug);
             effect.Shaders.Add(shaderData);

--- a/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.OpenGL.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.OpenGL.cs
@@ -51,13 +51,6 @@ namespace MonoGame.Effect
             // using MojoShader which works from HLSL bytecode.
             var bytecode = EffectObject.CompileHLSL(shaderResult, shaderFunction, shaderProfile, ref errorsAndWarnings);
 
-            // First look to see if we already created this same shader.
-            foreach (var shader in effect.Shaders)
-            {
-                if (bytecode.SequenceEqual(shader.Bytecode))
-                    return shader;
-            }
-
             var shaderInfo = shaderResult.ShaderInfo;
             var shaderData = ShaderData.CreateGLSL(bytecode, isVertexShader, effect.ConstantBuffers, effect.Shaders.Count, shaderInfo.SamplerStates, shaderResult.Debug);
             effect.Shaders.Add(shaderData);


### PR DESCRIPTION
As discussed in #7371 this should shorten compilation times whenever the same shader appears in multiple techniques.