### PR TITLE
fix 7402: enqueue buffer ref before sending to OAL

### DIFF
--- a/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.OpenAL.cs
@@ -89,9 +89,9 @@ namespace Microsoft.Xna.Framework.Audio
             }
 
             // Queue the buffer
+            _queuedBuffers.Enqueue(oalBuffer);
             AL.SourceQueueBuffer(SourceId, oalBuffer.OpenALDataBuffer);
             ALHelper.CheckError();
-            _queuedBuffers.Enqueue(oalBuffer);
 
             // If the source has run out of buffers, restart it
             var sourceState = AL.GetSourceState(SourceId);


### PR DESCRIPTION
Fixes #7402 

Moves the `Enqueue()` call to before the buffer is sent to OAL so that all attempts to dequeue all of the buffers that OAL is aware of do not try to dequeue more buffers references than have been enqueued by `DynamicSoundEffectInstance`.