### PR TITLE
Fixes Stopping Looped Sounds On Platforms Using XAudio

### DIFF
--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
@@ -204,7 +204,12 @@ namespace Microsoft.Xna.Framework.Audio
                     _voice.FlushSourceBuffers();
                 }
                 else
-                    _voice.Stop((int)PlayFlags.Tails);
+                {
+                    if (_loop)
+                        _voice.ExitLoop();
+                    else
+                        _voice.Stop((int)PlayFlags.Tails);
+                }
             }
 
             _paused = false;


### PR DESCRIPTION
This pull request is to fix stopping looped sound effects on platforms using XAudio. More details on the issue can be found under item 3 here: https://github.com/MonoGame/MonoGame/issues/7388

Stopping a looping sound with immediate set to false didn't stop the sound effect at the end of the loop. This needed ExitLoop to be called instead.