### PR TITLE
Fixes Buffer Bindings Cache Issue On Platforms Using OpenGL

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Xna.Framework.Graphics
         static readonly float[] _posFixup = new float[4];
 
         private static BufferBindingInfo[] _bufferBindingInfos;
+        private static int _activeBufferBindingInfosCount;
         private static bool[] _newEnabledVertexAttributes;
         internal static readonly List<int> _enabledVertexAttributes = new List<int>();
         internal static bool _attribsDirty;
@@ -187,6 +188,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 var offset = (IntPtr)(vertexDeclaration.VertexStride * (baseVertex + vertexBufferBinding.VertexOffset));
 
                 if (!_attribsDirty &&
+                    slot < _activeBufferBindingInfosCount &&
                     _bufferBindingInfos[slot].VertexOffset == offset &&
                     ReferenceEquals(_bufferBindingInfos[slot].AttributeInfo, attrInfo) &&
                     _bufferBindingInfos[slot].InstanceFrequency == vertexBufferBinding.InstanceFrequency &&
@@ -234,6 +236,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     foreach (var element in _bufferBindingInfos[slot].AttributeInfo.Elements)
                         _newEnabledVertexAttributes[element.AttributeLocation] = true;
                 }
+                _activeBufferBindingInfosCount = _vertexBuffers.Count;
             }
             SetVertexAttributeArray(_newEnabledVertexAttributes);
         }


### PR DESCRIPTION
This pull request is to fix a buffer bindings cache issue on platforms using OpenGL.

The issue (mentioned in https://github.com/MonoGame/MonoGame/issues/7193) is demostrated by the Draw project by OpenPachinko found here:
https://github.com/OpenPachinko/MonogameCompareBehaviors


The _bufferBindingInfos object within the GraphicsDevice contains a cache list of the last binding details for each vertex buffer slot set and is used to prevent unnecessary buffer bindings.

However when switching between using one and two vertex buffers (between non instanced and instanced draw events) the cached details of the second slot are dealt with as still being set even though they are potentially no longer current. This can cause issues as a non instanced draw call with a single vertex buffer can have overlapping element AttributeLocation values with the previously used second vertex buffer. Other details may also be out of sync.

For example in the above project the following element AttributeLocation values are used:

Draw Non Instanced
First Buffer Slot - Element Attribute Locations 0, 1

Draw Instanced
First Buffer Slot - Element Attribute Locations 2, 3, 4, 5
Second Buffer Slot - Element Attribute Locations 0, 1

One reason this appears to fail is because both the first and second buffer slots have element attribute locations that overlap  (0 & 1) between both draw events. As the cache list values match setting the second buffer is skipped even though these locations have been overwritten (the first frame will work but every frame after will fail). 

A fix for this is to treat cache list slots as inactive for vertex buffer slots that were not used in the last draw event.