### PR TITLE
proposal: additional vertex structs

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormal.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormal.cs
@@ -1,0 +1,76 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct VertexPositionColorNormal : IVertexType
+    {
+        public Vector3 Position;
+        public Color Color;
+        public Vector3 Normal;
+        public static readonly VertexDeclaration VertexDeclaration;
+
+        public VertexPositionColorNormal(Vector3 position, Color color, Vector3 normal)
+        {
+            Position = position;
+            Color = color;
+            Normal = normal;
+        }
+
+        VertexDeclaration IVertexType.VertexDeclaration
+        {
+            get
+            {
+                return VertexDeclaration;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Position.GetHashCode();
+                hashCode = (hashCode * 397) ^ Color.GetHashCode();
+                hashCode = (hashCode * 397) ^ Normal.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public override string ToString()
+        {
+            return "{{Position:" + this.Position + " Color:" + this.Color + " Normal:" + this.Normal + "}}";
+        }
+
+        public static bool operator ==(VertexPositionColorNormal left, VertexPositionColorNormal right)
+        {
+            return (((left.Position == right.Position) && (left.Color == right.Color)) && (left.Normal == right.Normal));
+        }
+
+        public static bool operator !=(VertexPositionColorNormal left, VertexPositionColorNormal right)
+        {
+            return !(left == right);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            if (obj.GetType() != base.GetType())
+                return false;
+
+            return (this == ((VertexPositionColorNormal)obj));
+        }
+
+        static VertexPositionColorNormal()
+        {
+            var elements = new VertexElement[]
+            {
+                new VertexElement(0, VertexElementFormat.Vector3, VertexElementUsage.Position, 0),
+                new VertexElement(12, VertexElementFormat.Color, VertexElementUsage.Color, 0),
+                new VertexElement(16, VertexElementFormat.Vector3, VertexElementUsage.Normal, 0)
+            };
+            VertexDeclaration = new VertexDeclaration(elements);
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormalTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormalTexture.cs
@@ -1,0 +1,80 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct VertexPositionColorNormalTexture : IVertexType
+    {
+        public Vector3 Position;
+        public Color Color;
+        public Vector3 Normal;
+        public Vector2 TextureCoordinate;
+        public static readonly VertexDeclaration VertexDeclaration;
+
+        public VertexPositionColorNormalTexture(Vector3 position, Color color, Vector3 normal, Vector2 textureCoordinate)
+        {
+            Position = position;
+            Color = color;
+            Normal = normal;
+            TextureCoordinate = textureCoordinate;
+        }
+
+        VertexDeclaration IVertexType.VertexDeclaration
+        {
+            get
+            {
+                return VertexDeclaration;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Position.GetHashCode();
+                hashCode = (hashCode * 397) ^ Color.GetHashCode();
+                hashCode = (hashCode * 397) ^ Normal.GetHashCode();
+                hashCode = (hashCode * 397) ^ TextureCoordinate.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public override string ToString()
+        {
+            return "{{Position:" + this.Position + " Color:" + this.Color + " Normal:" + this.Normal + " TextureCoordinate:" + this.TextureCoordinate + "}}";
+        }
+
+        public static bool operator ==(VertexPositionColorNormalTexture left, VertexPositionColorNormalTexture right)
+        {
+            return (((left.Position == right.Position) && (left.Color == right.Color)) && (left.Normal == right.Normal) && (left.TextureCoordinate == right.TextureCoordinate));
+        }
+
+        public static bool operator !=(VertexPositionColorNormalTexture left, VertexPositionColorNormalTexture right)
+        {
+            return !(left == right);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            if (obj.GetType() != base.GetType())
+                return false;
+
+            return (this == ((VertexPositionColorNormalTexture)obj));
+        }
+
+        static VertexPositionColorNormalTexture()
+        {
+            var elements = new VertexElement[]
+            {
+                new VertexElement(0, VertexElementFormat.Vector3, VertexElementUsage.Position, 0),
+                new VertexElement(12, VertexElementFormat.Color, VertexElementUsage.Color, 0),
+                new VertexElement(16, VertexElementFormat.Vector3, VertexElementUsage.Normal, 0),
+                new VertexElement(28, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 0)
+            };
+            VertexDeclaration = new VertexDeclaration(elements);
+        }
+    }
+}


### PR DESCRIPTION
We were discussing using different types of vertices that currently do not exist in the framework on Discord and it was suggested that I open a PR for them:
- Position-Color-Normal
- Position-Color-Normal-Texture

These are fairly simple vertex types and I'm somewhat surprised they were never in XNA to begin with.

The additional of these structs are non-breaking changes that fill legitimate gaps:
- simple colored-poly environments with lighting (e.g. Human Fall Flat's environment)
- dyed and textured environments with lighting (e.g. grass in Minecraft)