### PR TITLE
[WindowsDX] Fix window deactivated and activated immediately when minim…

### DIFF
--- a/MonoGame.Framework/Platform/Windows/WinFormsGameForm.cs
+++ b/MonoGame.Framework/Platform/Windows/WinFormsGameForm.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Xna.Framework.Windows
 
         public const int WM_SYSCOMMAND = 0x0112;
 
+        public const int WM_ACTIVATE = 0x0006;
+
         public bool AllowAltF4 = true;
 
         internal bool IsResizing { get; set; }
@@ -114,6 +116,14 @@ namespace Microsoft.Xna.Framework.Windows
                 case WM_KEYUP:
                 case WM_SYSKEYUP:
                     HandleKeyMessage(ref m);
+                    break;
+                case WM_ACTIVATE:
+                    bool minimized = ((m.WParam.ToInt32() & 0xFFFF0000) >> 16) != 0;
+                    bool activated = m.WParam != IntPtr.Zero;
+
+                    if (activated && !minimized)
+                        _window.OnActivated(this, null);
+
                     break;
 #endif
                 case WM_SYSCOMMAND:

--- a/MonoGame.Framework/Platform/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Platform/Windows/WinFormsGameWindow.cs
@@ -162,7 +162,6 @@ namespace MonoGame.Framework
             _resizeTickTimer = new System.Timers.Timer(1) { SynchronizingObject = Form, AutoReset = false };
             _resizeTickTimer.Elapsed += OnResizeTick;
 
-            Form.Activated += OnActivated;
             Form.Deactivate += OnDeactivate;
             Form.Resize += OnResize;
             Form.ResizeBegin += OnResizeBegin;
@@ -234,7 +233,7 @@ namespace MonoGame.Framework
             }
         }
 
-        private void OnActivated(object sender, EventArgs eventArgs)
+        internal void OnActivated(object sender, EventArgs eventArgs)
         {
             _platform.IsActive = true;
             Keyboard.SetActive(true);


### PR DESCRIPTION
…izing window by clicking on taskbar

`System.Windows.Forms.Form.Activated` event has a issue like [this](https://stackoverflow.com/questions/5811739/taskbar-minimize-c-sharp-windows-form-problem)

This PR fix the issue that game window still receive keyboard events when window is deactivated by clicking the taskbar.