### PR TITLE
Set pauseCount to zero on stop

### DIFF
--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.OpenAL.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Xna.Framework.Audio
         private void PlatformStop(bool immediate)
         {
             FreeSource();
+            pauseCount = 0;
             SoundState = SoundState.Stopped;
         }
 


### PR DESCRIPTION
This should the resolve the issues with pause state getting out of sync when stopping a paused SoundEffectInstance.

I am not sure why we are keeping track of both SoundState and pauseCount, it seem rather unintuitive. When would it make sense for pause count to be any value other than 0 (not paused) and 1 (paused)? @mrhelmut  maybe you can remember? it seems you added the code some 5 years ago.

I would recommend that we just get rid of the pauseCount, but I don't know the code and the quirks well enough.

Fixes #7372