### PR TITLE
Upgrade to use Xamarin.Legacy.Sdk [WIP]

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -9,7 +9,6 @@
     <PackageTags>monogame;.net core;core;.net standard;standard;android</PackageTags>
     <PackageId>MonoGame.Framework.Android</PackageId>
     <AppendTargetFrameworkToOutputPath>True</AppendTargetFrameworkToOutputPath>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Xamarin.Legacy.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetFrameworks>monoandroid90;net6.0-android</TargetFrameworks>
     <DefineConstants>ANDROID;GLES;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MGOpenGL>GLES</MGOpenGL>
@@ -9,6 +9,7 @@
     <PackageTags>monogame;.net core;core;.net standard;standard;android</PackageTags>
     <PackageId>MonoGame.Framework.Android</PackageId>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -73,7 +74,7 @@
     <Compile Include="Platform\Utilities\FuncLoader.Android.cs" />
     <Compile Include="Platform\Utilities\InteropHelpers.cs" />
     <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
-    
+
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp"/>
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp"/>
   </ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -8,7 +8,7 @@
     <Description>The MonoGame runtime for Android which supports Android 4.2 and newer.</Description>
     <PackageTags>monogame;.net core;core;.net standard;standard;android</PackageTags>
     <PackageId>MonoGame.Framework.Android</PackageId>
-    <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
+    <AppendTargetFrameworkToOutputPath>True</AppendTargetFrameworkToOutputPath>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Xamarin.Legacy.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFrameworks>xamarinios10;net6.0-ios</TargetFrameworks>
     <DefineConstants>IOS;GLES;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MGOpenGL>GLES</MGOpenGL>

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -8,7 +8,7 @@
     <Description>The MonoGame runtime for iOS which supports iOS Versions 10 and above. </Description>
     <PackageTags>monogame;.net core;core;.net standard;standard;ios</PackageTags>
     <PackageId>MonoGame.Framework.iOS</PackageId>
-    <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
+    <AppendTargetFrameworkToOutputPath>True</AppendTargetFrameworkToOutputPath>
     <SupportedOSPlatformVersion>11.2</SupportedOSPlatformVersion>
   </PropertyGroup>
 

--- a/MonoGame.Framework/global.json
+++ b/MonoGame.Framework/global.json
@@ -1,5 +1,6 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "2.0.54"
+        "MSBuild.Sdk.Extras": "2.0.54",
+        "Xamarin.Legacy.Sdk": "0.1.0-alpha1"
     }
 }

--- a/MonoGame.Framework/global.json
+++ b/MonoGame.Framework/global.json
@@ -1,6 +1,6 @@
 {
     "msbuild-sdks": {
         "MSBuild.Sdk.Extras": "2.0.54",
-        "Xamarin.Legacy.Sdk": "0.1.0-alpha6"
+        "Xamarin.Legacy.Sdk": "0.1.2-alpha6"
     }
 }

--- a/MonoGame.Framework/global.json
+++ b/MonoGame.Framework/global.json
@@ -1,6 +1,6 @@
 {
     "msbuild-sdks": {
         "MSBuild.Sdk.Extras": "2.0.54",
-        "Xamarin.Legacy.Sdk": "0.1.0-alpha1"
+        "Xamarin.Legacy.Sdk": "0.1.0-alpha6"
     }
 }


### PR DESCRIPTION
Switch the Android and iOS projects over to use [Xamarin.Legacy.Sdk](https://github.com/xamarin/Xamarin.Legacy.Sdk).
This is a new set of targets which allow us to produce both legacy Xamarin TargetFramework based Assemblies, as well as .net 6 ones. Currently `MSBuild.Sdk.Extras` is not able to do this, and it makes sense to allow the nuget packages support both old and new frameworks.

Todo

- [ ] Upgrade Nuget Packages for iOS and Android to include both legacy and .net based assemblies and .net 6 ones. 
- [ ] Figure out how to upgrade the Build system to use `dotnet build` rather than calling `msbuild` for iOS and Android (This might already happen in cake)
- [ ] Install the required .net 6 previews on the build hosts so we can build those.
- [ ] Possibly upgrade other projects to support .net 6 (possibly a different PR).
- [ ] Run unit tests under .net 6 (probably in a different PR).