### PR TITLE
Changed Math to MathF

### DIFF
--- a/MonoGame.Framework/Audio/Xact/Cue.cs
+++ b/MonoGame.Framework/Audio/Xact/Cue.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Xna.Framework.Audio
                     direction /= distance;
                 var right = Vector3.Cross(listener.Up, listener.Forward);
                 var slope = Vector3.Dot(direction, listener.Forward);
-                var angle = MathHelper.ToDegrees((float)Math.Acos(slope));
+                var angle = MathHelper.ToDegrees(MathF.Acos(slope));
                 var j = FindVariable("OrientationAngle");
                 _variables[j].SetValue(angle);
                 if (_curSound != null)

--- a/MonoGame.Framework/BoundingSphere.cs
+++ b/MonoGame.Framework/BoundingSphere.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Xna.Framework
                 float sqDist = diff.LengthSquared();
                 if (sqDist > sqRadius)
                 {
-                    float distance = (float)Math.Sqrt(sqDist); // equal to diff.Length();
+                    float distance = MathF.Sqrt(sqDist); // equal to diff.Length();
                     Vector3 direction = diff / distance;
                     Vector3 G = center - radius * direction;
                     center = (G + pt) / 2;
@@ -581,7 +581,7 @@ namespace Microsoft.Xna.Framework
         {
             BoundingSphere sphere = new BoundingSphere();
             sphere.Center = Vector3.Transform(this.Center, matrix);
-            sphere.Radius = this.Radius * ((float)Math.Sqrt((double)Math.Max(((matrix.M11 * matrix.M11) + (matrix.M12 * matrix.M12)) + (matrix.M13 * matrix.M13), Math.Max(((matrix.M21 * matrix.M21) + (matrix.M22 * matrix.M22)) + (matrix.M23 * matrix.M23), ((matrix.M31 * matrix.M31) + (matrix.M32 * matrix.M32)) + (matrix.M33 * matrix.M33)))));
+            sphere.Radius = this.Radius * MathF.Sqrt(Math.Max(((matrix.M11 * matrix.M11) + (matrix.M12 * matrix.M12)) + (matrix.M13 * matrix.M13), Math.Max(((matrix.M21 * matrix.M21) + (matrix.M22 * matrix.M22)) + (matrix.M23 * matrix.M23), ((matrix.M31 * matrix.M31) + (matrix.M32 * matrix.M32)) + (matrix.M33 * matrix.M33))));
             return sphere;
         }
 
@@ -593,7 +593,7 @@ namespace Microsoft.Xna.Framework
         public void Transform(ref Matrix matrix, out BoundingSphere result)
         {
             result.Center = Vector3.Transform(this.Center, matrix);
-            result.Radius = this.Radius * ((float)Math.Sqrt((double)Math.Max(((matrix.M11 * matrix.M11) + (matrix.M12 * matrix.M12)) + (matrix.M13 * matrix.M13), Math.Max(((matrix.M21 * matrix.M21) + (matrix.M22 * matrix.M22)) + (matrix.M23 * matrix.M23), ((matrix.M31 * matrix.M31) + (matrix.M32 * matrix.M32)) + (matrix.M33 * matrix.M33)))));
+            result.Radius = this.Radius * MathF.Sqrt(Math.Max(((matrix.M11 * matrix.M11) + (matrix.M12 * matrix.M12)) + (matrix.M13 * matrix.M13), Math.Max(((matrix.M21 * matrix.M21) + (matrix.M22 * matrix.M22)) + (matrix.M23 * matrix.M23), ((matrix.M31 * matrix.M31) + (matrix.M32 * matrix.M32)) + (matrix.M33 * matrix.M33))));
         }
 
         #endregion

--- a/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         private static byte Pack(float alpha)
         {
-            return (byte) Math.Round(
+            return (byte) MathF.Round(
                 MathHelper.Clamp(alpha, 0, 1) * 255.0f
             );
         }

--- a/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         private static UInt16 Pack(float x, float y, float z)
         {
-            return (UInt16) ((((int) Math.Round(MathHelper.Clamp(x, 0, 1) * 31.0f) & 0x1F) << 11) |
-                (((int) Math.Round(MathHelper.Clamp(y, 0, 1) * 63.0f) & 0x3F) << 5) |
-                ((int) Math.Round(MathHelper.Clamp(z, 0, 1) * 31.0f) & 0x1F));
+            return (UInt16) ((((int) MathF.Round(MathHelper.Clamp(x, 0, 1) * 31.0f) & 0x1F) << 11) |
+                (((int) MathF.Round(MathHelper.Clamp(y, 0, 1) * 63.0f) & 0x3F) << 5) |
+                ((int) MathF.Round(MathHelper.Clamp(z, 0, 1) * 31.0f) & 0x1F));
         }
 
         /// <summary>

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         private static UInt16 Pack(float x, float y, float z, float w)
         {
-            return (UInt16) ((((int) Math.Round(MathHelper.Clamp(w, 0, 1) * 15.0f) & 0x0F) << 12) |
-                (((int) Math.Round(MathHelper.Clamp(x, 0, 1) * 15.0f) & 0x0F) << 8) |
-                (((int) Math.Round(MathHelper.Clamp(y, 0, 1) * 15.0f) & 0x0F) << 4) |
-                ((int) Math.Round(MathHelper.Clamp(z, 0, 1) * 15.0f) & 0x0F));
+            return (UInt16) ((((int) MathF.Round(MathHelper.Clamp(w, 0, 1) * 15.0f) & 0x0F) << 12) |
+                (((int) MathF.Round(MathHelper.Clamp(x, 0, 1) * 15.0f) & 0x0F) << 8) |
+                (((int) MathF.Round(MathHelper.Clamp(y, 0, 1) * 15.0f) & 0x0F) << 4) |
+                ((int) MathF.Round(MathHelper.Clamp(z, 0, 1) * 15.0f) & 0x0F));
         }
 
         /// <summary>

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
@@ -127,10 +127,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         private static UInt16 Pack(float x, float y, float z, float w)
         {
             return (UInt16) (
-                (((int) Math.Round(MathHelper.Clamp(x, 0, 1) * 31.0f) & 0x1F) << 10) |
-                (((int) Math.Round(MathHelper.Clamp(y, 0, 1) * 31.0f) & 0x1F) << 5) |
-                (((int) Math.Round(MathHelper.Clamp(z, 0, 1) * 31.0f) & 0x1F) << 0) |
-                ((((int) Math.Round(MathHelper.Clamp(w, 0, 1)) & 0x1) << 15))
+                (((int) MathF.Round(MathHelper.Clamp(x, 0, 1) * 31.0f) & 0x1F) << 10) |
+                (((int) MathF.Round(MathHelper.Clamp(y, 0, 1) * 31.0f) & 0x1F) << 5) |
+                (((int) MathF.Round(MathHelper.Clamp(z, 0, 1) * 31.0f) & 0x1F) << 0) |
+                ((((int) MathF.Round(MathHelper.Clamp(w, 0, 1)) & 0x1) << 15))
             );
         }
     }

--- a/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
@@ -125,10 +125,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             const float min = 0.0f;
 
             // clamp the value between min and max values
-            var byte4 = (uint) Math.Round(MathHelper.Clamp(vector.X, min, max)) & 0xFF;
-            var byte3 = ((uint) Math.Round(MathHelper.Clamp(vector.Y, min, max)) & 0xFF) << 0x8;
-            var byte2 = ((uint) Math.Round(MathHelper.Clamp(vector.Z, min, max)) & 0xFF) << 0x10;
-            var byte1 = ((uint) Math.Round(MathHelper.Clamp(vector.W, min, max)) & 0xFF) << 0x18;
+            var byte4 = (uint) MathF.Round(MathHelper.Clamp(vector.X, min, max)) & 0xFF;
+            var byte3 = ((uint) MathF.Round(MathHelper.Clamp(vector.Y, min, max)) & 0xFF) << 0x8;
+            var byte2 = ((uint) MathF.Round(MathHelper.Clamp(vector.Z, min, max)) & 0xFF) << 0x10;
+            var byte1 = ((uint) MathF.Round(MathHelper.Clamp(vector.W, min, max)) & 0xFF) << 0x18;
 
             return byte4 | byte3 | byte2 | byte1;
         }

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
@@ -67,8 +67,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         private static ushort Pack(float x, float y)
         {
-            var byte2 = (((ushort) Math.Round(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) & 0xFF) << 0;
-            var byte1 = (((ushort) Math.Round(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) & 0xFF) << 8;
+            var byte2 = (((ushort) MathF.Round(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) & 0xFF) << 0;
+            var byte1 = (((ushort) MathF.Round(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) & 0xFF) << 8;
 
             return (ushort)(byte2 | byte1);
         }

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
@@ -67,10 +67,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         private static uint Pack(float x, float y, float z, float w)
         {
-            var byte4 = (((uint) Math.Round(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) & 0xff) << 0;
-            var byte3 = (((uint) Math.Round(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) & 0xff) << 8;
-            var byte2 = (((uint) Math.Round(MathHelper.Clamp(z, -1.0f, 1.0f) * 127.0f)) & 0xff) << 16;
-            var byte1 = (((uint) Math.Round(MathHelper.Clamp(w, -1.0f, 1.0f) * 127.0f)) & 0xff) << 24;
+            var byte4 = (((uint) MathF.Round(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) & 0xff) << 0;
+            var byte3 = (((uint) MathF.Round(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) & 0xff) << 8;
+            var byte2 = (((uint) MathF.Round(MathHelper.Clamp(z, -1.0f, 1.0f) * 127.0f)) & 0xff) << 16;
+            var byte1 = (((uint) MathF.Round(MathHelper.Clamp(w, -1.0f, 1.0f) * 127.0f)) & 0xff) << 24;
 
             return byte4 | byte3 | byte2 | byte1;
         }

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
@@ -81,8 +81,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 			// clamp the value between min and max values
             // Round rather than truncate.
-            var word2 = (uint)((int)MathHelper.Clamp((float)Math.Round(vectorX * maxPos), minNeg, maxPos) & 0xFFFF);
-            var word1 = (uint)(((int)MathHelper.Clamp((float)Math.Round(vectorY * maxPos), minNeg, maxPos) & 0xFFFF) << 0x10);
+            var word2 = (uint)((int)MathHelper.Clamp(MathF.Round(vectorX * maxPos), minNeg, maxPos) & 0xFFFF);
+            var word1 = (uint)(((int)MathHelper.Clamp(MathF.Round(vectorY * maxPos), minNeg, maxPos) & 0xFFFF) << 0x10);
 
 			return (word2 | word1);
 		}

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
@@ -71,10 +71,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             const long minNeg = -maxPos;
 
 			// clamp the value between min and max values
-            var word4 = (ulong)((int)Math.Round(MathHelper.Clamp(vectorX * maxPos, minNeg, maxPos)) & mask);
-            var word3 = (ulong)((int)Math.Round(MathHelper.Clamp(vectorY * maxPos, minNeg, maxPos)) & mask) << 0x10;
-            var word2 = (ulong)((int)Math.Round(MathHelper.Clamp(vectorZ * maxPos, minNeg, maxPos)) & mask) << 0x20;
-            var word1 = (ulong)((int)Math.Round(MathHelper.Clamp(vectorW * maxPos, minNeg, maxPos)) & mask) << 0x30;
+            var word4 = (ulong)((int)MathF.Round(MathHelper.Clamp(vectorX * maxPos, minNeg, maxPos)) & mask);
+            var word3 = (ulong)((int)MathF.Round(MathHelper.Clamp(vectorY * maxPos, minNeg, maxPos)) & mask) << 0x10;
+            var word2 = (ulong)((int)MathF.Round(MathHelper.Clamp(vectorZ * maxPos, minNeg, maxPos)) & mask) << 0x20;
+            var word1 = (ulong)((int)MathF.Round(MathHelper.Clamp(vectorW * maxPos, minNeg, maxPos)) & mask) << 0x30;
 
 			return (word4 | word3 | word2 | word1);
 		}

--- a/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
@@ -131,8 +131,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         private static uint Pack(float x, float y)
         {
             return (uint) (
-                (((int) Math.Round(MathHelper.Clamp(x, 0, 1) * 65535.0f) & 0xFFFF) ) |
-                (((int) Math.Round(MathHelper.Clamp(y, 0, 1) * 65535.0f) & 0xFFFF) << 16)
+                (((int) MathF.Round(MathHelper.Clamp(x, 0, 1) * 65535.0f) & 0xFFFF) ) |
+                (((int) MathF.Round(MathHelper.Clamp(y, 0, 1) * 65535.0f) & 0xFFFF) << 16)
             );
         }
     }

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
@@ -127,10 +127,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         private static uint Pack(float x, float y, float z, float w)
         {
             return (uint) (
-                (((int) Math.Round(MathHelper.Clamp(x, 0, 1) * 1023.0f) & 0x03FF) << 0) |
-                (((int) Math.Round(MathHelper.Clamp(y, 0, 1) * 1023.0f) & 0x03FF) << 10) |
-                (((int) Math.Round(MathHelper.Clamp(z, 0, 1) * 1023.0f) & 0x03FF) << 20) |
-                (((int) Math.Round(MathHelper.Clamp(w, 0, 1) * 3.0f) & 0x03) << 30)
+                (((int) MathF.Round(MathHelper.Clamp(x, 0, 1) * 1023.0f) & 0x03FF) << 0) |
+                (((int) MathF.Round(MathHelper.Clamp(y, 0, 1) * 1023.0f) & 0x03FF) << 10) |
+                (((int) MathF.Round(MathHelper.Clamp(z, 0, 1) * 1023.0f) & 0x03FF) << 20) |
+                (((int) MathF.Round(MathHelper.Clamp(w, 0, 1) * 3.0f) & 0x03) << 30)
             );
         }
     }

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
@@ -126,10 +126,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		private static ulong Pack(float x, float y, float z, float w)
 		{
 			return (ulong) (
-				(((ulong)Math.Round(MathHelper.Clamp(x * 0xFFFF, 0, 65535f)) ) ) |
-				(((ulong)Math.Round(MathHelper.Clamp(y * 0xFFFF, 0, 65535f)) ) << 16) |
-                (((ulong)Math.Round(MathHelper.Clamp(z * 0xFFFF, 0, 65535f)) ) << 32) |
-				(((ulong)Math.Round(MathHelper.Clamp(w * 0xFFFF, 0, 65535f)) ) << 48)
+				(((ulong)MathF.Round(MathHelper.Clamp(x * 0xFFFF, 0, 65535f)) ) ) |
+				(((ulong)MathF.Round(MathHelper.Clamp(y * 0xFFFF, 0, 65535f)) ) << 16) |
+                (((ulong)MathF.Round(MathHelper.Clamp(z * 0xFFFF, 0, 65535f)) ) << 32) |
+				(((ulong)MathF.Round(MathHelper.Clamp(w * 0xFFFF, 0, 65535f)) ) << 48)
             );
 		}
 	}

--- a/MonoGame.Framework/Graphics/PackedVector/Short2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short2.cs
@@ -80,8 +80,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			const float minNeg = ~(int)maxPos; // two's complement
 
             // clamp the value between min and max values
-            var word2 = ((uint) Math.Round(MathHelper.Clamp(vectorX, minNeg, maxPos)) & 0xFFFF);
-            var word1 = (((uint) Math.Round(MathHelper.Clamp(vectorY, minNeg, maxPos)) & 0xFFFF) << 0x10);
+            var word2 = ((uint) MathF.Round(MathHelper.Clamp(vectorX, minNeg, maxPos)) & 0xFFFF);
+            var word1 = (((uint) MathF.Round(MathHelper.Clamp(vectorY, minNeg, maxPos)) & 0xFFFF) << 0x10);
 
             return (word2 | word1);
 		}

--- a/MonoGame.Framework/Graphics/PackedVector/Short4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short4.cs
@@ -126,10 +126,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			const float minNeg = ~(int)maxPos; // two's complement
 
             // clamp the value between min and max values
-            var word4 = ((ulong)((int) Math.Round(MathHelper.Clamp(vector.X, minNeg, maxPos))) & mask);
-			var word3 = ((ulong)((int) Math.Round(MathHelper.Clamp(vector.Y, minNeg, maxPos)) & mask)) << 0x10;
-			var word2 = ((ulong)((int) Math.Round(MathHelper.Clamp(vector.Z, minNeg, maxPos)) & mask)) << 0x20;
-			var word1 = ((ulong)((int) Math.Round(MathHelper.Clamp(vector.W, minNeg, maxPos)) & mask)) << 0x30;
+            var word4 = ((ulong)((int) MathF.Round(MathHelper.Clamp(vector.X, minNeg, maxPos))) & mask);
+			var word3 = ((ulong)((int) MathF.Round(MathHelper.Clamp(vector.Y, minNeg, maxPos)) & mask)) << 0x10;
+			var word2 = ((ulong)((int) MathF.Round(MathHelper.Clamp(vector.Z, minNeg, maxPos)) & mask)) << 0x20;
+			var word1 = ((ulong)((int) MathF.Round(MathHelper.Clamp(vector.W, minNeg, maxPos)) & mask)) << 0x30;
 
             return word4 | word3 | word2 | word1;
         }

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -261,8 +261,8 @@ namespace Microsoft.Xna.Framework.Graphics
                         -origin.Y,
                         w,
                         h,
-                        (float)Math.Sin(rotation),
-                        (float)Math.Cos(rotation),
+                        MathF.Sin(rotation),
+                        MathF.Cos(rotation),
                         color,
                         _texCoordTL,
                         _texCoordBR,
@@ -398,8 +398,8 @@ namespace Microsoft.Xna.Framework.Graphics
                         -origin.Y,
                         destinationRectangle.Width,
                         destinationRectangle.Height,
-                        (float)Math.Sin(rotation),
-                        (float)Math.Cos(rotation),
+                        MathF.Sin(rotation),
+                        MathF.Cos(rotation),
                         color,
                         _texCoordTL,
                         _texCoordBR,
@@ -734,8 +734,8 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
-                cos = (float)Math.Cos(rotation);
-                sin = (float)Math.Sin(rotation);
+                cos = MathF.Cos(rotation);
+                sin = MathF.Sin(rotation);
                 transformation.M11 = (flippedHorz ? -scale.X : scale.X) * cos;
                 transformation.M12 = (flippedHorz ? -scale.X : scale.X) * sin;
                 transformation.M21 = (flippedVert ? -scale.Y : scale.Y) * (-sin);
@@ -1016,8 +1016,8 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
-                cos = (float)Math.Cos(rotation);
-                sin = (float)Math.Sin(rotation);
+                cos = MathF.Cos(rotation);
+                sin = MathF.Sin(rotation);
                 transformation.M11 = (flippedHorz ? -scale.X : scale.X) * cos;
                 transformation.M12 = (flippedHorz ? -scale.X : scale.X) * sin;
                 transformation.M21 = (flippedVert ? -scale.Y : scale.Y) * (-sin);

--- a/MonoGame.Framework/MathF.cs
+++ b/MonoGame.Framework/MathF.cs
@@ -1,0 +1,69 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace System
+{
+#if (!NETCOREAPP && !NETSTANDARD2_1) || NETCOREAPP1_0 || NETCOREAPP1_1
+    internal static class MathF
+    {
+        public const float E = (float)Math.E;
+        public const float PI = (float)Math.PI;
+
+        public static float Sqrt(float f)
+        {
+            return (float)Math.Sqrt(f);
+        }
+
+        public static float Pow(float x, float y)
+        {
+            return (float)Math.Pow(x, y);
+        }
+
+        public static float Sin(float f)
+        {
+            return (float)Math.Sin(f);
+        }
+
+        public static float Cos(float f)
+        {
+            return (float)Math.Cos(f);
+        }
+
+        public static float Tan(float f)
+        {
+            return (float)Math.Tan(f);
+        }
+
+        public static float Asin(float f)
+        {
+            return (float)Math.Asin(f);
+        }
+
+        public static float Acos(float f)
+        {
+            return (float)Math.Acos(f);
+        }
+
+        public static float Atan(float f)
+        {
+            return (float)Math.Atan(f);
+        }
+
+        public static float Round(float f)
+        {
+            return (float)Math.Round(f);
+        }
+
+        public static float Ceiling(float f)
+        {
+            return (float)Math.Ceiling(f);
+        }
+
+        public static float Floor(float f)
+        {
+            return (float)Math.Floor(f);
+        }
+    }
+#endif
+}

--- a/MonoGame.Framework/MathHelper.cs
+++ b/MonoGame.Framework/MathHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Xna.Framework
     	/// <summary>
         /// Represents the mathematical constant e(2.71828175).
         /// </summary>
-        public const float E = (float)Math.E;
+        public const float E = MathF.E;
         
         /// <summary>
         /// Represents the log base ten of e(0.4342945).
@@ -29,7 +29,7 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Represents the value of pi(3.14159274).
         /// </summary>
-        public const float Pi = (float)Math.PI;
+        public const float Pi = MathF.PI;
         
         /// <summary>
         /// Represents the value of pi divided by two(1.57079637).

--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -505,7 +505,7 @@ namespace Microsoft.Xna.Framework
             }
             else
             {
-                Vector3.Multiply(ref vector, (float)(1f / ((float)Math.Sqrt((double)num))), out vector);
+                Vector3.Multiply(ref vector, 1f / MathF.Sqrt(num), out vector);
             }
             Vector3.Cross(ref cameraUpVector, ref vector, out vector3);
             vector3.Normalize();
@@ -572,7 +572,7 @@ namespace Microsoft.Xna.Framework
 		    }
 		    else
 		    {
-		        Vector3.Multiply(ref vector2, (float) (1f / ((float) Math.Sqrt((double) num2))), out vector2);
+		        Vector3.Multiply(ref vector2, 1f / MathF.Sqrt(num2), out vector2);
 		    }
 		    Vector3 vector4 = rotateAxis;
 		    Vector3.Dot(ref rotateAxis, ref vector2, out num);
@@ -648,8 +648,8 @@ namespace Microsoft.Xna.Framework
             float x = axis.X;
 		    float y = axis.Y;
 		    float z = axis.Z;
-		    float num2 = (float) Math.Sin((double) angle);
-		    float num = (float) Math.Cos((double) angle);
+		    float num2 = MathF.Sin(angle);
+		    float num = MathF.Cos(angle);
 		    float num11 = x * x;
 		    float num10 = y * y;
 		    float num9 = z * z;
@@ -1089,8 +1089,8 @@ namespace Microsoft.Xna.Framework
         {
             result = Matrix.Identity;
 
-			var val1 = (float)Math.Cos(radians);
-			var val2 = (float)Math.Sin(radians);
+			var val1 = MathF.Cos(radians);
+			var val2 = MathF.Sin(radians);
 			
             result.M22 = val1;
             result.M23 = val2;
@@ -1119,8 +1119,8 @@ namespace Microsoft.Xna.Framework
         {
             result = Matrix.Identity;
 
-            var val1 = (float)Math.Cos(radians);
-			var val2 = (float)Math.Sin(radians);
+            var val1 = MathF.Cos(radians);
+			var val2 = MathF.Sin(radians);
 			
             result.M11 = val1;
             result.M13 = -val2;
@@ -1149,8 +1149,8 @@ namespace Microsoft.Xna.Framework
         {
             result = Matrix.Identity;
 
-			var val1 = (float)Math.Cos(radians);
-			var val2 = (float)Math.Sin(radians);
+			var val1 = MathF.Cos(radians);
+			var val2 = MathF.Sin(radians);
 			
             result.M11 = val1;
             result.M12 = val2;
@@ -1483,9 +1483,9 @@ namespace Microsoft.Xna.Framework
             float ys = (Math.Sign(M21 * M22 * M23 * M24) < 0) ? -1 : 1;
             float zs = (Math.Sign(M31 * M32 * M33 * M34) < 0) ? -1 : 1;
 
-            scale.X = xs * (float)Math.Sqrt(this.M11 * this.M11 + this.M12 * this.M12 + this.M13 * this.M13);
-            scale.Y = ys * (float)Math.Sqrt(this.M21 * this.M21 + this.M22 * this.M22 + this.M23 * this.M23);
-            scale.Z = zs * (float)Math.Sqrt(this.M31 * this.M31 + this.M32 * this.M32 + this.M33 * this.M33);
+            scale.X = xs * MathF.Sqrt(this.M11 * this.M11 + this.M12 * this.M12 + this.M13 * this.M13);
+            scale.Y = ys * MathF.Sqrt(this.M21 * this.M21 + this.M22 * this.M22 + this.M23 * this.M23);
+            scale.Z = zs * MathF.Sqrt(this.M31 * this.M31 + this.M32 * this.M32 + this.M33 * this.M33);
 
             if (scale.X == 0.0 || scale.Y == 0.0 || scale.Z == 0.0)
             {

--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Xna.Framework.Audio
 
             // NOTE: This is copy of what XAudio2.SemitonesToFrequencyRatio() does
             // which avoids the native call and is actually more accurate.
-             var pitch = (float)Math.Pow(2.0, value);
+             var pitch = MathF.Pow(2.0f, value);
              _voice.SetFrequencyRatio(pitch);
         }
 

--- a/MonoGame.Framework/Quaternion.cs
+++ b/MonoGame.Framework/Quaternion.cs
@@ -267,8 +267,8 @@ namespace Microsoft.Xna.Framework
         public static Quaternion CreateFromAxisAngle(Vector3 axis, float angle)
         {
 		    float half = angle * 0.5f;
-		    float sin = (float)Math.Sin(half);
-		    float cos = (float)Math.Cos(half);
+		    float sin = MathF.Sin(half);
+		    float cos = MathF.Cos(half);
 		    return new Quaternion(axis.X * sin, axis.Y * sin, axis.Z * sin, cos);
         }
 
@@ -281,8 +281,8 @@ namespace Microsoft.Xna.Framework
         public static void CreateFromAxisAngle(ref Vector3 axis, float angle, out Quaternion result)
         {
             float half = angle * 0.5f;
-		    float sin = (float)Math.Sin(half);
-		    float cos = (float)Math.Cos(half);
+		    float sin = MathF.Sin(half);
+		    float cos = MathF.Cos(half);
 		    result.X = axis.X * sin;
 		    result.Y = axis.Y * sin;
 		    result.Z = axis.Z * sin;
@@ -307,7 +307,7 @@ namespace Microsoft.Xna.Framework
 
 		    if (scale > 0.0f)
 		    {
-                sqrt = (float)Math.Sqrt(scale + 1.0f);
+                sqrt = MathF.Sqrt(scale + 1.0f);
 		        quaternion.W = sqrt * 0.5f;
                 sqrt = 0.5f / sqrt;
 
@@ -319,7 +319,7 @@ namespace Microsoft.Xna.Framework
 		    }
 		    if ((matrix.M11 >= matrix.M22) && (matrix.M11 >= matrix.M33))
 		    {
-                sqrt = (float) Math.Sqrt(1.0f + matrix.M11 - matrix.M22 - matrix.M33);
+                sqrt = MathF.Sqrt(1.0f + matrix.M11 - matrix.M22 - matrix.M33);
                 half = 0.5f / sqrt;
 
 		        quaternion.X = 0.5f * sqrt;
@@ -331,7 +331,7 @@ namespace Microsoft.Xna.Framework
 		    }
 		    if (matrix.M22 > matrix.M33)
 		    {
-                sqrt = (float) Math.Sqrt(1.0f + matrix.M22 - matrix.M11 - matrix.M33);
+                sqrt = MathF.Sqrt(1.0f + matrix.M22 - matrix.M11 - matrix.M33);
                 half = 0.5f / sqrt;
 
 		        quaternion.X = (matrix.M21 + matrix.M12) * half;
@@ -341,7 +341,7 @@ namespace Microsoft.Xna.Framework
 
 		        return quaternion;
 		    }
-            sqrt = (float) Math.Sqrt(1.0f + matrix.M33 - matrix.M11 - matrix.M22);
+            sqrt = MathF.Sqrt(1.0f + matrix.M33 - matrix.M11 - matrix.M22);
 		    half = 0.5f / sqrt;
 
 		    quaternion.X = (matrix.M31 + matrix.M13) * half;
@@ -365,7 +365,7 @@ namespace Microsoft.Xna.Framework
 
             if (scale > 0.0f)
             {
-                sqrt = (float)Math.Sqrt(scale + 1.0f);
+                sqrt = MathF.Sqrt(scale + 1.0f);
                 result.W = sqrt * 0.5f;
                 sqrt = 0.5f / sqrt;
 
@@ -376,7 +376,7 @@ namespace Microsoft.Xna.Framework
             else
             if ((matrix.M11 >= matrix.M22) && (matrix.M11 >= matrix.M33))
             {
-                sqrt = (float)Math.Sqrt(1.0f + matrix.M11 - matrix.M22 - matrix.M33);
+                sqrt = MathF.Sqrt(1.0f + matrix.M11 - matrix.M22 - matrix.M33);
                 half = 0.5f / sqrt;
 
                 result.X = 0.5f * sqrt;
@@ -386,7 +386,7 @@ namespace Microsoft.Xna.Framework
             }
             else if (matrix.M22 > matrix.M33)
             {
-                sqrt = (float) Math.Sqrt(1.0f + matrix.M22 - matrix.M11 - matrix.M33);
+                sqrt = MathF.Sqrt(1.0f + matrix.M22 - matrix.M11 - matrix.M33);
                 half = 0.5f/sqrt;
 
                 result.X = (matrix.M21 + matrix.M12)*half;
@@ -396,7 +396,7 @@ namespace Microsoft.Xna.Framework
             }
             else
             {
-                sqrt = (float)Math.Sqrt(1.0f + matrix.M33 - matrix.M11 - matrix.M22);
+                sqrt = MathF.Sqrt(1.0f + matrix.M33 - matrix.M11 - matrix.M22);
                 half = 0.5f / sqrt;
 
                 result.X = (matrix.M31 + matrix.M13) * half;
@@ -423,12 +423,12 @@ namespace Microsoft.Xna.Framework
             float halfPitch = pitch * 0.5f;
             float halfYaw = yaw * 0.5f;
 
-            float sinRoll = (float)Math.Sin(halfRoll);
-            float cosRoll = (float)Math.Cos(halfRoll);
-            float sinPitch = (float)Math.Sin(halfPitch);
-            float cosPitch = (float)Math.Cos(halfPitch);
-            float sinYaw = (float)Math.Sin(halfYaw);
-            float cosYaw = (float)Math.Cos(halfYaw);
+            float sinRoll = MathF.Sin(halfRoll);
+            float cosRoll = MathF.Cos(halfRoll);
+            float sinPitch = MathF.Sin(halfPitch);
+            float cosPitch = MathF.Cos(halfPitch);
+            float sinYaw = MathF.Sin(halfYaw);
+            float cosYaw = MathF.Cos(halfYaw);
 
             return new Quaternion((cosYaw * sinPitch * cosRoll) + (sinYaw * cosPitch * sinRoll),
                                   (sinYaw * cosPitch * cosRoll) - (cosYaw * sinPitch * sinRoll),
@@ -449,12 +449,12 @@ namespace Microsoft.Xna.Framework
             float halfPitch = pitch * 0.5f;
             float halfYaw = yaw * 0.5f;
 
-            float sinRoll = (float)Math.Sin(halfRoll);
-            float cosRoll = (float)Math.Cos(halfRoll);
-            float sinPitch = (float)Math.Sin(halfPitch);
-            float cosPitch = (float)Math.Cos(halfPitch);
-            float sinYaw = (float)Math.Sin(halfYaw);
-            float cosYaw = (float)Math.Cos(halfYaw);
+            float sinRoll = MathF.Sin(halfRoll);
+            float cosRoll = MathF.Cos(halfRoll);
+            float sinPitch = MathF.Sin(halfPitch);
+            float cosPitch = MathF.Cos(halfPitch);
+            float sinYaw = MathF.Sin(halfYaw);
+            float cosYaw = MathF.Cos(halfYaw);
 
             result.X = (cosYaw * sinPitch * cosRoll) + (sinYaw * cosPitch * sinRoll);
             result.Y = (sinYaw * cosPitch * cosRoll) - (cosYaw * sinPitch * sinRoll);
@@ -632,7 +632,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>The magnitude of the quaternion components.</returns>
         public float Length()
         {
-    		return (float) Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+    		return MathF.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
         }
 
         /// <summary>
@@ -674,7 +674,7 @@ namespace Microsoft.Xna.Framework
 		        quaternion.W = (num2 * quaternion1.W) - (num * quaternion2.W);
 		    }
 		    float num4 = (((quaternion.X * quaternion.X) + (quaternion.Y * quaternion.Y)) + (quaternion.Z * quaternion.Z)) + (quaternion.W * quaternion.W);
-		    float num3 = 1f / ((float) Math.Sqrt((double) num4));
+		    float num3 = 1f / MathF.Sqrt(num4);
 		    quaternion.X *= num3;
 		    quaternion.Y *= num3;
 		    quaternion.Z *= num3;
@@ -709,7 +709,7 @@ namespace Microsoft.Xna.Framework
 		        result.W = (num2 * quaternion1.W) - (num * quaternion2.W);
 		    }
 		    float num4 = (((result.X * result.X) + (result.Y * result.Y)) + (result.Z * result.Z)) + (result.W * result.W);
-		    float num3 = 1f / ((float) Math.Sqrt((double) num4));
+		    float num3 = 1f / MathF.Sqrt(num4);
 		    result.X *= num3;
 		    result.Y *= num3;
 		    result.Z *= num3;
@@ -748,10 +748,10 @@ namespace Microsoft.Xna.Framework
 		    }
 		    else
 		    {
-		        float num5 = (float) Math.Acos((double) num4);
+		        float num5 = MathF.Acos(num4);
 		        float num6 = (float) (1.0 / Math.Sin((double) num5));
-		        num3 = ((float) Math.Sin((double) ((1f - num) * num5))) * num6;
-		        num2 = flag ? (((float) -Math.Sin((double) (num * num5))) * num6) : (((float) Math.Sin((double) (num * num5))) * num6);
+		        num3 = MathF.Sin((1f - num) * num5) * num6;
+		        num2 = flag ? (-MathF.Sin(num * num5) * num6) : (MathF.Sin(num * num5) * num6);
 		    }
 		    quaternion.X = (num3 * quaternion1.X) + (num2 * quaternion2.X);
 		    quaternion.Y = (num3 * quaternion1.Y) + (num2 * quaternion2.Y);
@@ -786,10 +786,10 @@ namespace Microsoft.Xna.Framework
 		    }
 		    else
 		    {
-		        float num5 = (float) Math.Acos((double) num4);
+		        float num5 = MathF.Acos(num4);
 		        float num6 = (float) (1.0 / Math.Sin((double) num5));
-		        num3 = ((float) Math.Sin((double) ((1f - num) * num5))) * num6;
-		        num2 = flag ? (((float) -Math.Sin((double) (num * num5))) * num6) : (((float) Math.Sin((double) (num * num5))) * num6);
+		        num3 = MathF.Sin((1f - num) * num5) * num6;
+		        num2 = flag ? (-MathF.Sin(num * num5) * num6) : (MathF.Sin(num * num5) * num6);
 		    }
 		    result.X = (num3 * quaternion1.X) + (num2 * quaternion2.X);
 		    result.Y = (num3 * quaternion1.Y) + (num2 * quaternion2.Y);
@@ -955,7 +955,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Normalize()
         {
-		    float num = 1f / ((float) Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W)));
+		    float num = 1f / MathF.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
 		    X *= num;
 		    Y *= num;
 		    Z *= num;
@@ -970,7 +970,7 @@ namespace Microsoft.Xna.Framework
         public static Quaternion Normalize(Quaternion quaternion)
         {
             Quaternion result;
-		    float num = 1f / ((float) Math.Sqrt((quaternion.X * quaternion.X) + (quaternion.Y * quaternion.Y) + (quaternion.Z * quaternion.Z) + (quaternion.W * quaternion.W)));
+		    float num = 1f / MathF.Sqrt((quaternion.X * quaternion.X) + (quaternion.Y * quaternion.Y) + (quaternion.Z * quaternion.Z) + (quaternion.W * quaternion.W));
             result.X = quaternion.X * num;
             result.Y = quaternion.Y * num;
             result.Z = quaternion.Z * num;
@@ -985,7 +985,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The unit length quaternion an output parameter.</param>
         public static void Normalize(ref Quaternion quaternion, out Quaternion result)
         {
-		    float num = 1f / ((float) Math.Sqrt((quaternion.X * quaternion.X) + (quaternion.Y * quaternion.Y) + (quaternion.Z * quaternion.Z) + (quaternion.W * quaternion.W)));
+		    float num = 1f / MathF.Sqrt((quaternion.X * quaternion.X) + (quaternion.Y * quaternion.Y) + (quaternion.Z * quaternion.Z) + (quaternion.W * quaternion.W));
 		    result.X = quaternion.X * num;
 		    result.Y = quaternion.Y * num;
 		    result.Z = quaternion.Z * num;

--- a/MonoGame.Framework/Ray.cs
+++ b/MonoGame.Framework/Ray.cs
@@ -304,7 +304,7 @@ namespace Microsoft.Xna.Framework
             // if x^2 + z^2 - y^2 < 0, we do not intersect
             float dist = sphereRadiusSquared + distanceAlongRay * distanceAlongRay - differenceLengthSquared;
 
-            result = (dist < 0) ? null : distanceAlongRay - (float?)Math.Sqrt(dist);
+            result = (dist < 0) ? null : distanceAlongRay - (float?)MathF.Sqrt(dist);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -357,8 +357,8 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Ceiling()
         {
-            X = (float)Math.Ceiling(X);
-            Y = (float)Math.Ceiling(Y);
+            X = MathF.Ceiling(X);
+            Y = MathF.Ceiling(Y);
         }
 
         /// <summary>
@@ -368,8 +368,8 @@ namespace Microsoft.Xna.Framework
         /// <returns>The rounded <see cref="Vector2"/>.</returns>
         public static Vector2 Ceiling(Vector2 value)
         {
-            value.X = (float)Math.Ceiling(value.X);
-            value.Y = (float)Math.Ceiling(value.Y);
+            value.X = MathF.Ceiling(value.X);
+            value.Y = MathF.Ceiling(value.Y);
             return value;
         }
 
@@ -380,8 +380,8 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The rounded <see cref="Vector2"/>.</param>
         public static void Ceiling(ref Vector2 value, out Vector2 result)
         {
-            result.X = (float)Math.Ceiling(value.X);
-            result.Y = (float)Math.Ceiling(value.Y);
+            result.X = MathF.Ceiling(value.X);
+            result.Y = MathF.Ceiling(value.Y);
         }
 
         /// <summary>
@@ -420,7 +420,7 @@ namespace Microsoft.Xna.Framework
         public static float Distance(Vector2 value1, Vector2 value2)
         {
             float v1 = value1.X - value2.X, v2 = value1.Y - value2.Y;
-            return (float)Math.Sqrt((v1 * v1) + (v2 * v2));
+            return MathF.Sqrt((v1 * v1) + (v2 * v2));
         }
 
         /// <summary>
@@ -432,7 +432,7 @@ namespace Microsoft.Xna.Framework
         public static void Distance(ref Vector2 value1, ref Vector2 value2, out float result)
         {
             float v1 = value1.X - value2.X, v2 = value1.Y - value2.Y;
-            result = (float)Math.Sqrt((v1 * v1) + (v2 * v2));
+            result = MathF.Sqrt((v1 * v1) + (v2 * v2));
         }
 
         /// <summary>
@@ -563,8 +563,8 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Floor()
         {
-            X = (float)Math.Floor(X);
-            Y = (float)Math.Floor(Y);
+            X = MathF.Floor(X);
+            Y = MathF.Floor(Y);
         }
 
         /// <summary>
@@ -574,8 +574,8 @@ namespace Microsoft.Xna.Framework
         /// <returns>The rounded <see cref="Vector2"/>.</returns>
         public static Vector2 Floor(Vector2 value)
         {
-            value.X = (float)Math.Floor(value.X);
-            value.Y = (float)Math.Floor(value.Y);
+            value.X = MathF.Floor(value.X);
+            value.Y = MathF.Floor(value.Y);
             return value;
         }
 
@@ -586,8 +586,8 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The rounded <see cref="Vector2"/>.</param>
         public static void Floor(ref Vector2 value, out Vector2 result)
         {
-            result.X = (float)Math.Floor(value.X);
-            result.Y = (float)Math.Floor(value.Y);
+            result.X = MathF.Floor(value.X);
+            result.Y = MathF.Floor(value.Y);
         }
 
         /// <summary>
@@ -637,7 +637,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>The length of this <see cref="Vector2"/>.</returns>
         public float Length()
         {
-            return (float)Math.Sqrt((X * X) + (Y * Y));
+            return MathF.Sqrt((X * X) + (Y * Y));
         }
 
         /// <summary>
@@ -835,7 +835,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Normalize()
         {
-            float val = 1.0f / (float)Math.Sqrt((X * X) + (Y * Y));
+            float val = 1.0f / MathF.Sqrt((X * X) + (Y * Y));
             X *= val;
             Y *= val;
         }
@@ -847,7 +847,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>Unit vector.</returns>
         public static Vector2 Normalize(Vector2 value)
         {
-            float val = 1.0f / (float)Math.Sqrt((value.X * value.X) + (value.Y * value.Y));
+            float val = 1.0f / MathF.Sqrt((value.X * value.X) + (value.Y * value.Y));
             value.X *= val;
             value.Y *= val;
             return value;
@@ -860,7 +860,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Unit vector as an output parameter.</param>
         public static void Normalize(ref Vector2 value, out Vector2 result)
         {
-            float val = 1.0f / (float)Math.Sqrt((value.X * value.X) + (value.Y * value.Y));
+            float val = 1.0f / MathF.Sqrt((value.X * value.X) + (value.Y * value.Y));
             result.X = value.X * val;
             result.Y = value.Y * val;
         }
@@ -898,8 +898,8 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Round()
         {
-            X = (float)Math.Round(X);
-            Y = (float)Math.Round(Y);
+            X = MathF.Round(X);
+            Y = MathF.Round(Y);
         }
 
         /// <summary>
@@ -909,8 +909,8 @@ namespace Microsoft.Xna.Framework
         /// <returns>The rounded <see cref="Vector2"/>.</returns>
         public static Vector2 Round(Vector2 value)
         {
-            value.X = (float)Math.Round(value.X);
-            value.Y = (float)Math.Round(value.Y);
+            value.X = MathF.Round(value.X);
+            value.Y = MathF.Round(value.Y);
             return value;
         }
 
@@ -921,8 +921,8 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The rounded <see cref="Vector2"/>.</param>
         public static void Round(ref Vector2 value, out Vector2 result)
         {
-            result.X = (float)Math.Round(value.X);
-            result.Y = (float)Math.Round(value.Y);
+            result.X = MathF.Round(value.X);
+            result.Y = MathF.Round(value.Y);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -307,9 +307,9 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Ceiling()
         {
-            X = (float)Math.Ceiling(X);
-            Y = (float)Math.Ceiling(Y);
-            Z = (float)Math.Ceiling(Z);
+            X = MathF.Ceiling(X);
+            Y = MathF.Ceiling(Y);
+            Z = MathF.Ceiling(Z);
         }
 
         /// <summary>
@@ -319,9 +319,9 @@ namespace Microsoft.Xna.Framework
         /// <returns>The rounded <see cref="Vector3"/>.</returns>
         public static Vector3 Ceiling(Vector3 value)
         {
-            value.X = (float)Math.Ceiling(value.X);
-            value.Y = (float)Math.Ceiling(value.Y);
-            value.Z = (float)Math.Ceiling(value.Z);
+            value.X = MathF.Ceiling(value.X);
+            value.Y = MathF.Ceiling(value.Y);
+            value.Z = MathF.Ceiling(value.Z);
             return value;
         }
 
@@ -332,9 +332,9 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The rounded <see cref="Vector3"/>.</param>
         public static void Ceiling(ref Vector3 value, out Vector3 result)
         {
-            result.X = (float)Math.Ceiling(value.X);
-            result.Y = (float)Math.Ceiling(value.Y);
-            result.Z = (float)Math.Ceiling(value.Z);
+            result.X = MathF.Ceiling(value.X);
+            result.Y = MathF.Ceiling(value.Y);
+            result.Z = MathF.Ceiling(value.Z);
         }
 
         /// <summary>
@@ -404,7 +404,7 @@ namespace Microsoft.Xna.Framework
         {
             float result;
             DistanceSquared(ref value1, ref value2, out result);
-            return (float)Math.Sqrt(result);
+            return MathF.Sqrt(result);
         }
 
         /// <summary>
@@ -416,7 +416,7 @@ namespace Microsoft.Xna.Framework
         public static void Distance(ref Vector3 value1, ref Vector3 value2, out float result)
         {
             DistanceSquared(ref value1, ref value2, out result);
-            result = (float)Math.Sqrt(result);
+            result = MathF.Sqrt(result);
         }
 
         /// <summary>
@@ -556,9 +556,9 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Floor()
         {
-            X = (float)Math.Floor(X);
-            Y = (float)Math.Floor(Y);
-            Z = (float)Math.Floor(Z);
+            X = MathF.Floor(X);
+            Y = MathF.Floor(Y);
+            Z = MathF.Floor(Z);
         }
 
         /// <summary>
@@ -568,9 +568,9 @@ namespace Microsoft.Xna.Framework
         /// <returns>The rounded <see cref="Vector3"/>.</returns>
         public static Vector3 Floor(Vector3 value)
         {
-            value.X = (float)Math.Floor(value.X);
-            value.Y = (float)Math.Floor(value.Y);
-            value.Z = (float)Math.Floor(value.Z);
+            value.X = MathF.Floor(value.X);
+            value.Y = MathF.Floor(value.Y);
+            value.Z = MathF.Floor(value.Z);
             return value;
         }
 
@@ -581,9 +581,9 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The rounded <see cref="Vector3"/>.</param>
         public static void Floor(ref Vector3 value, out Vector3 result)
         {
-            result.X = (float)Math.Floor(value.X);
-            result.Y = (float)Math.Floor(value.Y);
-            result.Z = (float)Math.Floor(value.Z);
+            result.X = MathF.Floor(value.X);
+            result.Y = MathF.Floor(value.Y);
+            result.Z = MathF.Floor(value.Z);
         }
 
         /// <summary>
@@ -638,7 +638,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>The length of this <see cref="Vector3"/>.</returns>
         public float Length()
         {
-            return (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
+            return MathF.Sqrt((X * X) + (Y * Y) + (Z * Z));
         }
 
         /// <summary>
@@ -850,7 +850,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Normalize()
         {
-            float factor = (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
+            float factor = MathF.Sqrt((X * X) + (Y * Y) + (Z * Z));
             factor = 1f / factor;
             X *= factor;
             Y *= factor;
@@ -864,7 +864,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>Unit vector.</returns>
         public static Vector3 Normalize(Vector3 value)
         {
-            float factor = (float)Math.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z));
+            float factor = MathF.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z));
             factor = 1f / factor;
             return new Vector3(value.X * factor, value.Y * factor, value.Z * factor);
         }
@@ -876,7 +876,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Unit vector as an output parameter.</param>
         public static void Normalize(ref Vector3 value, out Vector3 result)
         {
-            float factor = (float)Math.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z));
+            float factor = MathF.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z));
             factor = 1f / factor;
             result.X = value.X * factor;
             result.Y = value.Y * factor;
@@ -928,9 +928,9 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Round()
         {
-            X = (float)Math.Round(X);
-            Y = (float)Math.Round(Y);
-            Z = (float)Math.Round(Z);
+            X = MathF.Round(X);
+            Y = MathF.Round(Y);
+            Z = MathF.Round(Z);
         }
 
         /// <summary>
@@ -940,9 +940,9 @@ namespace Microsoft.Xna.Framework
         /// <returns>The rounded <see cref="Vector3"/>.</returns>
         public static Vector3 Round(Vector3 value)
         {
-            value.X = (float)Math.Round(value.X);
-            value.Y = (float)Math.Round(value.Y);
-            value.Z = (float)Math.Round(value.Z);
+            value.X = MathF.Round(value.X);
+            value.Y = MathF.Round(value.Y);
+            value.Z = MathF.Round(value.Z);
             return value;
         }
 
@@ -953,9 +953,9 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The rounded <see cref="Vector3"/>.</param>
         public static void Round(ref Vector3 value, out Vector3 result)
         {
-            result.X = (float)Math.Round(value.X);
-            result.Y = (float)Math.Round(value.Y);
-            result.Z = (float)Math.Round(value.Z);
+            result.X = MathF.Round(value.X);
+            result.Y = MathF.Round(value.Y);
+            result.Z = MathF.Round(value.Z);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -292,10 +292,10 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Ceiling()
         {
-            X = (float)Math.Ceiling(X);
-            Y = (float)Math.Ceiling(Y);
-            Z = (float)Math.Ceiling(Z);
-            W = (float)Math.Ceiling(W);
+            X = MathF.Ceiling(X);
+            Y = MathF.Ceiling(Y);
+            Z = MathF.Ceiling(Z);
+            W = MathF.Ceiling(W);
         }
 
         /// <summary>
@@ -305,10 +305,10 @@ namespace Microsoft.Xna.Framework
         /// <returns>The rounded <see cref="Vector4"/>.</returns>
         public static Vector4 Ceiling(Vector4 value)
         {
-            value.X = (float)Math.Ceiling(value.X);
-            value.Y = (float)Math.Ceiling(value.Y);
-            value.Z = (float)Math.Ceiling(value.Z);
-            value.W = (float)Math.Ceiling(value.W);
+            value.X = MathF.Ceiling(value.X);
+            value.Y = MathF.Ceiling(value.Y);
+            value.Z = MathF.Ceiling(value.Z);
+            value.W = MathF.Ceiling(value.W);
             return value;
         }
 
@@ -319,10 +319,10 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The rounded <see cref="Vector4"/>.</param>
         public static void Ceiling(ref Vector4 value, out Vector4 result)
         {
-            result.X = (float)Math.Ceiling(value.X);
-            result.Y = (float)Math.Ceiling(value.Y);
-            result.Z = (float)Math.Ceiling(value.Z);
-            result.W = (float)Math.Ceiling(value.W);
+            result.X = MathF.Ceiling(value.X);
+            result.Y = MathF.Ceiling(value.Y);
+            result.Z = MathF.Ceiling(value.Z);
+            result.W = MathF.Ceiling(value.W);
         }
 
         /// <summary>
@@ -364,7 +364,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>The distance between two vectors.</returns>
         public static float Distance(Vector4 value1, Vector4 value2)
         {
-            return (float)Math.Sqrt(DistanceSquared(value1, value2));
+            return MathF.Sqrt(DistanceSquared(value1, value2));
         }
 
         /// <summary>
@@ -375,7 +375,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The distance between two vectors as an output parameter.</param>
         public static void Distance(ref Vector4 value1, ref Vector4 value2, out float result)
         {
-            result = (float)Math.Sqrt(DistanceSquared(value1, value2));
+            result = MathF.Sqrt(DistanceSquared(value1, value2));
         }
 
         /// <summary>
@@ -516,10 +516,10 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Floor()
         {
-            X = (float)Math.Floor(X);
-            Y = (float)Math.Floor(Y);
-            Z = (float)Math.Floor(Z);
-            W = (float)Math.Floor(W);
+            X = MathF.Floor(X);
+            Y = MathF.Floor(Y);
+            Z = MathF.Floor(Z);
+            W = MathF.Floor(W);
         }
 
         /// <summary>
@@ -529,10 +529,10 @@ namespace Microsoft.Xna.Framework
         /// <returns>The rounded <see cref="Vector4"/>.</returns>
         public static Vector4 Floor(Vector4 value)
         {
-            value.X = (float)Math.Floor(value.X);
-            value.Y = (float)Math.Floor(value.Y);
-            value.Z = (float)Math.Floor(value.Z);
-            value.W = (float)Math.Floor(value.W);
+            value.X = MathF.Floor(value.X);
+            value.Y = MathF.Floor(value.Y);
+            value.Z = MathF.Floor(value.Z);
+            value.W = MathF.Floor(value.W);
             return value;
         }
 
@@ -543,10 +543,10 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The rounded <see cref="Vector4"/>.</param>
         public static void Floor(ref Vector4 value, out Vector4 result)
         {
-            result.X = (float)Math.Floor(value.X);
-            result.Y = (float)Math.Floor(value.Y);
-            result.Z = (float)Math.Floor(value.Z);
-            result.W = (float)Math.Floor(value.W);
+            result.X = MathF.Floor(value.X);
+            result.Y = MathF.Floor(value.Y);
+            result.Z = MathF.Floor(value.Z);
+            result.W = MathF.Floor(value.W);
         }
 
         /// <summary>
@@ -605,7 +605,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>The length of this <see cref="Vector4"/>.</returns>
         public float Length()
         {
-            return (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+            return MathF.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
         }
 
         /// <summary>
@@ -830,7 +830,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Normalize()
         {
-            float factor = (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+            float factor = MathF.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
             factor = 1f / factor;
             X *= factor;
             Y *= factor;
@@ -845,7 +845,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>Unit vector.</returns>
         public static Vector4 Normalize(Vector4 value)
         {
-            float factor = (float)Math.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z) + (value.W * value.W));
+            float factor = MathF.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z) + (value.W * value.W));
             factor = 1f / factor;
             return new Vector4(value.X*factor,value.Y*factor,value.Z*factor,value.W*factor);
         }
@@ -857,7 +857,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Unit vector as an output parameter.</param>
         public static void Normalize(ref Vector4 value, out Vector4 result)
         {
-            float factor = (float)Math.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z) + (value.W * value.W));
+            float factor = MathF.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z) + (value.W * value.W));
             factor = 1f / factor;
             result.W = value.W * factor;
             result.X = value.X * factor;
@@ -870,10 +870,10 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Round()
         {
-            X = (float)Math.Round(X);
-            Y = (float)Math.Round(Y);
-            Z = (float)Math.Round(Z);
-            W = (float)Math.Round(W);
+            X = MathF.Round(X);
+            Y = MathF.Round(Y);
+            Z = MathF.Round(Z);
+            W = MathF.Round(W);
         }
 
         /// <summary>
@@ -883,10 +883,10 @@ namespace Microsoft.Xna.Framework
         /// <returns>The rounded <see cref="Vector4"/>.</returns>
         public static Vector4 Round(Vector4 value)
         {
-            value.X = (float)Math.Round(value.X);
-            value.Y = (float)Math.Round(value.Y);
-            value.Z = (float)Math.Round(value.Z);
-            value.W = (float)Math.Round(value.W);
+            value.X = MathF.Round(value.X);
+            value.Y = MathF.Round(value.Y);
+            value.Z = MathF.Round(value.Z);
+            value.W = MathF.Round(value.W);
             return value;
         }
 
@@ -897,10 +897,10 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The rounded <see cref="Vector4"/>.</param>
         public static void Round(ref Vector4 value, out Vector4 result)
         {
-            result.X = (float)Math.Round(value.X);
-            result.Y = (float)Math.Round(value.Y);
-            result.Z = (float)Math.Round(value.Z);
-            result.W = (float)Math.Round(value.W);
+            result.X = MathF.Round(value.X);
+            result.Y = MathF.Round(value.Y);
+            result.Z = MathF.Round(value.Z);
+            result.W = MathF.Round(value.W);
         }
 
         /// <summary>


### PR DESCRIPTION
Tried to avoid reducing precision of calculations this time.

Fixes #7382

I would like to make sure that this is verified for precision loss before merging, so that we don't end up rolling it back again. @nkast  do you have time to look this through? It is mostly the same changes as last time, except that I have avoided using MathF where it was used for double precision.

Also only DesktopDx will benefit from the changes as it is now, as that is the only platform that publishes a netcore3.1 package. (NetStandard2.0 does not have support for MathF). But we can look into that at a later point.