### PR TITLE
Fixed GLDesktop PlatformStop() resolving issue #7372

### DIFF
--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.OpenAL.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Xna.Framework.Audio
         private void PlatformStop(bool immediate)
         {
             FreeSource();
+            if (pauseCount > 0) pauseCount = 0;
             SoundState = SoundState.Stopped;
         }
 

--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Xna.Framework.Audio
                         _voice.Stop((int)PlayFlags.Tails);
                 }
             }
-
+            
             _paused = false;
         }
 

--- a/Tests/Framework/Audio/SoundEffectInstanceTest.cs
+++ b/Tests/Framework/Audio/SoundEffectInstanceTest.cs
@@ -9,6 +9,7 @@ using Microsoft.Xna.Framework.Audio;
 using NUnit.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+using System.Threading;
 
 namespace MonoGame.Tests.Audio
 {
@@ -26,9 +27,6 @@ namespace MonoGame.Tests.Audio
         /// is called after calling Pause(), Stop().
         /// </summary>
         [Test]
-#if !DESKTOPGL
-        [Ignore("bug is platform specific to GLDesktop")]
-#endif
         public void SoundEffectPauseStopPlay()
         {
 
@@ -38,15 +36,31 @@ namespace MonoGame.Tests.Audio
             {
                 instance.IsLooped = true; //ensures that the sound effect does not stop unless Stop() is called.
 
+                //Test Initial State
+                Assert.AreEqual(SoundState.Stopped, instance.State);
+
                 instance.Play();
                 Assert.AreEqual(SoundState.Playing, instance.State);
-
+                instance.Pause();
+                Assert.AreEqual(SoundState.Paused, instance.State);
                 instance.Stop();
+                SleepWhileDispatching(10);// XNA Requires Dispatcher to be updated
                 Assert.AreEqual(SoundState.Stopped, instance.State);
                 instance.Play();
                 Assert.AreEqual(SoundState.Playing, instance.State);
                 instance.Pause();
                 Assert.AreEqual(SoundState.Paused, instance.State);
+            }
+        }
+
+
+        private static void SleepWhileDispatching(int ms)
+        {
+            int cycles = ms / 10;
+            for (int i = 0; i < cycles; i++)
+            {
+                FrameworkDispatcher.Update();
+                Thread.Sleep(10);
             }
         }
 

--- a/Tests/Framework/Audio/SoundEffectInstanceTest.cs
+++ b/Tests/Framework/Audio/SoundEffectInstanceTest.cs
@@ -39,6 +39,7 @@ namespace MonoGame.Tests.Audio
                 //Test Initial State
                 Assert.AreEqual(SoundState.Stopped, instance.State);
 
+                //Test calling pause multiple times
                 instance.Play();
                 Assert.AreEqual(SoundState.Playing, instance.State);
                 instance.Pause();

--- a/Tests/Framework/Audio/SoundEffectInstanceTest.cs
+++ b/Tests/Framework/Audio/SoundEffectInstanceTest.cs
@@ -1,0 +1,54 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.IO;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Audio;
+using NUnit.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace MonoGame.Tests.Audio
+{
+    class SoundEffectInstanceTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            // Necessary to get audio initialised
+            FrameworkDispatcher.Update();
+        }
+
+        /// <summary>
+        /// Unit test for issue #7372 where the Sound effects instance does not play after Play()
+        /// is called after calling Pause(), Stop().
+        /// </summary>
+        [Test]
+#if !DESKTOPGL
+        [Ignore("bug is platform specific to GLDesktop")]
+#endif
+        public void SoundEffectPauseStopPlay()
+        {
+
+            var se = new SoundEffect(new byte[16000], 8000, AudioChannels.Mono);
+            
+            using (var instance = se.CreateInstance())
+            {
+                instance.IsLooped = true; //ensures that the sound effect does not stop unless Stop() is called.
+
+                instance.Play();
+                Assert.AreEqual(SoundState.Playing, instance.State);
+
+                instance.Stop();
+                Assert.AreEqual(SoundState.Stopped, instance.State);
+                instance.Play();
+                Assert.AreEqual(SoundState.Playing, instance.State);
+                instance.Pause();
+                Assert.AreEqual(SoundState.Paused, instance.State);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Bug addressed: When using DesktopGL the pause counter field is not reset when stop is called.

In SoundEffectInstance.PlatformStop() on the OpenAL platform. pauseCounter is set to 0 if its value is greater than 0. 

Fixes #7372.