### PR TITLE
Fixes Android not resuming to app after using Exit(); via backbutton

### DIFF
--- a/MonoGame.Framework/Platform/Android/AndroidGameActivity.cs
+++ b/MonoGame.Framework/Platform/Android/AndroidGameActivity.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Xna.Framework
         protected override void OnPause()
         {
             base.OnPause();
-            EventHelpers.Raise(this, Paused, EventArgs.Empty);
+            //EventHelpers.Raise(this, Paused, EventArgs.Empty);
 
             if (_orientationListener.CanDetectOrientation())
                 _orientationListener.Disable();


### PR DESCRIPTION
Android not resuming to app after using Exit(); via backbutton #7458
https://github.com/MonoGame/MonoGame/issues/7458
but needs probably more investigation because maybe the commented source is rerquired for other things.