### PR TITLE
Help with compatibility toward NativeAOT

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -1217,7 +1217,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformGetBackBufferData<T>(Rectangle? rectangle, T[] data, int startIndex, int count) where T : struct
         {
             var rect = rectangle ?? new Rectangle(0, 0, PresentationParameters.BackBufferWidth, PresentationParameters.BackBufferHeight);
-            var tSize = Marshal.SizeOf(typeof(T));
+            var tSize = Marshal.SizeOf<T>();
             var flippedY = PresentationParameters.BackBufferHeight - rect.Y - rect.Height;
             GL.ReadPixels(rect.X, flippedY, rect.Width, rect.Height, PixelFormat.Rgba, PixelType.UnsignedByte, data);
 

--- a/MonoGame.Framework/Platform/Graphics/Texture3D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture3D.OpenGL.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #else
             Threading.BlockOnUIThread(() =>
             {
-                var elementSizeInByte = Marshal.SizeOf(typeof(T));
+                var elementSizeInByte = Marshal.SizeOf<T>();
                 var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
                 var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startIndex * elementSizeInByte);
 

--- a/MonoGame.Framework/Platform/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             GL.BindBuffer(BufferTarget.ElementArrayBuffer, ibo);
             GraphicsExtensions.CheckGLError();
-            var elementSizeInByte = Marshal.SizeOf(typeof(T));
+            var elementSizeInByte = Marshal.SizeOf<T>();
             IntPtr ptr = GL.MapBuffer(BufferTarget.ElementArrayBuffer, BufferAccess.ReadOnly);
             // Pointer to the start of data to read in the index buffer
             ptr = new IntPtr(ptr.ToInt64() + offsetInBytes);
@@ -108,8 +108,8 @@ namespace Microsoft.Xna.Framework.Graphics
         private void BufferData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, SetDataOptions options) where T : struct
         {
             GenerateIfRequired();
-            
-            var elementSizeInByte = Marshal.SizeOf(typeof(T));
+
+            var elementSizeInByte = Marshal.SizeOf<T>();
             var sizeInBytes = elementSizeInByte * elementCount;
             var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
             var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startIndex * elementSizeInByte);

--- a/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
             }
 
-            var elementSizeInByte = Marshal.SizeOf(typeof(T));
+            var elementSizeInByte = Marshal.SizeOf<T>();
             if (elementSizeInByte == vertexStride || elementSizeInByte % vertexStride == 0)
             {
                 // there are no gaps so we can copy in one go

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.0",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Hello there,

This might provide a better reliance to NativeAOT even though the expected types should be safe enough already.

Fixes #7460

cc @Jjagg @harry-cpp 

EDIT: the build bot is still failing on .NET 5 because of this: https://github.com/dotnet/sdk/issues/12125#issuecomment-774181936

I have pushed a ```global.json``` to force the build bot to use .NET Core 3.1.
This will affect #7437 until .NET 5 fixes this issue.