### PR TITLE
Fix UWP Vsync support

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
@@ -47,11 +47,10 @@ namespace Microsoft.Xna.Framework.Graphics
         SharpDX.Direct2D1.Bitmap1 _bitmapTarget;
         SharpDX.DXGI.SwapChain1 _swapChain;
 
-#if WINDOWS_UAP
+        // Tearing (disabling V-Sync) support
+        bool _isTearingSupported;
+
 		SwapChainPanel _swapChainPanel;
-#else
-		SwapChainBackgroundPanel _swapChainBackgroundPanel;
-#endif
 
 		float _dpi; 
 #endif
@@ -251,10 +250,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void CreateSizeDependentResources()
         {
-#if WINDOWS_UAP
-            CheckForTearingSupport();
-#endif
-
             // Clamp MultiSampleCount
             PresentationParameters.MultiSampleCount =
                 GetClampedMultisampleCount(PresentationParameters.MultiSampleCount);
@@ -320,7 +315,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
             var swapChainFlags = SwapChainFlags.None;
 #if WINDOWS_UAP
-            if (PresentationParameters.PresentationInterval == PresentInterval.Immediate)
+            _isTearingSupported = IsTearingSupported();
+            if (_isTearingSupported)
             {
                 swapChainFlags = SwapChainFlags.AllowTearing;
             }
@@ -496,28 +492,28 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
 #if  WINDOWS_UAP
-        private void CheckForTearingSupport()
+        private bool IsTearingSupported()
         {
-            // Check if tearing is supported
-            if (PresentationParameters.PresentationInterval == PresentInterval.Immediate)
+            RawBool allowTearing;
+            using (var dxgiFactory2 = new Factory2())
             {
-                RawBool allowTearing;
-                using (var dxgiFactory2 = new Factory2())
+                unsafe
                 {
-                    unsafe
+                    var factory5 = dxgiFactory2.QueryInterface<Factory5>();
+                    try
                     {
-                        var factory5 = dxgiFactory2.QueryInterface<Factory5>();
-                        try
-                        {
-                            factory5.CheckFeatureSupport(SharpDX.DXGI.Feature.PresentAllowTearing, new IntPtr(&allowTearing), sizeof(RawBool));
-                        }
-                        catch (SharpDXException ex)
-                        {
-                            PresentationParameters.PresentationInterval = PresentInterval.Default;
-                        }
+                        factory5.CheckFeatureSupport(SharpDX.DXGI.Feature.PresentAllowTearing, new IntPtr(&allowTearing), sizeof(RawBool));
+
+                        return allowTearing;
+                    }
+                    catch (SharpDXException ex)
+                    {
+                        // can't request feature
                     }
                 }
             }
+
+            return false;
         }
 
         private void SetMultiSamplingToMaximum(PresentationParameters presentationParameters, out int quality)
@@ -1047,7 +1043,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // frames that will never be displayed to the screen.
                 lock (_d3dContext)
                 {
-                    if (PresentationParameters.PresentationInterval == PresentInterval.Immediate)
+                    if (PresentationParameters.PresentationInterval == PresentInterval.Immediate && _isTearingSupported)
                     {
                         _swapChain.Present(0, PresentFlags.AllowTearing);
                     }


### PR DESCRIPTION
Hi there,

UWP Vsync was broken following #7228 because the swap chain wasn't initialized with the proper flag (it was a partial implementation).

This PR also makes it so UWP apps will not crash on older Windows where tearing is not supported for UWP apps (Vsync off will be ignored instead of crashing; I believe it's non existant case only happening on out of support Windows versions like Windows 7 on which the Windows Store isn't available, so I don't think it's worth throwing a ```NoSuitableGraphicsDeviceException``` here).

Fixes #6020 

cc @Jjagg @harry-cpp 