### PR TITLE
Removed threading limitations

### DIFF
--- a/MonoGame.Framework/Platform/Threading.cs
+++ b/MonoGame.Framework/Platform/Threading.cs
@@ -19,9 +19,6 @@ namespace Microsoft.Xna.Framework
 {
     internal class Threading
     {
-        public const int MaxWaitForUIThread = 1000; // In milliseconds
-        public const int MaxPooledResetEvents = 32; // Throw away objects when above this amount
-
         static int _mainThreadId;
 
         static Stack<ManualResetEventSlim> _resetEventPool = new Stack<ManualResetEventSlim>();
@@ -142,8 +139,7 @@ namespace Microsoft.Xna.Framework
 
             try
             {
-                if (!resetEvent.Wait(MaxWaitForUIThread))
-                    throw new TimeoutException();
+                resetEvent.Wait(); // we don't know how much time the operation will take, so let's wait indefinitely
             }
             finally
             {
@@ -168,11 +164,8 @@ namespace Microsoft.Xna.Framework
 
             lock (_resetEventPool)
             {
-                if (_resetEventPool.Count < MaxPooledResetEvents)
-                {
-                    _resetEventPool.Push(resetEvent);
-                    return; // return here to skip dispose
-                }
+                _resetEventPool.Push(resetEvent);
+                return; // return here to skip dispose
             }
 
             resetEvent.Dispose();


### PR DESCRIPTION
Hello,

This PR removes the time threshold on ```BlockOnUIThread``` actions which was crashing depending on the action data size and hardware speed. Since we can't predict a maximum duration for every kind of operations and hardware, it is likely best to wait indefinitely for a blocked action to return (this was the behavior of MonoGame before #7384 introduced the threshold).

cc @Jjagg @harry-cpp 

Fixes #7471