### PR TITLE
Support drawing point primitives

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1435,6 +1435,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     return primitiveCount * 3;
                 case PrimitiveType.TriangleStrip:
                     return primitiveCount + 2;
+                case PrimitiveType.PointList:
+                    return primitiveCount;
             }
 
             throw new NotSupportedException();

--- a/MonoGame.Framework/Graphics/Vertices/PrimitiveType.cs
+++ b/MonoGame.Framework/Graphics/Vertices/PrimitiveType.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Xna.Framework.Graphics
     /// Defines how vertex data is ordered.
     /// </summary>
 	public enum PrimitiveType
-	{
+    {
         /// <summary>
         /// Renders the specified vertices as a sequence of isolated triangles. Each group of three vertices defines a separate triangle. Back-face culling is affected by the current winding-order render state.
         /// </summary>
@@ -28,5 +28,10 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Renders the vertices as a single polyline; the count may be any positive integer.
         /// </summary>
 		LineStrip,
-	}
+
+        /// <summary>
+        /// Renders the vertices as individual points; the count may be any positive integer.
+        /// </summary>
+        PointList
+    }
 }

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
@@ -1239,6 +1239,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     return PrimitiveTopology.TriangleList;
                 case PrimitiveType.TriangleStrip:
                     return PrimitiveTopology.TriangleStrip;
+                case PrimitiveType.PointList:
+                    return PrimitiveTopology.PointList;
             }
 
             throw new ArgumentException();

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -872,6 +872,8 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             switch (primitiveType)
             {
+                case PrimitiveType.PointList:
+                    return GLPrimitiveType.Points;
                 case PrimitiveType.LineList:
                     return GLPrimitiveType.Lines;
                 case PrimitiveType.LineStrip:

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -345,6 +345,7 @@ namespace MonoGame.OpenGL
 
     internal enum GLPrimitiveType
     {
+        Points = 0x0000,
         Lines = 0x0001,
         LineStrip = 0x0003,
         Triangles = 0x0004,

--- a/Tests/Framework/EnumConformingTest.cs
+++ b/Tests/Framework/EnumConformingTest.cs
@@ -240,6 +240,7 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(1, (int)PrimitiveType.TriangleStrip);
             Assert.AreEqual(2, (int)PrimitiveType.LineList);
             Assert.AreEqual(3, (int)PrimitiveType.LineStrip);
+            Assert.AreEqual(4, (int)PrimitiveType.PointList);
         }
 
         [Test]


### PR DESCRIPTION
Hey everyone,

For a particle system similar to https://directtovideo.wordpress.com/2009/10/06/a-thoroughly-modern-particle-system/ I wanted to draw point primitives. To my big surprise MonoGame only supports lines and triangles.

I've made a small PR that shows how easy it to add support for point primitives. I believe I can also make it work with the OpenGL version of MonoGame. However before I proceed I want to check if this PR would be welcomed? I don't have a Mac, Linux machine or any knowledge of iOS or Android so for those parts I would need help.

Please let me know :)

PS.

Apologies for the formatting changes, it seems a few files had mixed LF and CRLF line endings and I couldn't figure out a way to not change that. 