### PR TITLE
Fixed a small handful of typos in the comments of SpriteFont.

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		/// <param name="characters">The characters.</param>
 		/// <param name="lineSpacing">The line spacing (the distance from baseline to baseline) of the font.</param>
 		/// <param name="spacing">The spacing (tracking) between characters in the font.</param>
-		/// <param name="kerning">The letters kernings(X - left side bearing, Y - width and Z - right side bearing).</param>
+		/// <param name="kerning">The letters kernings (X - left side bearing, Y - width and Z - right side bearing).</param>
 		/// <param name="defaultCharacter">The character that will be substituted when a given character is not included in the font.</param>
 		public SpriteFont (
 			Texture2D texture, List<Rectangle> glyphBounds, List<Rectangle> cropping, List<char> characters,
@@ -120,7 +120,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Returns a copy of the dictionary containing the glyphs in this SpriteFont.
         /// </summary>
-        /// <returns>A new Dictionary containing all of the glyphs inthis SpriteFont</returns>
+        /// <returns>A new Dictionary containing all of the glyphs in this SpriteFont</returns>
         /// <remarks>Can be used to calculate character bounds when implementing custom SpriteFont rendering.</remarks>
         public Dictionary<char, Glyph> GetGlyphs()
         {
@@ -363,11 +363,11 @@ namespace Microsoft.Xna.Framework.Graphics
             /// </summary>
 			public Rectangle Cropping;
             /// <summary>
-            /// The amount of space between the left side ofthe character and its first pixel in the X dimention.
+            /// The amount of space between the left side of the character and its first pixel in the X dimension.
             /// </summary>
             public float LeftSideBearing;
             /// <summary>
-            /// The amount of space between the right side of the character and its last pixel in the X dimention.
+            /// The amount of space between the right side of the character and its last pixel in the X dimension.
             /// </summary>
             public float RightSideBearing;
             /// <summary>


### PR DESCRIPTION
Two misspellings of dimension ("dimention") and three places with missing spaces.