### PR TITLE
Fixes Duplicate/Missing Gamepads On Platforms Using SDL

### DIFF
--- a/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
@@ -65,6 +65,8 @@ namespace Microsoft.Xna.Framework.Input
 
             Gamepads.Add(id, gamepad);
             
+            RefreshTranslationTable();
+
             if (gamepad.HapticDevice == IntPtr.Zero)
                 return;
 
@@ -89,8 +91,6 @@ namespace Microsoft.Xna.Framework.Input
                 gamepad.HapticDevice = IntPtr.Zero;
                 Sdl.ClearError();
             }
-
-            RefreshTranslationTable();
         }
 
         internal static void RemoveDevice(int instanceid)

--- a/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
@@ -65,8 +65,6 @@ namespace Microsoft.Xna.Framework.Input
 
             Gamepads.Add(id, gamepad);
             
-            RefreshTranslationTable();
-
             if (gamepad.HapticDevice == IntPtr.Zero)
                 return;
 
@@ -91,6 +89,8 @@ namespace Microsoft.Xna.Framework.Input
                 gamepad.HapticDevice = IntPtr.Zero;
                 Sdl.ClearError();
             }
+
+            RefreshTranslationTable();
         }
 
         internal static void RemoveDevice(int instanceid)

--- a/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
@@ -22,9 +22,7 @@ namespace Microsoft.Xna.Framework.Input
         internal static void AddDevice(int deviceId)
         {
             var jdevice = Sdl.Joystick.Open(deviceId);
-            foreach (var entry in Joysticks)
-                if (jdevice == entry.Value)
-                    return;
+            if (Joysticks.ContainsValue(jdevice)) return;
 
             var id = 0;
 

--- a/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
@@ -12,9 +12,20 @@ namespace Microsoft.Xna.Framework.Input
         internal static Dictionary<int, IntPtr> Joysticks = new Dictionary<int, IntPtr>();
         private static int _lastConnectedIndex = -1;
 
+        internal static void AddDevices()
+        {
+            int numJoysticks = Sdl.Joystick.NumJoysticks();
+            for (int i = 0; i < numJoysticks; i++)
+                AddDevice(i);
+        }
+
         internal static void AddDevice(int deviceId)
         {
             var jdevice = Sdl.Joystick.Open(deviceId);
+            foreach (var entry in Joysticks)
+                if (jdevice == entry.Value)
+                    return;
+
             var id = 0;
 
             while (Joysticks.ContainsKey(id))

--- a/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Xna.Framework
                         _isExiting++;
                         break;
                     case Sdl.EventType.JoyDeviceAdded:
-                        Joystick.AddDevice(ev.JoystickDevice.Which);
+                        Joystick.AddDevices();
                         break;
                     case Sdl.EventType.JoyDeviceRemoved:
                         Joystick.RemoveDevice(ev.JoystickDevice.Which);


### PR DESCRIPTION
This pull request is to fix duplicate/missing gamepads on platforms using SDL.

This relates to issue #7457

When SDL builds it's initial list of controllers internally it can shuffle the detected controllers around and reorder them while doing so. SDL doesn't wait for the initial list to be fully built but rather each controller detected fires a JoyDeviceAdded event containing it's pre-shuffled device index before being reordered.

So when Monogame later reads the event's device index values (JoystickDevice.Which) these values are now potentially incorrect and really shouldn't be used with the SDL.Joystick.Open function. Because Monogame currently does use these values it creates duplicate controllers / has missing controllers.

A fix to this is whenever a JoyDeviceAdded event occurs attempt to open all available Joysticks (Sdl.Joystick.NumJoysticks gives the number of connected Joysticks) and don't use the received and likely out of date device index at all. Calling Sdl.Joystick.Open on an already opened Joystick simply returns it's existing pointer without issue, so checking if this already exists in Monogame's Joystick dictionary is all that is needed to prevent duplicates.

This fix is working for me but it could do with more testing with different controller/joystick combinations.