### PR TITLE
Fixes PacketNumber For Non-Haptic Gamepads On Platforms Using SDL

### DIFF
--- a/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
@@ -65,6 +65,8 @@ namespace Microsoft.Xna.Framework.Input
 
             Gamepads.Add(id, gamepad);
             
+            RefreshTranslationTable();
+
             if (gamepad.HapticDevice == IntPtr.Zero)
                 return;
 
@@ -89,8 +91,6 @@ namespace Microsoft.Xna.Framework.Input
                 gamepad.HapticDevice = IntPtr.Zero;
                 Sdl.ClearError();
             }
-
-            RefreshTranslationTable();
         }
 
         internal static void RemoveDevice(int instanceid)


### PR DESCRIPTION
This pull request is to fix PacketNumber updates for non-haptic detected gamepads on platforms using SDL.

The AddDevice function can be returned before RefreshTranslationTable is called in the case of non-haptic feedback gamepads. The gamepad's PacketNumber will not be updated unless the translation table has an entry for the device.

The fix is to always call RefreshTranslationTable before returning.