### PR TITLE
Reload disposed assets

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -245,7 +245,14 @@ namespace Microsoft.Xna.Framework.Content
             object asset = null;
             if (loadedAssets.TryGetValue(key, out asset))
             {
-                if (asset is T)
+                // Check if we're retrieving a disposed asset
+                // and if so, let's reload it instead
+                bool assetDisposed = false;
+                var disposable = asset as IDisposable;
+                if (disposable != null && disposable.IsDisposed)
+                    assetDisposed = true;
+                
+                if (asset is T && !assetDisposed)
                 {
                     return (T)asset;
                 }


### PR DESCRIPTION
Hey there,

Currently, if we manually dispose an asset loaded from the ```ContentManager``` and try to reload it, it will return the old disposed instance instead of a fresh one.

This PR checks the state and reloads the asset if it has previously been disposed and a reload is attempted.

cc @Jjagg @harry-cpp 