### PR TITLE
Update Mac Extension Link

### DIFF
--- a/Documentation/articles/getting_started/1_setting_up_your_development_environment_macos.md
+++ b/Documentation/articles/getting_started/1_setting_up_your_development_environment_macos.md
@@ -7,7 +7,7 @@ Go to the following URL to download and install Visual Studio for Mac: https://v
 
 ## Install MonoGame extension for Visual Studio for Mac
 
-Download the MonoGame extension for Visual Studio for Mac from the following link: https://github.com/MonoGame/MonoGame/releases/download/v3.8/MonoDevelop.MonoGame_IDE_VisualStudioForMac_3.8.0.1641.mpack
+Download the MonoGame extension for Visual Studio for Mac from the following link: https://github.com/MonoGame/MonoGame/releases/download/v3.8/MonoDevelop.MonoGame_IDE_VisualStudioForMac_v3.8.0.1643-vsm8.0.mpack
 
 Open up Visual Studio for Mac and you should be able to see a window like so:
 


### PR DESCRIPTION
The link to the MonoGame Visual Studio For Mac extension in the MacOS setup guide doesn't exist. I've updated it to work.

Here's the old link: https://github.com/MonoGame/MonoGame/releases/download/v3.8/MonoDevelop.MonoGame_IDE_VisualStudioForMac_3.8.0.1641.mpack

Here's the one that works:
https://github.com/MonoGame/MonoGame/releases/download/v3.8/MonoDevelop.MonoGame_IDE_VisualStudioForMac_v3.8.0.1643-vsm8.0.mpack