### PR TITLE
Prevent App suspension when the user press 'B' button on UWP (xbox controller)

### DIFF
--- a/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
@@ -127,6 +127,8 @@ namespace Microsoft.Xna.Framework
 
             if (Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.Phone.UI.Input.HardwareButtons"))
                 Windows.Phone.UI.Input.HardwareButtons.BackPressed += this.HardwareButtons_BackPressed;
+            else
+                SystemNavigationManager.GetForCurrentView().BackRequested += this.BackRequested;
 
             SetViewBounds(_appView.VisibleBounds.Width, _appView.VisibleBounds.Height);
 
@@ -314,6 +316,12 @@ namespace Microsoft.Xna.Framework
             else
                 _backPressed = true;
 
+            e.Handled = true;
+        }
+
+        private void BackRequested(object sender, BackRequestedEventArgs e)
+        {
+            // Prevent XBOX from suspending the app when the user press 'B' button.
             e.Handled = true;
         }
 


### PR DESCRIPTION
fixes #6404