### PR TITLE
fix PipelineBuildEvent deserialization

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineBuildEvent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineBuildEvent.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Xml;
 using System.Xml.Serialization;
 using Microsoft.Xna.Framework.Content.Pipeline;
 
@@ -122,7 +123,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             PipelineBuildEvent pipelineEvent;
             try
             {
-                using (var textReader = new StreamReader(fullFilePath))
+                using (var textReader = new XmlTextReader(fullFilePath))
                     pipelineEvent = (PipelineBuildEvent) deserializer.Deserialize(textReader);
             }
             catch (Exception)


### PR DESCRIPTION
With `StreamReader` `FirstCharacter` was deserialized as empty string.
`XmlTextReader` preserves whitespaces in nodes and correctly deserialize it as " ".

<pre><code>
  &lt;Parameters&gt;
    &lt;Key>FirstCharacter&lt;/Key&gt;
    &lt;Value>&nbsp;&lt;/Value&gt;
  &lt;/Parameters&gt;
</code></pre>

fixes #3400
closes #2877