### PR TITLE
Shared MSAA RenderTarget

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.DirectX.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             var desc = base.GetTexture2DDescription();
 
-            if (MultiSampleCount == 0)
+            if (MultiSampleCount == 0 || Shared)
                 desc.BindFlags |= BindFlags.RenderTarget;
 
             if (Mipmap)

--- a/Tests/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Tests/Framework/Graphics/RenderTarget2DTest.cs
@@ -157,10 +157,11 @@ namespace MonoGame.Tests.Graphics
         }
 
 #if DIRECTX
-        [Test]
-        public void GetSharedHandle()
+        [TestCase(1)]
+        [TestCase(2)]
+        public void GetSharedHandle(int preferredMultiSampleCount)
         {
-            var rt = new RenderTarget2D(gd, 16, 16, false, SurfaceFormat.Color, DepthFormat.None, 0, RenderTargetUsage.PlatformContents, true);            
+            var rt = new RenderTarget2D(gd, 16, 16, false, SurfaceFormat.Color, DepthFormat.None, preferredMultiSampleCount, RenderTargetUsage.PlatformContents, true);            
             var sharedHandle = rt.GetSharedHandle();
             Assert.AreNotEqual(sharedHandle, IntPtr.Zero);
 


### PR DESCRIPTION
When a rendertarget was created with multisampling, we were not setting the RenderTarget flag because only the resolved texture needs to be bound as rendertarget.

However shared RenderTargets always need the RenderTarget flag.
