### PR TITLE
Upgraded projects and documentation to NET5

### DIFF
--- a/Documentation/articles/getting_started/1_setting_up_your_development_environment_macos.md
+++ b/Documentation/articles/getting_started/1_setting_up_your_development_environment_macos.md
@@ -25,7 +25,7 @@ Finally, click on the Install button once again.
 
 ![Install VSM extension](~/images/getting_started/vsmac-mg-install-4.png)
 
-## [Optional] Install MonoGame templates for .NET Core CLI or Rider IDE
+## [Optional] Install MonoGame templates for .NET CLI or Rider IDE
 
 ```sh
 dotnet new --install MonoGame.Templates.CSharp

--- a/Documentation/articles/getting_started/1_setting_up_your_development_environment_ubuntu.md
+++ b/Documentation/articles/getting_started/1_setting_up_your_development_environment_ubuntu.md
@@ -2,7 +2,7 @@
 
 This section provides a step-by-step guide for setting up your development environment for Ubuntu 20.04.
 
-## Install .NET Core SDK
+## Install .NET SDK
 
 Add repository:
 
@@ -16,12 +16,12 @@ Install packages:
 
 ```sh
 sudo apt-get install -y apt-transport-https
-sudo apt-get install -y dotnet-sdk-3.1
+sudo apt-get install -y dotnet-sdk-5.0
 ```
 
 ## [Optional] Install mono
 
-Mono is a C# runtime, just like .NET Core. If you're targeting Linux only, it's unnecessary, but if you're targeting some other platforms like Android, it's required.
+Mono is a C# runtime, just like .NET. If you're targeting Linux only, it's unnecessary, but if you're targeting some other platforms like Android, it's required.
 
 Add repository:
 
@@ -63,7 +63,7 @@ code --install-extension ms-dotnettools.csharp
 
 ## Install MonoGame templates
 
-This will install templates for .NET Core CLI and the Rider IDE. There is no template support for MonoDevelop.
+This will install templates for .NET CLI and the Rider IDE. There is no template support for MonoDevelop.
 
 ```sh
 dotnet new --install MonoGame.Templates.CSharp

--- a/Documentation/articles/getting_started/1_setting_up_your_development_environment_windows.md
+++ b/Documentation/articles/getting_started/1_setting_up_your_development_environment_windows.md
@@ -6,7 +6,7 @@ This section provides a step-by-step guide for setting up your development envir
 
 Before installing Monogame, you'll need to install [Visual Studio 2019](https://visualstudio.microsoft.com/vs/) or later (any edition, including Community) with the following components, depending on your target platform:
 
-* .NET Core cross-platform development - For Desktop OpenGL and DirectX platforms
+* .NET cross-platform development - For Desktop OpenGL and DirectX platforms
 * Mobile Development with .NET - For Android and iOS platforms
 * Universal Windows Platform development - For Windows 10 and Xbox UWP platforms
 * .Net Desktop Development - For Desktop OpenGL and DirectX platforms to target normal .NET Framework
@@ -36,7 +36,7 @@ dotnet tool install --global dotnet-mgcb-editor
 mgcb-editor --register
 ```
 
-## [Optional] Install MonoGame templates for .NET Core CLI or Rider IDE
+## [Optional] Install MonoGame templates for .NET CLI or Rider IDE
 
 ```sh
 dotnet new --install MonoGame.Templates.CSharp

--- a/Documentation/articles/getting_started/2_creating_a_new_project_netcore.md
+++ b/Documentation/articles/getting_started/2_creating_a_new_project_netcore.md
@@ -1,4 +1,4 @@
-# .NET Core CLI
+# .NET CLI
 
 This guide will walk you through building a starter game with MonoGame using only the command line/terminal on your operating system and a lightweight coding tool of your choice (such as [Visual Studio Code](https://code.visualstudio.com/).
 

--- a/Documentation/articles/getting_started/toc.yml
+++ b/Documentation/articles/getting_started/toc.yml
@@ -12,7 +12,7 @@
     href: 2_creating_a_new_project_vs.md
   - name: Visual Studio for Mac
     href: 2_creating_a_new_project_vsm.md
-  - name: .NET Core CLI
+  - name: .NET CLI
     href: 2_creating_a_new_project_netcore.md
 - name: Understanding the Code
   href: 3_understanding_the_code.md

--- a/Documentation/articles/migrate_37.md
+++ b/Documentation/articles/migrate_37.md
@@ -42,7 +42,7 @@ You can remove these references and add a reference to the MonoGame NuGet packag
 
 ## Tooling
 
-MonoGame tools are now distributed as [.NET Core Tools](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools).
+MonoGame tools are now distributed as [.NET Tools](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools).
 You do not need the tools to build content for your games. The templates reference the `MonoGame.Content.Builder.Task`
 NuGet package that automatically builds your content when building your game.
 

--- a/Documentation/articles/packaging_games.md
+++ b/Documentation/articles/packaging_games.md
@@ -4,11 +4,11 @@ Once your game is ready to be published, it is recommended that you package it p
 
 ## Desktop games
 
-To publish desktop games, it is recommended that you build your project as a [self-contained](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained) .NET Core app. As such, your game will require absolutely no external dependencies and should run out-of-the-box as-is.
+To publish desktop games, it is recommended that you build your project as a [self-contained](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained) .NET app. As such, your game will require absolutely no external dependencies and should run out-of-the-box as-is.
 
 ### Building and packaging for Windows
 
-From the .NET Core CLI:
+From the .NET CLI:
 
 `dotnet publish -c Release -r win-x64 /p:PublishReadyToRun=false /p:TieredCompilation=false --self-contained`
 
@@ -18,7 +18,7 @@ If you are targeting WindowsDX, note that players will need [the DirectX June 20
 
 ### Building and packaging for Linux
 
-From the .NET Core CLI:
+From the .NET CLI:
 
 `dotnet publish -c Release -r linux-x64 /p:PublishReadyToRun=false /p:TieredCompilation=false --self-contained`
 
@@ -28,7 +28,7 @@ We recommend using the .tar.gz archiving format to preserve the execution permis
 
 ### Build and packaging for macOS
 
-From the .NET Core CLI:
+From the .NET CLI:
 
 `dotnet publish -c Release -r osx-x64 /p:PublishReadyToRun=false /p:TieredCompilation=false --self-contained`
 
@@ -89,9 +89,9 @@ After completing these steps, your .app folder should appear as an executable ap
 
 For archiving, we recommend using the .tar.gz format to preserve the execution permissions.
 
-## Special notes about .NET Core parameters
+## Special notes about .NET parameters
 
-.NET Core proposes several parameters when publishing apps that may sound helpful, but have many issues when it comes to games (because they were never meant for games in the first place, but for small lightweight applications).
+.NET proposes several parameters when publishing apps that may sound helpful, but have many issues when it comes to games (because they were never meant for games in the first place, but for small lightweight applications).
 
 ### ReadyToRun (R2R)
 
@@ -101,14 +101,14 @@ Ready2Run code is of low quality and makes the Just-In-Time compiler (JIT) trigg
 
 Disabling ReadyToRun solves this issue (at the cost of a slightly longer startup time, but typically very negligible).
 
-ReadyToRun is disabled by default. You can configure it by setting the `PublishReadyToRun` property in your csproj file. MonoGame templates for .NET Core projects explicitly set this to `false`.
+ReadyToRun is disabled by default. You can configure it by setting the `PublishReadyToRun` property in your csproj file. MonoGame templates for .NET projects explicitly set this to `false`.
 
 ### Tiered compilation
 
 [Tiered compilation](https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#tiered-compilation) is a companion system to ReadyToRun and works on the same principle to enhance startup time. We suggest disabling it to avoid any stutter while your game is running.
 
 Tiered compilation is **enabled by default**. To disable it set the `TieredCompilation` property to `false` in your csproj.
-MonoGame templates for .NET Core projects disable tiered compilation.
+MonoGame templates for .NET projects disable tiered compilation.
 
 ### SingleFilePublish
 

--- a/Documentation/articles/tools/mgcb.md
+++ b/Documentation/articles/tools/mgcb.md
@@ -7,8 +7,8 @@ of a MonoGame project. Alternatively you can use it yourself from the command li
 
 ## Installation
 
-MGCB can be installed as a [.NET Core tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools).
-Make sure you have the .NET Core SDK installed. You can download it [here](https://dotnet.microsoft.com/download).
+MGCB can be installed as a [.NET tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools).
+Make sure you have the .NET SDK installed. You can download it [here](https://dotnet.microsoft.com/download).
 
 In a terminal run `dotnet tool install -g dotnet-mgcb` to install MGCB. Then you can execute MGCB by simply running `mgcb`.
 

--- a/Documentation/articles/tools/mgcb_editor.md
+++ b/Documentation/articles/tools/mgcb_editor.md
@@ -19,7 +19,7 @@ The MGCB Editor has the following features:
 
 ## Installation Instructions
 
-The MGCB Editor is published as a [.NET Core tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools), Make sure you have the .NET Core SDK installed if you wish to install the editor. You can download it [here](https://dotnet.microsoft.com/download).
+The MGCB Editor is published as a [.NET tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools), Make sure you have the .NET SDK installed if you wish to install the editor. You can download it [here](https://dotnet.microsoft.com/download).
 
 In a command prompt/terminal window, run the following command to install the MGCB Editor:
 

--- a/Documentation/articles/tools/mgfxc.md
+++ b/Documentation/articles/tools/mgfxc.md
@@ -10,8 +10,8 @@ Effects compiled directly are not files and can not be loaded by the `ContentMan
 
 ## Installation
 
-MGFXC can be installed as a [.NET Core tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools).
-Make sure you have the .NET Core SDK installed. You can download it [here](https://dotnet.microsoft.com/download).
+MGFXC can be installed as a [.NET tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools).
+Make sure you have the .NET SDK installed. You can download it [here](https://dotnet.microsoft.com/download).
 
 In a terminal run `dotnet tool install -g dotnet-mgfxc` to install MGFXC.
 

--- a/Documentation/articles/tools/tools.md
+++ b/Documentation/articles/tools/tools.md
@@ -1,7 +1,7 @@
 # Tools
 
 MonoGame distributes tooling to help manage and build content for your game.
-These tools are available as [.NET Core Tools](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools).
+These tools are available as [.NET Tools](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools).
 Installation and usage instructions are on the following pages:
 
 - [MonoGame Content Builder](mgcb.md) (MGCB): used to build content pipeline content.

--- a/Documentation/articles/whats_new.md
+++ b/Documentation/articles/whats_new.md
@@ -4,21 +4,21 @@ The MonoGame 3.8 release marks some big changes in how we build and distribute.
 
 > [!NOTE] Refer to the [Changelog](../../CHANGELOG.md) for a more complete list of changes.
 
-## .NET Core Support
+## .NET Support
 
-We now support [.NET Core](https://docs.microsoft.com/en-us/dotnet/core/introduction) in addition to .NET 4.5 target frameworks.  This brings us up to date with the latest improvements in the .NET ecosystem and allow for exciting new features like [.NET Core Runtime](https://github.com/dotnet/corert) and much easier distribution of your games for Windows, macOS and Linux.
+We now support [.NET 5](https://docs.microsoft.com/en-us/dotnet/core/introduction) in addition to .NET 4.5 target frameworks.  This brings us up to date with the latest improvements in the .NET ecosystem and allow for exciting new features like [.NET NativeAOT Runtime](https://github.com/dotnet/runtimelab/tree/feature/NativeAOT) and much easier distribution of your games for Windows, macOS and Linux.
 
 ## NuGet Distribution
 
 With this release MonoGame has moved away from traditional installers and has opted for using [NuGet](https://www.nuget.org/profiles/MonoGame) for all distribution of assemblies and tools.  This also includes the new Visual Studio templates which are a VS extension.
 
-## Visual Studio 2019 and .NET Core CLI templates
+## Visual Studio 2019 and .NET CLI templates
 
-We now have templates for both Windows and macOS versions of Visual Studio 2019 as well as templates for the .NET Core CLI tools.
+We now have templates for both Windows and macOS versions of Visual Studio 2019 as well as templates for the .NET CLI tools.
 
 ## SDK-Style Projects in the repository
 
-[Protobuild](https://github.com/Protobuild/Protobuild) served us well in helping avoid manual synchronization of all our different platform projects.  With the new [SDK-style projects](https://docs.microsoft.com/en-us/dotnet/core/project-sdk/overview#project-files) supported in .NET Core, VS2017, and VS2019 we can now easily maintain the projects and solutions in the repo.
+[Protobuild](https://github.com/Protobuild/Protobuild) served us well in helping avoid manual synchronization of all our different platform projects.  With the new [SDK-style projects](https://docs.microsoft.com/en-us/dotnet/core/project-sdk/overview#project-files) supported in .NET, and VS2019 we can now easily maintain the projects and solutions in the repo.
 
 ## Removed Portable Assemblies
 

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net5.0</TargetFrameworks>
+    <TargetFrameworks>net452;net5.0-windows</TargetFrameworks>
     <DefineConstants>WINDOWS;XNADESIGNPROVIDED;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWindowsForms>true</UseWindowsForms>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;net5.0</TargetFrameworks>
     <DefineConstants>WINDOWS;XNADESIGNPROVIDED;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/.template.config/template.json
@@ -22,8 +22,8 @@
     "symbols": {
         "framework": {
             "type": "parameter",
-            "defaultValue": "netcoreapp3.1",
-            "replaces": "netcoreapp3.1"
+            "defaultValue": "net5.0",
+            "replaces": "net5.0"
         }
     }
 }

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <PublishReadyToRun>false</PublishReadyToRun>
     <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/.template.config/template.json
@@ -22,8 +22,8 @@
     "symbols": {
         "framework": {
             "type": "parameter",
-            "defaultValue": "netcoreapp3.1",
-            "replaces": "netcoreapp3.1"
+            "defaultValue": "net5.0",
+            "replaces": "net5.0"
         }
     }
 }

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/.template.config/template.json
@@ -22,8 +22,8 @@
     "symbols": {
         "framework": {
             "type": "parameter",
-            "defaultValue": "net5.0",
-            "replaces": "net5.0"
+            "defaultValue": "net5.0-windows",
+            "replaces": "net5.0-windows"
         }
     }
 }

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <PublishReadyToRun>false</PublishReadyToRun>
     <TieredCompilation>false</TieredCompilation>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <PublishReadyToRun>false</PublishReadyToRun>
     <TieredCompilation>false</TieredCompilation>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Templates/MonoGame.Templates.FSharp/content/MonoGame.Application.DesktopGL.FSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.FSharp/content/MonoGame.Application.DesktopGL.FSharp/.template.config/template.json
@@ -22,8 +22,8 @@
     "symbols": {
         "framework": {
             "type": "parameter",
-            "defaultValue": "netcoreapp3.1",
-            "replaces": "netcoreapp3.1"
+            "defaultValue": "net5.0",
+            "replaces": "net5.0"
         }
     }
 }

--- a/Templates/MonoGame.Templates.FSharp/content/MonoGame.Application.DesktopGL.FSharp/MGNamespace.fsproj
+++ b/Templates/MonoGame.Templates.FSharp/content/MonoGame.Application.DesktopGL.FSharp/MGNamespace.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <PublishReadyToRun>false</PublishReadyToRun>
     <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>

--- a/Tests/MonoGame.Tests.DesktopGL.csproj
+++ b/Tests/MonoGame.Tests.DesktopGL.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnitLite" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="NUnitLite" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/MonoGame.Tests.DesktopGL.csproj
+++ b/Tests/MonoGame.Tests.DesktopGL.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/Tests/MonoGame.Tests.WindowsDX.csproj
+++ b/Tests/MonoGame.Tests.WindowsDX.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/Tests/MonoGame.Tests.WindowsDX.csproj
+++ b/Tests/MonoGame.Tests.WindowsDX.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnitLite" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="NUnitLite" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/MonoGame.Tests.WindowsDX.csproj
+++ b/Tests/MonoGame.Tests.WindowsDX.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
+++ b/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Description>The unit tests for the MonoGame framework.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>

--- a/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
+++ b/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnitLite" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnitLite" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
   </ItemGroup>
 

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 #tool nuget:?package=vswhere&version=2.6.7
-#tool nuget:?package=NUnit.ConsoleRunner&version=3.4.0
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.12.0
 #addin nuget:?package=Cake.FileHelpers&version=3.3.0
 
 //////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -99,6 +99,7 @@ Task("BuildDesktopGL")
 
 Task("TestDesktopGL")
     .IsDependentOn("BuildDesktopGL")
+    .WithCriteria(() => IsRunningOnWindows())
     .Does(() =>
 {
     CreateDirectory("Artifacts/Tests/DesktopGL/Debug");


### PR DESCRIPTION
Hello there,

This PR cleans up the repository and documentation to finalize the full transition to .NET 5.0.

After that, MonoGame should be entirely .NET 5.0 compliant and should have no more components depending on .NET Core 3.1.

EDIT: macOS tests currently fail. Investigating...