### PR TITLE
Fix iOS GamePlatform to run pending background tasks #7520

### DIFF
--- a/MonoGame.Framework/Platform/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/Platform/iOS/iOSGamePlatform.cs
@@ -225,6 +225,7 @@ namespace Microsoft.Xna.Framework
             //        directly to NSTimer.CreateRepeatingTimer.
             _viewController.View.MakeCurrent();
             Game.Tick ();
+            Threading.Run();
 
             if (!IsPlayingVideo)
             {


### PR DESCRIPTION
In other `Platform` classes (such as `SDLGamePlatform` and `AndroidGamePlatform`, `Threading.Run()` is called during `Tick()` or `RunLoop()` (inconsistently, it may be called before or after `Game.Tick()` unfortunately).

Fixing this for `iOSGamePlatform`. `WinForms` and perhaps other platforms (Switch?) may suffer from the same issue.

Note that texture loading from background thread is discouraged however a lot of computationally intensive operations (reading/decoding the image file streams, allocating CPU buffers) could be done in the background thread and hence is a good practice to move such work alone into the bgthread until we request the actual texture from the main thread.