### PR TITLE
Update Game.cs

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Xna.Framework
 
                 if (value > _maxElapsedTime)
                     throw new ArgumentOutOfRangeException(
-                        "The time can not be larger than maxElapsedTime", default(Exception));
+                        "The time can not be larger than MaxElapsedTime", default(Exception));
 
                 if (value != _targetElapsedTime)
                 {

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -551,6 +551,10 @@ namespace Microsoft.Xna.Framework
             // Do not allow any update to take longer than our maximum.
             if (_accumulatedElapsedTime > _maxElapsedTime)
                 _accumulatedElapsedTime = _maxElapsedTime;
+            
+            // TargetElapsedTime can not be greater than our maximum.
+            if (_TargetElapsedTime > _maxElapsedTime)
+                _TargetElapsedTime = _maxElapsedTime;
 
             if (IsFixedTimeStep)
             {

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -215,9 +215,12 @@ namespace Microsoft.Xna.Framework
             set
             {
                 if (value < TimeSpan.Zero)
-                    throw new ArgumentOutOfRangeException("The time must be positive.", default(Exception));
+                    throw new ArgumentOutOfRangeException(
+                        "The time must be positive.", default(Exception));
+                
                 if (value < _targetElapsedTime)
-                    throw new ArgumentOutOfRangeException("The time must be at least TargetElapsedTime", default(Exception));
+                    throw new ArgumentOutOfRangeException(
+                        "The time must be at least TargetElapsedTime", default(Exception));
 
                 _maxElapsedTime = value;
             }
@@ -259,7 +262,7 @@ namespace Microsoft.Xna.Framework
 
                 if (value > _maxElapsedTime)
                     throw new ArgumentOutOfRangeException(
-                        "_targetElapsedTime can not be larger than _maxElapsedTime", default(Exception));
+                        "The time can not be larger than maxElapsedTime", default(Exception));
 
                 if (value != _targetElapsedTime)
                 {

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -257,6 +257,10 @@ namespace Microsoft.Xna.Framework
                     throw new ArgumentOutOfRangeException(
                         "The time must be positive and non-zero.", default(Exception));
 
+                if (value > _maxElapsedTime)
+                    throw new ArgumentOutOfRangeException(
+                        "_targetElapsedTime can not be larger than _maxElapsedTime", default(Exception));
+
                 if (value != _targetElapsedTime)
                 {
                     _targetElapsedTime = value;
@@ -551,10 +555,6 @@ namespace Microsoft.Xna.Framework
             // Do not allow any update to take longer than our maximum.
             if (_accumulatedElapsedTime > _maxElapsedTime)
                 _accumulatedElapsedTime = _maxElapsedTime;
-            
-            // TargetElapsedTime can not be greater than our maximum.
-            if (_TargetElapsedTime > _maxElapsedTime)
-                _TargetElapsedTime = _maxElapsedTime;
 
             if (IsFixedTimeStep)
             {


### PR DESCRIPTION
Fixes #6679 

Fixed the crashing issue that occurred due to _TargetElapsedTime being larger than _maxElapsedTime. Additionally I have changed the code in the maxElapsedTime setter to be more consistent with the TargetElapsedTime setter format wise.