### PR TITLE
Removed PS Vita support

### DIFF
--- a/Documentation/articles/platforms/0_platforms.md
+++ b/Documentation/articles/platforms/0_platforms.md
@@ -8,7 +8,6 @@ MonoGame supports the following systems:
 - Android
 - iOS
 - PlayStation 4
-- PlayStation Vita
 - Xbox One
 - Nintendo Switch
 - Google Stadia

--- a/Documentation/articles/tools/mgcb.md
+++ b/Documentation/articles/tools/mgcb.md
@@ -82,13 +82,12 @@ Set the target platform for this build. It must be a member of the [TargetPlatfo
 * PlayStation4
 * WindowsPhone8
 * RaspberryPi
-* PSVita
 * XboxOne
 * Switch
 
 If not set, it will default to Windows.
 
-NOTE: PlayStation 4, Xbox One, PS Vita, and Switch support is only available to licensed console developers.
+NOTE: PlayStation 4, Xbox One, and Switch support is only available to licensed console developers.
 
 ### Target Graphics Profile
 

--- a/Documentation/articles/tools/mgfxc.md
+++ b/Documentation/articles/tools/mgfxc.md
@@ -42,11 +42,10 @@ The `/Profile` option defines the platform we're targeting with this effect file
 - DirectX_11
 - OpenGL
 - PlayStation4
-- PSVita
 - XboxOne
 - Switch
 
-NOTE: PlayStation 4, Xbox One, PS Vita, and Switch support is only available to licensed console developers.
+NOTE: PlayStation 4, Xbox One, and Switch support is only available to licensed console developers.
 
 ### Help
 

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -41,6 +41,10 @@
         <Output TaskParameter="Output" ItemName="ContentReferences"/>
     </CollectContentReferences>
 
+    <Error Text="The MonoGamePlatform property was set to a deprecated platform. It is no longer possible to target it."
+       Condition="	'$(MonoGamePlatform)' != 'PlayStationMobile' Or       
+			'$(MonoGamePlatform)' != 'PSVita'" />
+
     <Error Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, WindowsStoreApp, WindowsPhone8, MacOSX, iOS, Linux, DesktopGL, RaspberryPi, Android, NativeClient, PlayStation4, PSVita, XboxOne or PlayStationMobile."
        Condition="	'$(MonoGamePlatform)' != 'Windows' And
 			'$(MonoGamePlatform)' != 'iOS' And       
@@ -50,11 +54,9 @@
 			'$(MonoGamePlatform)' != 'MacOSX' And       
 			'$(MonoGamePlatform)' != 'WindowsStoreApp' And       
 			'$(MonoGamePlatform)' != 'NativeClient' And       
-			'$(MonoGamePlatform)' != 'PlayStationMobile' And       
 			'$(MonoGamePlatform)' != 'WindowsPhone8' And       
 			'$(MonoGamePlatform)' != 'RaspberryPi' And       
 			'$(MonoGamePlatform)' != 'PlayStation4' And       
-			'$(MonoGamePlatform)' != 'PSVita' And       
 			'$(MonoGamePlatform)' != 'XboxOne' And 
 			'$(MonoGamePlatform)' != 'WindowsGL'" />
 

--- a/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
+++ b/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// <summary>
         /// PlayStation Vita
         /// </summary>
+		[Obsolete("PS Vita is no longer supported")]
         PSVita,
        
         /// <summary>

--- a/MonoGame.Framework/Utilities/MonoGamePlatform.cs
+++ b/MonoGame.Framework/Utilities/MonoGamePlatform.cs
@@ -45,11 +45,6 @@ namespace MonoGame.Framework.Utilities
         WebGL,
 
         /// <summary>
-        /// MonoGame PSVita platform.
-        /// </summary>
-        PSVita,
-
-        /// <summary>
         /// MonoGame Xbox One platform.
         /// </summary>
         XboxOne,

--- a/MonoGame.Framework/Utilities/PlatformInfo.cs
+++ b/MonoGame.Framework/Utilities/PlatformInfo.cs
@@ -36,8 +36,6 @@ namespace MonoGame.Framework.Utilities
                 return MonoGamePlatform.XboxOne;
 #elif PLAYSTATION4
                 return MonoGamePlatform.PlayStation4;
-#elif PSVITA
-                return MonoGamePlatform.PSVita;
 #elif STADIA
                 return MonoGamePlatform.Stadia;
 #endif

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ We support a growing list of platforms across the desktop, mobile, and console s
    * Windows Phone 10 (UWP)
  * Consoles (for registered developers)
    * PlayStation 4
-   * PlayStation Vita
    * Xbox One (both UWP and XDK)
    * Nintendo Switch
    * Google Stadia

--- a/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
+++ b/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
@@ -77,7 +77,6 @@
   <Import Project="..\..\Switch\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\Switch\MonoGame.Effect.Compiler.targets')" />
   <Import Project="..\..\XBoxOne\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\XBoxOne\MonoGame.Effect.Compiler.targets')" />
   <Import Project="..\..\PlayStation4\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\PlayStation4\MonoGame.Effect.Compiler.targets')" />
-  <Import Project="..\..\PSVita\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\PSVita\MonoGame.Effect.Compiler.targets')" />
   <Import Project="..\..\Stadia\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\Stadia\MonoGame.Effect.Compiler.targets')" />
 
 </Project>


### PR DESCRIPTION
Hello there,

Build submissions for the PS Vita are now permanently closed. It doesn't make sense anymore to support it.

This PR removes the platform support and marks it as deprecated if set as ```MonoGamePlatform```.

I would be in favor of entirely removing it with no deprecation warning. Let me know if I should go ahead with this or not.