### PR TITLE
OpenGL debug context for better error messages

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsContext.SDL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsContext.SDL.cs
@@ -41,6 +41,10 @@ namespace MonoGame.OpenGL
                 return;
             
             SetWindowHandle(info);
+#if DEBUG
+            // create debug context, so we get better error messages (glDebugMessageCallback)
+            Sdl.GL.SetAttribute(Sdl.GL.Attribute.ContextFlags, 1); // 1 = SDL_GL_CONTEXT_DEBUG_FLAG
+#endif
             _context = Sdl.GL.CreateContext(_winHandle);
 
             // GL entry points must be loaded after the GL context creation, otherwise some Windows drivers will return only GL 1.3 compatible functions


### PR DESCRIPTION
DesktopGL uses glDebugMessageCallback for error reporting, but doesn't use a debug context, when building in debug mode.

From https://www.khronos.org/opengl/wiki/Debug_Output:
"In Debug Contexts, debug output starts enabled. In non-debug contexts, the OpenGL implementation may not generate messages even if debug output is enabled."