### PR TITLE
Enable setting 8 render targets when targetting Windows

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private IndexBuffer _indexBuffer;
         private bool _indexBufferDirty;
 
-        private readonly RenderTargetBinding[] _currentRenderTargetBindings = new RenderTargetBinding[4];
+        private readonly RenderTargetBinding[] _currentRenderTargetBindings = new RenderTargetBinding[8];
         private int _currentRenderTargetCount;
         private readonly RenderTargetBinding[] _tempRenderTargetBinding = new RenderTargetBinding[1];
 

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
 
         // The active render targets.
-        readonly SharpDX.Direct3D11.RenderTargetView[] _currentRenderTargets = new SharpDX.Direct3D11.RenderTargetView[4];
+        readonly SharpDX.Direct3D11.RenderTargetView[] _currentRenderTargets = new SharpDX.Direct3D11.RenderTargetView[8];
 
         // The active depth view.
         SharpDX.Direct3D11.DepthStencilView _currentDepthStencilView;


### PR DESCRIPTION
Enables setting up to 8 render targets at once when targetting Windows.

Currently has to be enabled via reflection, which feels bad.

```cs
typeof(GraphicsDevice).GetField("_currentRenderTargets", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(_graphics, new SharpDX.Direct3D11.RenderTargetView[8]);
typeof(GraphicsDevice).GetField("_currentRenderTargetBindings", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(_graphics, new RenderTargetBinding[8]);
```