### PR TITLE
Remove dynamic MonoGamePlatform in props.

### DIFF
--- a/MonoGame.Framework/Directory.Build.props
+++ b/MonoGame.Framework/Directory.Build.props
@@ -3,7 +3,6 @@
   <Import Project="..\MonoGame.props" />
 
   <PropertyGroup>
-    <MonoGamePlatform>$(MSBuildProjectName.Substring(19))</MonoGamePlatform>
     <BaseIntermediateOutputPath>obj\$(MonoGamePlatform)</BaseIntermediateOutputPath>
     <BaseOutputPath>..\Artifacts\MonoGame.Framework\$(MonoGamePlatform)</BaseOutputPath>
     <AssemblyName>MonoGame.Framework</AssemblyName>


### PR DESCRIPTION
The  MonoGamePlatform is defined in target files for each platform.
In some cases there's a conflic, for WindowsDX.csproj this would resolve
to 'WindowsDX' while WindowsDX.targets define the correct platform
'Windows'.