### PR TITLE
Optimized ApplyAlpha by removing two unnecessary arithmetic operations

### DIFF
--- a/MonoGame.Framework/Graphics/DefaultColorProcessors.cs
+++ b/MonoGame.Framework/Graphics/DefaultColorProcessors.cs
@@ -6,11 +6,7 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         private static byte ApplyAlpha(byte color, byte alpha)
         {
-            var fc = color / 255.0f;
-            var fa = alpha / 255.0f;
-            var fr = (int)(255.0f * fc * fa);
-
-            return (byte)MathHelper.Clamp(fr, byte.MinValue, byte.MaxValue);
+            return (byte)MathHelper.Clamp(color * alpha / 255, byte.MinValue, byte.MaxValue);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Graphics/DefaultColorProcessors.cs
+++ b/MonoGame.Framework/Graphics/DefaultColorProcessors.cs
@@ -4,11 +4,6 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public unsafe static class DefaultColorProcessors
     {
-        private static byte ApplyAlpha(byte color, byte alpha)
-        {
-            return (byte)MathHelper.Clamp(color * alpha / 255, byte.MinValue, byte.MaxValue);
-        }
-
         /// <summary>
         /// Zeroes RGB of pixels having zero alpha(standard XNA behavior)
         /// </summary>
@@ -37,10 +32,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 byte* ptr = b;
                 for (var i = 0; i < data.Length; i += 4, ptr += 4)
                 {
-                    var a = ptr[3];
-                    ptr[0] = ApplyAlpha(ptr[0], a);
-                    ptr[1] = ApplyAlpha(ptr[1], a);
-                    ptr[2] = ApplyAlpha(ptr[2], a);
+                    var falpha = ptr[i + 3] / 255.0f;
+                    ptr[i] = (byte)(ptr[i] * falpha);
+                    ptr[i + 1] = (byte)(ptr[i + 1] * falpha);
+                    ptr[i + 2] = (byte)(ptr[i + 2] * falpha);
                 }
             }
         };

--- a/MonoGame.Framework/Graphics/DefaultColorProcessors.cs
+++ b/MonoGame.Framework/Graphics/DefaultColorProcessors.cs
@@ -32,10 +32,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 byte* ptr = b;
                 for (var i = 0; i < data.Length; i += 4, ptr += 4)
                 {
-                    var falpha = ptr[i + 3] / 255.0f;
-                    ptr[i] = (byte)(ptr[i] * falpha);
-                    ptr[i + 1] = (byte)(ptr[i + 1] * falpha);
-                    ptr[i + 2] = (byte)(ptr[i + 2] * falpha);
+                    var falpha = ptr[3] / 255.0f;
+                    ptr[i] = (byte)(ptr[0] * falpha);
+                    ptr[i + 1] = (byte)(ptr[1] * falpha);
+                    ptr[i + 2] = (byte)(ptr[2] * falpha);
                 }
             }
         };

--- a/MonoGame.Framework/Graphics/DefaultColorProcessors.cs
+++ b/MonoGame.Framework/Graphics/DefaultColorProcessors.cs
@@ -33,9 +33,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 for (var i = 0; i < data.Length; i += 4, ptr += 4)
                 {
                     var falpha = ptr[3] / 255.0f;
-                    ptr[i] = (byte)(ptr[0] * falpha);
-                    ptr[i + 1] = (byte)(ptr[1] * falpha);
-                    ptr[i + 2] = (byte)(ptr[2] * falpha);
+                    ptr[0] = (byte)(ptr[0] * falpha);
+                    ptr[1] = (byte)(ptr[1] * falpha);
+                    ptr[2] = (byte)(ptr[2] * falpha);
                 }
             }
         };


### PR DESCRIPTION
Actually maybe MathHelper.Clamp call isnt necessary either. Since in edge case, when both color and alpha are equal to 255, then the result will be 255 * 255 / 255 = 255. But I am unsure.