### PR TITLE
Null song parameters for MediaPlayer.Play are not allowed in XNA

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -118,6 +118,9 @@ namespace Microsoft.Xna.Framework.Media
         /// </summary>
         public static void Play(Song song, TimeSpan? startPosition)
         {
+            if (song == null)
+                throw new ArgumentNullException("song", "This method does not accept null for this parameter.");
+
             var previousSong = _queue.Count > 0 ? _queue[0] : null;
             _queue.Clear();
             _numSongsInQueuePlayed = 0;
@@ -132,6 +135,9 @@ namespace Microsoft.Xna.Framework.Media
 
 		public static void Play(SongCollection collection, int index = 0)
 		{
+            if (collection == null)
+                throw new ArgumentNullException("collection", "This method does not accept null for this parameter.");
+
             _queue.Clear();
             _numSongsInQueuePlayed = 0;
 
@@ -223,4 +229,3 @@ namespace Microsoft.Xna.Framework.Media
 		}
     }
 }
-


### PR DESCRIPTION
This PR tries to mirror xna behavior around null Songs and SongCollections. The caller should be able to catch and handle this before any internal states are changed in the player.