### PR TITLE
Fixes XACT Cue.IsPlaying Behaviour When Paused

### DIFF
--- a/MonoGame.Framework/Audio/Xact/Cue.cs
+++ b/MonoGame.Framework/Audio/Xact/Cue.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Xna.Framework.Audio
             get 
             {
                 if (_curSound != null)
-                    return _curSound.Playing;
+                    return _curSound.Playing || _curSound.IsPaused;
 
                 return false;
             }


### PR DESCRIPTION
This pull request is to fix the behaviour of XACT Cue.IsPlaying when paused. More details on the issue can be found here: #7562

For demonstration purposes please see the CueIsPlaying project for both XNA and Monogame here:
[https://github.com/squarebananas/MonoGameSamplesForIssues](https://github.com/squarebananas/MonoGameSamplesForIssues)