### PR TITLE
Fixes XACT ADPCM Compression Playback

### DIFF
--- a/MonoGame.Framework/Platform/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffect.OpenAL.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             if (codec == MiniFormatTag.Adpcm)
             {
-                PlatformInitializeAdpcm(buffer, 0, buffer.Length, sampleRate, (AudioChannels)channels, (blockAlignment + 16) * channels, loopStart, loopLength);
+                PlatformInitializeAdpcm(buffer, 0, buffer.Length, sampleRate, (AudioChannels)channels, (blockAlignment + 22) * channels, loopStart, loopLength);
                 duration = TimeSpan.FromSeconds(SoundBuffer.Duration);
                 return;
             }

--- a/MonoGame.Framework/Platform/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffect.XAudio.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Xna.Framework.Audio
             {
                 duration = TimeSpan.FromSeconds((float)loopLength / sampleRate);
 
-                CreateBuffers(  new WaveFormatAdpcm(sampleRate, channels, blockAlignment),
+                CreateBuffers(  new WaveFormatAdpcm(sampleRate, channels, (blockAlignment + 22) * channels),
                                 ToDataStream(0, buffer, buffer.Length),
                                 loopStart,
                                 loopLength);


### PR DESCRIPTION
This pull request is to fix XACT ADPCM compression playback. More details on the issue can be found here (the issue also includes Non-XACT playback which remains broken until FFMPEG is fixed, this only fixes XACT): #5662

The fix was originally posted by @tomspilman in 2018 here:
[https://github.com/MonoGame/MonoGame/issues/5662#issuecomment-410486541](https://github.com/MonoGame/MonoGame/issues/5662#issuecomment-410486541)

The issue relates to XAudio projects, however the same fix is required for OpenAL projects as well.

For demonstration purposes please see the AdpcmAlignment project within here:
[https://github.com/squarebananas/MonoGameSamplesForIssues](https://github.com/squarebananas/MonoGameSamplesForIssues)