### PR TITLE
Fixes EffectParameter SetValue Using Int For Float Parameters

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
@@ -446,6 +446,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		public void SetValue (int value)
 		{
+            if (ParameterType == EffectParameterType.Single)
+            {
+                SetValue((float)value);
+                return;
+            }
+
             if (ParameterClass != EffectParameterClass.Scalar || ParameterType != EffectParameterType.Int32)
                 throw new InvalidCastException();
 


### PR DESCRIPTION
This pull request is to fix the behaviour of EffectParameter SetValue to allow float parameters to be set with int values. More details on the issue can be found here: #7567