### PR TITLE
Fixes UWP Set Window Size Thread Access Error

### DIFF
--- a/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Xna.Framework
                 _viewBounds.Height == height)
                 return;
 
-            double rawPixelsPerViewPixel = 1d;
+            double rawPixelsPerViewPixel = 1.0d;
             if (CoreWindow.GetForCurrentThread() != null)
                 rawPixelsPerViewPixel = _dinfo.RawPixelsPerViewPixel;
             else

--- a/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
@@ -272,7 +273,16 @@ namespace Microsoft.Xna.Framework
                 _viewBounds.Height == height)
                 return;
 
-            var viewSize = new Windows.Foundation.Size(width / _dinfo.RawPixelsPerViewPixel, height / _dinfo.RawPixelsPerViewPixel);
+            double rawPixelsPerViewPixel = 1d;
+            if (CoreWindow.GetForCurrentThread() != null)
+                rawPixelsPerViewPixel = _dinfo.RawPixelsPerViewPixel;
+            else
+                Task.Run(async () =>
+                {
+                    await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(
+                        CoreDispatcherPriority.Normal, () => { rawPixelsPerViewPixel = _dinfo.RawPixelsPerViewPixel; });
+                }).Wait();
+            var viewSize = new Windows.Foundation.Size(width / rawPixelsPerViewPixel, height / rawPixelsPerViewPixel);
 
             //_appView.SetPreferredMinSize(viewSize);
             if (!_appView.TryResizeView(viewSize))


### PR DESCRIPTION
It should be possible to change the window size during Update by setting the preferred back buffer size and using ApplyChanges. However this results in a thread access error as Windows.Graphics.Display.DisplayInformation.RawPixelsPerViewPixel can only be accessed from the UI thread (different from the thread running the Game Tick).

For demonstration purposes please see the UWPSetWindowSize project within here:
https://github.com/squarebananas/MonoGameSamplesForIssues

This pull request fixes this by using the UI thread's dispatcher to retrieve the RawPixelsPerViewPixel value.