### PR TITLE
Added a keyboard shortcut (F2) to rename a file.

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
@@ -194,6 +194,7 @@ namespace MonoGame.Tools.Pipeline
             cmdRename = new Command();
             cmdRename.MenuText = "Rename";
             cmdRename.Image = Global.GetEtoIcon("Commands.Rename.png");
+            cmdRename.Shortcut = Keys.F2;
 
             cmdDelete = new Command();
             cmdDelete.MenuText = "Delete";


### PR DESCRIPTION
I was investigating another bug and tried to rename it with F2, which didn't work, because that keyboard shortcut hadn't been defined. That felt like low-hanging fruit, so I went and made this change.

This partially addresses #7233. I'd add the other two shortcuts listed there, but I'm not sure how to do it. A partial fix seemed like an improvement over no fix.

Is this something the MonoGame maintainers would be interested in pulling in?