### PR TITLE
Prevent the timing of audio tests from overrunning

### DIFF
--- a/Tests/Framework/Audio/DynamicSoundEffectInstanceTest.cs
+++ b/Tests/Framework/Audio/DynamicSoundEffectInstanceTest.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
@@ -415,12 +416,21 @@ namespace MonoGame.Tests.Audio
         /// </summary>
         private static void SleepWhileDispatching(int ms)
         {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
             int cycles = ms / 10;
             for (int i = 0; i < cycles; i++)
             {
                 FrameworkDispatcher.Update();
                 Thread.Sleep(10);
-            }
+
+                if (stopwatch.Elapsed.TotalMilliseconds > ms)
+                {
+                    stopwatch.Stop();
+                    break;
+                }
+            }            
         }
 
         /// <summary>

--- a/Tests/Framework/Audio/SoundEffectInstanceTest.cs
+++ b/Tests/Framework/Audio/SoundEffectInstanceTest.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using System.Threading;
+using System.Diagnostics;
 
 namespace MonoGame.Tests.Audio
 {
@@ -57,11 +58,20 @@ namespace MonoGame.Tests.Audio
 
         private static void SleepWhileDispatching(int ms)
         {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
             int cycles = ms / 10;
             for (int i = 0; i < cycles; i++)
             {
                 FrameworkDispatcher.Update();
                 Thread.Sleep(10);
+
+                if (stopwatch.Elapsed.TotalMilliseconds > ms)
+                {
+                    stopwatch.Stop();
+                    break;
+                }
             }
         }
 

--- a/Tests/Framework/Audio/XactTest.cs
+++ b/Tests/Framework/Audio/XactTest.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Microsoft.Xna.Framework.Audio;
@@ -356,11 +357,20 @@ namespace MonoGame.Tests.Audio
 
         private void SleepWhileAudioEngineUpdates(int ms)
         {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
             int cycles = ms / 10;
             for (int i = 0; i < cycles; i++)
             {
                 _audioEngine.Update();
                 Thread.Sleep(10);
+
+                if (stopwatch.Elapsed.TotalMilliseconds > ms)
+                {
+                    stopwatch.Stop();
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
There are currently three classes that simulate periodically updating sound effect objects by running Thread.Sleep in a loop. By placing a stopwatch around these loops it can be seen that this sometimes is quite an inaccurate method of timing.

This is likely contributing to audio tests that rely on timing randomly failing at times.

To fix this stopwatches can be used to exit the loops early, potentially preventing the tests from overrunning and failing.

Also it may be possible to reinstate the disabled BufferNeeded_DuringPlayback audio test for DesktopGL if this happens to be the cause of that. Maybe the test can be run manually a few times on the test server to see if this is the cause?