### PR TITLE
Fix NRE for Game._gameTimer

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -404,8 +404,12 @@ namespace Microsoft.Xna.Framework
         public void ResetElapsedTime()
         {
             Platform.ResetElapsedTime();
-            _gameTimer.Reset();
-            _gameTimer.Start();
+            if (_gameTimer != null)
+            {
+                _gameTimer.Reset();
+                _gameTimer.Start();
+            }
+
             _accumulatedElapsedTime = TimeSpan.Zero;
             _gameTime.ElapsedGameTime = TimeSpan.Zero;
             _previousTicks = 0L;
@@ -532,6 +536,11 @@ namespace Microsoft.Xna.Framework
             }
 
             // Advance the accumulated elapsed time.
+            if (_gameTimer == null)
+            {
+                _gameTimer = new Stopwatch();
+                _gameTimer.Start();
+            }
             var currentTicks = _gameTimer.Elapsed.Ticks;
             _accumulatedElapsedTime += TimeSpan.FromTicks(currentTicks - _previousTicks);
             _previousTicks = currentTicks;

--- a/Tests/Framework/GameTest.cs
+++ b/Tests/Framework/GameTest.cs
@@ -164,7 +164,16 @@ namespace MonoGame.Tests {
 				//Assert.That(_game, Has.Property("UpdateCount").GreaterThan(11));
 				//Assert.That(_game, Has.Property("DrawCount").EqualTo(10));
 			}
-		}
+
+            [Test]
+            public void GameTickTest()
+            {
+                // should not throw an exception
+                Game.ResetElapsedTime();
+                Assert.DoesNotThrow(() => Game.Tick());
+                Game.ResetElapsedTime();
+            }
+        }
 
         [TestFixture]
         public class Misc
@@ -213,6 +222,8 @@ namespace MonoGame.Tests {
 
                 g.Dispose();
             }
+
+
 
             private class ExitTestGame : CountCallsGame
             {


### PR DESCRIPTION
This pull requests addresses issue #6112 that an exception is not thrown when the game timer is not initialized. 