### PR TITLE
remove CLSCompliant(false) from internal members

### DIFF
--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -222,7 +222,6 @@ namespace MonoGame.OpenAL
 #endif
         }
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_alenable(int cap);
         internal static d_alenable Enable = FuncLoader.LoadFunction<d_alenable>(NativeLibrary, "alEnable");
@@ -257,7 +256,6 @@ namespace MonoGame.OpenAL
             }
         }
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal unsafe delegate void d_aldeletebuffers(int n, int* buffers);
         internal static d_aldeletebuffers alDeleteBuffers = FuncLoader.LoadFunction<d_aldeletebuffers>(NativeLibrary, "alDeleteBuffers");
@@ -275,7 +273,6 @@ namespace MonoGame.OpenAL
             }
         }
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_albufferi(int buffer, ALBufferi param, int value);
         internal static d_albufferi Bufferi = FuncLoader.LoadFunction<d_albufferi>(NativeLibrary, "alBufferi");
@@ -371,12 +368,10 @@ namespace MonoGame.OpenAL
             return errorCode.ToString();
         }
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate bool d_alissource(int source);
         internal static d_alissource IsSource = FuncLoader.LoadFunction<d_alissource>(NativeLibrary, "alIsSource");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_aldeletesources(int n, ref int sources);
         internal static d_aldeletesources alDeleteSources = FuncLoader.LoadFunction<d_aldeletesources>(NativeLibrary, "alDeleteSources");
@@ -386,7 +381,6 @@ namespace MonoGame.OpenAL
             alDeleteSources(1, ref source);
         }
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_alsourcestop(int sourceId);
         internal static d_alsourcestop SourceStop = FuncLoader.LoadFunction<d_alsourcestop>(NativeLibrary, "alSourceStop");
@@ -395,7 +389,6 @@ namespace MonoGame.OpenAL
         internal delegate void d_alsourcei(int sourceId, int i, int a);
         internal static d_alsourcei alSourcei = FuncLoader.LoadFunction<d_alsourcei>(NativeLibrary, "alSourcei");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_alsource3i(int sourceId, ALSourcei i, int a, int b, int c);
         internal static d_alsource3i alSource3i = FuncLoader.LoadFunction<d_alsource3i>(NativeLibrary, "alSource3i");
@@ -420,17 +413,14 @@ namespace MonoGame.OpenAL
             alSourcef(sourceId, i, dist);
         }
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_alsourcef(int sourceId, ALSourcef i, float a);
         internal static d_alsourcef alSourcef = FuncLoader.LoadFunction<d_alsourcef>(NativeLibrary, "alSourcef");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_alsource3f(int sourceId, ALSource3f i, float x, float y, float z);
         internal static d_alsource3f alSource3f = FuncLoader.LoadFunction<d_alsource3f>(NativeLibrary, "alSource3f");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_algetsourcei(int sourceId, ALGetSourcei i, out int state);
         internal static d_algetsourcei GetSource = FuncLoader.LoadFunction<d_algetsourcei>(NativeLibrary, "alGetSourcei");
@@ -442,32 +432,26 @@ namespace MonoGame.OpenAL
             return (ALSourceState)state;
         }
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_algetlistener3f(ALListener3f param, out float value1, out float value2, out float value3);
         internal static d_algetlistener3f GetListener = FuncLoader.LoadFunction<d_algetlistener3f>(NativeLibrary, "alGetListener3f");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_aldistancemodel(ALDistanceModel model);
         internal static d_aldistancemodel DistanceModel = FuncLoader.LoadFunction<d_aldistancemodel>(NativeLibrary, "alDistanceModel");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_aldopplerfactor(float value);
         internal static d_aldopplerfactor DopplerFactor = FuncLoader.LoadFunction<d_aldopplerfactor>(NativeLibrary, "alDopplerFactor");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal unsafe delegate void d_alsourcequeuebuffers(int sourceId, int numEntries, int* buffers);
         internal static d_alsourcequeuebuffers alSourceQueueBuffers = FuncLoader.LoadFunction<d_alsourcequeuebuffers>(NativeLibrary, "alSourceQueueBuffers");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal unsafe delegate void d_alsourceunqueuebuffers(int sourceId, int numEntries, int* salvaged);
         internal static d_alsourceunqueuebuffers alSourceUnqueueBuffers = FuncLoader.LoadFunction<d_alsourceunqueuebuffers>(NativeLibrary, "alSourceUnqueueBuffers");
 
-        [CLSCompliant(false)]
         internal static unsafe void SourceQueueBuffers(int sourceId, int numEntries, int[] buffers)
         {
             fixed (int* ptr = &buffers[0])
@@ -481,7 +465,6 @@ namespace MonoGame.OpenAL
             AL.alSourceQueueBuffers(sourceId, 1, &buffer);
         }
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_alsourceunqueuebuffers2(int sid, int numEntries, out int[] bids);
         internal static d_alsourceunqueuebuffers2 alSourceUnqueueBuffers2 = FuncLoader.LoadFunction<d_alsourceunqueuebuffers2>(NativeLibrary, "alSourceUnqueueBuffers");
@@ -534,7 +517,6 @@ namespace MonoGame.OpenAL
 
     internal partial class Alc
     {
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate IntPtr d_alccreatecontext(IntPtr device, int[] attributes);
         internal static d_alccreatecontext CreateContext = FuncLoader.LoadFunction<d_alccreatecontext>(AL.NativeLibrary, "alcCreateContext");
@@ -544,7 +526,6 @@ namespace MonoGame.OpenAL
             return GetErrorForDevice(IntPtr.Zero);
         }
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate AlcError d_alcgeterror(IntPtr device);
         internal static d_alcgeterror GetErrorForDevice = FuncLoader.LoadFunction<d_alcgeterror>(AL.NativeLibrary, "alcGetError");
@@ -558,27 +539,22 @@ namespace MonoGame.OpenAL
             alcGetIntegerv(device, (int)param, size, values);
         }
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate IntPtr d_alcgetcurrentcontext();
         internal static d_alcgetcurrentcontext GetCurrentContext = FuncLoader.LoadFunction<d_alcgetcurrentcontext>(AL.NativeLibrary, "alcGetCurrentContext");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_alcmakecontextcurrent(IntPtr context);
         internal static d_alcmakecontextcurrent MakeContextCurrent = FuncLoader.LoadFunction<d_alcmakecontextcurrent>(AL.NativeLibrary, "alcMakeContextCurrent");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_alcdestroycontext(IntPtr context);
         internal static d_alcdestroycontext DestroyContext = FuncLoader.LoadFunction<d_alcdestroycontext>(AL.NativeLibrary, "alcDestroyContext");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_alcclosedevice(IntPtr device);
         internal static d_alcclosedevice CloseDevice = FuncLoader.LoadFunction<d_alcclosedevice>(AL.NativeLibrary, "alcCloseDevice");
 
-        [CLSCompliant(false)]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate IntPtr d_alcopendevice(string device);
         internal static d_alcopendevice OpenDevice = FuncLoader.LoadFunction<d_alcopendevice>(AL.NativeLibrary, "alcOpenDevice");
@@ -710,7 +686,6 @@ namespace MonoGame.OpenAL
         }
     }
 
-    [CLSCompliant(false)]
     internal class EffectsExtension
     {
         /* Effect API */


### PR DESCRIPTION
fixes warnings CS3019 for types that are not visible from outside the
assembly.