### PR TITLE
added slash/pound keys and test cases

### DIFF
--- a/MonoGame.Framework/Input/Keys.cs
+++ b/MonoGame.Framework/Input/Keys.cs
@@ -574,6 +574,14 @@ namespace Microsoft.Xna.Framework.Input
         /// </summary>
 		OemBackslash = 226,
         /// <summary>
+        /// Forward Slash key
+        /// </summary>
+        ForwardSlash = 227,
+        /// <summary>
+        /// Pound key
+        /// </summary>
+        Pound = 228,
+        /// <summary>
         /// IME PROCESS key.
         /// </summary>
 		ProcessKey = 229,

--- a/Tests/Framework/Input/KeyboardTest.cs
+++ b/Tests/Framework/Input/KeyboardTest.cs
@@ -33,6 +33,10 @@ namespace MonoGame.Tests.Input
         [TestCase(new[] { Keys.Delete, Keys.U, Keys.RightWindows, Keys.L, Keys.NumPad2 }, false, false)]
         [TestCase(new[] { Keys.F9, Keys.F12, Keys.VolumeUp, Keys.OemAuto, Keys.NumPad3 }, false, false)]
         [TestCase(new[] { Keys.OemMinus, Keys.OemTilde, Keys.Tab, Keys.Zoom }, true, false)]
+        [TestCase(new[] { Keys.ForwardSlash}, false, false)]
+        [TestCase(new[] { Keys.ForwardSlash }, true, false)]
+        [TestCase(new[] { Keys.Pound}, false, false)]
+        [TestCase(new[] { Keys.Pound}, true, false)]
         public void TestState(Keys[] keys, bool capsLock, bool numLock)
         {
             var keyList = keys.ToList();


### PR DESCRIPTION
This pull request addresses issue #7488 where the user reported that forward slash and pound keys were not recognized. I've added those two keys and added the test cases as well.