### PR TITLE
code smell - removed duplicate code

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
@@ -111,12 +111,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 GL.InvalidateFramebuffer (FramebufferTarget.Framebuffer, 3, FramebufferAttachements);
             }
 
-            internal virtual void InvalidateReadFramebuffer()
-            {
-                Debug.Assert(this.SupportsInvalidateFramebuffer);
-                GL.InvalidateFramebuffer(FramebufferTarget.Framebuffer, 3, FramebufferAttachements);
-            }
-
             internal virtual void DeleteFramebuffer(int framebuffer)
             {
                 GL.DeleteFramebuffers(1, ref framebuffer);

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -803,7 +803,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     this.framebufferHelper.BlitFramebuffer(i, renderTarget.Width, renderTarget.Height);
                 }
                 if (renderTarget.RenderTargetUsage == RenderTargetUsage.DiscardContents && this.framebufferHelper.SupportsInvalidateFramebuffer)
-                    this.framebufferHelper.InvalidateReadFramebuffer();
+                    this.framebufferHelper.InvalidateDrawFramebuffer();
                 if (this._lastRasterizerState.ScissorTestEnable)
                 {
                     GL.Enable(EnableCap.ScissorTest);


### PR DESCRIPTION
I'm taking this class where I have to find the code smells using the tool and fix the issue/warning. I found that there were two methods with a different name but exactly the same implementation. The second method was only called once so I changed it to the first method and removed the duplicated method.