### PR TITLE
removed unnessesary null check from Texture2D.StbSharp

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
@@ -100,10 +100,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             finally
             {
-                if (data != null)
-                {
-                    data = null;
-                }
+                data = null;
             }
         }
     }


### PR DESCRIPTION
The if statement is unnecessary since the value will always end as null