### PR TITLE
Optimisations for Glyph Packing

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/Font/GlyphPacker.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Font/GlyphPacker.cs
@@ -3,9 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
@@ -38,17 +36,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 			int outputHeight = 0;
 
             // Choose positions for each glyph, one at a time.
-            // Keep a record of glyphs in a dictionary so we can look them up based on
-            // their index later for some optimisations
-            Dictionary<int, ArrangedGlyph> glyphDict = new Dictionary<int, ArrangedGlyph>();
-            for (int i = 0; i < glyphs.Count; i++)
-            {
-                glyphDict.Add(i, glyphs[i]);
-            }
-
 			for (int i = 0; i < glyphs.Count; i++)
 			{
-				PositionGlyph(glyphDict, i, outputWidth);
+				PositionGlyph(glyphs, i, outputWidth);
 
 				outputHeight = Math.Max(outputHeight, glyphs[i].Y + glyphs[i].Height);
 			}
@@ -100,7 +90,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
 
 		// Works out where to position a single glyph.
-		static void PositionGlyph(Dictionary<int, ArrangedGlyph> glyphs, int index, int outputWidth)
+		static void PositionGlyph(List<ArrangedGlyph> glyphs, int index, int outputWidth)
 		{
             int x = 0;
             int y = 0;
@@ -166,24 +156,23 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
 
 		// Checks if a proposed glyph position collides with anything that we already arranged.
-		static int FindIntersectingGlyph(Dictionary<int, ArrangedGlyph> glyphs, int index, int x, int y)
+		static int FindIntersectingGlyph(List<ArrangedGlyph> glyphs, int index, int x, int y)
 		{
 			int w = glyphs[index].Width;
 			int h = glyphs[index].Height;
 
 			for (int i = 0; i < index; i++)
 			{
-                var targetGlyph = glyphs[i];
-				if (targetGlyph.X >= x + w)
+				if (glyphs[i].X >= x + w)
 					continue;
 
-				if (targetGlyph.X + targetGlyph.Width <= x)
+				if (glyphs[i].X + glyphs[i].Width <= x)
 					continue;
 
-				if (targetGlyph.Y >= y + h)
+				if (glyphs[i].Y >= y + h)
 					continue;
 
-				if (targetGlyph.Y + targetGlyph.Height <= y)
+				if (glyphs[i].Y + glyphs[i].Height <= y)
 					continue;
 
 				return i;


### PR DESCRIPTION
The Glyph Packing process for larger fonts had some heavy performance sinks, attempting to build a 65k character font took about 10 days at the least before I gave up. With my changes below it successfully built in about 2-3 hours.

The changes can be summarised as;

- Storing each glyph in a dictionary based on its index to allow for some quicker lookups later down the line
- Starts our searching for the glyph's packed location at the maximum X and Y values of previously placed glyphs that are smaller than us (If it's smaller than us and has been placed at a position, we know there's no placed before that we could squeeze into)
- After searching through a row, instead of dropping by one pixel we drop the minimum amount to reach the bottom of a glyph we intersected (If we have searched a row full of glyphs and found no spots, we know there also wont be any spots until we clear the Y value of the smallest glyph we intersected)

A lot of the performance hits came from the repeated searching and intersecting of previous glyphs using loops as we iterate over the space trying to find where to pack our target glyph, as a result these changes aimed to minimise how often we needed to search.
I'm using the packed font in one of my other projects so can attest to it's functionality remaining consistent.