### PR TITLE
RTL text rendering overload for SpriteBatch.DrawString

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -934,196 +934,100 @@ namespace Microsoft.Xna.Framework.Graphics
             var firstGlyphOfLine = true;
 
             fixed (SpriteFont.Glyph* pGlyphs = spriteFont.Glyphs)
-                if (rtl)
-                    for (var i = 0; i < text.Length; ++i)
+                for (var i = 0; i < text.Length; ++i)
+                {
+                    var c = text[i];
+
+                    if (c == '\r')
+                        continue;
+
+                    if (c == '\n')
                     {
-                        var c = text[i];
-
-                        if (c == '\r')
-                            continue;
-
-                        if (c == '\n')
-                        {
-                            offset.X = 0;
-                            offset.Y += spriteFont.LineSpacing;
-                            firstGlyphOfLine = true;
-                            continue;
-                        }
-
-                        var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
-                        var pCurrentGlyph = pGlyphs + currentGlyphIndex;
-
-                        // The first character on a line might have a negative left side bearing.
-                        // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
-                        //  so that text does not hang off the left side of its rectangle.
-                        if (firstGlyphOfLine)
-                        {
-                            offset.X = Math.Max(pCurrentGlyph->RightSideBearing, 0);
-                            firstGlyphOfLine = false;
-                        }
-                        else
-                        {
-                            offset.X += spriteFont.Spacing + pCurrentGlyph->RightSideBearing;
-                        }
-
-                        var p = offset;
-
-                        if (!flippedHorz)
-                            p.X += pCurrentGlyph->BoundsInTexture.Width;
-                        p.X += pCurrentGlyph->Cropping.X;
-
-                        if (flippedVert)
-                            p.Y += pCurrentGlyph->BoundsInTexture.Height - spriteFont.LineSpacing;
-                        p.Y += pCurrentGlyph->Cropping.Y;
-
-                        Vector2.Transform(ref p, ref transformation, out p);
-
-                        var item = _batcher.CreateBatchItem();
-                        item.Texture = spriteFont.Texture;
-                        item.SortKey = sortKey;
-
-                        _texCoordTL.X = pCurrentGlyph->BoundsInTexture.X * spriteFont.Texture.TexelWidth;
-                        _texCoordTL.Y = pCurrentGlyph->BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
-                        _texCoordBR.X = (pCurrentGlyph->BoundsInTexture.X + pCurrentGlyph->BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
-                        _texCoordBR.Y = (pCurrentGlyph->BoundsInTexture.Y + pCurrentGlyph->BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
-
-                        if ((effects & SpriteEffects.FlipVertically) != 0)
-                        {
-                            var temp = _texCoordBR.Y;
-                            _texCoordBR.Y = _texCoordTL.Y;
-                            _texCoordTL.Y = temp;
-                        }
-                        if ((effects & SpriteEffects.FlipHorizontally) != 0)
-                        {
-                            var temp = _texCoordBR.X;
-                            _texCoordBR.X = _texCoordTL.X;
-                            _texCoordTL.X = temp;
-                        }
-
-                        if (rotation == 0f)
-                        {
-                            item.Set(p.X,
-                                    p.Y,
-                                    pCurrentGlyph->BoundsInTexture.Width * scale.X,
-                                    pCurrentGlyph->BoundsInTexture.Height * scale.Y,
-                                    color,
-                                    _texCoordTL,
-                                    _texCoordBR,
-                                    layerDepth);
-                        }
-                        else
-                        {
-                            item.Set(p.X,
-                                    p.Y,
-                                    0,
-                                    0,
-                                    pCurrentGlyph->BoundsInTexture.Width * scale.X,
-                                    pCurrentGlyph->BoundsInTexture.Height * scale.Y,
-                                    sin,
-                                    cos,
-                                    color,
-                                    _texCoordTL,
-                                    _texCoordBR,
-                                    layerDepth);
-                        }
-
-                        offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
+                        offset.X = 0;
+                        offset.Y += spriteFont.LineSpacing;
+                        firstGlyphOfLine = true;
+                        continue;
                     }
-                else
-                    for (var i = 0; i < text.Length; ++i)
+
+                    var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    var pCurrentGlyph = pGlyphs + currentGlyphIndex;
+
+                    // The first character on a line might have a negative left side bearing.
+                    // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
+                    //  so that text does not hang off the left side of its rectangle.
+                    if (firstGlyphOfLine)
                     {
-                        var c = text[i];
-
-                        if (c == '\r')
-                            continue;
-
-                        if (c == '\n')
-                        {
-                            offset.X = 0;
-                            offset.Y += spriteFont.LineSpacing;
-                            firstGlyphOfLine = true;
-                            continue;
-                        }
-
-                        var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
-                        var pCurrentGlyph = pGlyphs + currentGlyphIndex;
-
-                        // The first character on a line might have a negative left side bearing.
-                        // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
-                        //  so that text does not hang off the left side of its rectangle.
-                        if (firstGlyphOfLine)
-                        {
-                            offset.X = Math.Max(pCurrentGlyph->LeftSideBearing, 0);
-                            firstGlyphOfLine = false;
-                        }
-                        else
-                        {
-                            offset.X += spriteFont.Spacing + pCurrentGlyph->LeftSideBearing;
-                        }
-
-                        var p = offset;
-
-                        if (flippedHorz)
-                            p.X += pCurrentGlyph->BoundsInTexture.Width;
-                        p.X += pCurrentGlyph->Cropping.X;
-
-                        if (flippedVert)
-                            p.Y += pCurrentGlyph->BoundsInTexture.Height - spriteFont.LineSpacing;
-                        p.Y += pCurrentGlyph->Cropping.Y;
-
-                        Vector2.Transform(ref p, ref transformation, out p);
-
-                        var item = _batcher.CreateBatchItem();
-                        item.Texture = spriteFont.Texture;
-                        item.SortKey = sortKey;
-
-                        _texCoordTL.X = pCurrentGlyph->BoundsInTexture.X * spriteFont.Texture.TexelWidth;
-                        _texCoordTL.Y = pCurrentGlyph->BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
-                        _texCoordBR.X = (pCurrentGlyph->BoundsInTexture.X + pCurrentGlyph->BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
-                        _texCoordBR.Y = (pCurrentGlyph->BoundsInTexture.Y + pCurrentGlyph->BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
-
-                        if ((effects & SpriteEffects.FlipVertically) != 0)
-                        {
-                            var temp = _texCoordBR.Y;
-                            _texCoordBR.Y = _texCoordTL.Y;
-                            _texCoordTL.Y = temp;
-                        }
-                        if ((effects & SpriteEffects.FlipHorizontally) != 0)
-                        {
-                            var temp = _texCoordBR.X;
-                            _texCoordBR.X = _texCoordTL.X;
-                            _texCoordTL.X = temp;
-                        }
-
-                        if (rotation == 0f)
-                        {
-                            item.Set(p.X,
-                                    p.Y,
-                                    pCurrentGlyph->BoundsInTexture.Width * scale.X,
-                                    pCurrentGlyph->BoundsInTexture.Height * scale.Y,
-                                    color,
-                                    _texCoordTL,
-                                    _texCoordBR,
-                                    layerDepth);
-                        }
-                        else
-                        {
-                            item.Set(p.X,
-                                    p.Y,
-                                    0,
-                                    0,
-                                    pCurrentGlyph->BoundsInTexture.Width * scale.X,
-                                    pCurrentGlyph->BoundsInTexture.Height * scale.Y,
-                                    sin,
-                                    cos,
-                                    color,
-                                    _texCoordTL,
-                                    _texCoordBR,
-                                    layerDepth);
-                        }
-
-                        offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
+                        offset.X = Math.Max(pCurrentGlyph->LeftSideBearing, 0);
+                        firstGlyphOfLine = false;
                     }
+                    else
+                    {
+                        offset.X += spriteFont.Spacing + pCurrentGlyph->LeftSideBearing;
+                    }
+
+                    var p = offset;
+
+                    if (rtl ^ flippedHorz)
+                        p.X += pCurrentGlyph->BoundsInTexture.Width;
+                    p.X += pCurrentGlyph->Cropping.X;
+
+                    if (flippedVert)
+                        p.Y += pCurrentGlyph->BoundsInTexture.Height - spriteFont.LineSpacing;
+                    p.Y += pCurrentGlyph->Cropping.Y;
+
+                    Vector2.Transform(ref p, ref transformation, out p);
+
+                    var item = _batcher.CreateBatchItem();
+                    item.Texture = spriteFont.Texture;
+                    item.SortKey = sortKey;
+
+                    _texCoordTL.X = pCurrentGlyph->BoundsInTexture.X * spriteFont.Texture.TexelWidth;
+                    _texCoordTL.Y = pCurrentGlyph->BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
+                    _texCoordBR.X = (pCurrentGlyph->BoundsInTexture.X + pCurrentGlyph->BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
+                    _texCoordBR.Y = (pCurrentGlyph->BoundsInTexture.Y + pCurrentGlyph->BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
+
+                    if ((effects & SpriteEffects.FlipVertically) != 0)
+                    {
+                        var temp = _texCoordBR.Y;
+                        _texCoordBR.Y = _texCoordTL.Y;
+                        _texCoordTL.Y = temp;
+                    }
+                    if ((effects & SpriteEffects.FlipHorizontally) != 0)
+                    {
+                        var temp = _texCoordBR.X;
+                        _texCoordBR.X = _texCoordTL.X;
+                        _texCoordTL.X = temp;
+                    }
+
+                    if (rotation == 0f)
+                    {
+                        item.Set(p.X,
+                                p.Y,
+                                pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                                pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                color,
+                                _texCoordTL,
+                                _texCoordBR,
+                                layerDepth);
+                    }
+                    else
+                    {
+                        item.Set(p.X,
+                                p.Y,
+                                0,
+                                0,
+                                pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                                pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                sin,
+                                cos,
+                                color,
+                                _texCoordTL,
+                                _texCoordBR,
+                                layerDepth);
+                    }
+
+                    offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
+                }
 
             // We need to flush if we're using Immediate sort mode.
             FlushIfNeeded();

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -956,12 +956,12 @@ namespace Microsoft.Xna.Framework.Graphics
                     //  so that text does not hang off the left side of its rectangle.
                     if (firstGlyphOfLine)
                     {
-                        offset.X = Math.Max(pCurrentGlyph->LeftSideBearing, 0);
+                        offset.X = Math.Max(rtl ? pCurrentGlyph->RightSideBearing : pCurrentGlyph->LeftSideBearing, 0);
                         firstGlyphOfLine = false;
                     }
                     else
                     {
-                        offset.X += spriteFont.Spacing + pCurrentGlyph->LeftSideBearing;
+                        offset.X += spriteFont.Spacing + (rtl ? pCurrentGlyph->RightSideBearing : pCurrentGlyph->LeftSideBearing);
                     }
 
                     var p = offset;
@@ -1025,7 +1025,7 @@ namespace Microsoft.Xna.Framework.Graphics
                                 layerDepth);
                     }
 
-                    offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
+                    offset.X += pCurrentGlyph->Width + (rtl ? pCurrentGlyph->LeftSideBearing : pCurrentGlyph->RightSideBearing);
                 }
 
             // We need to flush if we're using Immediate sort mode.
@@ -1313,6 +1313,191 @@ namespace Microsoft.Xna.Framework.Graphics
 			// We need to flush if we're using Immediate sort mode.
 			FlushIfNeeded();
 		}
+
+        /// <summary>
+        /// Submit a text string of sprites for drawing in the current batch.
+        /// </summary>
+        /// <param name="spriteFont">A font.</param>
+        /// <param name="text">The text which will be drawn.</param>
+        /// <param name="position">The drawing location on screen.</param>
+        /// <param name="color">A color mask.</param>
+        /// <param name="rotation">A rotation of this string.</param>
+        /// <param name="origin">Center of the rotation. 0,0 by default.</param>
+        /// <param name="scale">A scaling of this string.</param>
+        /// <param name="effects">Modificators for drawing. Can be combined.</param>
+        /// <param name="layerDepth">A depth of the layer of this string.</param>
+        /// <param name="rtl">Text is Right to Left.</param>
+		public unsafe void DrawString(
+            SpriteFont spriteFont, StringBuilder text, Vector2 position, Color color,
+            float rotation, Vector2 origin, Vector2 scale, SpriteEffects effects, float layerDepth, bool rtl)
+        {
+            CheckValid(spriteFont, text);
+
+            float sortKey = 0;
+            // set SortKey based on SpriteSortMode.
+            switch (_sortMode)
+            {
+                // Comparison of Texture objects.
+                case SpriteSortMode.Texture:
+                    sortKey = spriteFont.Texture.SortingKey;
+                    break;
+                // Comparison of Depth
+                case SpriteSortMode.FrontToBack:
+                    sortKey = layerDepth;
+                    break;
+                // Comparison of Depth in reverse
+                case SpriteSortMode.BackToFront:
+                    sortKey = -layerDepth;
+                    break;
+            }
+
+            var flipAdjustment = Vector2.Zero;
+
+            var flippedVert = (effects & SpriteEffects.FlipVertically) == SpriteEffects.FlipVertically;
+            var flippedHorz = ((effects & SpriteEffects.FlipHorizontally) == SpriteEffects.FlipHorizontally) ^ rtl;
+
+            if (flippedVert || flippedHorz || rtl)
+            {
+                Vector2 size;
+
+                var source = new SpriteFont.CharacterSource(text);
+                spriteFont.MeasureString(ref source, out size);
+
+                if (flippedHorz ^ rtl)
+                {
+                    origin.X *= -1;
+                    flipAdjustment.X = -size.X;
+                }
+                if (flippedVert)
+                {
+                    origin.Y *= -1;
+                    flipAdjustment.Y = spriteFont.LineSpacing - size.Y;
+                }
+            }
+
+            Matrix transformation = Matrix.Identity;
+            float cos = 0, sin = 0;
+            if (rotation == 0)
+            {
+                transformation.M11 = (flippedHorz ? -scale.X : scale.X);
+                transformation.M22 = (flippedVert ? -scale.Y : scale.Y);
+                transformation.M41 = ((flipAdjustment.X - origin.X) * transformation.M11) + position.X;
+                transformation.M42 = ((flipAdjustment.Y - origin.Y) * transformation.M22) + position.Y;
+            }
+            else
+            {
+                cos = MathF.Cos(rotation);
+                sin = MathF.Sin(rotation);
+                transformation.M11 = (flippedHorz ? -scale.X : scale.X) * cos;
+                transformation.M12 = (flippedHorz ? -scale.X : scale.X) * sin;
+                transformation.M21 = (flippedVert ? -scale.Y : scale.Y) * (-sin);
+                transformation.M22 = (flippedVert ? -scale.Y : scale.Y) * cos;
+                transformation.M41 = (((flipAdjustment.X - origin.X) * transformation.M11) + (flipAdjustment.Y - origin.Y) * transformation.M21) + position.X;
+                transformation.M42 = (((flipAdjustment.X - origin.X) * transformation.M12) + (flipAdjustment.Y - origin.Y) * transformation.M22) + position.Y;
+            }
+
+            var offset = Vector2.Zero;
+            var firstGlyphOfLine = true;
+
+            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.Glyphs)
+                for (var i = 0; i < text.Length; ++i)
+                {
+                    var c = text[i];
+
+                    if (c == '\r')
+                        continue;
+
+                    if (c == '\n')
+                    {
+                        offset.X = 0;
+                        offset.Y += spriteFont.LineSpacing;
+                        firstGlyphOfLine = true;
+                        continue;
+                    }
+
+                    var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    var pCurrentGlyph = pGlyphs + currentGlyphIndex;
+
+                    // The first character on a line might have a negative left side bearing.
+                    // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
+                    //  so that text does not hang off the left side of its rectangle.
+                    if (firstGlyphOfLine)
+                    {
+                        offset.X = Math.Max(rtl ? pCurrentGlyph->RightSideBearing : pCurrentGlyph->LeftSideBearing, 0);
+                        firstGlyphOfLine = false;
+                    }
+                    else
+                    {
+                        offset.X += spriteFont.Spacing + (rtl ? pCurrentGlyph->RightSideBearing : pCurrentGlyph->LeftSideBearing);
+                    }
+
+                    var p = offset;
+
+                    if (flippedHorz)
+                        p.X += pCurrentGlyph->BoundsInTexture.Width;
+                    p.X += pCurrentGlyph->Cropping.X;
+
+                    if (flippedVert)
+                        p.Y += pCurrentGlyph->BoundsInTexture.Height - spriteFont.LineSpacing;
+                    p.Y += pCurrentGlyph->Cropping.Y;
+
+                    Vector2.Transform(ref p, ref transformation, out p);
+
+                    var item = _batcher.CreateBatchItem();
+                    item.Texture = spriteFont.Texture;
+                    item.SortKey = sortKey;
+
+                    _texCoordTL.X = pCurrentGlyph->BoundsInTexture.X * spriteFont.Texture.TexelWidth;
+                    _texCoordTL.Y = pCurrentGlyph->BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
+                    _texCoordBR.X = (pCurrentGlyph->BoundsInTexture.X + pCurrentGlyph->BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
+                    _texCoordBR.Y = (pCurrentGlyph->BoundsInTexture.Y + pCurrentGlyph->BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
+
+                    if ((effects & SpriteEffects.FlipVertically) != 0)
+                    {
+                        var temp = _texCoordBR.Y;
+                        _texCoordBR.Y = _texCoordTL.Y;
+                        _texCoordTL.Y = temp;
+                    }
+                    if ((effects & SpriteEffects.FlipHorizontally) != 0)
+                    {
+                        var temp = _texCoordBR.X;
+                        _texCoordBR.X = _texCoordTL.X;
+                        _texCoordTL.X = temp;
+                    }
+
+                    if (rotation == 0f)
+                    {
+                        item.Set(p.X,
+                                p.Y,
+                                pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                                pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                color,
+                                _texCoordTL,
+                                _texCoordBR,
+                                layerDepth);
+                    }
+                    else
+                    {
+                        item.Set(p.X,
+                                p.Y,
+                                0,
+                                0,
+                                pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                                pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                sin,
+                                cos,
+                                color,
+                                _texCoordTL,
+                                _texCoordBR,
+                                layerDepth);
+                    }
+
+                    offset.X += pCurrentGlyph->Width + (rtl ? pCurrentGlyph->LeftSideBearing : pCurrentGlyph->RightSideBearing);
+                }
+
+            // We need to flush if we're using Immediate sort mode.
+            FlushIfNeeded();
+        }
 
         /// <summary>
         /// Immediately releases the unmanaged resources used by this object.

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -887,21 +887,20 @@ namespace Microsoft.Xna.Framework.Graphics
             var flipAdjustment = Vector2.Zero;
 
             var flippedVert = (effects & SpriteEffects.FlipVertically) == SpriteEffects.FlipVertically;
-            var flippedHorz = (effects & SpriteEffects.FlipHorizontally) == SpriteEffects.FlipHorizontally;
+            var flippedHorz = ((effects & SpriteEffects.FlipHorizontally) == SpriteEffects.FlipHorizontally) ^ rtl;
 
-            if (flippedVert || flippedHorz)
+            if (flippedVert || flippedHorz || rtl)
             {
                 Vector2 size;
 
                 var source = new SpriteFont.CharacterSource(text);
                 spriteFont.MeasureString(ref source, out size);
 
-                if (flippedHorz)
+                if (flippedHorz ^ rtl)
                 {
                     origin.X *= -1;
                     flipAdjustment.X = -size.X;
                 }
-
                 if (flippedVert)
                 {
                     origin.Y *= -1;
@@ -967,7 +966,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                     var p = offset;
 
-                    if (rtl ^ flippedHorz)
+                    if (flippedHorz)
                         p.X += pCurrentGlyph->BoundsInTexture.Width;
                     p.X += pCurrentGlyph->Cropping.X;
 

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -854,6 +854,288 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="text">The text which will be drawn.</param>
         /// <param name="position">The drawing location on screen.</param>
         /// <param name="color">A color mask.</param>
+        /// <param name="rotation">A rotation of this string.</param>
+        /// <param name="origin">Center of the rotation. 0,0 by default.</param>
+        /// <param name="scale">A scaling of this string.</param>
+        /// <param name="effects">Modificators for drawing. Can be combined.</param>
+        /// <param name="layerDepth">A depth of the layer of this string.</param>
+        /// <param name="rtl">Text is Right to Left.</param>
+		public unsafe void DrawString(
+            SpriteFont spriteFont, string text, Vector2 position, Color color,
+            float rotation, Vector2 origin, Vector2 scale, SpriteEffects effects, float layerDepth, bool rtl)
+        {
+            CheckValid(spriteFont, text);
+
+            float sortKey = 0;
+            // set SortKey based on SpriteSortMode.
+            switch (_sortMode)
+            {
+                // Comparison of Texture objects.
+                case SpriteSortMode.Texture:
+                    sortKey = spriteFont.Texture.SortingKey;
+                    break;
+                // Comparison of Depth
+                case SpriteSortMode.FrontToBack:
+                    sortKey = layerDepth;
+                    break;
+                // Comparison of Depth in reverse
+                case SpriteSortMode.BackToFront:
+                    sortKey = -layerDepth;
+                    break;
+            }
+
+            var flipAdjustment = Vector2.Zero;
+
+            var flippedVert = (effects & SpriteEffects.FlipVertically) == SpriteEffects.FlipVertically;
+            var flippedHorz = (effects & SpriteEffects.FlipHorizontally) == SpriteEffects.FlipHorizontally;
+
+            if (flippedVert || flippedHorz)
+            {
+                Vector2 size;
+
+                var source = new SpriteFont.CharacterSource(text);
+                spriteFont.MeasureString(ref source, out size);
+
+                if (flippedHorz)
+                {
+                    origin.X *= -1;
+                    flipAdjustment.X = -size.X;
+                }
+
+                if (flippedVert)
+                {
+                    origin.Y *= -1;
+                    flipAdjustment.Y = spriteFont.LineSpacing - size.Y;
+                }
+            }
+
+            Matrix transformation = Matrix.Identity;
+            float cos = 0, sin = 0;
+            if (rotation == 0)
+            {
+                transformation.M11 = (flippedHorz ? -scale.X : scale.X);
+                transformation.M22 = (flippedVert ? -scale.Y : scale.Y);
+                transformation.M41 = ((flipAdjustment.X - origin.X) * transformation.M11) + position.X;
+                transformation.M42 = ((flipAdjustment.Y - origin.Y) * transformation.M22) + position.Y;
+            }
+            else
+            {
+                cos = MathF.Cos(rotation);
+                sin = MathF.Sin(rotation);
+                transformation.M11 = (flippedHorz ? -scale.X : scale.X) * cos;
+                transformation.M12 = (flippedHorz ? -scale.X : scale.X) * sin;
+                transformation.M21 = (flippedVert ? -scale.Y : scale.Y) * (-sin);
+                transformation.M22 = (flippedVert ? -scale.Y : scale.Y) * cos;
+                transformation.M41 = (((flipAdjustment.X - origin.X) * transformation.M11) + (flipAdjustment.Y - origin.Y) * transformation.M21) + position.X;
+                transformation.M42 = (((flipAdjustment.X - origin.X) * transformation.M12) + (flipAdjustment.Y - origin.Y) * transformation.M22) + position.Y;
+            }
+
+            var offset = Vector2.Zero;
+            var firstGlyphOfLine = true;
+
+            fixed (SpriteFont.Glyph* pGlyphs = spriteFont.Glyphs)
+                if (rtl)
+                    for (var i = 0; i < text.Length; ++i)
+                    {
+                        var c = text[i];
+
+                        if (c == '\r')
+                            continue;
+
+                        if (c == '\n')
+                        {
+                            offset.X = 0;
+                            offset.Y += spriteFont.LineSpacing;
+                            firstGlyphOfLine = true;
+                            continue;
+                        }
+
+                        var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                        var pCurrentGlyph = pGlyphs + currentGlyphIndex;
+
+                        // The first character on a line might have a negative left side bearing.
+                        // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
+                        //  so that text does not hang off the left side of its rectangle.
+                        if (firstGlyphOfLine)
+                        {
+                            offset.X = Math.Max(pCurrentGlyph->RightSideBearing, 0);
+                            firstGlyphOfLine = false;
+                        }
+                        else
+                        {
+                            offset.X += spriteFont.Spacing + pCurrentGlyph->RightSideBearing;
+                        }
+
+                        var p = offset;
+
+                        if (!flippedHorz)
+                            p.X += pCurrentGlyph->BoundsInTexture.Width;
+                        p.X += pCurrentGlyph->Cropping.X;
+
+                        if (flippedVert)
+                            p.Y += pCurrentGlyph->BoundsInTexture.Height - spriteFont.LineSpacing;
+                        p.Y += pCurrentGlyph->Cropping.Y;
+
+                        Vector2.Transform(ref p, ref transformation, out p);
+
+                        var item = _batcher.CreateBatchItem();
+                        item.Texture = spriteFont.Texture;
+                        item.SortKey = sortKey;
+
+                        _texCoordTL.X = pCurrentGlyph->BoundsInTexture.X * spriteFont.Texture.TexelWidth;
+                        _texCoordTL.Y = pCurrentGlyph->BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
+                        _texCoordBR.X = (pCurrentGlyph->BoundsInTexture.X + pCurrentGlyph->BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
+                        _texCoordBR.Y = (pCurrentGlyph->BoundsInTexture.Y + pCurrentGlyph->BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
+
+                        if ((effects & SpriteEffects.FlipVertically) != 0)
+                        {
+                            var temp = _texCoordBR.Y;
+                            _texCoordBR.Y = _texCoordTL.Y;
+                            _texCoordTL.Y = temp;
+                        }
+                        if ((effects & SpriteEffects.FlipHorizontally) != 0)
+                        {
+                            var temp = _texCoordBR.X;
+                            _texCoordBR.X = _texCoordTL.X;
+                            _texCoordTL.X = temp;
+                        }
+
+                        if (rotation == 0f)
+                        {
+                            item.Set(p.X,
+                                    p.Y,
+                                    pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                                    pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                    color,
+                                    _texCoordTL,
+                                    _texCoordBR,
+                                    layerDepth);
+                        }
+                        else
+                        {
+                            item.Set(p.X,
+                                    p.Y,
+                                    0,
+                                    0,
+                                    pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                                    pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                    sin,
+                                    cos,
+                                    color,
+                                    _texCoordTL,
+                                    _texCoordBR,
+                                    layerDepth);
+                        }
+
+                        offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
+                    }
+                else
+                    for (var i = 0; i < text.Length; ++i)
+                    {
+                        var c = text[i];
+
+                        if (c == '\r')
+                            continue;
+
+                        if (c == '\n')
+                        {
+                            offset.X = 0;
+                            offset.Y += spriteFont.LineSpacing;
+                            firstGlyphOfLine = true;
+                            continue;
+                        }
+
+                        var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                        var pCurrentGlyph = pGlyphs + currentGlyphIndex;
+
+                        // The first character on a line might have a negative left side bearing.
+                        // In this scenario, SpriteBatch/SpriteFont normally offset the text to the right,
+                        //  so that text does not hang off the left side of its rectangle.
+                        if (firstGlyphOfLine)
+                        {
+                            offset.X = Math.Max(pCurrentGlyph->LeftSideBearing, 0);
+                            firstGlyphOfLine = false;
+                        }
+                        else
+                        {
+                            offset.X += spriteFont.Spacing + pCurrentGlyph->LeftSideBearing;
+                        }
+
+                        var p = offset;
+
+                        if (flippedHorz)
+                            p.X += pCurrentGlyph->BoundsInTexture.Width;
+                        p.X += pCurrentGlyph->Cropping.X;
+
+                        if (flippedVert)
+                            p.Y += pCurrentGlyph->BoundsInTexture.Height - spriteFont.LineSpacing;
+                        p.Y += pCurrentGlyph->Cropping.Y;
+
+                        Vector2.Transform(ref p, ref transformation, out p);
+
+                        var item = _batcher.CreateBatchItem();
+                        item.Texture = spriteFont.Texture;
+                        item.SortKey = sortKey;
+
+                        _texCoordTL.X = pCurrentGlyph->BoundsInTexture.X * spriteFont.Texture.TexelWidth;
+                        _texCoordTL.Y = pCurrentGlyph->BoundsInTexture.Y * spriteFont.Texture.TexelHeight;
+                        _texCoordBR.X = (pCurrentGlyph->BoundsInTexture.X + pCurrentGlyph->BoundsInTexture.Width) * spriteFont.Texture.TexelWidth;
+                        _texCoordBR.Y = (pCurrentGlyph->BoundsInTexture.Y + pCurrentGlyph->BoundsInTexture.Height) * spriteFont.Texture.TexelHeight;
+
+                        if ((effects & SpriteEffects.FlipVertically) != 0)
+                        {
+                            var temp = _texCoordBR.Y;
+                            _texCoordBR.Y = _texCoordTL.Y;
+                            _texCoordTL.Y = temp;
+                        }
+                        if ((effects & SpriteEffects.FlipHorizontally) != 0)
+                        {
+                            var temp = _texCoordBR.X;
+                            _texCoordBR.X = _texCoordTL.X;
+                            _texCoordTL.X = temp;
+                        }
+
+                        if (rotation == 0f)
+                        {
+                            item.Set(p.X,
+                                    p.Y,
+                                    pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                                    pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                    color,
+                                    _texCoordTL,
+                                    _texCoordBR,
+                                    layerDepth);
+                        }
+                        else
+                        {
+                            item.Set(p.X,
+                                    p.Y,
+                                    0,
+                                    0,
+                                    pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                                    pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                    sin,
+                                    cos,
+                                    color,
+                                    _texCoordTL,
+                                    _texCoordBR,
+                                    layerDepth);
+                        }
+
+                        offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
+                    }
+
+            // We need to flush if we're using Immediate sort mode.
+            FlushIfNeeded();
+        }
+
+        /// <summary>
+        /// Submit a text string of sprites for drawing in the current batch.
+        /// </summary>
+        /// <param name="spriteFont">A font.</param>
+        /// <param name="text">The text which will be drawn.</param>
+        /// <param name="position">The drawing location on screen.</param>
+        /// <param name="color">A color mask.</param>
 		public unsafe void DrawString (SpriteFont spriteFont, StringBuilder text, Vector2 position, Color color)
 		{
             CheckValid(spriteFont, text);


### PR DESCRIPTION
Added new overload to the SpriteBatch.DrawString method that makes drawing right to left strings possible with a new rtl boolean parameter. Solves issue #7510.
Should work correctly, although I didn't test it because I didn't really figure out how one would go about testing that (This is my first PR in this repo).