### PR TITLE
Add thread locking to the UWP gamepads dictionary

### DIFF
--- a/MonoGame.Framework/Platform/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.UWP.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Xna.Framework.Input
 
         private static Dictionary<int, WGI.Gamepad> _gamepads;
 
+        private static readonly object _locker = new object();
+
         static GamePad()
         {
             _gamepads = new Dictionary<int, WGI.Gamepad>();
@@ -29,19 +31,25 @@ namespace Microsoft.Xna.Framework.Input
 
             WGI.Gamepad.GamepadAdded += (o, e) =>
             {
-                var index = 0;
-                while (_gamepads.ContainsKey(index))
-                    index++;
+                lock (_locker)
+                {
+                    var index = 0;
+                    while (_gamepads.ContainsKey(index))
+                        index++;
 
-                _gamepads[index] = e;
+                    _gamepads[index] = e;
+                }
             };
 
             WGI.Gamepad.GamepadRemoved += (o, e) =>
             {
-                int? key = _gamepads.FirstOrDefault(x => x.Value == e).Key;
+                lock (_locker)
+                {
+                    int? key = _gamepads.FirstOrDefault(x => x.Value == e).Key;
 
-                if (key.HasValue)
-                    _gamepads.Remove(key.Value);
+                    if (key.HasValue)
+                        _gamepads.Remove(key.Value);
+                }
             };
         }
 
@@ -52,41 +60,44 @@ namespace Microsoft.Xna.Framework.Input
 
         private static GamePadCapabilities PlatformGetCapabilities(int index)
         {
-            if (!_gamepads.ContainsKey(index))
-                return new GamePadCapabilities();
-            
-            var gamepad = _gamepads[index];
-
-            // we can't check gamepad capabilities for most stuff with Windows.Gaming.Input.Gamepad
-            return new GamePadCapabilities
+            lock (_locker)
             {
-                IsConnected = true,
-                GamePadType = GamePadType.GamePad,
-                HasAButton = true,
-                HasBButton = true,
-                HasXButton = true,
-                HasYButton = true,
-                HasBackButton = true,
-                HasStartButton = true,
-                HasDPadDownButton = true,
-                HasDPadLeftButton = true,
-                HasDPadRightButton = true,
-                HasDPadUpButton = true,
-                HasLeftShoulderButton = true,
-                HasRightShoulderButton = true,
-                HasLeftStickButton = true,
-                HasRightStickButton = true,
-                HasLeftTrigger = true,
-                HasRightTrigger = true,
-                HasLeftXThumbStick = true,
-                HasLeftYThumbStick = true,
-                HasRightXThumbStick = true,
-                HasRightYThumbStick = true,
-                HasLeftVibrationMotor = true,
-                HasRightVibrationMotor = true,
-                HasVoiceSupport = (gamepad.Headset != null && !string.IsNullOrEmpty(gamepad.Headset.CaptureDeviceId)),
-                HasBigButton = false //we can't detect the big button from Windows.Gaming.Input.Gamepad, so it's always false
-            };
+                if (!_gamepads.ContainsKey(index))
+                    return new GamePadCapabilities();
+
+                var gamepad = _gamepads[index];
+
+                // we can't check gamepad capabilities for most stuff with Windows.Gaming.Input.Gamepad
+                return new GamePadCapabilities
+                {
+                    IsConnected = true,
+                    GamePadType = GamePadType.GamePad,
+                    HasAButton = true,
+                    HasBButton = true,
+                    HasXButton = true,
+                    HasYButton = true,
+                    HasBackButton = true,
+                    HasStartButton = true,
+                    HasDPadDownButton = true,
+                    HasDPadLeftButton = true,
+                    HasDPadRightButton = true,
+                    HasDPadUpButton = true,
+                    HasLeftShoulderButton = true,
+                    HasRightShoulderButton = true,
+                    HasLeftStickButton = true,
+                    HasRightStickButton = true,
+                    HasLeftTrigger = true,
+                    HasRightTrigger = true,
+                    HasLeftXThumbStick = true,
+                    HasLeftYThumbStick = true,
+                    HasRightXThumbStick = true,
+                    HasRightYThumbStick = true,
+                    HasLeftVibrationMotor = true,
+                    HasRightVibrationMotor = true,
+                    HasVoiceSupport = (gamepad.Headset != null && !string.IsNullOrEmpty(gamepad.Headset.CaptureDeviceId)),
+                    HasBigButton = false //we can't detect the big button from Windows.Gaming.Input.Gamepad, so it's always false
+                };
+            }
         }
 
         private static GamePadState GetDefaultState()
@@ -98,73 +109,79 @@ namespace Microsoft.Xna.Framework.Input
 
         private static GamePadState PlatformGetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
         {
-            if (!_gamepads.ContainsKey(index))
-                return (index == 0 ? GetDefaultState() : GamePadState.Default);
+            lock (_locker)
+            {
+                if (!_gamepads.ContainsKey(index))
+                    return (index == 0 ? GetDefaultState() : GamePadState.Default);
+                
+                var state = _gamepads[index].GetCurrentReading();
 
-            var state = _gamepads[index].GetCurrentReading();
+                var sticks = new GamePadThumbSticks(
+                        new Vector2((float)state.LeftThumbstickX, (float)state.LeftThumbstickY),
+                        new Vector2((float)state.RightThumbstickX, (float)state.RightThumbstickY),
+                        leftDeadZoneMode,
+                        rightDeadZoneMode
+                    );
 
-            var sticks = new GamePadThumbSticks(
-                    new Vector2((float)state.LeftThumbstickX, (float)state.LeftThumbstickY),
-                    new Vector2((float)state.RightThumbstickX, (float)state.RightThumbstickY),
-                    leftDeadZoneMode,
-					rightDeadZoneMode
-                );
+                var triggers = new GamePadTriggers(
+                        (float)state.LeftTrigger,
+                        (float)state.RightTrigger
+                    );
 
-            var triggers = new GamePadTriggers(
-                    (float)state.LeftTrigger,
-                    (float)state.RightTrigger
-                );
+                Buttons buttonStates =
+                    (state.Buttons.HasFlag(WGI.GamepadButtons.A) ? Buttons.A : 0) |
+                    (state.Buttons.HasFlag(WGI.GamepadButtons.B) ? Buttons.B : 0) |
+                    ((state.Buttons.HasFlag(WGI.GamepadButtons.View) || Back) ? Buttons.Back : 0) |
+                    0 | //BigButton is unavailable by Windows.Gaming.Input.Gamepad
+                    (state.Buttons.HasFlag(WGI.GamepadButtons.LeftShoulder) ? Buttons.LeftShoulder : 0) |
+                    (state.Buttons.HasFlag(WGI.GamepadButtons.LeftThumbstick) ? Buttons.LeftStick : 0) |
+                    (state.Buttons.HasFlag(WGI.GamepadButtons.RightShoulder) ? Buttons.RightShoulder : 0) |
+                    (state.Buttons.HasFlag(WGI.GamepadButtons.RightThumbstick) ? Buttons.RightStick : 0) |
+                    (state.Buttons.HasFlag(WGI.GamepadButtons.Menu) ? Buttons.Start : 0) |
+                    (state.Buttons.HasFlag(WGI.GamepadButtons.X) ? Buttons.X : 0) |
+                    (state.Buttons.HasFlag(WGI.GamepadButtons.Y) ? Buttons.Y : 0) |
+                    0;
 
-            Buttons buttonStates =
-                (state.Buttons.HasFlag(WGI.GamepadButtons.A) ? Buttons.A : 0) |
-                (state.Buttons.HasFlag(WGI.GamepadButtons.B) ? Buttons.B : 0) |
-                ((state.Buttons.HasFlag(WGI.GamepadButtons.View) || Back) ? Buttons.Back : 0) |
-                0 | //BigButton is unavailable by Windows.Gaming.Input.Gamepad
-                (state.Buttons.HasFlag(WGI.GamepadButtons.LeftShoulder) ? Buttons.LeftShoulder : 0) |
-                (state.Buttons.HasFlag(WGI.GamepadButtons.LeftThumbstick) ? Buttons.LeftStick : 0) |
-                (state.Buttons.HasFlag(WGI.GamepadButtons.RightShoulder) ? Buttons.RightShoulder : 0) |
-                (state.Buttons.HasFlag(WGI.GamepadButtons.RightThumbstick) ? Buttons.RightStick : 0) |
-                (state.Buttons.HasFlag(WGI.GamepadButtons.Menu) ? Buttons.Start : 0) |
-                (state.Buttons.HasFlag(WGI.GamepadButtons.X) ? Buttons.X : 0) |
-                (state.Buttons.HasFlag(WGI.GamepadButtons.Y) ? Buttons.Y : 0) |
-                0;
+                // Check triggers
+                if (triggers.Left > TriggerThreshold)
+                    buttonStates |= Buttons.LeftTrigger;
+                if (triggers.Right > TriggerThreshold)
+                    buttonStates |= Buttons.RightTrigger;
 
-            // Check triggers
-            if (triggers.Left > TriggerThreshold)
-                buttonStates |= Buttons.LeftTrigger;
-            if (triggers.Right > TriggerThreshold)
-                buttonStates |= Buttons.RightTrigger;
+                var buttons = new GamePadButtons(buttonStates);
 
-            var buttons = new GamePadButtons(buttonStates);
+                var dpad = new GamePadDPad(
+                        state.Buttons.HasFlag(WGI.GamepadButtons.DPadUp) ? ButtonState.Pressed : ButtonState.Released,
+                        state.Buttons.HasFlag(WGI.GamepadButtons.DPadDown) ? ButtonState.Pressed : ButtonState.Released,
+                        state.Buttons.HasFlag(WGI.GamepadButtons.DPadLeft) ? ButtonState.Pressed : ButtonState.Released,
+                        state.Buttons.HasFlag(WGI.GamepadButtons.DPadRight) ? ButtonState.Pressed : ButtonState.Released
+                    );
 
-            var dpad = new GamePadDPad(
-                    state.Buttons.HasFlag(WGI.GamepadButtons.DPadUp) ? ButtonState.Pressed : ButtonState.Released,
-                    state.Buttons.HasFlag(WGI.GamepadButtons.DPadDown) ? ButtonState.Pressed : ButtonState.Released,
-                    state.Buttons.HasFlag(WGI.GamepadButtons.DPadLeft) ? ButtonState.Pressed : ButtonState.Released,
-                    state.Buttons.HasFlag(WGI.GamepadButtons.DPadRight) ? ButtonState.Pressed : ButtonState.Released
-                );
-
-            var result = new GamePadState(sticks, triggers, buttons, dpad);
-            result.PacketNumber = (int)state.Timestamp;
-            return result;
+                var result = new GamePadState(sticks, triggers, buttons, dpad);
+                result.PacketNumber = (int)state.Timestamp;
+                return result;
+            }
         }
 
         private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor, float leftTrigger, float rightTrigger)
         {
-            if (!_gamepads.ContainsKey(index))
-                return false;
-
-            var gamepad = _gamepads[index];
-
-            gamepad.Vibration = new WGI.GamepadVibration
+            lock (_locker)
             {
-                LeftMotor = leftMotor,
-                LeftTrigger = leftTrigger,
-                RightMotor = rightMotor,
-                RightTrigger = rightTrigger
-            };
+                if (!_gamepads.ContainsKey(index))
+                    return false;
 
-            return true;
+                var gamepad = _gamepads[index];
+
+                gamepad.Vibration = new WGI.GamepadVibration
+                {
+                    LeftMotor = leftMotor,
+                    LeftTrigger = leftTrigger,
+                    RightMotor = rightMotor,
+                    RightTrigger = rightTrigger
+                };
+
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request is to fix a potential thread issue that may occur when a gamepad is disconnected.

WGI.Gamepad.GamepadAdded and WGI.Gamepad.GamepadRemoved are adding and removing gamepads from a different thread to the game tick where PlatformGetState is likely to be called. If the timing was right a disconnected gamepad could be removed from the dictionary while also accessing it for GetState/GetCapabilities.

This can be prevented by adding a lock statement around each use of the gamepads dictionary.