### PR TITLE
terminology, spelling & grammar corrections

### DIFF
--- a/Documentation/articles/getting_started/1_setting_up_your_development_environment_windows.md
+++ b/Documentation/articles/getting_started/1_setting_up_your_development_environment_windows.md
@@ -8,8 +8,8 @@ Before installing Monogame, you'll need to install [Visual Studio 2019](https://
 
 * .NET cross-platform development - For Desktop OpenGL and DirectX platforms
 * Mobile Development with .NET - For Android and iOS platforms
-* Universal Windows Platform development - For Windows 10 and Xbox UWP platforms
-* .Net Desktop Development - For Desktop OpenGL and DirectX platforms to target normal .NET Framework
+* Universal Windows Platform development - For Windows 11, Windows 10 and Xbox UWP platforms
+* .NET Desktop Development - For Desktop OpenGL and DirectX platforms to target normal .NET Framework
 
 ![Visual Studio optional components](~/images/getting_started/1_installer_vs_components.png)
 

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -35,7 +35,7 @@
       <Header>/platform:$(MonoGamePlatform)</Header>
     </PropertyGroup>
 
-    <!-- Get all Mono Game Content References and store them in a list -->
+    <!-- Get all MonoGame Content References and store them in a list -->
     <!-- We do this here so we are compatible with xbuild -->
     <CollectContentReferences ContentReferences="@(MonoGameContentReference)" MonoGamePlatform="$(MonoGamePlatform)">
         <Output TaskParameter="Output" ItemName="ContentReferences"/>

--- a/MonoGame.Framework/Input/GamePadType.cs
+++ b/MonoGame.Framework/Input/GamePadType.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Xna.Framework.Input
         Unknown,
 
         /// <summary>
-        /// GamePad is the XBOX controller.
+        /// GamePad is the Xbox controller.
         /// </summary>
         GamePad,
 

--- a/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/Platform/WindowsUniversal/UAPGameWindow.cs
@@ -321,7 +321,7 @@ namespace Microsoft.Xna.Framework
 
         private void BackRequested(object sender, BackRequestedEventArgs e)
         {
-            // Prevent XBOX from suspending the app when the user press 'B' button.
+            // Prevent Xbox from suspending the app when the user press 'B' button.
             e.Handled = true;
         }
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Our [build server](http://teamcity.monogame.net/?guest=1) builds, tests, and pac
 We support a growing list of platforms across the desktop, mobile, and console space.  If there is a platform we don't support, please [make a request](https://github.com/MonoGame/MonoGame/issues) or [come help us](CONTRIBUTING.md) add it.
 
  * Desktop PCs
-   * Windows 10 Store Apps (UWP)
+   * Windows 11, Windows 10 Store Apps (UWP)
    * Windows Win32 (OpenGL & DirectX)
    * Linux (OpenGL)
-   * Mac OS X (OpenGL)
+   * macOS (OpenGL)
  * Mobile/Tablet Devices
    * Android (OpenGL)
    * iPhone/iPad (OpenGL)

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,7 +1,7 @@
 # MonoGame Tests
 
 The MonoGame Tests run against XNA on Windows and MonoGame on Windows,
-Mac OS X and Linux.  They serve as an assurance that MonoGame conforms
+macOS and Linux.  They serve as an assurance that MonoGame conforms
 as closely as possible to XNA.
 
 Simple unit tests make assertions about MonoGame's core class
@@ -10,7 +10,7 @@ those regards.  Additionally, visual tests verify via frame capture and
 comparison that MonoGame renders equivalently to XNA.
 
 Currently, on Windows, the tests can be run using NUnit and target
-either XNA or MonoGame.  On Mac OS X and Linux, the tests target
+either XNA or MonoGame.  On macOS and Linux, the tests target
 MonoGame and are implemented in an executable assembly that can be run
 and debugged directly.  After execution using the custom test runner,
 and HTML report of the results will be loaded in your default browser,


### PR DESCRIPTION
wording corrections, including:

- MacOS -> macOS
- .Net -> .NET
- OS X -> macOS
- Mac OS X -> macOS
- Mono Game -> MonoGame
- XBOX -> Xbox
- Windows 10 -> Windows 11, Windows 10