### PR TITLE
Fix memory leak on desktop gl static variable

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsCapabilities.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsCapabilities.OpenGL.cs
@@ -30,11 +30,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformInitialize(GraphicsDevice device)
         {
+            var extensions = GL.GetExtensions();
 #if GLES
-            SupportsNonPowerOfTwo = GL.Extensions.Contains("GL_OES_texture_npot") ||
-                GL.Extensions.Contains("GL_ARB_texture_non_power_of_two") ||
-                GL.Extensions.Contains("GL_IMG_texture_npot") ||
-                GL.Extensions.Contains("GL_NV_texture_npot_2D_mipmap");
+            SupportsNonPowerOfTwo = extensions.Contains("GL_OES_texture_npot") ||
+                extensions.Contains("GL_ARB_texture_non_power_of_two") ||
+                extensions.Contains("GL_IMG_texture_npot") ||
+                extensions.Contains("GL_NV_texture_npot_2D_mipmap");
 #else
             // Unfortunately non PoT texture support is patchy even on desktop systems and we can't
             // rely on the fact that GL2.0+ supposedly supports npot in the core.
@@ -42,13 +43,13 @@ namespace Microsoft.Xna.Framework.Graphics
             SupportsNonPowerOfTwo = device._maxTextureSize >= 8192;
 #endif
 
-            SupportsTextureFilterAnisotropic = GL.Extensions.Contains("GL_EXT_texture_filter_anisotropic");
+            SupportsTextureFilterAnisotropic = extensions.Contains("GL_EXT_texture_filter_anisotropic");
 
 #if GLES
-			SupportsDepth24 = GL.Extensions.Contains("GL_OES_depth24");
-			SupportsPackedDepthStencil = GL.Extensions.Contains("GL_OES_packed_depth_stencil");
-			SupportsDepthNonLinear = GL.Extensions.Contains("GL_NV_depth_nonlinear");
-            SupportsTextureMaxLevel = GL.Extensions.Contains("GL_APPLE_texture_max_level");
+			SupportsDepth24 = extensions.Contains("GL_OES_depth24");
+			SupportsPackedDepthStencil = extensions.Contains("GL_OES_packed_depth_stencil");
+			SupportsDepthNonLinear = extensions.Contains("GL_NV_depth_nonlinear");
+            SupportsTextureMaxLevel = extensions.Contains("GL_APPLE_texture_max_level");
 #else
             SupportsDepth24 = true;
             SupportsPackedDepthStencil = true;
@@ -56,15 +57,15 @@ namespace Microsoft.Xna.Framework.Graphics
             SupportsTextureMaxLevel = true;
 #endif
             // Texture compression
-            SupportsS3tc = GL.Extensions.Contains("GL_EXT_texture_compression_s3tc") ||
-                           GL.Extensions.Contains("GL_OES_texture_compression_S3TC") ||
-                           GL.Extensions.Contains("GL_EXT_texture_compression_dxt3") ||
-                           GL.Extensions.Contains("GL_EXT_texture_compression_dxt5");
-            SupportsDxt1 = SupportsS3tc || GL.Extensions.Contains("GL_EXT_texture_compression_dxt1");
-            SupportsPvrtc = GL.Extensions.Contains("GL_IMG_texture_compression_pvrtc");
-            SupportsEtc1 = GL.Extensions.Contains("GL_OES_compressed_ETC1_RGB8_texture");
-            SupportsAtitc = GL.Extensions.Contains("GL_ATI_texture_compression_atitc") ||
-                            GL.Extensions.Contains("GL_AMD_compressed_ATC_texture");
+            SupportsS3tc = extensions.Contains("GL_EXT_texture_compression_s3tc") ||
+                           extensions.Contains("GL_OES_texture_compression_S3TC") ||
+                           extensions.Contains("GL_EXT_texture_compression_dxt3") ||
+                           extensions.Contains("GL_EXT_texture_compression_dxt5");
+            SupportsDxt1 = SupportsS3tc || extensions.Contains("GL_EXT_texture_compression_dxt1");
+            SupportsPvrtc = extensions.Contains("GL_IMG_texture_compression_pvrtc");
+            SupportsEtc1 = extensions.Contains("GL_OES_compressed_ETC1_RGB8_texture");
+            SupportsAtitc = extensions.Contains("GL_ATI_texture_compression_atitc") ||
+                            extensions.Contains("GL_AMD_compressed_ATC_texture");
 
             if (GL.BoundApi == GL.RenderApi.ES)
             {
@@ -74,17 +75,17 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Framebuffer objects
 #if GLES
-            SupportsFramebufferObjectARB = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 2 || GL.Extensions.Contains("GL_ARB_framebuffer_object")); // always supported on GLES 2.0+
-            SupportsFramebufferObjectEXT = GL.Extensions.Contains("GL_EXT_framebuffer_object");;
-            SupportsFramebufferObjectIMG = GL.Extensions.Contains("GL_IMG_multisampled_render_to_texture") |
-                                                 GL.Extensions.Contains("GL_APPLE_framebuffer_multisample") |
-                                                 GL.Extensions.Contains("GL_EXT_multisampled_render_to_texture") |
-                                                 GL.Extensions.Contains("GL_NV_framebuffer_multisample");
+            SupportsFramebufferObjectARB = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 2 || extensions.Contains("GL_ARB_framebuffer_object")); // always supported on GLES 2.0+
+            SupportsFramebufferObjectEXT = extensions.Contains("GL_EXT_framebuffer_object");;
+            SupportsFramebufferObjectIMG = extensions.Contains("GL_IMG_multisampled_render_to_texture") |
+                                                 extensions.Contains("GL_APPLE_framebuffer_multisample") |
+                                                 extensions.Contains("GL_EXT_multisampled_render_to_texture") |
+                                                 extensions.Contains("GL_NV_framebuffer_multisample");
 #else
             // if we're on GL 3.0+, frame buffer extensions are guaranteed to be present, but extensions may be missing
             // it is then safe to assume that GL_ARB_framebuffer_object is present so that the standard function are loaded
-            SupportsFramebufferObjectARB = device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_ARB_framebuffer_object");
-            SupportsFramebufferObjectEXT = GL.Extensions.Contains("GL_EXT_framebuffer_object");
+            SupportsFramebufferObjectARB = device.glMajorVersion >= 3 || extensions.Contains("GL_ARB_framebuffer_object");
+            SupportsFramebufferObjectEXT = extensions.Contains("GL_EXT_framebuffer_object");
 #endif
             // Anisotropic filtering
             int anisotropy = 0;
@@ -97,22 +98,22 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // sRGB
 #if GLES
-            SupportsSRgb = GL.Extensions.Contains("GL_EXT_sRGB");
-            SupportsFloatTextures = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_EXT_color_buffer_float"));
-            SupportsHalfFloatTextures = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_EXT_color_buffer_half_float"));
-            SupportsNormalized = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 && GL.Extensions.Contains("GL_EXT_texture_norm16"));
+            SupportsSRgb = extensions.Contains("GL_EXT_sRGB");
+            SupportsFloatTextures = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 || extensions.Contains("GL_EXT_color_buffer_float"));
+            SupportsHalfFloatTextures = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 || extensions.Contains("GL_EXT_color_buffer_half_float"));
+            SupportsNormalized = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 && extensions.Contains("GL_EXT_texture_norm16"));
 #else
-            SupportsSRgb = GL.Extensions.Contains("GL_EXT_texture_sRGB") && GL.Extensions.Contains("GL_EXT_framebuffer_sRGB");
-            SupportsFloatTextures = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_ARB_texture_float"));
-            SupportsHalfFloatTextures = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_ARB_half_float_pixel"));;
-            SupportsNormalized = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_EXT_texture_norm16"));;
+            SupportsSRgb = extensions.Contains("GL_EXT_texture_sRGB") && extensions.Contains("GL_EXT_framebuffer_sRGB");
+            SupportsFloatTextures = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || extensions.Contains("GL_ARB_texture_float"));
+            SupportsHalfFloatTextures = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || extensions.Contains("GL_ARB_half_float_pixel"));;
+            SupportsNormalized = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || extensions.Contains("GL_EXT_texture_norm16"));;
 #endif
 
             // TODO: Implement OpenGL support for texture arrays
             // once we can author shaders that use texture arrays.
             SupportsTextureArrays = false;
 
-            SupportsDepthClamp = GL.Extensions.Contains("GL_ARB_depth_clamp");
+            SupportsDepthClamp = extensions.Contains("GL_ARB_depth_clamp");
 
             SupportsVertexTextures = false; // For now, until we implement vertex textures in OpenGL.
 
@@ -126,7 +127,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #if GLES
             SupportsSeparateBlendStates = false;
 #else
-            SupportsSeparateBlendStates = device.glMajorVersion >= 4 || GL.Extensions.Contains("GL_ARB_draw_buffers_blend");
+            SupportsSeparateBlendStates = device.glMajorVersion >= 4 || extensions.Contains("GL_ARB_draw_buffers_blend");
 #endif
         }
 

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Diagnostics;
 using MonoGame.Framework.Utilities;
+using System.Linq;
 
 #if __IOS__ || __TVOS__ || MONOMAC
 using ObjCRuntime;
@@ -1444,7 +1445,7 @@ namespace MonoGame.OpenGL
             string extstring = GL.GetString(StringName.Extensions);
             var error = GL.GetError();
             if (!string.IsNullOrEmpty(extstring) && error == ErrorCode.NoError)
-                Extensions.AddRange(extstring.Split(' '));
+                Extensions.AddRange(extstring.Split(' ').Where(e => !Extensions.Contains(e)));
 
             LogExtensions();
             // now load Extensions :)

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -1426,8 +1426,14 @@ namespace MonoGame.OpenGL
 
             LoadExtensions ();
         }
-
-        internal static List<string> Extensions = new List<string> ();
+        internal static List<string> GetExtensions()
+        {
+            string extstring = GL.GetString(StringName.Extensions);
+            var error = GL.GetError();
+            if (!string.IsNullOrEmpty(extstring) && error == ErrorCode.NoError)
+                return extstring.Split(' ').ToList();
+            return new List<string>();
+        }        
 
         //[Conditional("DEBUG")]
         //[DebuggerHidden]
@@ -1442,46 +1448,43 @@ namespace MonoGame.OpenGL
 
         internal static void LoadExtensions()
         {
-            string extstring = GL.GetString(StringName.Extensions);
-            var error = GL.GetError();
-            if (!string.IsNullOrEmpty(extstring) && error == ErrorCode.NoError)
-                Extensions.AddRange(extstring.Split(' ').Where(e => !Extensions.Contains(e)));
+            var extensions = GetExtensions();
 
             LogExtensions();
             // now load Extensions :)
-            if (GL.GenRenderbuffers == null && Extensions.Contains("GL_EXT_framebuffer_object"))
+            if (GL.GenRenderbuffers == null && extensions.Contains("GL_EXT_framebuffer_object"))
             {
                 GL.LoadFrameBufferObjectEXTEntryPoints();
             }
             if (GL.RenderbufferStorageMultisample == null)
             {                
-                if (Extensions.Contains("GL_APPLE_framebuffer_multisample"))
+                if (extensions.Contains("GL_APPLE_framebuffer_multisample"))
                 {
                     GL.RenderbufferStorageMultisample = LoadFunction<GL.RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleAPPLE");
                     GL.BlitFramebuffer = LoadFunction<GL.BlitFramebufferDelegate>("glResolveMultisampleFramebufferAPPLE");
                 }
-                else if (Extensions.Contains("GL_EXT_multisampled_render_to_texture"))
+                else if (extensions.Contains("GL_EXT_multisampled_render_to_texture"))
                 {
                     GL.RenderbufferStorageMultisample = LoadFunction<GL.RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleEXT");
                     GL.FramebufferTexture2DMultiSample = LoadFunction<GL.FramebufferTexture2DMultiSampleDelegate>("glFramebufferTexture2DMultisampleEXT");
 
                 }
-                else if (Extensions.Contains("GL_IMG_multisampled_render_to_texture"))
+                else if (extensions.Contains("GL_IMG_multisampled_render_to_texture"))
                 {
                     GL.RenderbufferStorageMultisample = LoadFunction<GL.RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleIMG");
                     GL.FramebufferTexture2DMultiSample = LoadFunction<GL.FramebufferTexture2DMultiSampleDelegate>("glFramebufferTexture2DMultisampleIMG");
                 }
-                else if (Extensions.Contains("GL_NV_framebuffer_multisample"))
+                else if (extensions.Contains("GL_NV_framebuffer_multisample"))
                 {
                     GL.RenderbufferStorageMultisample = LoadFunction<GL.RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleNV");
                     GL.BlitFramebuffer = LoadFunction<GL.BlitFramebufferDelegate>("glBlitFramebufferNV");
                 }
             }
-            if (GL.BlendFuncSeparatei == null && Extensions.Contains("GL_ARB_draw_buffers_blend"))
+            if (GL.BlendFuncSeparatei == null && extensions.Contains("GL_ARB_draw_buffers_blend"))
             {
                 GL.BlendFuncSeparatei = LoadFunction<GL.BlendFuncSeparateiDelegate>("BlendFuncSeparateiARB");
             }
-            if (GL.BlendEquationSeparatei == null && Extensions.Contains("GL_ARB_draw_buffers_blend"))
+            if (GL.BlendEquationSeparatei == null && extensions.Contains("GL_ARB_draw_buffers_blend"))
             {
                 GL.BlendEquationSeparatei = LoadFunction<GL.BlendEquationSeparateiDelegate>("BlendEquationSeparateiARB");
             }


### PR DESCRIPTION
From the issue #7665, there is a static variable ``GL.Extensions`` used in initialization that can grow invariably and wasn't being cleared. 
I replace the calls to the static variable to a local variable from the return result of a method. Part of the problem could be solved with a [simple check when filling ``GL.Extensions`` ](https://github.com/MonoGame/MonoGame/blob/9ce9e1b03d3e01df8b36a9afb6b3ca0d1d1ca48e/MonoGame.Framework/Platform/Graphics/OpenGL.cs#L1448). I decided to go with the route of using a local variable because it seemed a tiny change, and the memory would be cleared.