### PR TITLE
Improve GamePad support on macOS and introduce support for rumble

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ThirdParty/Dependencies"]
 	path = ThirdParty/Dependencies
-	url = https://github.com/surprised-turtle/MonoGame.Dependencies.git
+	url = https://github.com/MonoGame/MonoGame.Dependencies.git
 [submodule "ThirdParty/NVorbis"]
 	path = ThirdParty/NVorbis
 url=https://github.com/NVorbis/NVorbis.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ThirdParty/Dependencies"]
 	path = ThirdParty/Dependencies
-	url = https://github.com/MonoGame/MonoGame.Dependencies.git
+	url = https://github.com/surprised-turtle/MonoGame.Dependencies.git
 [submodule "ThirdParty/NVorbis"]
 	path = ThirdParty/NVorbis
 url=https://github.com/NVorbis/NVorbis.git

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -130,8 +130,8 @@
       <PackagePath>runtimes\osx\native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\ThirdParty\Dependencies\SDL\MacOS\Universal\libSDL2-2.0.0.dylib">
-      <Link>libSDL2-2.0.0.dylib</Link>
+    <Content Include="..\ThirdParty\Dependencies\SDL\MacOS\Universal\libSDL2.dylib">
+      <Link>libSDL2.dylib</Link>
       <PackagePath>runtimes\osx\native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
@@ -14,25 +14,11 @@ namespace Microsoft.Xna.Framework.Input
         private class GamePadInfo
         {
             public IntPtr Device;
-            public IntPtr HapticDevice;
-            public int HapticType;
             public int PacketNumber;
         }
 
         private static readonly Dictionary<int, GamePadInfo> Gamepads = new Dictionary<int, GamePadInfo>();
         private static readonly Dictionary<int, int> _translationTable = new Dictionary<int, int>();
-
-        private static Sdl.Haptic.Effect _hapticLeftRightEffect = new Sdl.Haptic.Effect
-        {
-            type = Sdl.Haptic.EffectId.LeftRight,
-            leftright = new Sdl.Haptic.LeftRight
-            {
-                Type = Sdl.Haptic.EffectId.LeftRight,
-                Length = Sdl.Haptic.Infinity,
-                LargeMagnitude = ushort.MaxValue,
-                SmallMagnitude = ushort.MaxValue
-            }
-        };
 
         public static void InitDatabase()
         {
@@ -57,40 +43,14 @@ namespace Microsoft.Xna.Framework.Input
         {
             var gamepad = new GamePadInfo();
             gamepad.Device = Sdl.GameController.Open(deviceId);
-            gamepad.HapticDevice = Sdl.Haptic.OpenFromJoystick(Sdl.GameController.GetJoystick(gamepad.Device));
 
             var id = 0;
             while (Gamepads.ContainsKey(id))
                 id++;
 
             Gamepads.Add(id, gamepad);
-            
+
             RefreshTranslationTable();
-
-            if (gamepad.HapticDevice == IntPtr.Zero)
-                return;
-
-            try
-            {
-                if (Sdl.Haptic.EffectSupported(gamepad.HapticDevice, ref _hapticLeftRightEffect) == 1)
-                {
-                    Sdl.Haptic.NewEffect(gamepad.HapticDevice, ref _hapticLeftRightEffect);
-                    gamepad.HapticType = 1;
-                }
-                else if (Sdl.Haptic.RumbleSupported(gamepad.HapticDevice) == 1)
-                {
-                    Sdl.Haptic.RumbleInit(gamepad.HapticDevice);
-                    gamepad.HapticType = 2;
-                }
-                else
-                    Sdl.Haptic.Close(gamepad.HapticDevice);
-            }
-            catch
-            {
-                Sdl.Haptic.Close(gamepad.HapticDevice);
-                gamepad.HapticDevice = IntPtr.Zero;
-                Sdl.ClearError();
-            }
         }
 
         internal static void RemoveDevice(int instanceid)
@@ -132,8 +92,6 @@ namespace Microsoft.Xna.Framework.Input
 
         private static void DisposeDevice(GamePadInfo info)
         {
-            if (info.HapticType > 0)
-                Sdl.Haptic.Close(info.HapticDevice);
             Sdl.GameController.Close(info.Device);
         }
 
@@ -162,7 +120,7 @@ namespace Microsoft.Xna.Framework.Input
             caps.IsConnected = true;
             caps.DisplayName = Sdl.GameController.GetName(gamecontroller);
             caps.Identifier = Sdl.Joystick.GetGUID(Sdl.GameController.GetJoystick(gamecontroller)).ToString();
-            caps.HasLeftVibrationMotor = caps.HasRightVibrationMotor = (Gamepads[index].HapticType != 0);
+            caps.HasLeftVibrationMotor = caps.HasRightVibrationMotor = Sdl.GameController.HasRumble(gamecontroller) != 0;
             caps.GamePadType = GamePadType.GamePad;
 
             foreach (var map in mapping)
@@ -316,23 +274,10 @@ namespace Microsoft.Xna.Framework.Input
 
             var gamepad = Gamepads[index];
 
-            if (gamepad.HapticType == 0)
-                return false;
-
-            if (leftMotor <= 0.0f && rightMotor <= 0.0f)
-                Sdl.Haptic.StopAll(gamepad.HapticDevice);
-            else if (gamepad.HapticType == 1)
-            {
-                _hapticLeftRightEffect.leftright.LargeMagnitude = (ushort)(65535f * leftMotor);
-                _hapticLeftRightEffect.leftright.SmallMagnitude = (ushort)(65535f * rightMotor);
-
-                Sdl.Haptic.UpdateEffect(gamepad.HapticDevice, 0, ref _hapticLeftRightEffect);
-                Sdl.Haptic.RunEffect(gamepad.HapticDevice, 0, 1);
-            }
-            else if (gamepad.HapticType == 2)
-                Sdl.Haptic.RumblePlay(gamepad.HapticDevice, Math.Max(leftMotor, rightMotor), Sdl.Haptic.Infinity);
-
-            return true;
+            return Sdl.GameController.Rumble(gamepad.Device, (ushort)(65535f * leftMotor),
+                       (ushort)(65535f * rightMotor), uint.MaxValue) == 0 &&
+                   Sdl.GameController.RumbleTriggers(gamepad.Device, (ushort)(65535f * leftTrigger),
+                       (ushort)(65535f * rightTrigger), uint.MaxValue) == 0;
         }
     }
 }

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -993,6 +993,16 @@ internal static class Sdl
         {
             return InteropHelpers.Utf8ToString(SDL_GameControllerName(gamecontroller));
         }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int d_sdl_gamecontrollerrumble(IntPtr gamecontroller, ushort left, ushort right, uint duration);
+        public static d_sdl_gamecontrollerrumble Rumble = FuncLoader.LoadFunction<d_sdl_gamecontrollerrumble>(NativeLibrary, "SDL_GameControllerRumble");
+        public static d_sdl_gamecontrollerrumble RumbleTriggers = FuncLoader.LoadFunction<d_sdl_gamecontrollerrumble>(NativeLibrary, "SDL_GameControllerRumbleTriggers");
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate byte d_sdl_gamecontrollerhasrumble(IntPtr gamecontroller);
+        public static d_sdl_gamecontrollerhasrumble HasRumble = FuncLoader.LoadFunction<d_sdl_gamecontrollerhasrumble>(NativeLibrary, "SDL_GameControllerHasRumble");
+        public static d_sdl_gamecontrollerhasrumble HasRumbleTriggers = FuncLoader.LoadFunction<d_sdl_gamecontrollerhasrumble>(NativeLibrary, "SDL_GameControllerHasRumbleTriggers");
     }
 
     public static class Haptic

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -20,7 +20,7 @@ internal static class Sdl
         else if (CurrentPlatform.OS == OS.Linux)
             return FuncLoader.LoadLibraryExt("libSDL2-2.0.so.0");
         else if (CurrentPlatform.OS == OS.MacOSX)
-            return FuncLoader.LoadLibraryExt("libSDL2-2.0.0.dylib");
+            return FuncLoader.LoadLibraryExt("libSDL2.dylib");
         else
             return FuncLoader.LoadLibraryExt("sdl2");
     }


### PR DESCRIPTION
Controller support on macOS is currently a little unstable. This seems to be due to the driver implementation in SDL that usually makes use of IOKit. According to Apple this is now considered a legacy way of interacting with game controllers and use of the new [Game Controller Framework](https://developer.apple.com/documentation/gamecontroller) should be preferred. SDL includes a driver [implementation](https://github.com/libsdl-org/SDL/blob/main/src/joystick/iphoneos/SDL_mfijoystick.m) that makes use of this new framework, which also brings rumble support to macOS. Unfortunately, this drivers is only [enabled](https://github.com/libsdl-org/SDL/blob/120c76c84bbce4c1bfed4e9eb74e10678bd83120/include/SDL_config_macosx.h#L164-L167) when you build SDL2 targeting macOS >= 10.8 but the official build targets macOS 10.6.

For controller rumble, MonoGame currently relies on the SDL Haptics API. In newer versions, SDL exposes new functions that are much simpler:

- [`SDL_GameControllerRumble()`](https://github.com/libsdl-org/SDL/blob/46616af722f299b56e68e418be179aa4c1408c54/include/SDL_gamecontroller.h#L845-L863)
- [`SDL_GameControllerRumbleTriggers()`](https://github.com/libsdl-org/SDL/blob/46616af722f299b56e68e418be179aa4c1408c54/include/SDL_gamecontroller.h#L865-L888)
- [`SDL_GameControllerHasRumble()`](https://github.com/libsdl-org/SDL/blob/46616af722f299b56e68e418be179aa4c1408c54/include/SDL_gamecontroller.h#L901-L912)
- [`SDL_GameControllerHasRumbleTriggers()`](https://github.com/libsdl-org/SDL/blob/46616af722f299b56e68e418be179aa4c1408c54/include/SDL_gamecontroller.h#L914-L925)

I built SDL version 2.0.20 ([Source](https://github.com/surprised-turtle/SDL/tree/release-2.0.20-macos-10.9)) targeting macOS 10.9 (the oldest officially supported SDK) and updated MonoGame to use the new rumble API. Please let me know what you think about these changes.

I uploaded the binaries here: https://github.com/surprised-turtle/MonoGame.Dependencies/commit/06e4bb47e41430327dec597277f8f13d3eb344ab. I'd be happy to create a pull request for those as well. The windows and linux binaries are taken from FNA.