### PR TITLE
Fix back and start buttons on iOS

### DIFF
--- a/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Xna.Framework.Input
                 capabilities.HasXButton = true;
                 capabilities.HasYButton = true;
                 capabilities.HasBackButton = true;
+                capabilities.HasStartButton = true;
                 capabilities.HasDPadUpButton = true;
                 capabilities.HasDPadDownButton = true;
                 capabilities.HasDPadLeftButton = true;
@@ -88,7 +89,6 @@ namespace Microsoft.Xna.Framework.Input
                 capabilities.HasBButton = true;
                 capabilities.HasXButton = true;
                 capabilities.HasYButton = true;
-                capabilities.HasBackButton = true;
                 capabilities.HasDPadUpButton = true;
                 capabilities.HasDPadDownButton = true;
                 capabilities.HasDPadLeftButton = true;
@@ -150,6 +150,11 @@ namespace Microsoft.Xna.Framework.Input
                         buttons |= Buttons.LeftTrigger;
                     if (controller.ExtendedGamepad.RightTrigger.IsPressed)
                         buttons |= Buttons.RightTrigger;
+
+                    if (controller.ExtendedGamepad.ButtonMenu.IsPressed)
+                        buttons |= Buttons.Start;
+                    if (controller.ExtendedGamepad.ButtonOptions.IsPressed)
+                        buttons |= Buttons.Back;
 
                     if (controller.ExtendedGamepad.DPad.Up.IsPressed)
                     {


### PR DESCRIPTION
Back and Start buttons were not implemented on iOS for MFi gamepads.

Tested working on device.