### PR TITLE
Console check fake project

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
@@ -1,25 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
-    <DefineConstants>OPENGL;OPENAL;XNADESIGNPROVIDED;LINUX;DESKTOPGL;SUPPORTS_EFX;NETSTANDARD;STBSHARP_INTERNAL</DefineConstants>
+    <DefineConstants>WINDOWS;XNADESIGNPROVIDED;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseWindowsForms>true</UseWindowsForms>
     <Description>Fake console assembly that checks if MonoGame's code is still compatible with the private console implementations and building against .NET 4.5.2 and C# 5.</Description>
+    <PackageTags>monogame;.net core;core;.net standard;standard;windowsdx</PackageTags>
+    <PackageId>MonoGame.Framework.WindowsDX</PackageId>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <LangVersion>5</LangVersion>
   </PropertyGroup>
-
-  <!-- NETFX reference assemblies let us target .NET Framework on Mac/Linux without Mono -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="bin\**\*" />
@@ -35,66 +26,63 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="Graphics\GraphicsAdapter.cs" />
-    <Compile Remove="Media\Video.cs" />
-    <Compile Remove="Media\VideoPlayer.cs" />
-    <Compile Remove="Content\ContentReaders\VideoReader.cs" />
-    <Compile Remove="Input\MessageBox.cs" />
-    <Compile Remove="Input\KeyboardInput.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="Platform\TitleContainer.Desktop.cs" />
-    <Compile Include="Platform\Audio\OggStream.cs" />
     <Compile Include="Platform\Audio\Xact\WaveBank.Default.cs" />
-    <Compile Include="Platform\Graphics\OpenGL.Common.cs" />
-    <Compile Include="Platform\Graphics\Texture2D.StbSharp.cs" />    
-    <Compile Include="Platform\SDL\SDL2.cs" />
-    <Compile Include="Platform\SDL\SDLGamePlatform.cs" />
-    <Compile Include="Platform\SDL\SDLGameWindow.cs" />
+    <Compile Include="Platform\GamePlatform.Desktop.cs" />
+    <Compile Include="Platform\Graphics\SwapChainRenderTarget.cs" />
+    <Compile Include="Platform\Graphics\Texture2D.StbSharp.cs" />
+    <Compile Include="Platform\Input\GamePad.XInput.cs" />
+    <Compile Include="Platform\Input\InputKeyEventArgs.cs" />
+    <Compile Include="Platform\Input\Joystick.Default.cs" />
+    <Compile Include="Platform\Input\Keyboard.Windows.cs" />
+    <Compile Include="Platform\Input\KeyboardInput.Windows.cs" />
+    <Compile Include="Platform\Input\KeysHelper.cs" />
+    <Compile Include="Platform\Input\MessageBox.Windows.cs" />
+    <Compile Include="Platform\Input\Mouse.Windows.cs" />
+    <Compile Include="Platform\Input\MouseCursor.Windows.cs" />
+
+    <Compile Include="Platform\Media\MediaLibrary.Default.cs" />
+    <Compile Include="Platform\Media\MediaManagerState.cs" />
+    <Compile Include="Platform\Media\MediaPlayer.WMS.cs" />
+    <Compile Include="Platform\Media\Song.WMS.cs" />
+    <Compile Include="Platform\Media\Video.WMS.cs" />
+    <Compile Include="Platform\Media\VideoPlayer.WMS.cs" />
+    <Compile Include="Platform\Media\VideoSampleGrabber.cs" />
+    <Compile Include="Platform\TitleContainer.Desktop.cs" />
     <Compile Include="Platform\Utilities\AssemblyHelper.cs" />
     <Compile Include="Platform\Utilities\CurrentPlatform.cs" />
-    <Compile Include="Platform\Utilities\FuncLoader.Desktop.cs" />
-    <Compile Include="Platform\Utilities\InteropHelpers.cs" />
-    <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
-    <Compile Include="Platform\Media\MediaLibrary.Default.cs" />
-    <Compile Include="Platform\Media\MediaPlayer.Default.cs" />
-    <Compile Include="Platform\Media\Song.NVorbis.cs" />
-    <Compile Include="Platform\Input\GamePad.SDL.cs" />
-    <Compile Include="Platform\Input\InputKeyEventArgs.cs" />
-    <Compile Include="Platform\Input\Joystick.SDL.cs" />
-    <Compile Include="Platform\Input\Keyboard.SDL.cs" />
-    <Compile Include="Platform\Input\KeyboardUtil.SDL.cs" />
-    <Compile Include="Platform\Input\KeysHelper.cs" />
-    <Compile Include="Platform\Input\Mouse.SDL.cs" />
-    <Compile Include="Platform\Input\MouseCursor.SDL.cs" />
-    <Compile Include="Platform\Graphics\GraphicsContext.SDL.cs" />
-    <Compile Include="Platform\Graphics\OpenGL.SDL.cs" />
-    <Compile Include="Platform\Graphics\WindowInfo.SDL.cs" />
-    <Compile Include="Platform\Graphics\GraphicsAdapter.Legacy.cs" />
-    <Compile Include="Platform\GamePlatform.Desktop.cs" />
-    <Compile Include="Platform\GraphicsDeviceManager.SDL.cs" />
-    
+    <Compile Include="Platform\Utilities\ReflectionHelpers.Legacy.cs" />
+    <Compile Include="Platform\Utilities\TimerHelper.cs" />
+    <Compile Include="Platform\Windows\HorizontalMouseWheelEventArgs.cs" />
+    <Compile Include="Platform\Windows\WinFormsGameForm.cs" />
+    <Compile Include="Platform\Windows\WinFormsGamePlatform.cs" />
+    <Compile Include="Platform\Windows\WinFormsGameWindow.cs" />
+  </ItemGroup> 
+
+  <ItemGroup>
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
-
-    <Compile Include="..\ThirdParty\NVorbis\NVorbis\**\*.cs" LinkBase="ThirdParty\NVorbis" />
-    <Compile Remove="..\ThirdParty\NVorbis\NVorbis\Properties\AssemblyInfo.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="MonoGame.bmp">
-      <LogicalName>MonoGame.bmp</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\ThirdParty\SDL_GameControllerDB\gamecontrollerdb.txt">
-      <LogicalName>gamecontrollerdb.txt</LogicalName>
-    </EmbeddedResource>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Content Include="MonoGame.Framework.DesktopGL.targets" PackagePath="build" />
+    <Content Include="MonoGame.Framework.WindowsDX.targets" PackagePath="build" />
   </ItemGroup>
 
-  <Import Project="Platform\OpenGL.targets" />
-  <Import Project="Platform\OpenAL.targets" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Version="4.0.1" Include="SharpDX" />
+    <PackageReference Version="4.0.1" Include="SharpDX.Direct2D1" />
+    <PackageReference Version="4.0.1" Include="SharpDX.Direct3D11" />
+    <PackageReference Version="4.0.1" Include="SharpDX.DXGI" />
+    <PackageReference Version="4.0.1" Include="SharpDX.MediaFoundation" />
+    <PackageReference Version="4.0.1" Include="SharpDX.XAudio2" />
+    <PackageReference Version="4.0.1" Include="SharpDX.XInput" />
+  </ItemGroup>
+
+  <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+
+  <Import Project="Platform\DirectX.targets" />
+  <Import Project="Platform\XAudio.targets" />
 </Project>

--- a/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
@@ -1,0 +1,100 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net452</TargetFramework>
+    <DefineConstants>OPENGL;OPENAL;XNADESIGNPROVIDED;LINUX;DESKTOPGL;SUPPORTS_EFX;NETSTANDARD;STBSHARP_INTERNAL</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Description>Fake console assembly that checks if MonoGame's code is still compatible with the private console implementations and building against .NET 4.5.2 and C# 5.</Description>
+    <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
+    <LangVersion>5</LangVersion>
+  </PropertyGroup>
+
+  <!-- NETFX reference assemblies let us target .NET Framework on Mac/Linux without Mono -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="bin\**\*" />
+    <Compile Remove="obj\**\*" />
+    <Compile Remove="Platform\**\*" />
+    <Compile Remove="Properties\**\*" />
+    <Compile Remove="Utilities\System.Numerics.Vectors\**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Platform\**\*" />
+    <None Remove="Utilities\System.Numerics.Vectors\**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Graphics\GraphicsAdapter.cs" />
+    <Compile Remove="Media\Video.cs" />
+    <Compile Remove="Media\VideoPlayer.cs" />
+    <Compile Remove="Content\ContentReaders\VideoReader.cs" />
+    <Compile Remove="Input\MessageBox.cs" />
+    <Compile Remove="Input\KeyboardInput.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Platform\TitleContainer.Desktop.cs" />
+    <Compile Include="Platform\Audio\OggStream.cs" />
+    <Compile Include="Platform\Audio\Xact\WaveBank.Default.cs" />
+    <Compile Include="Platform\Graphics\OpenGL.Common.cs" />
+    <Compile Include="Platform\Graphics\Texture2D.StbSharp.cs" />    
+    <Compile Include="Platform\SDL\SDL2.cs" />
+    <Compile Include="Platform\SDL\SDLGamePlatform.cs" />
+    <Compile Include="Platform\SDL\SDLGameWindow.cs" />
+    <Compile Include="Platform\Utilities\AssemblyHelper.cs" />
+    <Compile Include="Platform\Utilities\CurrentPlatform.cs" />
+    <Compile Include="Platform\Utilities\FuncLoader.Desktop.cs" />
+    <Compile Include="Platform\Utilities\InteropHelpers.cs" />
+    <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
+    <Compile Include="Platform\Media\MediaLibrary.Default.cs" />
+    <Compile Include="Platform\Media\MediaPlayer.Default.cs" />
+    <Compile Include="Platform\Media\Song.NVorbis.cs" />
+    <Compile Include="Platform\Input\GamePad.SDL.cs" />
+    <Compile Include="Platform\Input\InputKeyEventArgs.cs" />
+    <Compile Include="Platform\Input\Joystick.SDL.cs" />
+    <Compile Include="Platform\Input\Keyboard.SDL.cs" />
+    <Compile Include="Platform\Input\KeyboardUtil.SDL.cs" />
+    <Compile Include="Platform\Input\KeysHelper.cs" />
+    <Compile Include="Platform\Input\Mouse.SDL.cs" />
+    <Compile Include="Platform\Input\MouseCursor.SDL.cs" />
+    <Compile Include="Platform\Graphics\GraphicsContext.SDL.cs" />
+    <Compile Include="Platform\Graphics\OpenGL.SDL.cs" />
+    <Compile Include="Platform\Graphics\WindowInfo.SDL.cs" />
+    <Compile Include="Platform\Graphics\GraphicsAdapter.Legacy.cs" />
+    <Compile Include="Platform\GamePlatform.Desktop.cs" />
+    <Compile Include="Platform\GraphicsDeviceManager.SDL.cs" />
+    
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
+
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\**\*.cs" LinkBase="ThirdParty\NVorbis" />
+    <Compile Remove="..\ThirdParty\NVorbis\NVorbis\Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="MonoGame.bmp">
+      <LogicalName>MonoGame.bmp</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\ThirdParty\SDL_GameControllerDB\gamecontrollerdb.txt">
+      <LogicalName>gamecontrollerdb.txt</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Content Include="MonoGame.Framework.DesktopGL.targets" PackagePath="build" />
+  </ItemGroup>
+
+  <Import Project="Platform\OpenGL.targets" />
+  <Import Project="Platform\OpenAL.targets" />
+</Project>

--- a/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
@@ -6,9 +6,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWindowsForms>true</UseWindowsForms>
     <Description>Fake console assembly that checks if MonoGame's code is still compatible with the private console implementations and building against .NET 4.5.2 and C# 5.</Description>
-    <PackageTags>monogame;.net core;core;.net standard;standard;windowsdx</PackageTags>
-    <PackageId>MonoGame.Framework.WindowsDX</PackageId>
-    <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <LangVersion>5</LangVersion>
   </PropertyGroup>
 
@@ -81,8 +78,10 @@
     <PackageReference Version="4.0.1" Include="SharpDX.XInput" />
   </ItemGroup>
 
-  <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-
+  <ItemGroup>
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+  </ItemGroup>
+  
   <Import Project="Platform\DirectX.targets" />
   <Import Project="Platform\XAudio.targets" />
 </Project>

--- a/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.targets
+++ b/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.targets
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <MonoGamePlatform>DesktopGL</MonoGamePlatform>
+    <MonoGamePlatform>Windows</MonoGamePlatform>
   </PropertyGroup>
 </Project>

--- a/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.targets
+++ b/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.targets
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <MonoGamePlatform>DesktopGL</MonoGamePlatform>
+  </PropertyGroup>
+</Project>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -66,10 +66,6 @@
     <Content Include="MonoGame.Framework.WindowsDX.targets" PackagePath="build" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <UseWindowsForms>true</UseWindowsForms>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -82,10 +78,6 @@
     <PackageReference Version="4.0.1" Include="SharpDX.MediaFoundation" />
     <PackageReference Version="4.0.1" Include="SharpDX.XAudio2" />
     <PackageReference Version="4.0.1" Include="SharpDX.XInput" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 
   <Import Project="Platform\DirectX.targets" />

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -9,7 +9,6 @@
     <PackageTags>monogame;.net core;core;.net standard;standard;windowsdx</PackageTags>
     <PackageId>MonoGame.Framework.WindowsDX</PackageId>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
-    <LangVersion>5</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build.cake
+++ b/build.cake
@@ -100,6 +100,14 @@ Task("Prep")
     dnPackSettings.Configuration = configuration;
 });
 
+Task("BuildConsoleCheck")
+    .IsDependentOn("Prep")
+    .Does(() =>
+{
+    DotNetRestore("MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj");
+    DotNetBuild("MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj");
+});
+
 Task("BuildDesktopGL")
     .IsDependentOn("Prep")
     .Does(() =>
@@ -268,6 +276,7 @@ Task("SanityCheck")
     .IsDependentOn("Prep");
 
 Task("BuildAll")
+    .IsDependentOn("BuildConsoleCheck")
     .IsDependentOn("BuildDesktopGL")
     .IsDependentOn("BuildWindowsDX")
     .IsDependentOn("BuildAndroid")

--- a/build.cake
+++ b/build.cake
@@ -102,6 +102,7 @@ Task("Prep")
 
 Task("BuildConsoleCheck")
     .IsDependentOn("Prep")
+    .WithCriteria(() => IsRunningOnWindows())
     .Does(() =>
 {
     DotNetRestore("MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj");


### PR DESCRIPTION
When we moved to .NET 6, we cleaned projects and removed compatibility toward .NET 4.5.2, which was a target used to ensure that MonoGame's main repository was still compatible with the private console implementations (which requires .NET 4.5.2 and C# 5).

We removed this target in preparation to .NET 7 deprecating it and not supporting to build it.

This PR adds a backup plan to still ensure that console repositories are building by adding a "fake" target (which is a copy of DesktopGL) to build against .NET 4.5.2 with C# 5.
This fake project named ```ConsoleCheck``` will help us to know if future PRs break might consoles or not by having the github actions building it (but without packaging it as a nuget to avoid confusion).

@tomspilman thoughts?

@harry-cpp I moved the LangVersion from WindowsDX to this project.