### PR TITLE
Make the VS extension to open .mgcb

### DIFF
--- a/Templates/MonoGame.Templates.VSExtension/MonoGameTemplatesVSExtensionPackage.cs
+++ b/Templates/MonoGame.Templates.VSExtension/MonoGameTemplatesVSExtensionPackage.cs
@@ -28,7 +28,7 @@ namespace MonoGame.Templates.VSExtension
     /// </remarks>
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [Guid(MonoGameTemplatesVSExtensionPackage.PackageGuidString)]
-    [ProvideEditorExtension(typeof(EditorFactory), ".mgcb", int.MaxValue)]
+    [ProvideEditorExtension(typeof(EditorFactory), ".mgcb", int.MaxValue, DefaultName = "MGCB Editor")]
     public sealed class MonoGameTemplatesVSExtensionPackage : AsyncPackage
     {
         /// <summary>

--- a/Templates/MonoGame.Templates.VSExtension/MonoGameTemplatesVSExtensionPackage.cs
+++ b/Templates/MonoGame.Templates.VSExtension/MonoGameTemplatesVSExtensionPackage.cs
@@ -1,7 +1,10 @@
-﻿using Microsoft.VisualStudio.Shell;
+﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Diagnostics;
 using Task = System.Threading.Tasks.Task;
 
 namespace MonoGame.Templates.VSExtension
@@ -25,6 +28,7 @@ namespace MonoGame.Templates.VSExtension
     /// </remarks>
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [Guid(MonoGameTemplatesVSExtensionPackage.PackageGuidString)]
+    [ProvideEditorExtension(typeof(EditorFactory), ".mgcb", int.MaxValue)]
     public sealed class MonoGameTemplatesVSExtensionPackage : AsyncPackage
     {
         /// <summary>
@@ -34,20 +38,74 @@ namespace MonoGame.Templates.VSExtension
 
     #region Package Members
 
-    /// <summary>
-    /// Initialization of the package; this method is called right after the package is sited, so this is the place
-    /// where you can put all the initialization code that rely on services provided by VisualStudio.
-    /// </summary>
-    /// <param name="cancellationToken">A cancellation token to monitor for initialization cancellation, which can occur when VS is shutting down.</param>
-    /// <param name="progress">A provider for progress updates.</param>
-    /// <returns>A task representing the async work of package initialization, or an already completed task if there is none. Do not return null from this method.</returns>
-    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
-    {
-        // When initialized asynchronously, the current thread may be a background thread at this point.
-        // Do any initialization that requires the UI thread after switching to the UI thread.
-        await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-    }
+        /// <summary>
+        /// Initialization of the package; this method is called right after the package is sited, so this is the place
+        /// where you can put all the initialization code that rely on services provided by VisualStudio.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to monitor for initialization cancellation, which can occur when VS is shutting down.</param>
+        /// <param name="progress">A provider for progress updates.</param>
+        /// <returns>A task representing the async work of package initialization, or an already completed task if there is none. Do not return null from this method.</returns>
+        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            RegisterEditorFactory(new EditorFactory());
+
+            // When initialized asynchronously, the current thread may be a background thread at this point.
+            // Do any initialization that requires the UI thread after switching to the UI thread.
+            await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        }
 
     #endregion
-}
+    }
+
+    [Guid(EditorFactory.GUID)]
+    public class EditorFactory : IVsEditorFactory
+    {
+        public const string GUID = "3ec6cbd1-65bd-4b26-a758-3b207d048872";
+
+        public int CreateEditorInstance(uint grfCreateDoc, string pszMkDocument, string pszPhysicalView, IVsHierarchy pvHier, uint itemid, IntPtr punkDocDataExisting, out IntPtr ppunkDocView, out IntPtr ppunkDocData, out string pbstrEditorCaption, out Guid pguidCmdUI, out int pgrfCDW)
+        {
+            ppunkDocView = IntPtr.Zero;
+            ppunkDocData = IntPtr.Zero;
+            pguidCmdUI = new Guid(GUID);
+            pgrfCDW = 0;
+            pbstrEditorCaption = null;
+
+            // open MGCB editor here
+            var process = new Process();
+            process.StartInfo.FileName = "dotnet.exe";
+            process.StartInfo.Arguments = $"mgcb-editor \"{pszMkDocument}\"";
+            process.StartInfo.WorkingDirectory = System.IO.Path.GetDirectoryName(pszMkDocument);
+            process.StartInfo.CreateNoWindow = true;
+            process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+
+            process.Start();
+
+            while (!process.StandardOutput.EndOfStream)
+            {
+                string str = process.StandardOutput.ReadLine();
+                System.Diagnostics.Debug.WriteLine(str);
+            }
+
+            return VSConstants.S_OK;
+        }
+
+        public int SetSite(Microsoft.VisualStudio.OLE.Interop.IServiceProvider psp)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int Close()
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int MapLogicalView(ref Guid rguidLogicalView, out string pbstrPhysicalView)
+        {
+            pbstrPhysicalView = null;
+
+            return VSConstants.S_OK;
+        }
+    }
 }


### PR DESCRIPTION
When the VS extension is installed, double clicking on an .mgcb file will open the MGCB Editor.

I'm not sure if this is the cleanest way to do that, but welp, it seems to work.