### PR TITLE
Added VS code Launch and Task base templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ Installers/Linux/tmp_run/
 *.run
 *.deb
 
+#Visual Studio Code files
+.vscode/
+
 #Visual Studio files
 *.pidb
 *.userprefs

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,24 +3,23 @@
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 
-    //The echo command is valid on all three platforms
     "version": "0.2.0",
     "configurations": [
         {
             "name": "MGCB Editor",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "mgcb-editor",
-            "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder/Debug/mgcb",
+            "preLaunchTask": "Build mgcb-editor",
+            "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder/Debug/Windows/mgcb-editor-windows.exe",
             "windows": {
-                "program": "${workspaceFolder}//Artifacts/MonoGame.Content.Builder/Debug/mgcb",
+                "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder/Debug/Windows/mgcb-editor-windows.exe",
                 "args": [],
-                "cwd": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Debug",
+                "cwd": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Windows/Debug",
             },
             "linux": {
-                "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder/Debug/mgcb",
+                "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Linux/Debug/mgcb-editor-linux",
                 "args": [],
-                "cwd": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Debug",
+                "cwd": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Linux/Debug",
             },
             "osx": {
                 "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Mac/Debug/MGCB Editor.app/Contents/MacOS/mgcb-editor-mac",
@@ -29,56 +28,6 @@
             },
             "console": "internalConsole",
             "stopAtEntry": false
-        },
-        {
-            "name": "Build DesktopGL",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "Build MonoGame Framework (DesktopGL)",
-            "program": "echo ",
-            "args": [],
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "Build IOS",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "Build MonoGame Framework (IOS)",
-            "program": "echo ",
-            "args": [],
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "Build WindowsDX",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "Build MonoGame Framework (WindowsDX)",
-            "program": "echo ",
-            "args": [],
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "Build WindowsUniversal",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "Build MonoGame Framework (WindowsUniversal)",
-            "program": "echo ",
-            "args": [],
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "Build MonoGame Framework Content Pipeline",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "Build MonoGame Framework Content Pipeline",
-            "program": "echo ",
-            "args": [],
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
+        }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,18 +2,83 @@
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+
+    //The echo command is valid on all three platforms
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "MGCB Editor (Mac)",
+            "name": "MGCB Editor",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "mgcb-editor-mac",
-            "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Mac/Debug/MGCB Editor.app/Contents/MacOS/mgcb-editor-mac",
-            "args": [],
-            "cwd": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Mac/Debug",
+            "preLaunchTask": "mgcb-editor",
+            "program": "${workspaceFolder}//Artifacts/MonoGame.Content.Builder/Debug/mgcb",
+            "windows": {
+                "program": "${workspaceFolder}//Artifacts/MonoGame.Content.Builder/Debug/mgcb",
+                "args": [],
+                "cwd": "${workspaceFolder}//Artifacts/MonoGame.Content.Builder.Editor/Debug",
+            },
+            "linux": {
+                "program": "${workspaceFolder}//Artifacts/MonoGame.Content.Builder/Debug/mgcb",
+                "args": [],
+                "cwd": "${workspaceFolder}//Artifacts/MonoGame.Content.Builder.Editor/Debug",
+            },
+            "osx": {
+                "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Mac/Debug/MGCB Editor.app/Contents/MacOS/mgcb-editor-mac",
+                "args": [],
+                "cwd": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Mac/Debug/MGCB Editor.app/Contents/MacOS",
+            },
             "console": "internalConsole",
             "stopAtEntry": false
-        }
+        },
+        {
+            "name": "Build DesktopGL",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build MonoGame Framework (DesktopGL)",
+            "program": "echo ",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Build IOS",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build MonoGame Framework (IOS)",
+            "program": "echo ",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Build WindowsDX",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build MonoGame Framework (WindowsDX)",
+            "program": "echo ",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Build WindowsUniversal",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build MonoGame Framework (WindowsUniversal)",
+            "program": "echo ",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Build MonoGame Framework Content Pipeline",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build MonoGame Framework Content Pipeline",
+            "program": "echo ",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,16 +11,16 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "mgcb-editor",
-            "program": "${workspaceFolder}//Artifacts/MonoGame.Content.Builder/Debug/mgcb",
+            "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder/Debug/mgcb",
             "windows": {
                 "program": "${workspaceFolder}//Artifacts/MonoGame.Content.Builder/Debug/mgcb",
                 "args": [],
-                "cwd": "${workspaceFolder}//Artifacts/MonoGame.Content.Builder.Editor/Debug",
+                "cwd": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Debug",
             },
             "linux": {
-                "program": "${workspaceFolder}//Artifacts/MonoGame.Content.Builder/Debug/mgcb",
+                "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder/Debug/mgcb",
                 "args": [],
-                "cwd": "${workspaceFolder}//Artifacts/MonoGame.Content.Builder.Editor/Debug",
+                "cwd": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Debug",
             },
             "osx": {
                 "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Mac/Debug/MGCB Editor.app/Contents/MacOS/mgcb-editor-mac",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -79,7 +79,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj",
+                "${workspaceFolder}/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj",
                 "/property:GenerateFullPaths=true"
             ],
             "problemMatcher": "$msCompile"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,6 @@
             "label": "Build MonoGame Framework (Android)",
             "command": "dotnet",
             "type": "process",
-            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
             "args": [
                 "build",
                 "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.Android.csproj",
@@ -17,7 +16,6 @@
             "label": "Build MonoGame Framework (ConsoleCheck)",
             "command": "dotnet",
             "type": "process",
-            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
             "args": [
                 "build",
                 "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj",
@@ -29,7 +27,6 @@
             "label": "Build MonoGame Framework (DesktopGL)",
             "command": "dotnet",
             "type": "process",
-            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
             "args": [
                 "build",
                 "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj",
@@ -41,7 +38,6 @@
             "label": "Build MonoGame Framework (IOS)",
             "command": "dotnet",
             "type": "process",
-            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
             "args": [
                 "build",
                 "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.IOS.csproj",
@@ -53,7 +49,6 @@
             "label": "Build MonoGame Framework (WindowsDX)",
             "command": "dotnet",
             "type": "process",
-            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
             "args": [
                 "build",
                 "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj",
@@ -65,7 +60,6 @@
             "label": "Build MonoGame Framework (WindowsUniversal)",
             "command": "dotnet",
             "type": "process",
-            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
             "args": [
                 "build",
                 "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj",
@@ -88,7 +82,6 @@
             "label": "Build mgcb-editor",
             "command": "dotnet",
             "type": "process",
-            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
             "osx": {                
                 "args": [
                     "build",
@@ -116,29 +109,98 @@
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "Run mgcb-editor",
+            "label": "Clean MonoGame Framework (Android)",
             "command": "dotnet",
             "type": "process",
-            "osx": {
+            "args": [
+                "clean",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.Android.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Clean MonoGame Framework (ConsoleCheck)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "clean",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Clean MonoGame Framework (DesktopGL)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "clean",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Clean MonoGame Framework (IOS)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "clean",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.IOS.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Clean MonoGame Framework (WindowsDX)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "clean",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Clean MonoGame Framework (WindowsUniversal)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "clean",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Clean MonoGame Framework Content Pipeline",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "clean",
+                "${workspaceFolder}/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Clean mgcb-editor",
+            "command": "dotnet",
+            "type": "process",
+            "osx": {                
                 "args": [
-                    "run",
-                    "--project ${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj"
+                    "clean",
+                    "${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj"
                 ]
             },
             "linux": {
                 "args": [
-                    "run",
-                    "--project ${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Linux.csproj"
+                    "clean",
+                    "${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Linux.csproj"
                 ]
-            },
+            }, 
             "windows": {
                 "args": [
-                    "run",
-                    "--project ${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Windows.csproj"
+                    "clean",
+                    "${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Windows.csproj"
                 ]
             },
             "problemMatcher": "$msCompile"
         }
-        
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,16 +2,143 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "mgcb-editor-mac",
+            "label": "Build MonoGame Framework (Android)",
+            "command": "dotnet",
+            "type": "process",
+            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
+            "args": [
+                "build",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.Android.csproj",
+                "/property:GenerateFullPaths=true"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build MonoGame Framework (ConsoleCheck)",
+            "command": "dotnet",
+            "type": "process",
+            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
+            "args": [
+                "build",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj",
+                "/property:GenerateFullPaths=true"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build MonoGame Framework (DesktopGL)",
+            "command": "dotnet",
+            "type": "process",
+            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
+            "args": [
+                "build",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj",
+                "/property:GenerateFullPaths=true"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build MonoGame Framework (IOS)",
+            "command": "dotnet",
+            "type": "process",
+            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
+            "args": [
+                "build",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.IOS.csproj",
+                "/property:GenerateFullPaths=true"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build MonoGame Framework (WindowsDX)",
+            "command": "dotnet",
+            "type": "process",
+            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
+            "args": [
+                "build",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj",
+                "/property:GenerateFullPaths=true"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build MonoGame Framework (WindowsUniversal)",
+            "command": "dotnet",
+            "type": "process",
+            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
+            "args": [
+                "build",
+                "${workspaceFolder}/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj",
+                "/property:GenerateFullPaths=true"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build MonoGame Framework Content Pipeline",
             "command": "dotnet",
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
+                "${workspaceFolder}MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj",
+                "/property:GenerateFullPaths=true"
             ],
             "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build mgcb-editor",
+            "command": "dotnet",
+            "type": "process",
+            "dependsOn": ["Build MonoGame Framework Content Pipeline"],
+            "osx": {                
+                "args": [
+                    "build",
+                    "${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj",
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary"
+                ]
+            },
+            "linux": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Linux.csproj",
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary"
+                ]
+            }, 
+            "windows": {
+                "args": [
+                    "build",
+                    "${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Windows.csproj",
+                    "/property:GenerateFullPaths=true",
+                    "/consoleloggerparameters:NoSummary"
+                ]
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Run mgcb-editor",
+            "command": "dotnet",
+            "type": "process",
+            "osx": {
+                "args": [
+                    "run",
+                    "--project ${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj"
+                ]
+            },
+            "linux": {
+                "args": [
+                    "run",
+                    "--project ${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Linux.csproj"
+                ]
+            },
+            "windows": {
+                "args": [
+                    "run",
+                    "--project ${workspaceFolder}/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Windows.csproj"
+                ]
+            },
+            "problemMatcher": "$msCompile"
         }
+        
     ]
 }


### PR DESCRIPTION
My attempt at making the VS Code Launch and Tasks work on platforms other than Mac.

VS Code is the only editor available on Linux, capable of supporting builds for multiple platforms without manual configuration when changing build targets. 

