### PR TITLE
Build system upgrades

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,8 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v2
+      - name: Clone repository
+        uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
@@ -39,10 +40,19 @@ jobs:
         run: dotnet cake build.cake
         env:
           GITHUB_ACTIONS: true
-      - uses: actions/upload-artifact@main
+      - name: Package nuget artifacts
+        uses: actions/upload-artifact@main
         with:
-          name: Nuget Packages ${{ matrix.os }}
+          name: nuget-${{ matrix.os }}
           path: |
-            Artifacts/**/*.nupkg
+            Artifacts/NuGet/*.nupkg
+          if-no-files-found: error
+      - name: Package Visual Studio extension artifact
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@main
+        with:
+          name: Visual Studio Extension
+          path: |
+            Artifacts/MonoGame.Templates.VSExtension/*.vsix
           if-no-files-found: error
 

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/MGNamespace.csproj
@@ -8,7 +8,7 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1" />
-    <PackageReference Include="MonoGame.Framework.Android" Version="3.8.1.1" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1-develop" />
+    <PackageReference Include="MonoGame.Framework.Android" Version="3.8.1.1-develop" />
   </ItemGroup>
 </Project>

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
@@ -21,7 +21,7 @@
     <TrimmerRootAssembly Include="MonoGame.Framework" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.1" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.1-develop" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1-develop" />
   </ItemGroup>
 </Project>

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.CoreApp.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.CoreApp.CSharp/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.CoreApp.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.CoreApp.CSharp/MGNamespace.csproj
@@ -114,8 +114,8 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.13</Version>
     </PackageReference>
-    <PackageReference Include="MonoGame.Framework.WindowsUniversal" Version="3.8.1.1" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1" />
+    <PackageReference Include="MonoGame.Framework.WindowsUniversal" Version="3.8.1.1-develop" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1-develop" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.XAML.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.XAML.CSharp/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.XAML.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.XAML.CSharp/MGNamespace.csproj
@@ -127,8 +127,8 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.13</Version>
     </PackageReference>
-    <PackageReference Include="MonoGame.Framework.WindowsUniversal" Version="3.8.1.1" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1" />
+    <PackageReference Include="MonoGame.Framework.WindowsUniversal" Version="3.8.1.1-develop" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1-develop" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
@@ -14,7 +14,7 @@
     <TrimmerRootAssembly Include="MonoGame.Framework" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.1" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1" />
+    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.1-develop" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1-develop" />
   </ItemGroup>
 </Project>

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.iOS.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.iOS.CSharp/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.iOS.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.iOS.CSharp/MGNamespace.csproj
@@ -5,7 +5,7 @@
     <SupportedOSPlatformVersion>11.2</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1" />
-    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.1.1" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1-develop" />
+    <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.1.1-develop" />
   </ItemGroup>
 </Project>

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.CSharp/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.1",
+      "version": "3.8.1.1-develop",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.CSharp/MGNamespace.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.1">
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.1-develop">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.Pipeline.Extension.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.Pipeline.Extension.CSharp/MGNamespace.csproj
@@ -3,10 +3,10 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.Content.Pipeline" Version="3.8.1.1">
+    <PackageReference Include="MonoGame.Framework.Content.Pipeline" Version="3.8.1.1-develop">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.1">
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.1-develop">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/Templates/MonoGame.Templates.VSExtension/MonoGame.Templates.VSExtension.csproj
+++ b/Templates/MonoGame.Templates.VSExtension/MonoGame.Templates.VSExtension.csproj
@@ -70,7 +70,7 @@
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Target Name="PreCreateVsixContainer" BeforeTargets="GetVsixSourceItems">
     <ItemGroup>
-      <_TemplatePackage Include="..\..\Artifacts\MonoGame.Templates.CSharp\Release\*.nupkg" />
+      <_TemplatePackage Include="..\..\Artifacts\NuGet\MonoGame.Templates.CSharp.*.nupkg" />
     </ItemGroup>
     <Error Text="No template files found." Condition="@(_TemplatePackage-&gt;Count()) == 0" />
     <Message Text="Template nuget packages found: @(_TemplatePackage)" Importance="low" />

--- a/Templates/MonoGame.Templates.VSMacExtension/MonoGame.Templates.VSMacExtension.csproj
+++ b/Templates/MonoGame.Templates.VSMacExtension/MonoGame.Templates.VSMacExtension.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AddinFile Include="..\..\Artifacts\MonoGame.Templates.CSharp\Release\*.nupkg">
+    <AddinFile Include="..\..\Artifacts\NuGet\MonoGame.Templates.CSharp.*.nupkg">
       <Link>Templates\MonoGame.Templates.CSharp.nupkg</Link>
     </AddinFile>
   </ItemGroup>

--- a/Templates/MonoGame.Templates.VSMacExtension/Properties/AddinInfo.cs
+++ b/Templates/MonoGame.Templates.VSMacExtension/Properties/AddinInfo.cs
@@ -1,7 +1,7 @@
 using System;
 using Mono.Addins;
 using Mono.Addins.Description;
-[assembly: Addin("MonoGame.Templates.VSMacExtension", Version = "3.8.1.137-develop")]
+[assembly: Addin("MonoGame.Templates.VSMacExtension", Version = "1.0.0")]
 [assembly: AddinName("MonoGame Extension")]
 [assembly: AddinCategory("Game Development")]
 [assembly: AddinDescription("MonoGame Extension ofr VisualStudio for Mac")]

--- a/Tools/MonoGame.Content.Builder.Editor/Info.plist
+++ b/Tools/MonoGame.Content.Builder.Editor/Info.plist
@@ -51,7 +51,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>net.monogame.mgcb-editor</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.0.1-develop</string>
+	<string>3.8.1.1-develop</string>
 	<key>CFBundleIconFile</key>
 	<string>Icon.icns</string>
 </dict>

--- a/build.cake
+++ b/build.cake
@@ -90,6 +90,7 @@ Task("Prep")
     msPackSettings.Configuration = configuration;
     msPackSettings.Restore = true;
     msPackSettings.WithProperty("Version", version);
+    msPackSettings.WithProperty("OutputDirectory", "Artifacts/NuGet");
     msPackSettings.WithTarget("Pack");
 
     mdPackSettings = new MSBuildSettings();
@@ -114,6 +115,7 @@ Task("Prep")
     dnPackSettings = new DotNetPackSettings();
     dnPackSettings.MSBuildSettings = dnMsBuildSettings;
     dnPackSettings.Verbosity = DotNetVerbosity.Minimal;
+    dnPackSettings.OutputDirectory = "Artifacts/NuGet";
     dnPackSettings.Configuration = configuration;
 
     dnPublishSettings = new DotNetPublishSettings();
@@ -238,17 +240,17 @@ Task("BuildTools")
     if (IsRunningOnWindows())
     {
         PublishDotnet("Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Windows.csproj");
-        PackDotnet("Tools/MonoGame.Content.Builder.Editor.Launcher/MonoGame.Content.Builder.Editor.Launcher.Windows.csproj");
+        DotNetBuild("Tools/MonoGame.Content.Builder.Editor.Launcher/MonoGame.Content.Builder.Editor.Launcher.Windows.csproj", dnBuildSettings);
     }
     else if (IsRunningOnMacOs())
     {
         PackDotnet("Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj");
-        PackDotnet("Tools/MonoGame.Content.Builder.Editor.Launcher/MonoGame.Content.Builder.Editor.Launcher.Mac.csproj");
+        DotNetBuild("Tools/MonoGame.Content.Builder.Editor.Launcher/MonoGame.Content.Builder.Editor.Launcher.Mac.csproj", dnBuildSettings);
     }
     else
     {
         PublishDotnet("Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Linux.csproj");
-        PackDotnet("Tools/MonoGame.Content.Builder.Editor.Launcher/MonoGame.Content.Builder.Editor.Launcher.Linux.csproj");
+        DotNetBuild("Tools/MonoGame.Content.Builder.Editor.Launcher/MonoGame.Content.Builder.Editor.Launcher.Linux.csproj", dnBuildSettings);
     }
 
     PackDotnet("Tools/MonoGame.Content.Builder.Editor.Launcher.Bootstrap/MonoGame.Content.Builder.Editor.Launcher.Bootstrap.csproj");


### PR DESCRIPTION
- Output all nugets into the same folder
- Commit all the files that have their versions modified when running `dotnet cake`
- Name some unnamed actions in github workflows file
- Rename nugets artifact and expose visual studio extension
- Build instead of packge mgcb-editor (the launcher is the project that needs to be packaged up)