### PR TITLE
[MGCB Editor] Added file watcher for the content project file with project reload prompt

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
@@ -306,6 +306,7 @@ namespace MonoGame.Tools.Pipeline
                 _projectFileWatcher.Path = dirName;
                 _projectFileWatcher.Filter = fileName;
             }
+            _projectFileWatcherIgnoreEvent = false;
 
             UpdateTree();
             View.UpdateTreeItem(_project);

--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Eto.Forms;
 using MonoGame.Content.Builder;
 using PathHelper = MonoGame.Framework.Content.Pipeline.Builder.PathHelper;
 
@@ -345,7 +344,7 @@ namespace MonoGame.Tools.Pipeline
             if (!_reloadProjectPrompted)
             {
                 _reloadProjectPrompted = true;
-                Application.Instance.Invoke(() => PromptReloadProject(e.FullPath));
+                View.Invoke(() => PromptReloadProject(e.FullPath));
             }
         }
 
@@ -380,6 +379,13 @@ namespace MonoGame.Tools.Pipeline
             // save the project if they need too.
             if (!AskSaveProject())
                 return;
+
+            // Uninitialize the File Watcher
+            if (_projectFileWatcher != null)
+            {
+                _projectFileWatcher.Changed -= ProjectFileWatcherOnChanged;
+                _projectFileWatcher = null;
+            }
 
             ProjectOpen = false;
             ProjectDirty = false;

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -228,6 +228,16 @@ namespace MonoGame.Tools.Pipeline
             return dialog.Show(this);
         }
 
+        public AskResult ShowReloadProjectDialog()
+        {
+            var result = MessageBox.Show(this, "The project file has been updated outside of the editor, do you want to reload the project? (Your changes will be lost)", "Reload Project", MessageBoxButtons.YesNo, MessageBoxType.Question);
+
+            if (result == DialogResult.Yes)
+                return AskResult.Yes;
+
+            return AskResult.No;
+        }
+
         public bool ShowEditDialog(string title, string text, string oldname, bool file, out string newname)
         {
             var dialog = new EditDialog(title, text, oldname, file);

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -230,7 +230,7 @@ namespace MonoGame.Tools.Pipeline
 
         public AskResult ShowReloadProjectDialog()
         {
-            var result = MessageBox.Show(this, "The project file has been updated outside of the editor, do you want to reload the project? (Your changes will be lost)", "Reload Project", MessageBoxButtons.YesNo, MessageBoxType.Question);
+            var result = MessageBox.Show(this, "The project file has been updated outside of the editor, do you want to reload the project? (Any unsaved changes will be lost)", "Reload Project", MessageBoxButtons.YesNo, MessageBoxType.Question);
 
             if (result == DialogResult.Yes)
                 return AskResult.Yes;


### PR DESCRIPTION
Right now, if you have the MGCB Editor open and you pull in changes to the content project file from Git, the editor won't reload those changes automatically nor will it warn you that the project file has been changed outside of the editor. If you then go ahead and make some changes and save, the changes you pulled in would be overwritten.

This PR adds a file watcher for the content project file and prompts a dialog asking if the user would like to reload the project whenever an unexpected change is detected.

![image](https://user-images.githubusercontent.com/14330158/168112182-c820f2c7-a634-443d-a393-bbcb73cb3139.png)


