### PR TITLE
fix list of supported surfaces

### DIFF
--- a/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
@@ -853,7 +853,7 @@ namespace Microsoft.Xna.Framework
             static int GetAttribute(EGLConfig config, IEGL10 egl, EGLDisplay eglDisplay,int attribute)
             {
                 int[] data = new int[1];
-                egl.EglGetConfigAttrib(eglDisplay, config, EGL11.EglRedSize, data);
+                egl.EglGetConfigAttrib(eglDisplay, config, attribute, data);
                 return data[0];
             }
 


### PR DESCRIPTION
currently I am getting the following output during startup (emulator)
```
Device Supports
Red:5 Green:5 Blue:5 Alpha:5 Depth:5 Stencil:5 SampleBuffers:5 Samples:5
Red:8 Green:8 Blue:8 Alpha:8 Depth:8 Stencil:8 SampleBuffers:8 Samples:8
Red:8 Green:8 Blue:8 Alpha:8 Depth:8 Stencil:8 SampleBuffers:8 Samples:8
```

The corrected output:
```
Device Supports
Red:5 Green:6 Blue:5 Alpha:0 Depth:24 Stencil:8 SampleBuffers:0 Samples:0
Red:8 Green:8 Blue:8 Alpha:0 Depth:24 Stencil:8 SampleBuffers:0 Samples:0
Red:8 Green:8 Blue:8 Alpha:8 Depth:24 Stencil:8 SampleBuffers:0 Samples:0
Red:8 Green:8 Blue:8 Alpha:8 Depth:24 Stencil:8 SampleBuffers:0 Samples:0
```

This output is generated here, 
https://github.com/MonoGame/MonoGame/blob/807455fae2371057b2bb621332392aac82c40606/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs#L952-L956