### PR TITLE
Automatic issue closing

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,20 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 350
+          days-before-issue-close: 15
+          stale-issue-message: "Greetings! It looks like this issue doesn't have much traction. It has been marked as _stale_ and will be closed automatically if no further information or confirmation are provided within 15 days. Please make sure that you verify this issue against the latest version. Providing a sample project exposing this issue might help improving its resolution."
+          close-issue-message: "Greetings! This issue was closed because it has been inactive for a year. If you feel like this issue still needs to be investigated, please test it against the latest version and open a new issue if it is still a valid concern. Providing a sample project might help this issue to get more traction."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,9 +2,6 @@
 # Please make sure that the issue is present in the
 # develop branch of MonoGame before reporting
 #
-# You can download the development build installer from:
-# http://www.monogame.net/downloads/
-#
 # GitHub issues are only for bug reports / feature requests
 # if you have a question, ask it on the community site:
 # https://community.monogame.net
@@ -19,11 +16,20 @@
 <!-- System stats -->
 
 #### What version of MonoGame does the bug occur on:
-- MonoGame 3.7
+- MonoGame 3.8.1
 
 #### What operating system are you using:
+<!-- e.g. Windows, Linux, macOS -->
 - Windows
 
+#### Which verion of the .NET SDK are you using:
+<!-- you can type "dotnet --version" in a command prompt to verify your SDK version -->
+- .NET SDK 6.0.300
+
+#### What IDE are you using:
+<!-- e.g. Visual Studio 2022, Visual Studio 2022 for Mac, JetBrains Rider, Visual Studio Code -->
+- Visual Studio 2022
+
 #### What MonoGame platform are you using:
-<!-- e.g. DesktopGL, WindowsDX, WindowsUWP, Android -->
+<!-- e.g. DesktopGL, WindowsDX, WindowsUWP, Android, iOS -->
 - DesktopGL


### PR DESCRIPTION
This PR adds an automatic github actions that will run every day at 12am UTC.

This action will mark issues (not PRs) that have been inactive for 350 days with a notice message inviting to bump the issue.

If no activity is detected within the next 15 days after being marked as inactive, the issue will be closed automatically (and inviting to verify the validity of the issue against the latest version before opening a new issue).

If an issue gets active again, the mark is removed automatically.

It's basically a "prune inactive issues older than 1 year" action.

We can adjust the timing. As of now, it would close 591 out of 672 issues (or 450 if we set it to 2 years).
If need be, we can configure the action to never expire issues that we mark with a specific label.