### PR TITLE
Removed trimming property from templates

### DIFF
--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
@@ -20,9 +20,6 @@
     <EmbeddedResource Include="Icon.bmp" />
   </ItemGroup>
   <ItemGroup>
-    <TrimmerRootAssembly Include="MonoGame.Framework" Visible="false" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.1-develop" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1-develop" />
   </ItemGroup>

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/MGNamespace.csproj
@@ -13,9 +13,6 @@
     <ApplicationIcon>Icon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <TrimmerRootAssembly Include="MonoGame.Framework" Visible="false" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.1-develop" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.1-develop" />
   </ItemGroup>


### PR DESCRIPTION
Since .NET 6, the default assembly trimming behavior is to trim assemblies marked as ```IsTrimmable```. MonoGame isn't, so we might as well remove those properties from the templates because they might actually result in errors.