### PR TITLE
Refactored AndroidGameActivity to allow custom Activity classes

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Xna.Framework
 
 #if ANDROID
         [CLSCompliant(false)]
-        public static AndroidGameActivity Activity { get; internal set; }
+        public static Android.App.Activity Activity { get; internal set; }
 #endif
         private static Game _instance = null;
         internal static Game Instance { get { return Game._instance; } }

--- a/MonoGame.Framework/Platform/Android/AndroidGamePlatform.cs
+++ b/MonoGame.Framework/Platform/Android/AndroidGamePlatform.cs
@@ -15,7 +15,10 @@ namespace Microsoft.Xna.Framework
             : base(game)
         {
             System.Diagnostics.Debug.Assert(Game.Activity != null, "Must set Game.Activity before creating the Game instance");
-            Game.Activity.Game = Game;
+
+            var androidActivity = (IAndroidGameActivity)(Game.Activity);
+            androidActivity.InitializeGame(Game);
+
             AndroidGameActivity.Paused += Activity_Paused;
             AndroidGameActivity.Resumed += Activity_Resumed;
 
@@ -120,9 +123,11 @@ namespace Microsoft.Xna.Framework
         {
             if (!IsActive)
             {
+                var androidActivity = Game.Activity as IAndroidGameActivity;
+
                 IsActive = true;
                 _gameWindow.GameView.Resume();
-                if (_MediaPlayer_PrevState == MediaState.Playing && Game.Activity.AutoPauseAndResumeMediaPlayer)
+                if (_MediaPlayer_PrevState == MediaState.Playing && (androidActivity?.AutoPauseAndResumeMediaPlayer ?? true))
                     MediaPlayer.Resume();
                 if (!_gameWindow.GameView.IsFocused)
                     _gameWindow.GameView.RequestFocus();
@@ -135,12 +140,14 @@ namespace Microsoft.Xna.Framework
         {
             if (IsActive)
             {
+                var androidActivity = Game.Activity as IAndroidGameActivity;
+
                 IsActive = false;
                 _MediaPlayer_PrevState = MediaPlayer.State;
                 _gameWindow.GameView.Pause();
                 _gameWindow.GameView.ClearFocus();
-                if (Game.Activity.AutoPauseAndResumeMediaPlayer)
-                    MediaPlayer.Pause();
+
+                if (androidActivity?.AutoPauseAndResumeMediaPlayer ?? true) MediaPlayer.Pause();
             }
         }
 

--- a/MonoGame.Framework/Platform/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Platform/Android/AndroidGameWindow.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Xna.Framework
             Resumer = resumer;
         }
 
-        public AndroidGameWindow(AndroidGameActivity activity, Game game)
+        public AndroidGameWindow(Android.App.Activity activity, Game game)
         {
             _game = game;
 
@@ -57,10 +57,16 @@ namespace Microsoft.Xna.Framework
 
         private void Initialize(Context context, Point size)
         {
-            _clientBounds = new Rectangle(0, 0, size.X, size.Y);
+            _clientBounds = new Rectangle(0, 0, size.X, size.Y);            
             
             GameView = new MonoGameAndroidGameView(context, this, _game);
-            GameView.RenderOnUIThread = Game.Activity.RenderOnUIThread;
+
+            GameView.RenderOnUIThread = true;
+            if (Game.Activity is IAndroidGameActivity androidActivity)
+            {
+                GameView.RenderOnUIThread = androidActivity.RenderOnUIThread;
+            }
+
             GameView.RenderFrame += OnRenderFrame;
             GameView.UpdateFrame += OnUpdateFrame;
 


### PR DESCRIPTION
Related to #7831 and #7191

AndroidGameActivity is hardcoded, which prevents a number of scenarios.

This PR makes the whole thing a bit more flexible allowing, with some work on the developer's side, to use a custom Activity.

Notice that this is critical to support new features available in modern android devices, because the recomended use case is to make the MainActivity to derive from `AndroidX.Core.App.ComponentActivity` or one of its derived classes.