### PR TITLE
Added Documentation generation and Source code embedding into symbol nuget packages

### DIFF
--- a/MonoGame.Framework/Directory.Build.props
+++ b/MonoGame.Framework/Directory.Build.props
@@ -10,5 +10,14 @@
     <RootNamespace>Microsoft.Xna.Framework</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <EmbedAllSources>true</EmbedAllSources>
+    <PathMap>$(MSBuildProjectDirectory)=X:\sources</PathMap>
+  </PropertyGroup>
+
 </Project>
 


### PR DESCRIPTION
This is a quality of life PR that adds the following features:
- generates a symbols package (.snupkg) along with the main nuget package, Containing the debug .PDB file.
- Adds documentation.xml to the nuget package, which will allow VS to decorate monogame methods and classes.
- Embeds monogame's source code into Symbols nuget package (.snupkg), which allows to navigate into the source from any project referencing the nugets (*)

(*) Microsoft recently introduced a fake "navigate to source" which uses ILSpy to decompile the IL of the assembly and present it as "the source"... but it's not the real thing, among other things, it's missing the documentation.

Note: usually, .snupkg files must be uploaded to the package manager after the .nupkg files have been uploaded (some tools also upload it automatically if they find a .snupkg side by side with a .nupkg