### PR TITLE
Added identity to UWP CoreApp template

### DIFF
--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.CoreApp.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.CoreApp.CSharp/.template.config/template.json
@@ -5,6 +5,7 @@
     ],
     "name": "MonoGame Windows Universal CoreApp Application",
     "groupIdentity": "MonoGame.Application.UWP.CoreApp",
+    "identity": "MonoGame.Application.UWP.CoreApp.CSharp",
     "shortName": "mguwpcore",
     "tags": {
         "language": "C#",


### PR DESCRIPTION
Apparently this may cause VS2022 to not show this template in the project creation wizard.