### PR TITLE
mgfxc_wine_setup.sh download dotnet x64 instead of dotnet x86

### DIFF
--- a/Tools/MonoGame.Effect.Compiler/mgfxc_wine_setup.sh
+++ b/Tools/MonoGame.Effect.Compiler/mgfxc_wine_setup.sh
@@ -36,7 +36,7 @@ wine64 regedit crashdialog.reg
 popd
 
 # get dotnet
-DOTNET_URL="https://download.visualstudio.microsoft.com/download/pr/e71628cc-8b6c-498f-ae7a-c0dc60019696/aaadc51ad300f1aa58250427e5373527/dotnet-sdk-6.0.202-win-x86.zip"
+DOTNET_URL="https://download.visualstudio.microsoft.com/download/pr/44d08222-aaa9-4d35-b24b-d0db03432ab7/52a4eb5922afd19e8e0d03e0dbbb41a0/dotnet-sdk-6.0.302-win-x64.zip"
 curl $DOTNET_URL --output "$SCRIPT_DIR/dotnet-sdk.zip"
 7z x "$SCRIPT_DIR/dotnet-sdk.zip" -o"$WINEPREFIX/drive_c/windows/system32/"
 


### PR DESCRIPTION
One-liner fixes #7898