### PR TITLE
Correct minor grammatical typos in Texture2D source code comments

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Xna.Framework.Graphics
             Threading.EnsureUIThread();
 
 #if GLES
-            // TODO: check for for non renderable formats (formats that can't be attached to FBO)
+            // TODO: check for non renderable formats (formats that can't be attached to FBO)
 
             var framebufferId = 0;
             GL.GenFramebuffers(1, out framebufferId);

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
-                // If stream doesnt provide seek functionaly, use MemoryStream instead
+                // If stream doesn't provide seek functionality, use MemoryStream instead
                 using (var ms = new MemoryStream())
                 {
                     stream.CopyTo(ms);


### PR DESCRIPTION
Noticed these while trying to build MonoGame from source. Very minor in grand scope.