### PR TITLE
Set the SupportedOSPlatformVersion within the Android project file

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-android</TargetFramework>
+    <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
     <DefineConstants>ANDROID;GLES;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MGOpenGL>GLES</MGOpenGL>


### PR DESCRIPTION
Set the SupportedOSPlatformVersion within the Android project file to prevent large quantities of Warning CA1416 when targeting an API earlier than 31 on Android.

Resolves #7896.

I set the SupportedOSPlatformVersion to API 23 (Marshmallow V6.0, released Aug 2015, since it was mentioned in the issue and everything compiles ok. Might be good for someone to check that this is appropriate before merging though.

Image of warnings prior to implementing this change below:
![image](https://user-images.githubusercontent.com/15183337/185818218-f4a31ced-4d3d-4790-b0a3-a295c373ce4c.png)
