### PR TITLE
VSInputTxVc Color and TexCoord swap.

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/Effect/Resources/Structures.fxh
+++ b/MonoGame.Framework/Platform/Graphics/Effect/Resources/Structures.fxh
@@ -28,8 +28,8 @@ struct VSInputTx
 struct VSInputTxVc
 {
     float4 Position : POSITION;
-    float2 TexCoord : TEXCOORD;
     float4 Color    : COLOR;
+    float2 TexCoord : TEXCOORD;
 };
 
 struct VSInputNm


### PR DESCRIPTION
Swapped VSInputTxVc Color and TexCoord to match VertexPositionColorTexture layout. Some platforms require them to be in the same order, otherwise you get garbled textures/colors when using texture and colors without normals.