### PR TITLE
Fix Android triggers

### DIFF
--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -268,8 +268,8 @@ namespace Microsoft.Xna.Framework.Input
 
             gamePad._leftStick = new Vector2(e.GetAxisValue(Axis.X), -e.GetAxisValue(Axis.Y));
             gamePad._rightStick = new Vector2(e.GetAxisValue(Axis.Z), -e.GetAxisValue(Axis.Rz));
-            gamePad._leftTrigger = e.GetAxisValue(Axis.Ltrigger);
-            gamePad._rightTrigger = e.GetAxisValue(Axis.Rtrigger);
+            gamePad._leftTrigger = e.GetAxisValue(Axis.Brake);
+            gamePad._rightTrigger = e.GetAxisValue(Axis.Gas);
 
             if(!gamePad.DPadButtons)
             {


### PR DESCRIPTION
For some reason, Google changed the naming of the gamepad trigger events since API 18 (which is below MG's target). They state in the documentation that the old and new events should still work the same and mimic each other, but this is wrong and the old names just generate ```0.0f``` values, breaking gamepad triggers entirely.