### PR TITLE
Use SharpDX and NVorbis from Nuget

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "ThirdParty/Dependencies"]
 	path = ThirdParty/Dependencies
 	url = https://github.com/MonoGame/MonoGame.Dependencies.git
-[submodule "ThirdParty/NVorbis"]
-	path = ThirdParty/NVorbis
-url=https://github.com/NVorbis/NVorbis.git
 [submodule "ThirdParty/SDL_GameControllerDB"]
 	path = ThirdParty/SDL_GameControllerDB
 	url = https://github.com/gabomdq/SDL_GameControllerDB.git

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -50,12 +50,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="SharpDX">
-      <HintPath>..\ThirdParty\Dependencies\SharpDX\net40\SharpDX.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.D3DCompiler">
-      <HintPath>..\ThirdParty\Dependencies\SharpDX\SharpDX.D3DCompiler.dll</HintPath>
-    </Reference>
     <Reference Include="CppNet">
       <HintPath>..\ThirdParty\Dependencies\CppNet\CppNet.dll</HintPath>
     </Reference>
@@ -88,6 +82,8 @@
 
   <ItemGroup>
     <PackageReference Include="AssimpNet" Version="4.1.0" />
+    <PackageReference Include="SharpDX" Version="4.0.1" />
+    <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(CopyContentFiles)' == 'True'">

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="NVorbis" Version="0.10.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/Platform/Audio/OggStream.cs
+++ b/MonoGame.Framework/Platform/Audio/OggStream.cs
@@ -1,7 +1,7 @@
 ﻿// This code originated from:
 //
 //    http://theinstructionlimit.com/ogg-streaming-using-opentk-and-nvorbis
-//    https://github.com/renaudbedard/nvorbis/
+//    https://github.com/NVorbis/NVorbis
 //
 // It was released to the public domain by the author (Renaud Bedard).
 // No other license is intended or required.
@@ -9,7 +9,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using NVorbis;
@@ -160,7 +159,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         public void SeekToPosition(TimeSpan pos)
         {
-            Reader.DecodedTime = pos;
+            Reader.TimePosition = pos;
             AL.SourceStop(alSourceId);
             ALHelper.CheckError("Failed to stop source.");
         }
@@ -170,7 +169,7 @@ namespace Microsoft.Xna.Framework.Audio
             if (Reader == null)
                 return TimeSpan.Zero;
 
-            return Reader.DecodedTime;
+            return Reader.TimePosition;
         }
 
         public TimeSpan GetLength()

--- a/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
+++ b/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
@@ -69,8 +69,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="..\..\ThirdParty\Dependencies\SharpDX\net40\SharpDX.dll" />
-    <Reference Include="..\..\ThirdParty\Dependencies\SharpDX\SharpDX.D3DCompiler.dll" />
+    <PackageReference Include="SharpDX" Version="4.0.1" />
+    <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="..\..\ThirdParty\Dependencies\CppNet\CppNet.dll" />
   </ItemGroup>
   


### PR DESCRIPTION
Based on #7089 and #6144 I made changes to use SharpDX and NVorbis with Nuget.