### PR TITLE
Add SDL mapping for Key 35 (102 key backslash or UK pound key)

### DIFF
--- a/MonoGame.Framework/Platform/Input/KeyboardUtil.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/KeyboardUtil.SDL.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Xna.Framework.Input
             _map.Add(13, Keys.Enter);
             _map.Add(27, Keys.Escape);
             _map.Add(32, Keys.Space);
+            _map.Add(35, Keys.Oem8);
             _map.Add(39, Keys.OemQuotes);
             _map.Add(43, Keys.Add);
             _map.Add(44, Keys.OemComma);


### PR DESCRIPTION
See #7488 
Adding this key entry as Oem8 due to lack of suitable existing mappings in the Oem keys and I wasn't sure it was right to necessarily add a new one for this use case.

The UK keyboard #/~ key maps as key code 35 in SDL due to its internal conversion to ascii, however there is no OEM Pound virtual key, and in native UK keyboard mappings this key maps to OEM 7 (which is OEM Quote in mono's mappings).
By Mapping this key to Oem8 we can allow support for this key in DesktopGL for 102 key users, however it may need to be checked/verified with someone that has a US 102 key layout keyboard to ensure the mapping comes through correctly.