### PR TITLE
Added CollectBundleResourcesDependsOn in target to fix BundleResource…

### DIFF
--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -8,6 +8,9 @@
   <!-- This disables the IDE feature that skips executing msbuild in some build situations. -->
   <PropertyGroup>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+	<CollectBundleResourcesDependsOn>
+	    IncludeContent;
+	</CollectBundleResourcesDependsOn>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
#7897 
Adding CollectBundleResourcesDependsOn to .targets file to get Content to be added properly to iOS .app files.
Would love to see this go out as a hotfix for the NuGet package MonoGame.Content.Builder.Task if approved so users could utilize iOS Content pipeline using default templates out of the box.