### PR TITLE
Added missing identity for the uwpcore template

### DIFF
--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.CoreApp.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.CoreApp.CSharp/.template.config/template.json
@@ -5,6 +5,7 @@
     ],
     "name": "MonoGame Windows Universal CoreApp Application",
     "groupIdentity": "MonoGame.Application.UWP.CoreApp",
+    "identity": "MonoGame.Application.UWP.CoreApp.CSharp",
     "shortName": "mguwpcore",
     "tags": {
         "language": "C#",


### PR DESCRIPTION
Without this the templates fails to install with this error:
```
Error: Failed to load template from C:\Users<UserName>.templateengine\packages\MonoGame.Templates.CSharp.3.8.1.303.nupkg(/content/content/MonoGame.Application.UWP.CoreApp.CSharp/.template.config/template.json):
Missing ‘identity’.
```