### PR TITLE
Added code to .targets to fix iOS Content inclusion

### DIFF
--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -8,6 +8,9 @@
   <!-- This disables the IDE feature that skips executing msbuild in some build situations. -->
   <PropertyGroup>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+	<CollectBundleResourcesDependsOn>
+	  IncludeContent;
+	</CollectBundleResourcesDependsOn>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
#7897 
Fixes an issue of Content not copying into an iOS build when compiling/debugging.  This fixes issues when loading content on iOS when running `Content.Load<T>` due to the content not being there.
Would be helpful to redeploy the MonoGame.Content.Builder.Task NuGet package with this fix to allow iOS MonoGame template to use content.