### PR TITLE
Removed NET Core checks

### DIFF
--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -21,8 +21,6 @@ namespace Microsoft.Xna.Framework.Content
 
         private static readonly string _assemblyName;
 
-        private static readonly bool _isRunningOnNetCore = Type.GetType("System.Private.CoreLib") != null;
-
         static ContentTypeReaderManager()
         {
             _locker = new object();
@@ -221,15 +219,10 @@ namespace Microsoft.Xna.Framework.Content
             if (preparedType.Contains("PublicKeyToken"))
                 preparedType = Regex.Replace(preparedType, @"(.+?), Version=.+?$", "$1");
 
-            // TODO: For WinRT this is most likely broken!
             preparedType = preparedType.Replace(", Microsoft.Xna.Framework.Graphics", string.Format(", {0}", _assemblyName));
             preparedType = preparedType.Replace(", Microsoft.Xna.Framework.Video", string.Format(", {0}", _assemblyName));
             preparedType = preparedType.Replace(", Microsoft.Xna.Framework", string.Format(", {0}", _assemblyName));
-
-            if (_isRunningOnNetCore)
-                preparedType = preparedType.Replace("mscorlib", "System.Private.CoreLib");
-            else
-                preparedType = preparedType.Replace("System.Private.CoreLib", "mscorlib");
+            preparedType = preparedType.Replace("mscorlib", "System.Private.CoreLib");
 
             return preparedType;
         }


### PR DESCRIPTION
#7868 
When deploying to physical iOS devices, errors are occurring due to code that tried to detect NET core environments or not and replace names of libraries to load.  This shouldn't be necessary anymore, as the updated templates all use NET 6 and use 'Core' libraries.  I've tested this removal on all types of projects, including WindowsUniversal, DirectX, OpenGL, Android and iOS projects, and deployed to Android and iOS physical devices and found this fix works across those scenarios.