### PR TITLE
Moved MSBuild Sdk version to fix Project Loading

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
 
   <PropertyGroup>
     <TargetFramework>uap10.0</TargetFramework>

--- a/MonoGame.Framework/global.json
+++ b/MonoGame.Framework/global.json
@@ -1,5 +1,0 @@
-{
-    "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "2.0.54"
-    }
-}


### PR DESCRIPTION
#7959 
Moved version of MSBuild out of global.json file and into project.  Fixes loading of solution and also allows for reference directly from the MonoGame UWP template (where is currently doesn't load in VS 2022).