### PR TITLE
Added null check for ExtendedGamepad.ButtonOptions for iOS compatibility

### DIFF
--- a/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Xna.Framework.Input
 
                     if (controller.ExtendedGamepad.ButtonMenu.IsPressed)
                         buttons |= Buttons.Start;
-                    if (controller.ExtendedGamepad.ButtonOptions.IsPressed)
+                    if (controller.ExtendedGamepad.ButtonOptions?.IsPressed == true)
                         buttons |= Buttons.Back;
 
                     if (controller.ExtendedGamepad.DPad.Up.IsPressed)


### PR DESCRIPTION
When debugging iOS MonoGame, doing a GamePad.GetState was crashing out the program due to a null state for ExtendedGamepad.ButtonOptions.  This addresses the issue by adding a null check.

Addresses issue #7965 