### PR TITLE
[SDL] Fixed SdlGameWindow fails to load Icon.bmp.

### DIFF
--- a/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
@@ -108,13 +108,14 @@ namespace Microsoft.Xna.Framework
             Sdl.SetHint("SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "1");
 
             // when running NUnit tests entry assembly can be null
-            if (Assembly.GetEntryAssembly() != null)
+            var entryAssembly = Assembly.GetEntryAssembly();
+            if (entryAssembly != null)
             {
                 using (
                     var stream =
-                        Assembly.GetEntryAssembly().GetManifestResourceStream(Assembly.GetEntryAssembly().EntryPoint.DeclaringType.Namespace + ".Icon.bmp") ??
-                        Assembly.GetEntryAssembly().GetManifestResourceStream("Icon.bmp") ??
-                        Assembly.GetExecutingAssembly().GetManifestResourceStream("MonoGame.bmp"))
+                        entryAssembly.GetManifestResourceStream(entryAssembly.GetName().Name + ".Icon.bmp") ??
+                        entryAssembly.GetManifestResourceStream("Icon.bmp") ??
+                        typeof(SdlGameWindow).Assembly.GetManifestResourceStream("MonoGame.bmp"))
                 {
                     if (stream != null)
                         using (var br = new BinaryReader(stream))


### PR DESCRIPTION
It occurs when the namespace of the entry point class is not the same as the name of the entry assembly.
This is also the case for the top-level statements, which generates an entry point class with no namespace.

Changed to use the name of the entry assembly for the resource name of Icon.bmp.

Also changed to use Type.Assembly for the fall back case, which is the recommended way when available instead of
Assembly.GetExecutingAssembly().