### PR TITLE
Restore Color.TransparentBlack

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Xna.Framework
     {
         static Color()
         {
+            TransparentBlack = new Color(0);
             Transparent = new Color(0);
             AliceBlue = new Color(0xfffff8f0);
             AntiqueWhite = new Color(0xffd7ebfa);
@@ -429,6 +430,15 @@ namespace Microsoft.Xna.Framework
         }
 
         #region Color Bank
+        /// <summary>
+        /// TransparentBlack color (R:0,G:0,B:0,A:0).
+        /// </summary>
+        [Obsolete("Use Color.Transparent instead. In future versions this method can be removed.")]
+        public static Color TransparentBlack
+        {
+            get;
+            private set;
+        }
         
         /// <summary>
         /// Transparent color (R:0,G:0,B:0,A:0).


### PR DESCRIPTION
The static property `Color.TransparentBlack` was removed in version 3.8.1 due to it being deprecated. This is a violation of the [semantic versioning specification](https://semver.org/):

> Patch version Z (x.y.Z | x > 0) MUST be incremented if only backwards compatible bug fixes are introduced. A bug fix is defined as an internal change that fixes incorrect behavior.

Although the functionality was deprecated, removing it is still a backwards-incompatible change and shouldn't occur in a minor or patch release.

This PR simply restores the property along with its `Obsolete` attribute.