### PR TITLE
Added instructions for targeting M1.

### DIFF
--- a/Documentation/articles/packaging_games.md
+++ b/Documentation/articles/packaging_games.md
@@ -28,9 +28,13 @@ We recommend using the .tar.gz archiving format to preserve the execution permis
 
 ### Build and packaging for macOS
 
-From the .NET CLI:
+From the .NET CLI (x64):
 
 `dotnet publish -c Release -r osx-x64 /p:PublishReadyToRun=false /p:TieredCompilation=false --self-contained`
+
+If targeting M1:
+
+`dotnet publish -c Release -r osx-arm64 /p:PublishReadyToRun=false /p:TieredCompilation=false --self-contained`
 
 We recommend that you distribute your game as an [application bundle](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html). Application bundles are directories with the following file structure:
 


### PR DESCRIPTION
Maybe it's obvious to everyone else, but I kept trying to build for M1 using the old `osx-x64` command since MonoGame is supposedly able to build M1 native binaries now with no extra work needed.

I don't know if anything else needs changing to publish for M1, but the example Info.plist file says

```xml
    <key>LSMinimumSystemVersion</key>
    <string>10.15</string>
```

and I take it that number should be something higher for M1 apps?