### PR TITLE
Fix buffer overflow in WinFormsGameForm DragQueryFile call.

### DIFF
--- a/MonoGame.Framework/Platform/Windows/WinFormsGameForm.cs
+++ b/MonoGame.Framework/Platform/Windows/WinFormsGameForm.cs
@@ -215,16 +215,16 @@ namespace Microsoft.Xna.Framework.Windows
         void HandleDropMessage(ref Message m)
         {
             IntPtr hdrop = m.WParam;
-            StringBuilder builder = new StringBuilder();
 
             uint count = DragQueryFile(hdrop, uint.MaxValue, null, 0);
 
             string[] files = new string[count];
             for (uint i = 0; i < count; i++)
             {
-                DragQueryFile(hdrop, i, builder, int.MaxValue);
+                uint buffSize = DragQueryFile(hdrop, i, null, int.MaxValue);
+                StringBuilder builder = new StringBuilder((int)buffSize);
+                DragQueryFile(hdrop, i, builder, buffSize);
                 files[i] = builder.ToString();
-                builder.Clear();
             }
 
             _window.OnFileDrop(new FileDropEventArgs(files));


### PR DESCRIPTION
When reading file names from `DragQueryFile`, a default-constructed `StringBuilder` was being used as the `lpszFile` buffer to hold the resulting name. The default capacity of a `StringBuilder` is 16 characters ([link](https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder?view=net-7.0#how-stringbuilder-works)). In practice this results in the `DragQueryFile` call overflowing the `StringBuilder`'s internal buffer when the name is too long, which corrupts memory and may crash the application. I was able to consistently crash a new MonoGame project created through the Visual Studio template with no changes to the project by dragging a certain file into the window.

`DragQueryFile` reports the size of the buffer needed to hold the file name by calling it with a null buffer ([link](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-dragqueryfilea)). This PR introduces an extra to call to `DragQueryFile` to get the buffer size, then constructs a `StringBuilder` with the needed size before passing the `StringBuilder` back to `DragQueryFile` to fill. This strategy of using a `StringBuilder` with an explicit capacity for fixed length string buffers is described at the end of [this document](https://learn.microsoft.com/en-us/dotnet/framework/interop/default-marshalling-for-strings). In practice this fixes the crash caused by dragging some files into the application.