### PR TITLE
Fixed effect parameter shifting

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
@@ -522,6 +522,20 @@ namespace Microsoft.Xna.Framework.Graphics
                 fData[10] = value.M33;
                 fData[11] = value.M43;
             }
+            else if (RowCount == 4 && ColumnCount == 2)
+            {
+                var fData = (float[])Data;
+
+                fData[0] = value.M11;
+                fData[1] = value.M21;
+                fData[2] = value.M31;
+                fData[3] = value.M41;
+
+                fData[4] = value.M12;
+                fData[5] = value.M22;
+                fData[6] = value.M32;
+                fData[7] = value.M42;
+            }
             else if (RowCount == 3 && ColumnCount == 4)
             {
                 var fData = (float[])Data;
@@ -624,6 +638,20 @@ namespace Microsoft.Xna.Framework.Graphics
                 fData[9] = value.M41;
                 fData[10] = value.M42;
                 fData[11] = value.M43;
+            }
+            else if (RowCount == 4 && ColumnCount == 2)
+            {
+                var fData = (float[])Data;
+
+                fData[0] = value.M11;
+                fData[1] = value.M21;
+                fData[2] = value.M31;
+                fData[3] = value.M41;
+
+                fData[4] = value.M12;
+                fData[5] = value.M22;
+                fData[6] = value.M32;
+                fData[7] = value.M42;
             }
             else if (RowCount == 3 && ColumnCount == 4)
             {
@@ -728,6 +756,23 @@ namespace Microsoft.Xna.Framework.Graphics
                     fData[9] = value[i].M23;
                     fData[10] = value[i].M33;
                     fData[11] = value[i].M43;
+                }
+            }
+            else if (RowCount == 4 && ColumnCount == 2)
+            {
+                for (var i = 0; i < value.Length; i++)
+                {
+                    var fData = (float[])Elements[i].Data;
+
+                    fData[0] = value[i].M11;
+                    fData[1] = value[i].M21;
+                    fData[2] = value[i].M31;
+                    fData[3] = value[i].M41;
+
+                    fData[4] = value[i].M12;
+                    fData[5] = value[i].M22;
+                    fData[6] = value[i].M32;
+                    fData[7] = value[i].M42;
                 }
             }
             else if (RowCount == 3 && ColumnCount == 4)

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.cs
@@ -85,10 +85,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Take care of the single copy case!
             else if (rows == 1 || (rows == 4 && columns == 4)) {
-                // take care of shader compiler optimization
-                int len = rows * columns * elementSize;
-                if (_buffer.Length - offset > len)
-                len = _buffer.Length - offset;
                 Buffer.BlockCopy(data as Array, 0, _buffer, offset, rows*columns*elementSize);
             } else
             {

--- a/Tools/MonoGame.Effect.Compiler/Effect/ConstantBufferData.mojo.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ConstantBufferData.mojo.cs
@@ -64,6 +64,11 @@ namespace MonoGame.Effect
 
                 case MojoShader.MOJOSHADER_symbolClass.MOJOSHADER_SYMCLASS_MATRIX_COLUMNS:
                     param.class_ = EffectObject.D3DXPARAMETER_CLASS.MATRIX_COLUMNS;
+
+                    // MojoShader optimizes matrices to occupy less registers.
+                    // This effectively convert a Matrix4x4 into Matrix4x3, Matrix4x2 or Matrix4x1.
+                    param.columns = Math.Min(param.columns, symbol.register_count);
+
                     break;
 
                 default:


### PR DESCRIPTION
It was possible for the effect compiler to optimize matrices making them load wrong. Also removed the band-aid code that wasn't being used.

Should fix #911 and #6716.

Credit to nkast.