### PR TITLE
Fixes bug in `CalculateNormals` that picked the wrong normal for each point.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/MeshHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/MeshHelper.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             // Set the new normals on the vertex channel.
             for (var i = 0; i < channel.Count; i++)
-                channel[i] = normals[geom.Indices[i]];
+                channel[i] = normals[geom.Vertices.PositionIndices[i]];
         }
 
         /// <summary>

--- a/Tools/MonoGame.Tools.Tests/MeshHelperTest.cs
+++ b/Tools/MonoGame.Tools.Tests/MeshHelperTest.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using Assimp.Configs;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using NUnit.Framework;
@@ -53,6 +54,138 @@ namespace MonoGame.Tests.ContentPipeline
             Assert.AreEqual(1, geom.Vertices.PositionIndices[1]);
             Assert.AreEqual(0, geom.Vertices.PositionIndices[2]);
         }
+
+[Test]
+public void TestNormalGeneration()
+{
+    var mb = MeshBuilder.StartMesh("Test");
+
+    // A 5x5 grid of points around the origin, with the centerpoint raised a bit.
+    mb.CreatePosition(new Vector3(-2, 0, -2));
+    mb.CreatePosition(new Vector3(-1, 0, -2));
+    mb.CreatePosition(new Vector3( 0, 0, -2));
+    mb.CreatePosition(new Vector3(+1, 0, -2));
+    mb.CreatePosition(new Vector3(+2, 0, -2));
+    mb.CreatePosition(new Vector3(-2, 0, -1));
+    mb.CreatePosition(new Vector3(-1, 0, -1));
+    mb.CreatePosition(new Vector3( 0, 0, -1));
+    mb.CreatePosition(new Vector3(+1, 0, -1));
+    mb.CreatePosition(new Vector3(+2, 0, -1));
+    mb.CreatePosition(new Vector3(-2, 0,  0));
+    mb.CreatePosition(new Vector3(-1, 0,  0));
+    mb.CreatePosition(new Vector3( 0,0.5f,0)); // The bump in the center.
+    mb.CreatePosition(new Vector3(+1, 0,  0));
+    mb.CreatePosition(new Vector3(+2, 0,  0));
+    mb.CreatePosition(new Vector3(-2, 0, +1));
+    mb.CreatePosition(new Vector3(-1, 0, +1));
+    mb.CreatePosition(new Vector3( 0, 0, +1));
+    mb.CreatePosition(new Vector3(+1, 0, +1));
+    mb.CreatePosition(new Vector3(+2, 0, +1));
+    mb.CreatePosition(new Vector3(-2, 0, +2));
+    mb.CreatePosition(new Vector3(-1, 0, +2));
+    mb.CreatePosition(new Vector3( 0, 0, +2));
+    mb.CreatePosition(new Vector3(+1, 0, +2));
+    mb.CreatePosition(new Vector3(+2, 0, +2));
+
+    // Create triangles like this, starting with the quad in the bottom left, then
+    // bottom right, then top left, then top right, doing the bottom/right-most triangle
+    // first in each quad.
+    // 20--21--22--23--24
+    // | / | / | / | / |
+    // 15--16--17--18--19
+    // | / | / | / | / |
+    // 10--11--12--13--14
+    // | / | / | / | / |
+    // 5---6---7---8---9
+    // | / | / | / | / |
+    // 0---1---2---3---4
+    // In this diagram, horizontal is the x-axis, vertical is the z-axis, and the y-axis
+    // comes out of the screen.
+    void AddTriangle(int a, int b, int c) { mb.AddTriangleVertex(a); mb.AddTriangleVertex(b); mb.AddTriangleVertex(c); }
+    AddTriangle( 0,  1,  6); AddTriangle( 0,  6,  5);
+    AddTriangle( 1,  2,  7); AddTriangle( 1,  7,  6);
+    AddTriangle( 2,  3,  8); AddTriangle( 2,  8,  7);
+    AddTriangle( 3,  4,  9); AddTriangle( 3,  9,  8);
+
+    AddTriangle( 5,  6, 11); AddTriangle( 5, 11, 10);
+    AddTriangle( 6,  7, 12); AddTriangle( 6, 12, 11);
+    AddTriangle( 7,  8, 13); AddTriangle( 7, 13, 12);
+    AddTriangle( 8,  9, 14); AddTriangle( 8, 14, 13);
+            
+    AddTriangle(10, 11, 16); AddTriangle(10, 16, 15);
+    AddTriangle(11, 12, 17); AddTriangle(11, 17, 16);
+    AddTriangle(12, 13, 18); AddTriangle(12, 18, 17);
+    AddTriangle(13, 14, 19); AddTriangle(13, 19, 18);
+
+    AddTriangle(15, 16, 21); AddTriangle(15, 21, 20);
+    AddTriangle(16, 17, 22); AddTriangle(16, 22, 21);
+    AddTriangle(17, 18, 23); AddTriangle(17, 23, 22);
+    AddTriangle(18, 19, 24); AddTriangle(18, 24, 23);
+
+    MeshContent meshContent = mb.FinishMesh();
+
+    // The MergeDuplicateVertices code has reordered these (without merging anything,
+    // since they're all different positions), and the new numbering is the order they
+    // appeared in the actual indexing:
+    // 21--20--22--23--24
+    // | / | / | / | / |
+    // 16--15--17--18--19
+    // | / | / | / | / |
+    // 11--10--12--13--14
+    // | / | / | / | / |
+    // 3---2---5---7---9
+    // | / | / | / | / |
+    // 0---1---4---6---8
+
+    // At this point, the positions are now reordered, but we can assert that their positions
+    // are right.
+    var vertexPositions = meshContent.Geometry[0].Vertices.Positions;
+    Assert.AreEqual(new Vector3(-2, 0, -2), vertexPositions[ 0]);
+    Assert.AreEqual(new Vector3(-1, 0, -2), vertexPositions[ 1]);
+    Assert.AreEqual(new Vector3(-1, 0, -1), vertexPositions[ 2]);
+    Assert.AreEqual(new Vector3(-2, 0, -1), vertexPositions[ 3]);
+    Assert.AreEqual(new Vector3( 0, 0, -2), vertexPositions[ 4]);
+    Assert.AreEqual(new Vector3( 0, 0, -1), vertexPositions[ 5]);
+    Assert.AreEqual(new Vector3(+1, 0, -2), vertexPositions[ 6]);
+    Assert.AreEqual(new Vector3(+1, 0, -1), vertexPositions[ 7]);
+    Assert.AreEqual(new Vector3(+2, 0, -2), vertexPositions[ 8]);
+    Assert.AreEqual(new Vector3(+2, 0, -1), vertexPositions[ 9]);
+    Assert.AreEqual(new Vector3(-1, 0,  0), vertexPositions[10]);
+    Assert.AreEqual(new Vector3(-2, 0,  0), vertexPositions[11]);
+    Assert.AreEqual(new Vector3( 0,0.5f,0), vertexPositions[12]);
+    Assert.AreEqual(new Vector3(+1, 0,  0), vertexPositions[13]);
+    Assert.AreEqual(new Vector3(+2, 0,  0), vertexPositions[14]);
+    Assert.AreEqual(new Vector3(-1, 0,  1), vertexPositions[15]);
+    Assert.AreEqual(new Vector3(-2, 0,  1), vertexPositions[16]);
+    Assert.AreEqual(new Vector3( 0, 0,  1), vertexPositions[17]);
+    Assert.AreEqual(new Vector3(+1, 0,  1), vertexPositions[18]);
+    Assert.AreEqual(new Vector3(+2, 0,  1), vertexPositions[19]);
+    Assert.AreEqual(new Vector3(-1, 0,  2), vertexPositions[20]);
+    Assert.AreEqual(new Vector3(-2, 0,  2), vertexPositions[21]);
+    Assert.AreEqual(new Vector3( 0, 0,  2), vertexPositions[22]);
+    Assert.AreEqual(new Vector3(+1, 0,  2), vertexPositions[23]);
+    Assert.AreEqual(new Vector3(+2, 0,  2), vertexPositions[24]);
+
+    var normalsChannel = meshContent.Geometry[0].Vertices.Channels.Get<Vector3>(VertexChannelNames.Normal());
+    // All of the points around the edge should be pointed up. Some of the ones on the interior will be affected
+    // by the center point being shifted up, so we won't check those.
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[ 0]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[ 1]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[ 4]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[ 6]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[ 8]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[ 9]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[14]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[19]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[24]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[23]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[22]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[20]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[21]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[16]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[11]);
+    Assert.AreEqual(Vector3.UnitY, normalsChannel[ 3]);
+}
 
         [Test]
         public void TestMergePositionsMultipleGeometries()

--- a/Tools/MonoGame.Tools.Tests/MeshHelperTest.cs
+++ b/Tools/MonoGame.Tools.Tests/MeshHelperTest.cs
@@ -2,7 +2,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using Assimp.Configs;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using NUnit.Framework;


### PR DESCRIPTION
This fixes #8006, as best as I can tell.

The issue is described in great detail over there, but the short version is that if your model doesn't have normals, when the `CalculateNormals` method runs, it correctly computes the normals, but then wasn't getting the right normals put in the right spots. The change in this PR adds a unit test that helped me track down the issue and a tweak to the code that decides which normal should go into which index, using `geom.Vertices.PositionIndicies[i]` instead of `geom.Indices[i]`.