### PR TITLE
Removed the blank line at the start of Program.cs in the DekstopGL template

### DIFF
--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/Program.cs
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/Program.cs
@@ -1,3 +1,2 @@
-﻿
 using var game = new MGNamespace.Game1();
 game.Run();


### PR DESCRIPTION
The desktopGL template had an unnecessary blank line at the start of ```Program.cs```
It just really bothered me