### PR TITLE
Removed blank spaces in Program.cs in two templates

### DIFF
--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/Program.cs
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/Program.cs
@@ -1,3 +1,2 @@
-﻿
-using var game = new MGNamespace.Game1();
+﻿using var game = new MGNamespace.Game1();
 game.Run();

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/Program.cs
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/Program.cs
@@ -1,3 +1,2 @@
-﻿
-using var game = new MGNamespace.Game1();
+﻿using var game = new MGNamespace.Game1();
 game.Run();


### PR DESCRIPTION
The ```Program.cs``` file in the DesktopGL and WindowsDX templates had unnecessary blank lines at the start.
They just really bothered me.