### PR TITLE
NativeAOT: Add `[ContentReadersConsumer]` attribute to enable preserving content readers while trimming

### DIFF
--- a/MonoGame.Framework/Content/ContentReadersConsumerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentReadersConsumerAttribute.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Xna.Framework.Content;
+
+/// <summary>
+/// Mark the target assembly as one that requires content readers assemblies at runtime.
+/// </summary>
+/// <remarks>
+/// By default, when using NativeAOT with MonoGame, trimmer will cut off content reader types from the native output, because they are used
+/// in the consumer project, but not by MonoGame itself. The attribute will tell the linker that all MonoGame-bundled content readers should be presented in the output.
+/// </remarks>
+/// <example>[assembly: ContentReadersConsumer]</example>
+[AttributeUsage(AttributeTargets.Assembly)]
+public class ContentReadersConsumerAttribute : Attribute
+{
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.ByteReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.SByteReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.DateTimeReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.DecimalReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.BoundingSphereReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.BoundingFrustumReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.RayReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.ListReader`1", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.ArrayReader`1", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.SpriteFontReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.Texture2DReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.CharReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.RectangleReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.StringReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.Vector2Reader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.Vector3Reader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.Vector4Reader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.CurveReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.IndexBufferReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.BoundingBoxReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.MatrixReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.BasicEffectReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.VertexBufferReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.AlphaTestEffectReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.EnumReader`1", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.ArrayReader`1", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.EnumReader`1", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.NullableReader`1", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.EffectMaterialReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.ExternalReferenceReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.SoundEffectReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.SongReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.ModelReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.Int32Reader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.EffectReader", "MonoGame.Framework")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Microsoft.Xna.Framework.Content.SingleReader", "MonoGame.Framework")]
+    static ContentReadersConsumerAttribute()
+    {
+    }
+}


### PR DESCRIPTION
## About

While investigating the potential implementation for the proposal stated in https://github.com/MonoGame/MonoGame/issues/8005#issuecomment-1494415800 I found a quite appealing way of providing users with the one-liner ability to include content readers into the executable.

My proposed solution is to use a special meta-attribute with all necessary inner [`[DynamicDependency]` attributes](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming?source=recommendations#dynamicdependency) specified.

## Usage

Attach attribute to a consumer assembly in the code:
```csharp
// AssemblyInfo.cs
[assembly: ContentReadersConsumer]
```

Or attach an attribute to a consumer assembly via `.csproj`:
```xml
<ItemGroup>
   <AssemblyAttribute Include="Microsoft.Xna.Framework.Content.ContentReadersAttribute"/>
</ItemGroup>
```

## Notes

It is also possible to add this (a bit boilerplate) code to the templates or embed it directly to a platform-specific NuGets. Still, I'm not sure about that as it will enforce more testing with different platforms adding a new layer of "magic" things to the background, which is not a great thing IMO.