### PR TITLE
Fixes a bug in the property grid

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/Controls/PropertyGridTable.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Controls/PropertyGridTable.cs
@@ -203,7 +203,7 @@ namespace MonoGame.Tools.Pipeline
 
             if (overGroup) // TODO: Group collapsing/expanding?
                 SetCursor(CursorType.Arrow);
-            else if ((new Rectangle(_separatorPos - _separatorWidth / 2, 0, _separatorWidth, Height)).Contains(_mouseLocation))
+            else if (new Rectangle(_separatorPos - _separatorWidth / 2, 0, _separatorWidth, _height).Contains(_mouseLocation))
                 SetCursor(CursorType.VerticalSplit);
             else
                 SetCursor(CursorType.Arrow);


### PR DESCRIPTION
In the property grid, there is a little divider that allows you to resize the two columns. When you hover over it, you get a different cursor and can choose to drag it to either side. However, this region did not always extend to the full height of the control, leading to the occasional situation where you couldn't resize the two columns, depending on where, within the control, your mouse was.

This PR addresses this minor bug.

**Before:**
![MGCBEditorDividerBug](https://user-images.githubusercontent.com/3482875/232183827-c3c2c46d-fbe5-4bdb-a078-f80e72376215.gif)

**After:**
![MGCBEditorDividerFix](https://user-images.githubusercontent.com/3482875/232183862-5a938a2f-74af-4a34-b427-b1ce89978e1e.gif)
