### PR TITLE
Fixes a reader/writer mismatch for the environment map effect

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/EnvironmentMapEffectWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/EnvironmentMapEffectWriter.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
             output.WriteExternalReference(value.Textures.ContainsKey(EnvironmentMapMaterialContent.EnvironmentMapKey) ? value.EnvironmentMap : null);
             output.Write(value.EnvironmentMapAmount.HasValue ? value.EnvironmentMapAmount.Value : 1.0f);
             output.Write(value.EnvironmentMapSpecular.HasValue ? value.EnvironmentMapSpecular.Value : Vector3.Zero);
+            output.Write(value.FresnelFactor.HasValue ? value.FresnelFactor.Value : 0.0f);
             output.Write(value.DiffuseColor.HasValue ? value.DiffuseColor.Value : Vector3.One);
             output.Write(value.EmissiveColor.HasValue ? value.EmissiveColor.Value : Vector3.Zero);
             output.Write(value.Alpha.HasValue ? value.Alpha.Value : 1.0f);

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/EnvironmentMapEffectWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/EnvironmentMapEffectWriter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
             output.WriteExternalReference(value.Textures.ContainsKey(EnvironmentMapMaterialContent.EnvironmentMapKey) ? value.EnvironmentMap : null);
             output.Write(value.EnvironmentMapAmount.HasValue ? value.EnvironmentMapAmount.Value : 1.0f);
             output.Write(value.EnvironmentMapSpecular.HasValue ? value.EnvironmentMapSpecular.Value : Vector3.Zero);
-            output.Write(value.FresnelFactor.HasValue ? value.FresnelFactor.Value : 0.0f);
+            output.Write(value.FresnelFactor.HasValue ? value.FresnelFactor.Value : 1.0f);
             output.Write(value.DiffuseColor.HasValue ? value.DiffuseColor.Value : Vector3.One);
             output.Write(value.EmissiveColor.HasValue ? value.EmissiveColor.Value : Vector3.Zero);
             output.Write(value.Alpha.HasValue ? value.Alpha.Value : 1.0f);

--- a/MonoGame.Framework/Graphics/Effect/EnvironmentMapEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/EnvironmentMapEffect.cs
@@ -316,8 +316,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Higher values make the environment map only visible around the silhouette 
         /// edges of the object, while lower values make it visible everywhere. 
         /// Setting this property to 0 disables Fresnel entirely, making the 
-        /// environment map equally visible regardless of view angle. The default is 
-        /// 1. Fresnel only affects the environment map RGB (the intensity of which is 
+        /// environment map equally visible regardless of view angle. The default is 1. 
+        /// Fresnel only affects the environment map RGB (the intensity of which is 
         /// controlled by EnvironmentMapAmount). The alpha contribution (controlled by 
         /// EnvironmentMapSpecular) is not affected by the Fresnel setting.
         /// </summary>


### PR DESCRIPTION
`EnvironmentMapEffectReader` was expecting to read a `FresnelFactor` as a `float` from the stream. But `EnvironmentMapEffectWriter` never wrote that value into the stream. This was causing an "end of stream" exception.

I've fixed it by writing the fresnel factor to the stream in the writer, though I'm not totally sure how this would even get populated.

I defaulted it to a value of 1. After reading the documentation for `EnvironmentMapEffect.FresnelFactor`, that seems consistent with the default over there.

While I was reading the documentation, I also saw that the comment was being rendered weird. Because it has a sentence that says, "The default value is 1." but the "1." ends up wrapping around to the next line, the documentation rendering system was treating that as a numbered list, as shown in the picture below.

![image](https://user-images.githubusercontent.com/3482875/232320803-db0a3b25-6c2a-4bba-a79c-51ef7e53727d.png)

(link to the page: https://docs.monogame.net/api/Microsoft.Xna.Framework.Graphics.EnvironmentMapEffect.html)

I moved that "1." up to the previous line, which should get it to render correctly, without inadvertently turning it into a numbered list item.