### PR TITLE
Adds a description to an InvalidOperationException for clarity.

### DIFF
--- a/MonoGame.Framework/Graphics/Model.cs
+++ b/MonoGame.Framework/Graphics/Model.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Xna.Framework.Graphics
 					IEffectMatrices effectMatricies = effect as IEffectMatrices;
 					if (effectMatricies == null)
                     {
-						throw new InvalidOperationException($"Effect must implement {nameof(IEffectMatrices)} to support this call.");
+						throw new InvalidOperationException($"This model contains a custom effect which does not implement the {nameof(IEffectMatrices)} interface, so it cannot be drawn using {nameof(Model)}.{nameof(Draw)}. Instead, call {nameof(ModelMesh)}.{nameof(ModelMesh.Draw)} after setting the appropriate effect parameters.");
 					}
                     effectMatricies.World = sharedDrawBoneMatrices[mesh.ParentBone.Index] * world;
                     effectMatricies.View = view;

--- a/MonoGame.Framework/Graphics/Model.cs
+++ b/MonoGame.Framework/Graphics/Model.cs
@@ -130,8 +130,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 foreach (Effect effect in mesh.Effects)
                 {
 					IEffectMatrices effectMatricies = effect as IEffectMatrices;
-					if (effectMatricies == null) {
-						throw new InvalidOperationException();
+					if (effectMatricies == null)
+                    {
+						throw new InvalidOperationException($"Effect must implement {nameof(IEffectMatrices)} to support this call.");
 					}
                     effectMatricies.World = sharedDrawBoneMatrices[mesh.ParentBone.Index] * world;
                     effectMatricies.View = view;


### PR DESCRIPTION
This should "fix" #8004, if that's something the maintainers wish to do something about.

I was porting some really old XNA code to MonoGame and bumped into an issue where I got an `InvalidOperationException`. I think the exception was correct, but in order to understand what was going on, I had to pull down the code and step through it to discover that the effect's type was expected to implement `IEffectMatrices`. Once I saw that, I knew how to fix it. But I had to dig quite deep to find it.

This change would hopefully prevent somebody else from having to do the same digging in the future.

On the original issue, there was a comment by @nkast suggesting another possible solution: Just do a cast and let the runtime handle things. I feel that solution would also address my problem, if we'd rather go that route. Though that might run a slightly higher risk of breaking people, since it changes the exception type.

If the maintainers would prefer that solution, or any other tweaks to this solution, let me know and I'll change it.

If we don't want to do anything with this at all, you won't hurt my feelings to just decline this PR.