### PR TITLE
Fixes DesktopGL template so Icons display in Window Titlebar and Taskbar

### DIFF
--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/MGNamespace.csproj
@@ -15,8 +15,12 @@
     <None Remove="Icon.bmp" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Icon.ico" />
-    <EmbeddedResource Include="Icon.bmp" />
+    <EmbeddedResource Include="Icon.ico">
+      <LogicalName>Icon.ico</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Icon.bmp">
+      <LogicalName>Icon.bmp</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.1-develop" />


### PR DESCRIPTION
## Description
This pull request adjusts the `MonoGame.Application.DesktopGL.CSharp` template by setting the `<LogicalName>` tag for the embedded icons.  By doing this, the icons set by users will be picked up properly when the `SDLGameWindow` is created at
https://github.com/MonoGame/MonoGame/blob/b21463b419e55b4c898030fc22bee77dabb11210/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs#L115

## Reference
This pull request was created in reference to issue #8035 that was created.  

## Additional Notes
The issue of the icons not displaying properly in the title bar and task bar was only experienced when creating a `DesktopGL` project, so only that template was updated.