### PR TITLE
adding an implicit operator from System.Drawing.Color to Microsoft.Xna.Framework.Color

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -312,6 +312,12 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Convert a <see cref="System.Drawing.Color" /> to a <see cref="Color" />.
+        /// </summary>
+        /// <param name="color"></param>
+        public static implicit operator Color(System.Drawing.Color color) => new(color.R, color.G, color.B, color.A);
+
+        /// <summary>
         /// Gets or sets the blue component.
         /// </summary>
         [DataMember]


### PR DESCRIPTION
I've occasionally wanted to use `System.Drawing.Color` colors in MonoGame (for color palettes provided by other, non-MonoGame-aware libraries, for example), and manually converting them can be a little tedious, so I figured I'd put this PR together, and see if it sticks. if this change does not mesh with MonoGame's philosophies, a thousand pardons, and feel free to just close it.