### PR TITLE
Automatically Restore NuGets When New Project Created From Templates

### DIFF
--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/.template.config/template.json
@@ -18,5 +18,17 @@
     ],
     "sourceName": "MGNamespace",
     "preferNameDirectory": "true",
-    "description": "A MonoGame game project for Android using OpenGL."
+    "description": "A MonoGame game project for Android using OpenGL.",
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
 }

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/.template.config/template.json
@@ -18,5 +18,17 @@
     ],
     "sourceName": "MGNamespace",
     "preferNameDirectory": "true",
-    "description": "A MonoGame game project for Windows, Linux and macOS using OpenGL."
+    "description": "A MonoGame game project for Windows, Linux and macOS using OpenGL.",
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
 }

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.CoreApp.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.CoreApp.CSharp/.template.config/template.json
@@ -18,5 +18,17 @@
     ],
     "sourceName": "MGNamespace",
     "preferNameDirectory": "true",
-    "description": "A MonoGame game project for Windows Universal using DirectX and setup as a CoreApplication."
+    "description": "A MonoGame game project for Windows Universal using DirectX and setup as a CoreApplication.",
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
 }

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.XAML.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.UWP.XAML.CSharp/.template.config/template.json
@@ -18,5 +18,17 @@
     ],
     "sourceName": "MGNamespace",
     "preferNameDirectory": "true",
-    "description": "A MonoGame game project for Windows Universal using DirectX and setup in a XAML page."
+    "description": "A MonoGame game project for Windows Universal using DirectX and setup in a XAML page.",
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
 }

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/.template.config/template.json
@@ -18,5 +18,17 @@
     ],
     "sourceName": "MGNamespace",
     "preferNameDirectory": "true",
-    "description": "A MonoGame game project for Windows using DirectX."
+    "description": "A MonoGame game project for Windows using DirectX.",
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
 }

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.iOS.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.iOS.CSharp/.template.config/template.json
@@ -18,5 +18,17 @@
     ],
     "sourceName": "MGNamespace",
     "preferNameDirectory": "true",
-    "description": "A MonoGame game project for iOS compatible with iPhone and iPad devices."
+    "description": "A MonoGame game project for iOS compatible with iPhone and iPad devices.",
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
 }

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.CSharp/.template.config/template.json
@@ -18,5 +18,17 @@
     ],
     "sourceName": "MGNamespace",
     "preferNameDirectory": "true",
-    "description": "A MonoGame game library project that can be used to share game code between platforms."
+    "description": "A MonoGame game library project that can be used to share game code between platforms.",
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
 }

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.Pipeline.Extension.CSharp/.template.config/template.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.Pipeline.Extension.CSharp/.template.config/template.json
@@ -18,5 +18,17 @@
     ],
     "sourceName": "MGNamespace",
     "preferNameDirectory": "true",
-    "description": "A MonoGame content pipeline extension library project."
+    "description": "A MonoGame content pipeline extension library project.",
+    "postActions": [
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [
+                {
+                    "text": "Run 'dotnet restore'"
+                }
+            ],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
 }


### PR DESCRIPTION
## Description
This pull request edits all `template.json` configuration files to include a `postActions` section that will automatically perform a `dotnet restore` when a new project is created from the template.

This is something that is done by default automatically with Visual Studio, however it is not something done automatically by other IDEs such as VSCode.  By including this post action, it ensures that when new users create new projects based on the templates, regardless of IDE, the NuGets should be restored and they are not presented with the initial errors that the namespaces used by MonoGame cannot be found.

More information about the `postActions` can be found at https://github.com/dotnet/templating/wiki/Post-Action-Registry#restore-nuget-packages

This pull request is in reference to Issue #8045 that I opened just prior.