### PR TITLE
Correct Mac Getting Started Documentation

### DIFF
--- a/Documentation/articles/getting_started/1_setting_up_your_development_environment_macos.md
+++ b/Documentation/articles/getting_started/1_setting_up_your_development_environment_macos.md
@@ -12,7 +12,7 @@ Go to the following URL to download and install Visual Studio 2022 for Mac: http
 
 ### Install MonoGame extension for Visual Studio for Mac
 
-Download the MonoGame extension for Visual Studio 2022 for Mac from the following link: https://github.com/MonoGame/MonoGame/releases/tag/v3.8.1
+Download the MonoGame extension for Visual Studio 2022 for Mac from the following link: https://github.com/MonoGame/MonoGame/releases/tag/v3.8.1_HOTFIX
 
 Open up Visual Studio 2022 for Mac and you should be able to see a window as shown below:
 


### PR DESCRIPTION
## Description
This comment changes the link in the Mac Getting Started documentation from https://github.com/MonoGame/MonoGame/releases/tag/v3.8.1 to the correct https://github.com/MonoGame/MonoGame/releases/tag/v3.8.1_HOTFIX.

Reference:
This PR is in reference to the issue I opened at Issue #8047, which was created in response to this community forum post at https://community.monogame.net/t/i-cant-setup-monogame-for-mac/17978/13