### PR TITLE
Resolves Crash When Setting `Window.Title` To An Empty String

### DIFF
--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -465,7 +465,7 @@ internal static class Sdl
 
         public static void SetTitle(IntPtr handle, string title)
         {
-            var bytes = Encoding.UTF8.GetBytes(title);
+            var bytes = Encoding.UTF8.GetBytes(title + '\0');
             SDL_SetWindowTitle(handle, ref bytes[0]);
         }
 


### PR DESCRIPTION
## Description
When setting `Window.Title` to an empty string (e.g `""` or `string.Empty`, the game will crash due to `SDL_SetWindowTitle` passing `ref byte[0]` on a `byte[]` that has a zero length, causing an `IndexOutOfBoundsException`.

This PR resolves this issue by appending a `'\0'` null terminator character to the `title` parameter, ensuring that the `byte[]` generated is non-zero length and still produces an empty string for the title.

## Reference:
This PR is in reference to the issue I submitted at Issue #8050 