### PR TITLE
Respect setting `Window.Title` in `Game1` constructor

### DIFF
--- a/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Xna.Framework
             _height = GraphicsDeviceManager.DefaultBackBufferHeight;
 
             _handle = Sdl.Window.Create(
-                AssemblyHelper.GetDefaultWindowTitle(),
+                Title == null ? AssemblyHelper.GetDefaultWindowTitle() : Title,
                 winx, winy, _width, _height, initflags
             );
 


### PR DESCRIPTION
## Description
When setting the `Window.Title` in the `Game1` constructor, the title set is ignored.  This is because the `SDLGameWindow.CreateWindow()` method explicitly chooses to use `AssemblyHelper.GetDefaultWindowTItle()`.  During this time, the `SDLGameWindow.Title` property contains the correct window title that is set during the `Game1` constructor, but ignores this.

This PR resolves this issue by explicitly checking if `SDLGameWindow.Title` is `null`, and if so, then it will use `AssemblyHelper.GetDefaultWindowTitle()`, otherwise it will use the title that was set by the user in the `Game1` constructor as expected.

Reference:
An issue was opened previously at Issue #7913 

Note:
This PR is also related to PR #8051, however I created two separate PRs as each focuses on a separate issue to fix.