### PR TITLE
Correct error message in `DefaultTextureProfile`

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                             platform == TargetPlatform.Web)
                 {
                     if (format != TextureProcessorOutputFormat.DxtCompressed)
-                        throw new PlatformNotSupportedException(format + " platform only supports DXT texture compression");
+                        throw new PlatformNotSupportedException(platform + " platform only supports DXT texture compression");
                 }
             }
 


### PR DESCRIPTION
## Description
This pull request is to correct the error message presented at https://github.com/MonoGame/MonoGame/blob/b21463b419e55b4c898030fc22bee77dabb11210/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs#L71

by replacing the `format` variable with the `platform` variable.

## Reference
This is in reference to and resolves issue #8054.  Thanks to @KUNGERMOoN for opening the issue and sharing the resolve, I've created the PR in place since they were unable to according to the issue they opened.