### PR TITLE
Updated dotnet install command

### DIFF
--- a/Documentation/articles/getting_started/1_setting_up_your_development_environment_windows.md
+++ b/Documentation/articles/getting_started/1_setting_up_your_development_environment_windows.md
@@ -35,7 +35,7 @@ If you prefer to use JetBrains Rider or Visual Studio Code, and after installing
 Once the .NET 6 SDK is installed, you can open a Command Prompt and install the MonoGame templates by typing the following command:
 
 ```sh
-dotnet new --install MonoGame.Templates.CSharp
+dotnet new install MonoGame.Templates.CSharp
 ```
 
 **Next up:** [Creating a new project](2_creating_a_new_project_vs.md)


### PR DESCRIPTION
Dotnet new --install is now deprecated.
I replaced `dotnet new --install MonoGame.Templates.CSharp` with `dotnet new install MonoGame.Templates.CSharp`.