### PR TITLE
Change to fix ILC warning

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     var tmpPtr = tmpHandle.AddrOfPinnedObject();
                     for (var i = 0; i < elementCount; i++)
                     {
-                        data[startIndex + i] = (T)Marshal.PtrToStructure(tmpPtr, typeof(T));
+                        data[startIndex + i] = Marshal.PtrToStructure<T>(tmpPtr);
                         tmpPtr = (IntPtr)(tmpPtr.ToInt64() + vertexStride);
                     }
                 }


### PR DESCRIPTION
Building with ```PublishAot``` generates warning when using runtime reflection. It is best to switch code paths to their generic type parameters so that typed versions of those calls can be compiled in fully AOT'd contexts (i.e. reflection-free mode).