### PR TITLE
Update MonoGame.Library.SDL dependency to 2.28.4.8

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MonoGame.Library.SDL" Version="2.26.5.5" />
+    <PackageReference Include="MonoGame.Library.SDL" Version="2.28.4.8" />
     <PackageReference Include="NVorbis" Version="0.10.4" />
   </ItemGroup>
 


### PR DESCRIPTION
Updates the referenced [MonoGame.Library.SDL](https://github.com/MonoGame/MonoGame.Library.SDL) nuget to the latest version.

This fixes #8082 and an (unreported) issue in Windows when moving a full-screen window to another monitor via Shift+Win+Arrow.