### PR TITLE
Fixed Game.IsActive on initial window creation

### DIFF
--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Xna.Framework
 
         protected TimeSpan _inactiveSleepTime = TimeSpan.FromMilliseconds(20.0);
         protected bool _needsToResetElapsedTime = false;
+        bool ignoredInitialActivation = false;
         bool disposed;
         protected bool InFullScreenMode = false;
         protected bool IsDisposed { get { return disposed; } }
@@ -60,7 +61,14 @@ namespace Microsoft.Xna.Framework
             get { return _isActive; }
             internal set
             {
-                if (_isActive != value)
+                if (!ignoredInitialActivation)
+                {
+                    ignoredInitialActivation = true;
+
+                    _isActive = false;
+                    EventHelpers.Raise(this, _isActive ? Activated : Deactivated, EventArgs.Empty);
+                }
+                else if (_isActive != value)
                 {
                     _isActive = value;
                     EventHelpers.Raise(this, _isActive ? Activated : Deactivated, EventArgs.Empty);


### PR DESCRIPTION
The following bug occurs upon executing a game build with MonoGame.Framework.DesktopGL on Windows:
If one quickly (before the game's window has been instantiated) changes the focus to another window by alt-tabbing or dragging another window with the mouse, the IsActive flag of the Game class will be set to true even though the game's window is not in focus. this persists until the game's window is actually in focus once.

This pull request fixed this bug. However, it does not do so in the most elegant way. This is intended more as an issue including a potential fix.