### PR TITLE
MGCB Editor and Readme.md url updates changing to the new website

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you'd like to help the project by supporting us financially, consider support
 
 Money goes towards hosting, new hardware and if enough people subscribe a dedicated developer.
 
-There are several options on our [Patreon Page](https://www.patreon.com/MonoGame/).
+There are several options on our [Donation Page](https://www.patreon.com/MonoGame/).
 
 ## Source Code
 
@@ -87,7 +87,7 @@ A high level breakdown of the components of the framework:
 * Use our [community forums](http://community.monogame.net/) for support questions.
 * You can [join the Discord server](https://discord.gg/monogame) and chat live with the core developers and other users.
 * The [official documentation](https://monogame.net/articles/index.html) is on our website.
-* Here are the [Getting Started](https://monogame.net/articles/getting_started/index.html) instructions for each platform, or you can download a specific release from [here](https://github.com/MonoGame/MonoGame/releases).
+* Download release [packages](https://github.com/MonoGame/MonoGame/releases).
 * Follow [@MonoGameTeam](https://twitter.com/monogameteam) on Twitter.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you'd like to help the project by supporting us financially, consider support
 
 Money goes towards hosting, new hardware and if enough people subscribe a dedicated developer.
 
-There are several options on our [Donation Page](http://www.monogame.net/donate/).
+There are several options on our [Patreon Page](https://www.patreon.com/MonoGame/).
 
 ## Source Code
 
@@ -86,8 +86,8 @@ A high level breakdown of the components of the framework:
 * Our [issue tracker](https://github.com/MonoGame/MonoGame/issues) is on GitHub.
 * Use our [community forums](http://community.monogame.net/) for support questions.
 * You can [join the Discord server](https://discord.gg/monogame) and chat live with the core developers and other users.
-* The [official documentation](http://www.monogame.net/documentation/) is on our website.
-* Download release and development [packages](http://www.monogame.net/downloads/).
+* The [official documentation](https://monogame.net/articles/index.html) is on our website.
+* Here are the [Getting Started](https://monogame.net/articles/getting_started/index.html) instructions for each platform, or you can download a specific release from [here](https://github.com/MonoGame/MonoGame/releases).
 * Follow [@MonoGameTeam](https://twitter.com/monogameteam) on Twitter.
 
 ## License

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -569,7 +569,7 @@ namespace MonoGame.Tools.Pipeline
 
         private void CmdHelp_Executed(object sender, EventArgs e)
         {
-            Process.Start(new ProcessStartInfo() { FileName = "https://docs.monogame.net/articles/tools/mgcb_editor.html", UseShellExecute = true, Verb = "open" });
+            Process.Start(new ProcessStartInfo() { FileName = "https://monogame.net/articles/tools/mgcb_editor.html", UseShellExecute = true, Verb = "open" });
         }
 
         private void CmdAbout_Executed(object sender, EventArgs e)


### PR DESCRIPTION
Small updates to Urls:

- The Help link in the MGCB Editor pointed to the previous doc site. That is updated here.
- Updated Documentation reference to go to the new site instead of a 404
- Changed the Donations link (returns a 404) from the old website to the Patreon link. (For now assuming there may be other options to donate in the future, but thought it made sense to have a working link for the time being!)
- Updated downloads link to point to GitHub releases instead of the old download page that returns a 404.
