### PR TITLE
Remove "not" wording from branch check

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -10,7 +10,7 @@ body:
   attributes:
     label: Prerequisites
     options:
-      - label: I have verified this issue is not present in the `develop` branch
+      - label: I have verified this issue is present in the `develop` branch
         required: true
       - label: I have searched [open](https://github.com/MonoGame/MonoGame/issues) and [closed](https://github.com/MonoGame/MonoGame/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported.
         required: true


### PR DESCRIPTION
The required checkmark statement was incorrectly asking the user to verify that the issue was **not** present in the develop branch.

I should instead ask them to verify that the issue **is** present in the develop branch
(Thanks to @Apostolique for point this out)