### PR TITLE
Fix DesktopGL function loader ILC error

### DIFF
--- a/MonoGame.Framework/Platform/Utilities/FuncLoader.Desktop.cs
+++ b/MonoGame.Framework/Platform/Utilities/FuncLoader.Desktop.cs
@@ -38,7 +38,7 @@ namespace MonoGame.Framework.Utilities
         public static IntPtr LoadLibraryExt(string libname)
         {
             var ret = IntPtr.Zero;
-            var assemblyLocation = Path.GetDirectoryName(typeof(FuncLoader).Assembly.Location) ?? "./";
+            var assemblyLocation = Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "./";
 
             // Try .NET Framework / mono locations
             if (CurrentPlatform.OS == OS.MacOSX)


### PR DESCRIPTION
Updated the function loader for DesktopGL project to not crash on macOS when compiling with ```PublishAot```.