### PR TITLE
Fix Android song unable to find a specified URI

### DIFF
--- a/MonoGame.Framework/Platform/Media/Song.Android.cs
+++ b/MonoGame.Framework/Platform/Media/Song.Android.cs
@@ -77,15 +77,22 @@ namespace Microsoft.Xna.Framework.Media
 
             if (assetUri != null)
             {
+                // Check if we have a direct asset URI.
                 _androidPlayer.SetDataSource(MediaLibrary.Context, this.assetUri);
+            }
+            else if (_name.StartsWith("file://"))
+            {
+                // Otherwise, check if this is a file URI.
+                _androidPlayer.SetDataSource(_name);
             }
             else
             {
-                var afd = Game.Activity.Assets.OpenFd(_name);
-                if (afd == null)
-                    return;
-
-                _androidPlayer.SetDataSource(afd.FileDescriptor, afd.StartOffset, afd.Length);
+                // Otherwise, assume it's a file path. (This might throw if the file doesn't exist)
+                var afd = Game.Activity?.Assets?.OpenFd(_name);
+                if (afd != null)
+                {
+                	_androidPlayer.SetDataSource(afd.FileDescriptor, afd.StartOffset, afd.Length);
+                }
             }
 
 


### PR DESCRIPTION
Changed Android `Song` to differentiate between Assets/URI-based `DataSource`.

@tomspilman @mrhelmut 