### PR TITLE
Fix DesktopGL for documentation generation

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -36,11 +36,6 @@
 
   <ItemGroup>
     <Compile Remove="Graphics\GraphicsAdapter.cs" />
-    <Compile Remove="Media\Video.cs" />
-    <Compile Remove="Media\VideoPlayer.cs" />
-    <Compile Remove="Content\ContentReaders\VideoReader.cs" />
-    <Compile Remove="Input\MessageBox.cs" />
-    <Compile Remove="Input\KeyboardInput.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -60,14 +55,18 @@
     <Compile Include="Platform\Media\MediaLibrary.Default.cs" />
     <Compile Include="Platform\Media\MediaPlayer.Default.cs" />
     <Compile Include="Platform\Media\Song.NVorbis.cs" />
+    <Compile Include="Platform\Media\VideoPlayer.Default.cs" />
+    <Compile Include="Platform\Media\Video.Default.cs" />
     <Compile Include="Platform\Input\GamePad.SDL.cs" />
     <Compile Include="Platform\Input\InputKeyEventArgs.cs" />
     <Compile Include="Platform\Input\Joystick.SDL.cs" />
     <Compile Include="Platform\Input\Keyboard.SDL.cs" />
     <Compile Include="Platform\Input\KeyboardUtil.SDL.cs" />
+    <Compile Include="Platform\Input\KeyboardInput.Default.cs" />
     <Compile Include="Platform\Input\KeysHelper.cs" />
     <Compile Include="Platform\Input\Mouse.SDL.cs" />
     <Compile Include="Platform\Input\MouseCursor.SDL.cs" />
+    <Compile Include="Platform\Input\MessageBox.Default.cs" />
     <Compile Include="Platform\Graphics\GraphicsContext.SDL.cs" />
     <Compile Include="Platform\Graphics\OpenGL.SDL.cs" />
     <Compile Include="Platform\Graphics\WindowInfo.SDL.cs" />

--- a/MonoGame.Framework/Platform/Media/Video.Default.cs
+++ b/MonoGame.Framework/Platform/Media/Video.Default.cs
@@ -1,0 +1,21 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+namespace Microsoft.Xna.Framework.Media
+{
+    public sealed partial class Video : IDisposable
+    {
+        private void PlatformInitialize()
+        {
+            throw new NotImplementedException("Video is not implemented on this platform.");
+        }
+
+        private void PlatformDispose(bool disposing)
+        {
+            throw new NotImplementedException("Video is not implemented on this platform.");
+        }
+    }
+}

--- a/MonoGame.Framework/Platform/Media/VideoPlayer.Default.cs
+++ b/MonoGame.Framework/Platform/Media/VideoPlayer.Default.cs
@@ -1,0 +1,72 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Microsoft.Xna.Framework.Media
+{
+    public sealed partial class VideoPlayer : IDisposable
+    {
+        private void PlatformInitialize()
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+
+        private Texture2D PlatformGetTexture()
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+
+        private void PlatformGetState(ref MediaState result)
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+
+        private void PlatformPause()
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+
+        private void PlatformResume()
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+
+        private void PlatformPlay()
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+
+        private void PlatformStop()
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+
+        private void PlatformSetIsLooped()
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+
+        private void PlatformSetIsMuted()
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+
+        private TimeSpan PlatformGetPlayPosition()
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+
+        private void PlatformSetVolume()
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+
+        private void PlatformDispose(bool disposing)
+        {
+            throw new NotImplementedException("VideoPlayer is not implemented on this platform.");
+        }
+    }
+}


### PR DESCRIPTION
Adding empty implementations of types that are missing from the documentation because the website uses DesktopGL to generation the documentation.

For reference: https://github.com/MonoGame/monogame.github.io/issues/58