### PR TITLE
Update WindowsDX csproj to Microsoft.NET.Sdk

### DIFF
--- a/Tests/MonoGame.Tests.WindowsDX.csproj
+++ b/Tests/MonoGame.Tests.WindowsDX.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Small cleanup on the project tag to match the other updated csprojs and remove the following warnings on MonoGame.Tests.WindowsDX.csproj:

- warning NETSDK1137: It is no longer necessary to use the Microsoft.NET.Sdk.WindowsDesktop SDK. Consider changing the Sdk attribute of the root Project element to 'Microsoft.NET.Sdk'.
- warning NETSDK1106: Microsoft.NET.Sdk.WindowsDesktop requires 'UseWpf' or 'UseWindowsForms' to be set to 'true'