### PR TITLE
Fix the WindowsDX tests

### DIFF
--- a/Tests/Framework/Graphics/GraphicsAdapterTest.cs
+++ b/Tests/Framework/Graphics/GraphicsAdapterTest.cs
@@ -53,6 +53,8 @@ namespace MonoGame.Tests.Graphics
                 Assert.IsNotNull(adapter.CurrentDisplayMode); 
                 Assert.IsNotNull(adapter.SupportedDisplayModes);
                 Assert.GreaterOrEqual(adapter.SupportedDisplayModes.Count(), 1);
+
+                // This Assert can fail on laptops or systems with onboard graphics.
                 Assert.AreEqual(1, adapter.SupportedDisplayModes.Count(m => Equals(m, adapter.CurrentDisplayMode)));
 
                 // Seems like XNA treats aspect ratios above 16:10 as wide screen. A 1680x1050 display (exactly 16:10) was considered not to be wide screen.

--- a/Tests/Framework/TestGameBase.cs
+++ b/Tests/Framework/TestGameBase.cs
@@ -30,9 +30,10 @@ namespace MonoGame.Tests {
 #if XNA
             Content.RootDirectory = AppDomain.CurrentDomain.BaseDirectory;
 #endif
-            // We do all the tests using the reference device to
+            // We do all the tests using the reference/warp device to
             // avoid driver glitches and get consistent rendering.
             GraphicsAdapter.UseReferenceDevice = true;
+            GraphicsAdapter.UseDriverType = GraphicsAdapter.DriverType.FastSoftware;
 
             Services.AddService<IFrameInfoSource>(this);
 			SuppressExtraUpdatesAndDraws = true;
@@ -231,7 +232,7 @@ namespace MonoGame.Tests {
             Exit();
 #else
             // NOTE: We avoid Game.Exit() here as we marked it
-            // obsolete on platforms that disallow exit in 
+            // obsolete on platforms that disallow exit in
             // shipping games.
             //
             // We however need it here to halt the app after we

--- a/Tests/MonoGame.Tests.WindowsDX.csproj
+++ b/Tests/MonoGame.Tests.WindowsDX.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Creating as a Draft as these fixes are likely not ideal/final, and probably controversial. Assuming we can discuss here or on the issue. The Reference Driver type is not successfully being created by the call to the SharpDX.Direct3D11.Device constructor. It is throwing this error: _The specified device interface or feature level is not supported on this system._

Switching the test suite to run using the Hardware Driver Type makes all of the tests work on a variety of my Windows dev machines. However, there is one unrelated Adapter test that fails on machines using onboard graphics (but it also fails on Master on those machines today), so I added a comment to just identify that for now. It is does not actually use the TestGameBase.cs today and already executes with the Hardware driver type so it is not exactly the same issue.

This is in regards to Issue #8128 where I will be adding some research notes and further information that may hopefully lead to a better fix if this is not acceptable.