### PR TITLE
Fix the WindowsDX tests

### DIFF
--- a/Tests/Framework/Graphics/GraphicsAdapterTest.cs
+++ b/Tests/Framework/Graphics/GraphicsAdapterTest.cs
@@ -53,6 +53,8 @@ namespace MonoGame.Tests.Graphics
                 Assert.IsNotNull(adapter.CurrentDisplayMode); 
                 Assert.IsNotNull(adapter.SupportedDisplayModes);
                 Assert.GreaterOrEqual(adapter.SupportedDisplayModes.Count(), 1);
+
+                // This Assert can fail on laptops or systems with onboard graphics.
                 Assert.AreEqual(1, adapter.SupportedDisplayModes.Count(m => Equals(m, adapter.CurrentDisplayMode)));
 
                 // Seems like XNA treats aspect ratios above 16:10 as wide screen. A 1680x1050 display (exactly 16:10) was considered not to be wide screen.

--- a/Tests/Framework/TestGameBase.cs
+++ b/Tests/Framework/TestGameBase.cs
@@ -30,9 +30,10 @@ namespace MonoGame.Tests {
 #if XNA
             Content.RootDirectory = AppDomain.CurrentDomain.BaseDirectory;
 #endif
-            // We do all the tests using the reference device to
+            // We do all the tests using the reference/warp device to
             // avoid driver glitches and get consistent rendering.
             GraphicsAdapter.UseReferenceDevice = true;
+            GraphicsAdapter.UseDriverType = GraphicsAdapter.DriverType.FastSoftware;
 
             Services.AddService<IFrameInfoSource>(this);
 			SuppressExtraUpdatesAndDraws = true;


### PR DESCRIPTION
This is a cleaner version of PR #8151 without some of my messy commits. This is to fix the issue #8128 

- Resolves the failing WindowsDX tests that are failing, because of the REF device. Using the WARP device does work for the tests and is better than my previous fix that relied on using Hardware.
- Also adds a comment to an Assert that I saw failures for on machines using onboard graphics. The GraphicsAdapterTest.cs does not use the TestGameBase.cs, and relies on the Hardware device for testing today so that is a separate intermittent/device specific issue.