### PR TITLE
`Sdl.Version` Implement `GetHashCode`

### DIFF
--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -168,6 +168,18 @@ internal static class Sdl
             return version == (Version)obj;
         }
 
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 23 + Major.GetHashCode();
+                hash = hash * 23 + Minor.GetHashCode();
+                hash = hash * 23 + Patch.GetHashCode();
+                return hash;
+            }
+        }
+
         public static bool operator !=(Version version1, Version version2)
         {
             return !(version1 == version2);


### PR DESCRIPTION
## Description
Implements `Sdl.Version.GetHashCode` to resolve the following build warning:

```sh
warning: /home/runner/work/monogame-11ty/monogame-11ty/external/MonoGame/MonoGame.Framework/Platform/SDL/SDL2.cs(139,19): warning CS0659: 'Sdl.Version' overrides Object.Equals(object o) but does not override Object.GetHashCode()
```

## Related Issues
Related to documentation repo issue https://github.com/MonoGame/monogame.github.io/issues/92