### PR TITLE
Rename `uif` to `UIF` to resolve CS8981

### DIFF
--- a/MonoGame.Framework/Graphics/PackedVector/HalfTypeHelper.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfTypeHelper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
     internal class HalfTypeHelper
     {
         [StructLayout(LayoutKind.Explicit)]
-        private struct uif
+        private struct UIF
         {
             [FieldOffset(0)]
             public float f;
@@ -22,7 +22,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         internal static UInt16 Convert(float f)
         {
-            uif uif = new uif();
+            UIF uif = new UIF();
             uif.f = f;
             return Convert(uif.i);
         }
@@ -109,7 +109,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
                 rst = (uint)(((((uint)value & 0x8000) << 16) | ((((((uint)value >> 10) & 0x1f) - 15) + 127) << 23)) | (mantissa << 13));
             }
 
-            var uif = new uif();
+            var uif = new UIF();
             uif.u = rst;
             return uif.f;
         }


### PR DESCRIPTION
## Description
`Microsoft.Xna.Framework.Graphics.PackedVector.HalfTypeHelper.uif` produces warning [CS8981](https://msdn.microsoft.com/query/roslyn.query?appId%3Droslyn%26k%3Dk%28CS8981%29)

```
The type name 'uif' only contains lower-cased ascii characters. Such names may become reserved for the language.CS8981
```

This PR renames it from `uif` to `UIF`.

I only see references to it within the `HalfTypeHelper` class where it's nested so changing the name to resolve this shouldn't cause any breaking changes I'm aware of.  If the name change is a problem `#pramga`'s can be added to tell the warning to be ignored instead of changing the name.

## Related Issues
Related to documentation repo issue https://github.com/MonoGame/monogame.github.io/issues/92
