### PR TITLE
Resolve CS3021 warning on public members

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -173,10 +173,13 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="packedValue">The packed value.</param>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public Color(uint packedValue)
+        #pragma warning restore CS3021
         {
             _packedValue = packedValue;
         }
+
 
         /// <summary>
         /// Constructs an RGBA color from the XYZW unit length components of a vector.
@@ -1788,7 +1791,9 @@ namespace Microsoft.Xna.Framework
         /// Gets or sets packed value of this <see cref="Color"/>.
         /// </summary>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public UInt32 PackedValue
+        #pragma warning restore CS3021
         {
             get { return _packedValue; }
             set { _packedValue = value; }

--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -172,10 +172,7 @@ namespace Microsoft.Xna.Framework
         /// The value is a 32-bit unsigned integer, with R in the least significant octet.
         /// </summary>
         /// <param name="packedValue">The packed value.</param>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public Color(uint packedValue)
-        #pragma warning restore CS3021
         {
             _packedValue = packedValue;
         }
@@ -1790,10 +1787,7 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Gets or sets packed value of this <see cref="Color"/>.
         /// </summary>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public UInt32 PackedValue
-        #pragma warning restore CS3021
         {
             get { return _packedValue; }
             set { _packedValue = value; }

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -335,7 +335,9 @@ namespace Microsoft.Xna.Framework
         /// The system window that this game is displayed on.
         /// </summary>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public GameWindow Window
+        #pragma warning restore CS3021
         {
             get { return Platform.Window; }
         }

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -334,10 +334,7 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// The system window that this game is displayed on.
         /// </summary>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public GameWindow Window
-        #pragma warning restore CS3021
         {
             get { return Platform.Window; }
         }

--- a/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
@@ -16,10 +16,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <summary>
         /// Gets and sets the packed value.
         /// </summary>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public byte PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// Gets and sets the packed value.
         /// </summary>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public byte PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
@@ -43,10 +43,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <summary>
         /// Gets and sets the packed value.
         /// </summary>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public UInt16 PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
@@ -44,7 +44,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// Gets and sets the packed value.
         /// </summary>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public UInt16 PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
@@ -45,10 +45,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <summary>
         /// Gets and sets the packed value.
         /// </summary>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public UInt16 PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
@@ -46,7 +46,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// Gets and sets the packed value.
         /// </summary>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public UInt16 PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
@@ -15,10 +15,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <summary>
         /// Gets and sets the packed value.
         /// </summary>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public UInt16 PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// Gets and sets the packed value.
         /// </summary>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public UInt16 PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
@@ -62,7 +62,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// </summary>
         /// <value>The packed representation of the value.</value>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public uint PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
@@ -61,10 +61,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// Directly gets or sets the packed representation of the value.
         /// </summary>
         /// <value>The packed representation of the value.</value>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public uint PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
@@ -15,10 +15,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             packedValue = HalfTypeHelper.Convert(single);
         }
 
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public ushort PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public ushort PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
@@ -49,10 +49,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return new Vector4(vector.X, vector.Y, 0f, 1f);
         }
 
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public uint PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
@@ -50,7 +50,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public uint PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
@@ -76,7 +76,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// </summary>
         /// <value>The packed representation of the value.</value>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public ulong PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
@@ -75,10 +75,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// Directly gets or sets the packed representation of the value.
         /// </summary>
         /// <value>The packed representation of the value.</value>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public ulong PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
@@ -31,10 +31,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return a._packed == b._packed;
         }
 
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public ushort PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
@@ -32,7 +32,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public ushort PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
@@ -32,7 +32,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public uint PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
@@ -31,10 +31,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return a._packed == b._packed;
         }
 
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public uint PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
@@ -31,10 +31,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			return a.Equals (b);
 		}
 
-        [CLSCompliant(false)]
-		#pragma warning disable CS3021
         public uint PackedValue
-		#pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
@@ -32,7 +32,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		}
 
         [CLSCompliant(false)]
+		#pragma warning disable CS3021
         public uint PackedValue
+		#pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
@@ -31,10 +31,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			return a.Equals (b);
 		}
 
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public ulong PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
@@ -32,7 +32,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		}
 
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public ulong PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
@@ -14,10 +14,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <summary>
         /// Gets and sets the packed value.
         /// </summary>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public uint PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
@@ -15,7 +15,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// Gets and sets the packed value.
         /// </summary>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public uint PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// Gets and sets the packed value.
         /// </summary>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public uint PackedValue
+        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
@@ -15,10 +15,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <summary>
         /// Gets and sets the packed value.
         /// </summary>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public uint PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
@@ -15,7 +15,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// Gets and sets the packed value.
 		/// </summary>
 		[CLSCompliant(false)]
+		#pragma warning disable CS3021
 		public ulong PackedValue
+		#pragma warning restore CS3021
 		{
 			get
 			{

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
@@ -14,10 +14,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		/// <summary>
 		/// Gets and sets the packed value.
 		/// </summary>
-		[CLSCompliant(false)]
-		#pragma warning disable CS3021
 		public ulong PackedValue
-		#pragma warning restore CS3021
 		{
 			get
 			{

--- a/MonoGame.Framework/Graphics/PackedVector/Short2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short2.cs
@@ -32,7 +32,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		}
 
         [CLSCompliant(false)]
+		#pragma warning disable CS3021
 		public uint PackedValue
+		#pragma warning restore CS3021
         {
 			get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Short2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short2.cs
@@ -31,10 +31,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			return a.PackedValue == b.PackedValue;
 		}
 
-        [CLSCompliant(false)]
-		#pragma warning disable CS3021
 		public uint PackedValue
-		#pragma warning restore CS3021
         {
 			get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Short4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short4.cs
@@ -61,10 +61,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// Directly gets or sets the packed representation of the value.
         /// </summary>
         /// <value>The packed representation of the value.</value>
-        [CLSCompliant(false)]
-        #pragma warning disable CS3021
         public ulong PackedValue
-        #pragma warning restore CS3021
         {
             get
             {

--- a/MonoGame.Framework/Graphics/PackedVector/Short4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short4.cs
@@ -62,7 +62,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// </summary>
         /// <value>The packed representation of the value.</value>
         [CLSCompliant(false)]
+        #pragma warning disable CS3021
         public ulong PackedValue
+        #pragma warning restore CS3021
         {
             get
             {


### PR DESCRIPTION
## Description
This PR is to resolve the following warning displayed when building the project and building the documentation

```sh
warning CS3021: '[member] does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute
```

This is due to the `[CLSCompliant(false)]` attribute used on the following public members: 

- `Microsoft.Xna.Framework.Color.PackedValue`
- `Microsoft.Xna.Framework.Game.Window`
- `Microsoft.Xna.Framework.Graphics.PackedVector.Short4.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.Short2.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.Rgba64.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.Rgba1010102.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.Rg32.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.NormalizedShort4.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.NormalizedShort2.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.Bgr565.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.Bgra4444.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.HalfVector4.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.Bgra5551.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.Byte4.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.HalfVector2.PackedValue`
- `Microsoft.Xna.Framework.Graphics.PackedVector.HalfSingle.PackedValue`

## Additional Information
The assembly is marked as CLSCompliant in the **AssemblyInfo.cs** file at 

https://github.com/MonoGame/MonoGame/blob/ab267dc28bc94bc5ccb7f0f188a27636d152133a/MonoGame.Framework/Properties/AssemblyInfo.cs#L18

However, with SDK style projects, which are what MonoGame is using now, information that you would have put in the **AssemblyInfo.cs** in the past should now be put in the **.csproj** instead.  The AssemblyInfo.cs is then auto-generated based on the properties in the **.csproj**. 

If instead you want to use the **AssemblyInfo.cs** still, you need to add the following to the **.csproj** file

```xml
<PropertyGroup>
   <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
</PropertyGroup> 
```

**However, I am unable to determine if the `MonoGame.Framework.ConsoleCheck.csproj` would still require the AssemblyInfo.cs file when tests are performed to ensure console compatibility at the moment.**  If the AssemblyInfo.cs is no longer needed for the console check project and/or the assemblies should still be marked as CLSCompliant(true), then a better solution would be to add the following to the **Directory.Build.prop** file instead of 

```xml
<ItemGroup>
    <AssemblyAttribute Include="System.CLSCompliant">
        <_Parameter1>true</_Parameter1>
        <_Parameter1_TypeName>System.Boolean</_Parameter1_TypeName>
    </AssemblyAttribute>
</ItemGroup>
```

This would mark all assemblies as compliant and remove the need for the `#pragma warning disable` changes I've made.

## Related Issues
Related to documentation repo issue https://github.com/MonoGame/monogame.github.io/issues/92

