### PR TITLE
Fix Invalid cref warning for BoundingBox

### DIFF
--- a/MonoGame.Framework/BoundingBox.cs
+++ b/MonoGame.Framework/BoundingBox.cs
@@ -461,6 +461,7 @@ namespace Microsoft.Xna.Framework
         ///   <code>true</code> if <see cref="other"/> is equal to this <see cref="BoundingBox"/>,
         ///   <code>false</code> if it is not.
         /// </returns>
+        ///   <code>true</code> if <paramref name="other"/> is equal to this <see cref="BoundingBox"/>,
         public bool Equals(BoundingBox other)
         {
             return (this.Min == other.Min) && (this.Max == other.Max);
@@ -474,6 +475,7 @@ namespace Microsoft.Xna.Framework
         ///   <code>true</code> if <see cref="obj"/> is equal to this <see cref="BoundingBox"/>,
         ///   <code>false</code> if it is not.
         /// </returns>
+        ///   <code>true</code> if <paramref name="obj"/> is equal to this <see cref="BoundingBox"/>,
         public override bool Equals(object obj)
         {
             return (obj is BoundingBox) && this.Equals((BoundingBox)obj);
@@ -758,6 +760,7 @@ namespace Microsoft.Xna.Framework
         ///   <code>true</code> if <see cref="a"/> is equal to this <see cref="b"/>,
         ///   <code>false</code> if it is not.
         /// </returns>
+        ///   <code>true</code> if <paramref name="a"/> is equal to this <paramref name="b"/>,
         public static bool operator ==(BoundingBox a, BoundingBox b)
         {
             return a.Equals(b);
@@ -772,6 +775,7 @@ namespace Microsoft.Xna.Framework
         ///   <code>true</code> if <see cref="a"/> is not equal to this <see cref="b"/>,
         ///   <code>false</code> if it is.
         /// </returns>
+        ///   <code>true</code> if <paramref name="a"/> is not equal to this <paramref name="b"/>,
         public static bool operator !=(BoundingBox a, BoundingBox b)
         {
             return !a.Equals(b);

--- a/MonoGame.Framework/BoundingBox.cs
+++ b/MonoGame.Framework/BoundingBox.cs
@@ -458,7 +458,6 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="other">The <see cref="BoundingBox"/> to compare with this <see cref="BoundingBox"/>.</param>
         /// <returns>
-        ///   <code>true</code> if <see cref="other"/> is equal to this <see cref="BoundingBox"/>,
         ///   <code>false</code> if it is not.
         /// </returns>
         ///   <code>true</code> if <paramref name="other"/> is equal to this <see cref="BoundingBox"/>,
@@ -472,7 +471,6 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="obj">The <see cref="Object"/> to compare with this <see cref="BoundingBox"/>.</param>
         /// <returns>
-        ///   <code>true</code> if <see cref="obj"/> is equal to this <see cref="BoundingBox"/>,
         ///   <code>false</code> if it is not.
         /// </returns>
         ///   <code>true</code> if <paramref name="obj"/> is equal to this <see cref="BoundingBox"/>,
@@ -757,7 +755,6 @@ namespace Microsoft.Xna.Framework
         /// <param name="a">A <see cref="BoundingBox"/> to compare the other.</param>
         /// <param name="b">A <see cref="BoundingBox"/> to compare the other.</param>
         /// <returns>
-        ///   <code>true</code> if <see cref="a"/> is equal to this <see cref="b"/>,
         ///   <code>false</code> if it is not.
         /// </returns>
         ///   <code>true</code> if <paramref name="a"/> is equal to this <paramref name="b"/>,
@@ -772,7 +769,6 @@ namespace Microsoft.Xna.Framework
         /// <param name="a">A <see cref="BoundingBox"/> to compare the other.</param>
         /// <param name="b">A <see cref="BoundingBox"/> to compare the other.</param>
         /// <returns>
-        ///   <code>true</code> if <see cref="a"/> is not equal to this <see cref="b"/>,
         ///   <code>false</code> if it is.
         /// </returns>
         ///   <code>true</code> if <paramref name="a"/> is not equal to this <paramref name="b"/>,


### PR DESCRIPTION
## Description
This resolves the invalid `cref` warning in BoundingBox when building the project and building documentation in the documentation repo.  The `<see cref=""/>` tags should have been `<paramref name=""/>` tags

## Related Issues
Related to documentation repo issue https://github.com/MonoGame/monogame.github.io/issues/92