### PR TITLE
Remove obsolete `GetObjectData` method

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/InvalidContentException.cs
+++ b/MonoGame.Framework.Content.Pipeline/InvalidContentException.cs
@@ -89,20 +89,5 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             : this(message, null, innerException)
         {
         }
-
-        /// <summary>
-        /// When overridden in a derived class, returns information about the exception.
-        /// In addition to the base behavior, this method provides serialization functionality.
-        /// </summary>
-        /// <param name="info">Information necessary for serialization and deserialization of the content item.</param>
-        /// <param name="context">Information necessary for the source and destination of a given serialized stream. Also provides an additional caller-defined context.</param>
-        public override void GetObjectData(
-            SerializationInfo info,
-            StreamingContext context
-            )
-        {
-            base.GetObjectData(info, context);
-            // TODO: Complete me...
-        }
     }
 }


### PR DESCRIPTION
## Description
The base `GetObjectData` has been marked obsolete.  The override implementation here does nothing itself except call the base.  This can be removed which also resolves the warning message shown during build and documentation build.

```sh
warning: /home/runner/work/monogame-11ty/monogame-11ty/external/MonoGame/MonoGame.Framework.Content.Pipeline/InvalidContentException.cs(99,30): warning CS0672: Member 'InvalidContentException.GetObjectData(SerializationInfo, StreamingContext)' overrides obsolete member 'Exception.GetObjectData(SerializationInfo, StreamingContext)'. Add the Obsolete attribute to 'InvalidContentException.GetObjectData(SerializationInfo, StreamingContext)'.
```


## Related Issues
Related to documentation repo issue https://github.com/MonoGame/monogame.github.io/issues/92