### PR TITLE
Fix MGCB Color parsing error on ColorKeyColor

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/Convertors/StringToColorConverter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/Convertors/StringToColorConverter.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors
             if (value.GetType() == typeof(string))
             {
                 string strValue = (string)value;
-                int r, g, b, a;
 
                 // Check if the string is in the older XNA "{R:0 G:0 B:0 A:0}" format
                 if (strValue.StartsWith('{') && strValue.EndsWith('}'))
@@ -49,10 +48,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors
                     var parts = strValue.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                     if (parts.Length == 4)
                     {
-                        r = int.Parse(parts[0].Split(':')[1]);
-                        g = int.Parse(parts[1].Split(':')[1]);
-                        b = int.Parse(parts[2].Split(':')[1]);
-                        a = int.Parse(parts[3].Split(':')[1]);
+                        var r = int.Parse(parts[0].Split(':')[1]);
+                        var g = int.Parse(parts[1].Split(':')[1]);
+                        var b = int.Parse(parts[2].Split(':')[1]);
+                        var a = int.Parse(parts[3].Split(':')[1]);
                         return new Microsoft.Xna.Framework.Color(r, g, b, a);
                     }
                     else
@@ -66,10 +65,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors
                     string[] values = (strValue).Split(new char[] { ',' }, StringSplitOptions.None);
                     if (values.Length == 4)
                     {
-                        r = int.Parse(values[0].Trim());
-                        g = int.Parse(values[1].Trim());
-                        b = int.Parse(values[2].Trim());
-                        a = int.Parse(values[3].Trim());
+                        var r = int.Parse(values[0].Trim());
+                        var g = int.Parse(values[1].Trim());
+                        var b = int.Parse(values[2].Trim());
+                        var a = int.Parse(values[3].Trim());
                         return new Microsoft.Xna.Framework.Color(r, g, b, a);
                     }
                     else

--- a/MonoGame.Framework.Content.Pipeline/Builder/Convertors/StringToColorConverter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/Convertors/StringToColorConverter.cs
@@ -57,9 +57,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors
                         throw new ArgumentException(string.Format("Could not convert from string({0}) to Color, expected format is 'r,g,b,a' or '{R:0 G:0 B:0 A:0}'", value));
                     }
                 }
-                // Assume the string is in the MonoGame "r,g,b,a" format
-                else
-                {
+                else // Assume the string is in the MonoGame "r,g,b,a" format
+                {                    
                     string[] values = (strValue).Split(new char[] { ',' }, StringSplitOptions.None);
                     if (values.Length == 4)
                     {

--- a/MonoGame.Framework.Content.Pipeline/Builder/Convertors/StringToColorConverter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/Convertors/StringToColorConverter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Net.Http.Headers;
 using System.Text;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors
@@ -23,7 +22,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors
                 return base.ConvertTo(context, culture, value, destinationType);
 
             var color = (Color)value;
-
             return string.Format("{0},{1},{2},{3}", color.R, color.G, color.B, color.A);
         }
 

--- a/MonoGame.Framework.Content.Pipeline/Builder/Convertors/StringToColorConverter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/Convertors/StringToColorConverter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Net.Http.Headers;
 using System.Text;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors
@@ -22,6 +23,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors
                 return base.ConvertTo(context, culture, value, destinationType);
 
             var color = (Color)value;
+
             return string.Format("{0},{1},{2},{3}", color.R, color.G, color.B, color.A);
         }
 
@@ -33,25 +35,52 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors
 			return base.CanConvertFrom (context, sourceType);
 		}
 
-		public override object ConvertFrom (ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
-		{
-			if (value.GetType () == typeof (string)) {
-				string[] values = ((string)value).Split(new char[] {','},StringSplitOptions.None);
-                if (values.Length == 4)
+        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            if (value.GetType() == typeof(string))
+            {
+                string strValue = (string)value;
+                int r, g, b, a;
+
+                // Check if the string is in the older XNA "{R:0 G:0 B:0 A:0}" format
+                if (strValue.StartsWith('{') && strValue.EndsWith('}'))
                 {
-                    var r = int.Parse(values[0].Trim());
-                    var g = int.Parse(values[1].Trim());
-                    var b = int.Parse(values[2].Trim());
-                    var a = int.Parse(values[3].Trim());
-                    return new Microsoft.Xna.Framework.Color(r, g, b, a);
+                    strValue = strValue.Trim(new char[] { '{', '}' });
+                    var parts = strValue.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length == 4)
+                    {
+                        r = int.Parse(parts[0].Split(':')[1]);
+                        g = int.Parse(parts[1].Split(':')[1]);
+                        b = int.Parse(parts[2].Split(':')[1]);
+                        a = int.Parse(parts[3].Split(':')[1]);
+                        return new Microsoft.Xna.Framework.Color(r, g, b, a);
+                    }
+                    else
+                    {
+                        throw new ArgumentException(string.Format("Could not convert from string({0}) to Color, expected format is 'r,g,b,a' or '{R:0 G:0 B:0 A:0}'", value));
+                    }
                 }
+                // Assume the string is in the MonoGame "r,g,b,a" format
                 else
                 {
-                    throw new ArgumentException(string.Format("Could not convert from string({0}) to Color, expected format is 'r,g,b,a'", value));                    
+                    string[] values = (strValue).Split(new char[] { ',' }, StringSplitOptions.None);
+                    if (values.Length == 4)
+                    {
+                        r = int.Parse(values[0].Trim());
+                        g = int.Parse(values[1].Trim());
+                        b = int.Parse(values[2].Trim());
+                        a = int.Parse(values[3].Trim());
+                        return new Microsoft.Xna.Framework.Color(r, g, b, a);
+                    }
+                    else
+                    {
+                        throw new ArgumentException(string.Format("Could not convert from string({0}) to Color, expected format is 'r,g,b,a' or '{R:0 G:0 B:0 A:0}'", value));
+                    }
                 }
-			}
+            }
 
-			return base.ConvertFrom (context, culture, value);
-		}
-	}
+            return base.ConvertFrom(context, culture, value);
+        }
+
+    }
 }

--- a/MonoGame.Framework.Content.Pipeline/Builder/Convertors/StringToColorConverter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/Convertors/StringToColorConverter.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors
                     }
                     else
                     {
-                        throw new ArgumentException(string.Format("Could not convert from string({0}) to Color, expected format is 'r,g,b,a' or '{R:0 G:0 B:0 A:0}'", value));
+                        throw new ArgumentException(string.Format("Could not convert from string({0}) to Color, expected format is 'r,g,b,a' or '{{R:0 G:0 B:0 A:0}}'", value));
                     }
                 }
                 else // Assume the string is in the MonoGame "r,g,b,a" format
@@ -70,7 +70,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors
                     }
                     else
                     {
-                        throw new ArgumentException(string.Format("Could not convert from string({0}) to Color, expected format is 'r,g,b,a' or '{R:0 G:0 B:0 A:0}'", value));
+                        throw new ArgumentException(string.Format("Could not convert from string({0}) to Color, expected format is 'r,g,b,a' or '{{R:0 G:0 B:0 A:0}}'", value));
                     }
                 }
             }

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -569,7 +569,7 @@ namespace MonoGame.Tools.Pipeline
 
         private void CmdHelp_Executed(object sender, EventArgs e)
         {
-            Process.Start(new ProcessStartInfo() { FileName = "https://monogame.net/articles/tools/mgcb_editor/", UseShellExecute = true, Verb = "open" });
+            Process.Start(new ProcessStartInfo() { FileName = "https://monogame.net/articles/tools/mgcb_editor.html", UseShellExecute = true, Verb = "open" });
         }
 
         private void CmdAbout_Executed(object sender, EventArgs e)

--- a/Tools/MonoGame.Tools.Tests/StringToColorConverterTests.cs
+++ b/Tools/MonoGame.Tools.Tests/StringToColorConverterTests.cs
@@ -1,0 +1,70 @@
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content.Pipeline.Builder.Convertors;
+using NUnit.Framework;
+using System;
+
+namespace MonoGame.Tests.ContentPipeline
+{
+    internal class StringToColorConverterTests
+    {
+        [Test]
+        public void ConvertFromMGColorString()
+        {
+            StringToColorConverter _converter = new StringToColorConverter();
+            var input = "255,255,255,255";
+
+            var result = _converter.ConvertFrom(null, null, input);
+
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<Color>(result);
+            var color = (Color)result;
+            Assert.AreEqual(255, color.R);
+            Assert.AreEqual(255, color.G);
+            Assert.AreEqual(255, color.B);
+            Assert.AreEqual(255, color.A);
+        }
+
+        [Test]
+        public void ConvertFromXNAColorString()
+        {            
+            StringToColorConverter _converter = new StringToColorConverter();
+            var input = "{R:255 G:255 B:255 A:255}";
+            
+            var result = _converter.ConvertFrom(null, null, input);
+         
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<Color>(result);
+            var color = (Color)result;
+            Assert.AreEqual(255, color.R);
+            Assert.AreEqual(255, color.G);
+            Assert.AreEqual(255, color.B);
+            Assert.AreEqual(255, color.A);
+        }
+
+        [Test]
+        public void InvalidStringThrowsFormatException()
+        {
+            StringToColorConverter _converter = new StringToColorConverter();
+
+            string inputMGShort = "255,255,255";
+            Assert.Throws<FormatException>(() => _converter.ConvertFrom(null, null, inputMGShort));
+
+            string inputMGLong = "255,255,255,255,255";
+            Assert.Throws<FormatException>(() => _converter.ConvertFrom(null, null, inputMGLong));
+
+            string inputXNAInvalid = "{R:255G:255B:255A:255}";
+            Assert.Throws<FormatException>(() => _converter.ConvertFrom(null, null, inputXNAInvalid));
+
+            string inputXNAShort = "{R:255 G:255 B:255}";
+            Assert.Throws<FormatException>(() => _converter.ConvertFrom(null, null, inputXNAShort));
+
+            string inputXNALong = "{R:255 G:255 B:255 A:255 Q:255}";
+            Assert.Throws<FormatException>(() => _converter.ConvertFrom(null, null, inputXNALong));
+        }
+
+    }
+}

--- a/Tools/MonoGame.Tools.Tests/StringToColorConverterTests.cs
+++ b/Tools/MonoGame.Tools.Tests/StringToColorConverterTests.cs
@@ -11,59 +11,56 @@ namespace MonoGame.Tests.ContentPipeline
 {
     internal class StringToColorConverterTests
     {
-        [Test]
-        public void ConvertFromMGColorString()
+        [TestCase("255,255,255,255", 255, 255, 255, 255)]
+        [TestCase("255,0,255,255", 255, 0, 255, 255)]
+        [TestCase("0,0,0,0", 0, 0, 0, 0)]
+        [TestCase("100,149,237,255", 100, 149, 237, 255)]
+        [TestCase("231,60,0,255", 231, 60, 0, 255)]
+        public void ConvertFromMGString(string input, int r, int g, int b, int a)
         {
             StringToColorConverter _converter = new StringToColorConverter();
-            var input = "255,255,255,255";
 
             var result = _converter.ConvertFrom(null, null, input);
 
             Assert.IsNotNull(result);
             Assert.IsInstanceOf<Color>(result);
             var color = (Color)result;
-            Assert.AreEqual(255, color.R);
-            Assert.AreEqual(255, color.G);
-            Assert.AreEqual(255, color.B);
-            Assert.AreEqual(255, color.A);
+            Assert.AreEqual(r, color.R);
+            Assert.AreEqual(g, color.G);
+            Assert.AreEqual(b, color.B);
+            Assert.AreEqual(a, color.A);
         }
 
-        [Test]
-        public void ConvertFromXNAColorString()
-        {            
-            StringToColorConverter _converter = new StringToColorConverter();
-            var input = "{R:255 G:255 B:255 A:255}";
-            
-            var result = _converter.ConvertFrom(null, null, input);
-         
-            Assert.IsNotNull(result);
-            Assert.IsInstanceOf<Color>(result);
-            var color = (Color)result;
-            Assert.AreEqual(255, color.R);
-            Assert.AreEqual(255, color.G);
-            Assert.AreEqual(255, color.B);
-            Assert.AreEqual(255, color.A);
-        }
-
-        [Test]
-        public void InvalidStringThrowsFormatException()
+        [TestCase("{R:255 G:255 B:255 A:255}", 255, 255, 255, 255)]
+        [TestCase("{R:255 G:0 B:255 A:255}", 255, 0, 255, 255)]
+        [TestCase("{R:0 G:0 B:0 A:0}", 0, 0, 0, 0)]
+        [TestCase("{R:100 G:149 B:237 A:255}", 100, 149, 237, 255)]
+        [TestCase("{R:231 G:60 B:0 A:255}", 231, 60, 0, 255)]
+        public void ConvertFromXNAString(string input, int r, int g, int b, int a)
         {
             StringToColorConverter _converter = new StringToColorConverter();
 
-            string inputMGShort = "255,255,255";
-            Assert.Throws<FormatException>(() => _converter.ConvertFrom(null, null, inputMGShort));
+            var result = _converter.ConvertFrom(null, null, input);
 
-            string inputMGLong = "255,255,255,255,255";
-            Assert.Throws<FormatException>(() => _converter.ConvertFrom(null, null, inputMGLong));
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOf<Color>(result);
+            var color = (Color)result;
+            Assert.AreEqual(r, color.R);
+            Assert.AreEqual(g, color.G);
+            Assert.AreEqual(b, color.B);
+            Assert.AreEqual(a, color.A);
+        }
 
-            string inputXNAInvalid = "{R:255G:255B:255A:255}";
-            Assert.Throws<FormatException>(() => _converter.ConvertFrom(null, null, inputXNAInvalid));
+        [TestCase("255,255,255")]
+        [TestCase("255,255,255,255,255")]
+        [TestCase("{R:255G:255B:255A:255}")]
+        [TestCase("{R:255 G:255 B:255}")]
+        [TestCase("{R:255 G:255 B:255 A:255 Q:255}")]
+        public void InvalidStringThrowsArgumentException(string input)
+        {
+            StringToColorConverter _converter = new StringToColorConverter();
 
-            string inputXNAShort = "{R:255 G:255 B:255}";
-            Assert.Throws<FormatException>(() => _converter.ConvertFrom(null, null, inputXNAShort));
-
-            string inputXNALong = "{R:255 G:255 B:255 A:255 Q:255}";
-            Assert.Throws<FormatException>(() => _converter.ConvertFrom(null, null, inputXNALong));
+            Assert.Throws<ArgumentException>(() => _converter.ConvertFrom(null, null, input));
         }
 
     }


### PR DESCRIPTION
This is a fix for #8154 . There are multiple ways to do this, and I even had a regex version... But I went with kind a simpler more old school way. Please feel free to make any suggestions or request any changes to it!

- Added code that checks for the XNA format {R:0 G:0 B:0 A:0} and parses it into a Color. If the format is the r,g,b,a format it is handled as it was before. 
- Updated the exception message to include both formats.

-Unrelated to this change specifically, but I updated the Help link in the MGCB Editor while I was in there to correctly point to the website after the latest changes.