### PR TITLE
[Documentation]: Adds missing XML Documentation for AlbumCollection class

### DIFF
--- a/MonoGame.Framework/Media/AlbumCollection.cs
+++ b/MonoGame.Framework/Media/AlbumCollection.cs
@@ -8,6 +8,22 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// A collection of albums in the media library
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="AlbumCollection"/> class provides access to albums in the 
+    /// device's media library
+    /// </para>
+    /// <para>
+    /// Use the <see cref="MediaLibrary.Albums"/> property to obtain a collection
+    /// of all albums in the media library, the <see cref="Artist.Albums"/> property
+    /// to obtain a collection of albums associated with a particular artist, and
+    /// the <see cref="Genre.Albums"/> property to obtain a collection of albums
+    /// associated with a particular genre.
+    /// </para>
+    /// </remarks>
     public sealed class AlbumCollection : IDisposable
     {
         private List<Album> albumCollection;
@@ -34,14 +50,25 @@ namespace Microsoft.Xna.Framework.Media
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <b>AlbumCollection</b> class, using
+        /// a specified collection of <see cref="Album"/> instances.
+        /// </summary>
+        /// <param name="albums">
+        /// The <see cref="Album"/> collection to initialize this <b>AlbumCollection</b> with.
+        /// </param>
         public AlbumCollection(List<Album> albums)
         {
             this.albumCollection = albums;
         }
 
         /// <summary>
-        /// Gets the Album at the specified index in the AlbumCollection.
+        /// Gets the <see cref="Album"/> at the specified index in the <see cref="AlbumCollection"/>.
         /// </summary>
+        /// <value>
+        /// A new <see cref="Album"/> representing the album at the specified index
+        /// in this <b>AlbumCollection</b>
+        /// </value>
         /// <param name="index">Index of the Album to get.</param>
         public Album this[int index]
         {


### PR DESCRIPTION
## Description
This PR adds the missing XML documentation for the Album class.

## Notes:
- Original XNA documentation includes a `<remark>` section for the class documentation that references how the AlbumCollection does not immediately instantiate all instances of **Album** in it's collection. Looking at the source, the MonoGame implementation of AlbumCollection looks like all instances of **Album** are already instantiated and just returned from the indexer.  Because of this, that remark section was excluded
- There was no documentation for the constructor in the XNA documentation. Most likely this is because the constructor was `private` or `internal` in XNA, but it is `public` in MonoGame. There was no existing documentation to use, but new documentation was added to resolve the missing XML warning.