### PR TITLE
[Documentation] Add missing XML documentation for Artist class

### DIFF
--- a/MonoGame.Framework/Audio/Xact/AudioEngine.cs
+++ b/MonoGame.Framework/Audio/Xact/AudioEngine.cs
@@ -381,6 +381,10 @@ namespace Microsoft.Xna.Framework.Audio
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Allows this object to attempt to free resources and perform other
+        /// cleanup operations before garbage collection reclaims the object.
+        /// </summary>
         ~AudioEngine()
         {
             Dispose(false);

--- a/MonoGame.Framework/Media/Artist.cs
+++ b/MonoGame.Framework/Media/Artist.cs
@@ -6,6 +6,17 @@ using System;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// Provides access to artist information in the media library.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="Artist"/> class provides information about an artist, including the artist's <see cref="Name"/>, <see cref="Albums"/>, and <see cref="Songs"/>
+    /// </para>
+    /// <para>
+    /// You can obtain an <b>Artist</b> through the <see cref="Album.Artist"/> and <see cref="Song.Artist"/> properties.
+    /// </para>
+    /// </remarks>
     public sealed class Artist : IDisposable
     {
         private string artist;
@@ -54,6 +65,10 @@ namespace Microsoft.Xna.Framework.Media
             }
         }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="Artist"/> class.
+        /// </summary>
+        /// <param name="artist">Name of the artist.</param>
         public Artist(string artist)
         {
             this.artist = artist;


### PR DESCRIPTION
## Notes
- MonoGame does not have an ArtistCollection class, so part of the documentation that mentioned it has been omitted:
`You can obtain an Artist object through the`<strike>`ArtistCollection.Item indexer and`</strike>`Album.Artist and Song.Artist properties`