### PR TITLE
[Documentation]: Adds missing XML Documentation for Audio namespace

### DIFF
--- a/MonoGame.Framework/Audio/Microphone.cs
+++ b/MonoGame.Framework/Audio/Microphone.cs
@@ -13,7 +13,13 @@ namespace Microsoft.Xna.Framework.Audio
     /// </summary>
     public enum MicrophoneState
     {
+        /// <summary>
+        /// The <see cref="Microphone"/> audio capture has started.
+        /// </summary>
         Started,
+        /// <summary>
+        /// The <see cref="Microphone"/> audio capture has stopped.
+        /// </summary>
         Stopped
     }
 

--- a/MonoGame.Framework/Audio/Xact/AudioEngine.cs
+++ b/MonoGame.Framework/Audio/Xact/AudioEngine.cs
@@ -381,6 +381,10 @@ namespace Microsoft.Xna.Framework.Audio
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Allows this object to attempt to free resources and perform other
+        /// cleanup operations before garbage collection reclaims the object.
+        /// </summary>
         ~AudioEngine()
         {
             Dispose(false);

--- a/MonoGame.Framework/Audio/Xact/Cue.cs
+++ b/MonoGame.Framework/Audio/Xact/Cue.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Xna.Framework.Audio
             }
         }
 
+        /// <summary>Returns whether the cue is stopping playback.</summary>
         public bool IsStopping
         {
             get
@@ -73,13 +74,16 @@ namespace Microsoft.Xna.Framework.Audio
             }
         }
 
+        /// <summary>Returns whether the cue is preparing to play.</summary>
         public bool IsPreparing 
         {
             get { return false; }
         }
 
+        /// <summary>Returns whether the cue is prepared to play.</summary>
         public bool IsPrepared { get; internal set; }
 
+        /// <summary>Returns whether the cue has been created.</summary>
         public bool IsCreated { get; internal set; }
 
         /// <summary>Gets the friendly name of the cue.</summary>

--- a/MonoGame.Framework/Audio/Xact/SoundBank.cs
+++ b/MonoGame.Framework/Audio/Xact/SoundBank.cs
@@ -332,6 +332,10 @@ namespace Microsoft.Xna.Framework.Audio
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Allows this object to attempt to free resources and perform other
+        /// cleanup operations before garbage collection reclaims the object.
+        /// </summary>
         ~SoundBank()
         {
             Dispose(false);

--- a/MonoGame.Framework/Audio/Xact/WaveBank.cs
+++ b/MonoGame.Framework/Audio/Xact/WaveBank.cs
@@ -393,6 +393,10 @@ namespace Microsoft.Xna.Framework.Audio
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Allows this object to attempt to free resources and perform other
+        /// cleanup operations before garbage collection reclaims the object.
+        /// </summary>
         ~WaveBank()
         {
             Dispose(false);


### PR DESCRIPTION
This PR adds the documentation for the following classes in `Microsoft.Xna.Framework.Audio` namespace:
- `AudioEngine`
- `Cue`
- `SoundBank`
- `WaveBank`
- `MicrophoneState` (enum, located in `Microphone.cs`)