### PR TITLE
Fix to avoid allocation/garbage when submitting OpenAL buffers.

### DIFF
--- a/MonoGame.Framework/Platform/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Platform/Audio/OALSoundBuffer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 		public OALSoundBuffer()
 		{
-            AL.GenBuffers(1, out openALDataBuffer);
+            AL.GenBuffer(out openALDataBuffer);
             ALHelper.CheckError("Failed to generate OpenAL data buffer.");
 		}
 

--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -303,11 +303,12 @@ namespace MonoGame.OpenAL
             }
         }
 
-        internal static void GenBuffers(int count, out int buffer)
+        internal unsafe static void GenBuffer(out int buffer)
         {
-            int[] ret;
-            GenBuffers(count, out ret);
-            buffer = ret[0];
+            fixed (int* ptr = &buffer)
+            {
+                alGenBuffers(1, ptr);
+            }
         }
 
         internal static int[] GenBuffers(int count)


### PR DESCRIPTION
This is a minor change to prevent a new int array from being allocated every time DynamicSoundEffectInstance.SubmitBuffer() is called.

I found this by running a performance profile on a project I'm working on that uses DynamicSoundEffectInstance for the audio. It was allocating over 2000 arrays in 15 seconds.

For reference the previous version was calling the below method and always passing in 1 as the count. So this is just doing the exact same thing without allocating a new array on the heap.

```
internal unsafe static void GenBuffers(int count, out int[] buffers)
{
    buffers = new int[count];
    fixed (int* ptr = &buffers[0])
    {
        alGenBuffers(count, ptr);
    }
}
```