### PR TITLE
[Documentation]: Adds missing XML Documentation for PackedVector Namespace Members

### DIFF
--- a/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
@@ -127,11 +127,29 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return _packedValue.GetHashCode();
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Bgr565"/> values are equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Bgr565"/> on the left of the equality operator.</param>
+        /// <param name="rhs">The <see cref="Bgr565"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/> are equal; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(Bgr565 lhs, Bgr565 rhs)
         {
             return lhs._packedValue == rhs._packedValue;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Bgr565"/> values are not equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Bgr565"/> on the left of the inequality operator.</param>
+        /// <param name="rhs">The <see cref="Bgr565"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/> are different; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(Bgr565 lhs, Bgr565 rhs)
         {
             return lhs._packedValue != rhs._packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
@@ -120,11 +120,29 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return _packedValue.GetHashCode();
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Bgra4444"/> values are equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Bgra4444"/> on the left of the equality operator.</param>
+        /// <param name="rhs">The <see cref="Bgra4444"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/> are equal; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(Bgra4444 lhs, Bgra4444 rhs)
         {
             return lhs._packedValue == rhs._packedValue;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Bgra4444"/> values are not equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Bgra4444"/> on the left of the inequality operator.</param>
+        /// <param name="rhs">The <see cref="Bgra4444"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/> are different; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(Bgra4444 lhs, Bgra4444 rhs)
         {
             return lhs._packedValue != rhs._packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
@@ -113,11 +113,29 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return packedValue.GetHashCode();
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Bgra5551"/> values are equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Bgra5551"/> on the left of the equality operator.</param>
+        /// <param name="rhs">The <see cref="Bgra5551"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/> are equal; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(Bgra5551 lhs, Bgra5551 rhs)
         {
             return lhs.packedValue == rhs.packedValue;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Bgra5551"/> values are not equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Bgra5551"/> on the left of the inequality operator.</param>
+        /// <param name="rhs">The <see cref="Bgra5551"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/> are different; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(Bgra5551 lhs, Bgra5551 rhs)
         {
             return lhs.packedValue != rhs.packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
@@ -6,15 +6,28 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
+    /// <summary>
+    /// Packed vector type containing a single 16-bit floating point
+    /// </summary>
     public struct HalfSingle : IPackedVector<UInt16>, IEquatable<HalfSingle>, IPackedVector
     {
         UInt16 packedValue;
 
+        /// <summary>
+        /// Creates a new <see cref="HalfSingle"/> initialized with the specified value.
+        /// </summary>
+        /// <param name="single">The initial value of the <see cref="HalfSingle"/></param>
         public HalfSingle(float single)
         {
             packedValue = HalfTypeHelper.Convert(single);
         }
 
+        /// <summary>
+        /// Gets or Sets the packed representation of this <see cref="HalfSingle"/>.
+        /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="HalfSingle"/>
+        /// </value>
         public ushort PackedValue
         {
             get
@@ -27,6 +40,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             }
         }
 
+        /// <summary>
+        /// Expands this <see cref="HalfSingle"/> to a <see cref="Single"/>
+        /// </summary>
+        /// <returns>
+        /// The expanded <see cref="HalfSingle"/> as a <see cref="Single"/>.
+        /// </returns>
         public float ToSingle()
         {
             return HalfTypeHelper.Convert(this.packedValue);
@@ -46,6 +65,15 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return new Vector4(this.ToSingle(), 0f, 0f, 1f);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether this <see cref="HalfSingle"/>
+        /// and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with this <see cref="HalfSingle"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="HalfSingle"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             if (obj != null && obj.GetType() == this.GetType())
@@ -56,26 +84,67 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return false;
         }
 
+        /// <summary>
+        /// Returns a value tha indicates whether this <see cref="HalfSingle"/>
+        /// and a specified <see cref="HalfSingle"/> are equal.
+        /// </summary>
+        /// <param name="other">The other <see cref="HalfSingle"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="HalfSingle"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(HalfSingle other)
         {
             return this.packedValue == other.packedValue;
         }
 
+        /// <summary>
+        /// Returns the string representation of this <see cref="HalfSingle"/> value.
+        /// </summary>
+        /// <returns>
+        /// The string representation of this <see cref="HalfSingle"/> value.
+        /// </returns>
         public override string ToString()
         {
             return this.ToSingle().ToString();
         }
 
+        /// <summary>
+        /// Returns the hash code for this <see cref="HalfSingle"/> value.
+        /// </summary>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="HalfSingle"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return this.packedValue.GetHashCode();
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="HalfSingle"/>
+        /// values are equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="HalfSingle"/> on the left of the equality operator.</param>
+        /// <param name="rhs">The <see cref="HalfSingle"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(HalfSingle lhs, HalfSingle rhs)
         {
             return lhs.packedValue == rhs.packedValue;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="HalfSingle"/>
+        /// values are not equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="HalfSingle"/> on the left of the inequality operator.</param>
+        /// <param name="rhs">The <see cref="HalfSingle"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(HalfSingle lhs, HalfSingle rhs)
         {
             return lhs.packedValue != rhs.packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
@@ -6,14 +6,30 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
+    /// <summary>
+    /// Packed vector type containing two 16-bit floating-point values.
+    /// </summary>
     public struct HalfVector2 : IPackedVector<uint>, IPackedVector, IEquatable<HalfVector2>
     {
         private uint packedValue;
+
+        /// <summary>
+        /// Creates a new <see cref="HalfVector2"/> from the specified component values.
+        /// </summary>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
         public HalfVector2(float x, float y)
         {
             this.packedValue = PackHelper(x, y);
         }
 
+        /// <summary>
+        /// Creates a new <see cref="HalfVector2"/> from the specified <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="vector">
+        /// The <see cref="Vector2"/> whos components contain the initial values
+        /// for this <see cref="HalfVector2"/>.
+        /// </param>
         public HalfVector2(Vector2 vector)
         {
             this.packedValue = PackHelper(vector.X, vector.Y);
@@ -31,6 +47,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return (num2 | num);
         }
 
+        /// <summary>
+        /// Expands this <see cref="HalfVector2"/> to a <see cref="Vector2"/>
+        /// </summary>
+        /// <returns>
+        /// The expanded <see cref="HalfVector2"/> as a <see cref="Vector2"/>.
+        /// </returns>
         public Vector2 ToVector2()
         {
             Vector2 vector;
@@ -49,6 +71,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return new Vector4(vector.X, vector.Y, 0f, 1f);
         }
 
+        /// <summary>
+        /// Gets or Sets the packed representation of this <see cref="HalfVector2"/>.
+        /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="HalfVector2"/>
+        /// </value>
         public uint PackedValue
         {
             get
@@ -60,31 +88,82 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
                 this.packedValue = value;
             }
         }
+
+        /// <summary>
+        /// Returns the string representation of this <see cref="HalfVector2"/> value.
+        /// </summary>
+        /// <returns>
+        /// The string representation of this <see cref="HalfVector2"/> value.
+        /// </returns>
         public override string ToString()
         {
             return this.ToVector2().ToString();
         }
 
+        /// <summary>
+        /// Returns the hash code for this <see cref="HalfVector2"/> value.
+        /// </summary>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="HalfVector2"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return this.packedValue.GetHashCode();
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether this <see cref="HalfVector2"/>
+        /// and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with this <see cref="HalfVector2"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="HalfVector2"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             return ((obj is HalfVector2) && this.Equals((HalfVector2)obj));
         }
 
+        /// <summary>
+        /// Returns a value tha indicates whether this <see cref="HalfVector2"/>
+        /// and a specified <see cref="HalfVector2"/> are equal.
+        /// </summary>
+        /// <param name="other">The other <see cref="HalfVector2"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="HalfVector2"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(HalfVector2 other)
         {
             return this.packedValue.Equals(other.packedValue);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="HalfVector2"/>
+        /// values are equal.
+        /// </summary>
+        /// <param name="a">The <see cref="HalfVector2"/> on the left of the equality operator.</param>
+        /// <param name="b">The <see cref="HalfVector2"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(HalfVector2 a, HalfVector2 b)
         {
             return a.Equals(b);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="HalfVector2"/>
+        /// values are not equal.
+        /// </summary>
+        /// <param name="a">The <see cref="HalfVector2"/> on the left of the inequality operator.</param>
+        /// <param name="b">The <see cref="HalfVector2"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(HalfVector2 a, HalfVector2 b)
         {
             return !a.Equals(b);

--- a/MonoGame.Framework/Graphics/PackedVector/IPackedVector.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/IPackedVector.cs
@@ -7,18 +7,38 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
-	// http://msdn.microsoft.com/en-us/library/microsoft.xna.framework.graphics.packedvector.ipackedvector.aspx
+    /// <summary>
+    /// Interface that converts packed vector types to and from <see cref="Vector4"/>
+    /// values, allowing multiple encodings to be manipulated in a generic way.
+    /// </summary>
 	public interface IPackedVector
 	{
+        /// <summary>
+        /// Sets the packed representation from a <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="vector">
+        /// The <see cref="Vector4"/> to create the packed representation from.
+        /// </param>
 		void PackFromVector4 (Vector4 vector);
 
+        /// <summary>
+        /// Expands the packed representation into a <see cref="Vector4"/>.
+        /// </summary>
+        /// <returns>The expanded <see cref="Vector4"/>.</returns>
 		Vector4 ToVector4 ();
 	}
-	
-	// PackedVector Generic interface
-	// http://msdn.microsoft.com/en-us/library/bb197661.aspx
+
+    /// <summary>
+    /// Converts packed vector types to and from <see cref="Vector4"/> values.
+    /// </summary>
 	public interface IPackedVector<TPacked> : IPackedVector
 	{
+        /// <summary>
+        /// Directly gets or sets the packed representation of the value.
+        /// </summary>
+        /// <value>
+        /// The packed representation of the value.
+        /// </value>
 		TPacked PackedValue { get; set; }
 	}
 

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
@@ -7,30 +7,71 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
+    /// <summary>
+    /// Packed vector type containing two 8-bit signed normalized values, ranging from −1 to 1.
+    /// </summary>
     public struct NormalizedByte2 : IPackedVector<ushort>, IEquatable<NormalizedByte2>
     {
         private ushort _packed;
 
+        /// <summary>
+        /// Creates a new <see cref="NormalizedByte2"/> from the specified <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="vector">
+        /// The <see cref="Vector2"/> whos components contain the initial values
+        /// for this <see cref="NormalizedByte2"/>.
+        /// </param>
         public NormalizedByte2(Vector2 vector)
         {
             _packed = Pack(vector.X, vector.Y);
         }
 
+        /// <summary>
+        /// Creates a new <see cref="NormalizedByte2"/> from the specified component values.
+        /// </summary>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
         public NormalizedByte2(float x, float y)
         {
             _packed = Pack(x, y);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="NormalizedByte2"/>
+        /// values are not equal.
+        /// </summary>
+        /// <param name="a">The <see cref="NormalizedByte2"/> on the left of the inequality operator.</param>
+        /// <param name="b">The <see cref="NormalizedByte2"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(NormalizedByte2 a, NormalizedByte2 b)
         {
             return a._packed != b._packed;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="NormalizedByte2"/>
+        /// values are equal.
+        /// </summary>
+        /// <param name="a">The <see cref="NormalizedByte2"/> on the left of the equality operator.</param>
+        /// <param name="b">The <see cref="NormalizedByte2"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(NormalizedByte2 a, NormalizedByte2 b)
         {
             return a._packed == b._packed;
         }
 
+        /// <summary>
+        /// Gets or Sets the packed representation of this <see cref="NormalizedByte2"/>.
+        /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="NormalizedByte2"/>
+        /// </value>
         public ushort PackedValue
         {
             get
@@ -43,22 +84,52 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             }
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether this <see cref="NormalizedByte2"/>
+        /// and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with this <see cref="NormalizedByte2"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="NormalizedByte2"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             return (obj is NormalizedByte2) &&
                     ((NormalizedByte2)obj)._packed == _packed;
         }
 
+        /// <summary>
+        /// Returns a value tha indicates whether this <see cref="NormalizedByte2"/>
+        /// and a specified <see cref="NormalizedByte2"/> are equal.
+        /// </summary>
+        /// <param name="other">The other <see cref="NormalizedByte2"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="NormalizedByte2"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(NormalizedByte2 other)
         {
             return _packed == other._packed;
         }
 
+        /// <summary>
+        /// Returns the hash code for this <see cref="NormalizedByte2"/> value.
+        /// </summary>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="NormalizedByte2"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return _packed.GetHashCode();
         }
 
+        /// <summary>
+        /// Returns the string representation of this <see cref="NormalizedByte2"/> value.
+        /// </summary>
+        /// <returns>
+        /// The string representation of this <see cref="NormalizedByte2"/> value.
+        /// </returns>
         public override string ToString()
         {
             return _packed.ToString("X");
@@ -86,6 +157,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return new Vector4(ToVector2(), 0.0f, 1.0f);
         }
 
+        /// <summary>
+        /// Expands this <see cref="NormalizedByte2"/> to a <see cref="Vector2"/>
+        /// </summary>
+        /// <returns>
+        /// The expanded <see cref="NormalizedByte2"/> as a <see cref="Vector2"/>.
+        /// </returns>
         public Vector2 ToVector2()
         {
             return new Vector2(

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
@@ -7,30 +7,73 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
+    /// <summary>
+    /// Packed vector type containing four 8-bit signed normalized values, ranging from −1 to 1.
+    /// </summary>
     public struct NormalizedByte4 : IPackedVector<uint>, IEquatable<NormalizedByte4>
     {
         private uint _packed;
 
+        /// <summary>
+        /// Creates a new <see cref="NormalizedByte4"/> from the specified <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="vector">
+        /// The <see cref="Vector4"/> whos components contain the initial values
+        /// for this <see cref="NormalizedByte4"/>.
+        /// </param>
         public NormalizedByte4(Vector4 vector)
         {
             _packed = Pack(vector.X, vector.Y, vector.Z, vector.W);
         }
 
+        /// <summary>
+        /// Creates a new <see cref="NormalizedByte4"/> from the specified component values.
+        /// </summary>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
+        /// <param name="z">The initial z-component value.</param>
+        /// <param name="w">The initial w-component value.</param>
         public NormalizedByte4(float x, float y, float z, float w)
         {
             _packed = Pack(x, y, z, w);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="NormalizedByte4"/>
+        /// values are not equal.
+        /// </summary>
+        /// <param name="a">The <see cref="NormalizedByte4"/> on the left of the inequality operator.</param>
+        /// <param name="b">The <see cref="NormalizedByte4"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(NormalizedByte4 a, NormalizedByte4 b)
         {
             return a._packed != b._packed;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="NormalizedByte4"/>
+        /// values are equal.
+        /// </summary>
+        /// <param name="a">The <see cref="NormalizedByte4"/> on the left of the equality operator.</param>
+        /// <param name="b">The <see cref="NormalizedByte4"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(NormalizedByte4 a, NormalizedByte4 b)
         {
             return a._packed == b._packed;
         }
 
+        /// <summary>
+        /// Gets or Sets the packed representation of this <see cref="NormalizedByte4"/>.
+        /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="NormalizedByte4"/>
+        /// </value>
         public uint PackedValue
         {
             get
@@ -43,22 +86,52 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             }
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether this <see cref="NormalizedByte4"/>
+        /// and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with this <see cref="NormalizedByte4"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="NormalizedByte4"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             return  (obj is NormalizedByte4) &&
                     ((NormalizedByte4)obj)._packed == _packed;
         }
 
+        /// <summary>
+        /// Returns a value tha indicates whether this <see cref="NormalizedByte4"/>
+        /// and a specified <see cref="NormalizedByte4"/> are equal.
+        /// </summary>
+        /// <param name="other">The other <see cref="NormalizedByte4"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="NormalizedByte4"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(NormalizedByte4 other)
         {
             return _packed == other._packed;
         }
 
+        /// <summary>
+        /// Returns the hash code for this <see cref="NormalizedByte4"/> value.
+        /// </summary>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="NormalizedByte4"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return _packed.GetHashCode();
         }
 
+        /// <summary>
+        /// Returns the string representation of this <see cref="NormalizedByte4"/> value.
+        /// </summary>
+        /// <returns>
+        /// The string representation of this <see cref="NormalizedByte4"/> value.
+        /// </returns>
         public override string ToString()
         {
             return _packed.ToString("X");
@@ -79,6 +152,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             _packed = Pack(vector.X, vector.Y, vector.Z, vector.W);
         }
 
+        /// <summary>
+        /// Expands this <see cref="NormalizedByte4"/> to a <see cref="Vector4"/>
+        /// </summary>
+        /// <returns>
+        /// The expanded <see cref="NormalizedByte4"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             return new Vector4(

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
@@ -7,30 +7,71 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
+    /// <summary>
+    /// Packed vector type containing two 16-bit signed normalized values, ranging from −1 to 1.
+    /// </summary>
 	public struct NormalizedShort2 : IPackedVector<uint>, IEquatable<NormalizedShort2>
 	{
 		private uint short2Packed;
 
+        /// <summary>
+        /// Creates a new <see cref="NormalizedShort2"/> from the specified <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="vector">
+        /// The <see cref="Vector2"/> whos components contain the initial values
+        /// for this <see cref="NormalizedShort2"/>.
+        /// </param>
         public NormalizedShort2(Vector2 vector)
 		{
             short2Packed = PackInTwo(vector.X, vector.Y);
 		}
 
+        /// <summary>
+        /// Creates a new <see cref="NormalizedShort2"/> from the specified component values.
+        /// </summary>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
         public NormalizedShort2(float x, float y)
 		{
             short2Packed = PackInTwo(x, y);
 		}
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="NormalizedShort2"/>
+        /// values are not equal.
+        /// </summary>
+        /// <param name="a">The <see cref="NormalizedShort2"/> on the left of the inequality operator.</param>
+        /// <param name="b">The <see cref="NormalizedShort2"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(NormalizedShort2 a, NormalizedShort2 b)
 		{
 			return !a.Equals (b);
 		}
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="NormalizedShort2"/>
+        /// values are equal.
+        /// </summary>
+        /// <param name="a">The <see cref="NormalizedShort2"/> on the left of the equality operator.</param>
+        /// <param name="b">The <see cref="NormalizedShort2"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(NormalizedShort2 a, NormalizedShort2 b)
 		{
 			return a.Equals (b);
 		}
 
+        /// <summary>
+        /// Gets or Sets the packed representation of this <see cref="NormalizedShort2"/>.
+        /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="NormalizedShort2"/>
+        /// </value>
         public uint PackedValue
         {
             get
@@ -43,26 +84,62 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             }
 		}
 
+        /// <summary>
+        /// Returns a value that indicates whether this <see cref="NormalizedShort2"/>
+        /// and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with this <see cref="NormalizedShort2"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="NormalizedShort2"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
 		public override bool Equals (object obj)
 		{
             return (obj is NormalizedShort2) && Equals((NormalizedShort2)obj);
 		}
 
+        /// <summary>
+        /// Returns a value tha indicates whether this <see cref="NormalizedShort2"/>
+        /// and a specified <see cref="NormalizedShort2"/> are equal.
+        /// </summary>
+        /// <param name="other">The other <see cref="NormalizedShort2"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="NormalizedShort2"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(NormalizedShort2 other)
 		{
             return short2Packed.Equals(other.short2Packed);
 		}
 
+        /// <summary>
+        /// Returns the hash code for this <see cref="NormalizedShort2"/> value.
+        /// </summary>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="NormalizedShort2"/> value.
+        /// </returns>
 		public override int GetHashCode ()
 		{
 			return short2Packed.GetHashCode();
 		}
 
+        /// <summary>
+        /// Returns the string representation of this <see cref="NormalizedShort2"/> value.
+        /// </summary>
+        /// <returns>
+        /// The string representation of this <see cref="NormalizedShort2"/> value.
+        /// </returns>
 		public override string ToString ()
 		{
             return short2Packed.ToString("X");
 		}
 
+        /// <summary>
+        /// Expands this <see cref="NormalizedShort2"/> to a <see cref="Vector2"/>
+        /// </summary>
+        /// <returns>
+        /// The expanded <see cref="NormalizedShort2"/> as a <see cref="Vector2"/>.
+        /// </returns>
 		public Vector2 ToVector2 ()
 		{
             const float maxVal = 0x7FFF;
@@ -92,9 +169,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		}
 
         /// <summary>
-        /// Gets the packed vector in Vector4 format.
+        /// Expands this <see cref="NormalizedShort2"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The packed vector in Vector4 format</returns>
+        /// <returns>
+        /// The expanded <see cref="NormalizedShort2"/> as a <see cref="Vector4"/>.
+        /// </returns>
 		public Vector4 ToVector4 ()
 		{
             const float maxVal = 0x7FFF;

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
@@ -7,30 +7,73 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
+    /// <summary>
+    /// Packed vector type containing four 16-bit signed normalized values, ranging from −1 to 1.
+    /// </summary>
     public struct NormalizedShort4 : IPackedVector<ulong>, IEquatable<NormalizedShort4>
 	{
 		private ulong short4Packed;
 
+        /// <summary>
+        /// Creates a new <see cref="NormalizedShort4"/> from the specified <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="vector">
+        /// The <see cref="Vector4"/> whos components contain the initial values
+        /// for this <see cref="NormalizedShort4"/>.
+        /// </param>
         public NormalizedShort4(Vector4 vector)
 		{
             short4Packed = PackInFour(vector.X, vector.Y, vector.Z, vector.W);
 		}
 
+        /// <summary>
+        /// Creates a new <see cref="NormalizedShort4"/> from the specified component values.
+        /// </summary>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
+        /// <param name="z">The initial z-component value.</param>
+        /// <param name="w">The initial w-component value.</param>
         public NormalizedShort4(float x, float y, float z, float w)
 		{
             short4Packed = PackInFour(x, y, z, w);
 		}
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="NormalizedShort4"/>
+        /// values are not equal.
+        /// </summary>
+        /// <param name="a">The <see cref="NormalizedShort4"/> on the left of the inequality operator.</param>
+        /// <param name="b">The <see cref="NormalizedShort4"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(NormalizedShort4 a, NormalizedShort4 b)
 		{
 			return !a.Equals (b);
 		}
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="NormalizedShort4"/>
+        /// values are equal.
+        /// </summary>
+        /// <param name="a">The <see cref="NormalizedShort4"/> on the left of the equality operator.</param>
+        /// <param name="b">The <see cref="NormalizedShort4"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(NormalizedShort4 a, NormalizedShort4 b)
 		{
 			return a.Equals (b);
 		}
 
+        /// <summary>
+        /// Gets or Sets the packed representation of this <see cref="NormalizedShort4"/>.
+        /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="NormalizedShort4"/>
+        /// </value>
         public ulong PackedValue
         {
             get
@@ -43,21 +86,51 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             }
 		}
 
+        /// <summary>
+        /// Returns a value that indicates whether this <see cref="NormalizedShort4"/>
+        /// and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with this <see cref="NormalizedShort4"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="NormalizedShort4"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             return (obj is NormalizedShort4) && Equals((NormalizedShort4)obj);
         }
 
+        /// <summary>
+        /// Returns a value tha indicates whether this <see cref="NormalizedShort4"/>
+        /// and a specified <see cref="NormalizedShort4"/> are equal.
+        /// </summary>
+        /// <param name="other">The other <see cref="NormalizedShort4"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="NormalizedShort4"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(NormalizedShort4 other)
         {
             return short4Packed.Equals(other.short4Packed);
         }
 
+        /// <summary>
+        /// Returns the hash code for this <see cref="NormalizedShort4"/> value.
+        /// </summary>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="NormalizedShort4"/> value.
+        /// </returns>
 		public override int GetHashCode ()
 		{
 			return short4Packed.GetHashCode();
 		}
 
+        /// <summary>
+        /// Returns the string representation of this <see cref="NormalizedShort4"/> value.
+        /// </summary>
+        /// <returns>
+        /// The string representation of this <see cref="NormalizedShort4"/> value.
+        /// </returns>
 		public override string ToString ()
 		{
             return short4Packed.ToString("X");
@@ -83,6 +156,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             short4Packed = PackInFour(vector.X, vector.Y, vector.Z, vector.W);
 		}
 
+        /// <summary>
+        /// Expands this <see cref="NormalizedShort4"/> to a <see cref="Vector4"/>
+        /// </summary>
+        /// <returns>
+        /// The expanded <see cref="NormalizedShort4"/> as a <see cref="Vector4"/>.
+        /// </returns>
 		public Vector4 ToVector4 ()
 		{
             const float maxVal = 0x7FFF;

--- a/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
@@ -117,11 +117,31 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return packedValue.GetHashCode();
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Rg32"/> values
+        /// are equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Rg32"/> on the left of the equality operator.</param>
+        /// <param name="rhs">The <see cref="Rg32"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(Rg32 lhs, Rg32 rhs)
         {
             return lhs.packedValue == rhs.packedValue;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Rg32"/> values
+        /// are not equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Rg32"/> on the left of the inequality operator.</param>
+        /// <param name="rhs">The <see cref="Rg32"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(Rg32 lhs, Rg32 rhs)
         {
             return lhs.packedValue != rhs.packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
@@ -113,11 +113,31 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return packedValue.GetHashCode();
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Rgba1010102"/>
+        /// values are equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Rgba1010102"/> on the left of the equality operator.</param>
+        /// <param name="rhs">The <see cref="Rgba1010102"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(Rgba1010102 lhs, Rgba1010102 rhs)
         {
             return lhs.packedValue == rhs.packedValue;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Rgba1010102"/>
+        /// values are not equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Rgba1010102"/> on the left of the inequality operator.</param>
+        /// <param name="rhs">The <see cref="Rgba1010102"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(Rgba1010102 lhs, Rgba1010102 rhs)
         {
             return lhs.packedValue != rhs.packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
@@ -112,11 +112,31 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			return packedValue.GetHashCode();
 		}
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Rgba64"/>
+        /// values are equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Rgba64"/> on the left of the equality operator.</param>
+        /// <param name="rhs">The <see cref="Rgba64"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
 		public static bool operator ==(Rgba64 lhs, Rgba64 rhs)
 		{
 			return lhs.packedValue == rhs.packedValue;
 		}
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Rgba64"/>
+        /// values are not equal.
+        /// </summary>
+        /// <param name="lhs">The <see cref="Rgba64"/> on the left of the inequality operator.</param>
+        /// <param name="rhs">The <see cref="Rgba64"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
 		public static bool operator !=(Rgba64 lhs, Rgba64 rhs)
 		{
 			return lhs.packedValue != rhs.packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Short2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short2.cs
@@ -7,30 +7,71 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
+    /// <summary>
+    /// Packed vector type containing two 16-bit signed integer values.
+    /// </summary>
 	public struct Short2 : IPackedVector<uint>, IEquatable<Short2>
 	{
 		private uint _short2Packed;
 
+        /// <summary>
+        /// Creates a new <see cref="Short2"/> from the specified <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="vector">
+        /// The <see cref="Vector2"/> whos components contain the initial values
+        /// for this <see cref="Short2"/>.
+        /// </param>
 		public Short2 (Vector2 vector)
 		{
 			_short2Packed = PackInTwo (vector.X, vector.Y);
 		}
 
+        /// <summary>
+        /// Creates a new <see cref="Short2"/> from the specified component values.
+        /// </summary>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
 		public Short2 (Single x,Single y)
 		{
 			_short2Packed = PackInTwo (x, y);
 		}
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Short2"/>
+        /// values are not equal.
+        /// </summary>
+        /// <param name="a">The <see cref="Short2"/> on the left of the inequality operator.</param>
+        /// <param name="b">The <see cref="Short2"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
 		public static bool operator !=(Short2 a, Short2 b)
 		{
 			return a.PackedValue != b.PackedValue;
 		}
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="Short2"/>
+        /// values are equal.
+        /// </summary>
+        /// <param name="a">The <see cref="Short2"/> on the left of the equality operator.</param>
+        /// <param name="b">The <see cref="Short2"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
 		public static bool operator ==(Short2 a, Short2 b)
 		{
 			return a.PackedValue == b.PackedValue;
 		}
 
+        /// <summary>
+        /// Gets or Sets the packed representation of this <see cref="Short2"/>.
+        /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="Short2"/>
+        /// </value>
 		public uint PackedValue
         {
 			get
@@ -43,6 +84,15 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			}
 		}
 
+        /// <summary>
+        /// Returns a value that indicates whether this <see cref="Short2"/>
+        /// and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with this <see cref="Short2"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="Short2"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
 		public override bool Equals (object obj)
 		{
             if (obj is Short2)
@@ -50,21 +100,48 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return false;
 		}
 
+        /// <summary>
+        /// Returns a value tha indicates whether this <see cref="Short2"/>
+        /// and a specified <see cref="Short2"/> are equal.
+        /// </summary>
+        /// <param name="other">The other <see cref="Short2"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="Short2"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
 		public bool Equals (Short2 other)
 		{
             return this == other;
 		}
 
+        /// <summary>
+        /// Returns the hash code for this <see cref="Short2"/> value.
+        /// </summary>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="Short2"/> value.
+        /// </returns>
 		public override int GetHashCode ()
 		{
 			return _short2Packed.GetHashCode();
 		}
 
+        /// <summary>
+        /// Returns the string representation of this <see cref="Short2"/> value.
+        /// </summary>
+        /// <returns>
+        /// The string representation of this <see cref="Short2"/> value.
+        /// </returns>
 		public override string ToString ()
 		{
             return _short2Packed.ToString("x8");
 		}
 
+        /// <summary>
+        /// Expands this <see cref="Short2"/> to a <see cref="Vector2"/>
+        /// </summary>
+        /// <returns>
+        /// The expanded <see cref="Short2"/> as a <see cref="Vector2"/>.
+        /// </returns>
 		public Vector2 ToVector2 ()
 		{
 			var v2 = new Vector2 ();


### PR DESCRIPTION
## Description
This PR adds the missing XML documentation for the following members of the `Microsoft.Xna.Framework.Graphics.PackedVector` namespace
- `Bgr565`
- `Bgra4444`
- `Bgra5551`
- `HalfSingle`
- `HalfVector2`
- `IPackedVector`
- `Short2`
- `Rgba64`
- `Rgba1010102`
- `Rg32`
- `NormalizedShort4`
- `NormalizedShort2`
- `NormalizedByte4`
- `NormalizedByte2`

## Reference:
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)