### PR TITLE
[Documentation]: Add XML documentation to Media namespace

### DIFF
--- a/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
@@ -107,11 +107,29 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             return packedValue.GetHashCode();
         }
 
+        /// <summary>
+        /// Compares the current instance of a class to another instance to determine
+        /// whether they are the same.
+        /// </summary>
+        /// <param name="lhs">The object on the left of the equality operator.</param>
+        /// <param name="rhs">The object on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator ==(Alpha8 lhs, Alpha8 rhs)
         {
             return lhs.packedValue == rhs.packedValue;
         }
 
+        /// <summary>
+        /// Compares teh current instance of a class to another instance to determine
+        /// whether they are different.
+        /// </summary>
+        /// <param name="lhs">The object to the left of the inequality operator.</param>
+        /// <param name="rhs">The object to the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator !=(Alpha8 lhs, Alpha8 rhs)
         {
             return lhs.packedValue != rhs.packedValue;

--- a/MonoGame.Framework/Media/Album.cs
+++ b/MonoGame.Framework/Media/Album.cs
@@ -23,12 +23,13 @@ namespace Microsoft.Xna.Framework.Media
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The <see cref="Album"/> class provides information about an album, 
+    /// The <b>Album</b> class provides information about an album, 
     /// including the album's <see cref="Name"/>, <see cref="Artist"/>, and <see cref="Songs"/>.
     /// </para>
     /// <para>
-    /// You can obtain an <b>Album</b> object through the <see cref="P:Microsoft.Xna.Framework.Media.AlbumCollection.Item(System.Int32)"/>
-    /// indexer and the <see cref="Song.Album"/> property.
+    /// You can obtain an <b>Album</b> object through the
+    /// <see cref="P:Microsoft.Xna.Framework.Media.AlbumCollection.Item(System.Int32)"/>
+    /// indexer and the <see cref="Song.Album">Song.Album</see> property.
     /// </para>
     /// </remarks>
     public sealed class Album : IDisposable
@@ -46,10 +47,10 @@ namespace Microsoft.Xna.Framework.Media
 #endif
 
         /// <summary>
-        /// Gets the <see cref="Microsoft.Xna.Framework.Media.Artist"/> of the <see cref="Album"/>.
+        /// Gets the <see cref="Media.Artist"/> of the Album.
         /// </summary>
         /// <value>
-        /// <see cref="Microsoft.Xna.Framework.Media.Artist"/> of this <b>Album</b>.
+        /// <see cref="Media.Artist"/> of this Album.
         /// </value>
         public Artist Artist
         {
@@ -71,7 +72,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Gets the Genre of the Album.
+        /// Gets the <see cref="Media.Genre"/> of the Album.
         /// </summary>
         public Genre Genre
         {
@@ -124,7 +125,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Gets a SongCollection that contains the songs on the album.
+        /// Gets a <see cref="Media.SongCollection"/> that contains the songs on the Album.
         /// </summary>
         public SongCollection Songs
         {
@@ -161,9 +162,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 #endif
 
-        /// <summary>
-        /// Immediately releases the unmanaged resources used by this object.
-        /// </summary>
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
 #if WINDOWS_UAP

--- a/MonoGame.Framework/Media/AlbumCollection.cs
+++ b/MonoGame.Framework/Media/AlbumCollection.cs
@@ -26,6 +26,9 @@ namespace Microsoft.Xna.Framework.Media
     /// </remarks>
     public sealed class AlbumCollection : IDisposable
     {
+        /// <summary>
+        /// Returns a <see cref="AlbumCollection"/> with no contents.
+        /// </summary>
         public static readonly AlbumCollection Empty = new AlbumCollection(new List<Album>());
 
         private List<Album> albumCollection;

--- a/MonoGame.Framework/Media/AlbumCollection.cs
+++ b/MonoGame.Framework/Media/AlbumCollection.cs
@@ -9,25 +9,25 @@ using System.Collections.Generic;
 namespace Microsoft.Xna.Framework.Media
 {
     /// <summary>
-    /// A collection of albums in the media library
+    /// Represents a collection of albums in the device media library. 
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The <see cref="AlbumCollection"/> class provides access to albums in the 
+    /// The AlbumCollection class provides access to albums in the 
     /// device's media library
     /// </para>
     /// <para>
-    /// Use the <see cref="MediaLibrary.Albums"/> property to obtain a collection
-    /// of all albums in the media library, the <see cref="Artist.Albums"/> property
+    /// Use the <see cref="MediaLibrary.Albums">MediaLibrary.Albums</see> property to obtain a collection
+    /// of all albums in the media library, the <see cref="Artist.Albums">Artist.Albums</see> property
     /// to obtain a collection of albums associated with a particular artist, and
-    /// the <see cref="Genre.Albums"/> property to obtain a collection of albums
+    /// the <see cref="Genre.Albums">Genre.Albums</see> property to obtain a collection of albums
     /// associated with a particular genre.
     /// </para>
     /// </remarks>
     public sealed class AlbumCollection : IDisposable
     {
         /// <summary>
-        /// Returns a <see cref="AlbumCollection"/> with no contents.
+        /// Returns an AlbumCollection with no contents.
         /// </summary>
         public static readonly AlbumCollection Empty = new AlbumCollection(new List<Album>());
 
@@ -56,11 +56,11 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Initializes a new instance of the <b>AlbumCollection</b> class, using
+        /// Initializes a new instance of the AlbumCollection class, using
         /// a specified collection of <see cref="Album"/> instances.
         /// </summary>
         /// <param name="albums">
-        /// The <see cref="Album"/> collection to initialize this <b>AlbumCollection</b> with.
+        /// The <see cref="Album"/> collection to initialize this AlbumCollection with.
         /// </param>
         public AlbumCollection(List<Album> albums)
         {
@@ -68,13 +68,13 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Gets the <see cref="Album"/> at the specified index in the <see cref="AlbumCollection"/>.
+        /// Gets the <see cref="Album"/> at the specified index in the AlbumCollection.
         /// </summary>
         /// <value>
         /// A new <see cref="Album"/> representing the album at the specified index
-        /// in this <b>AlbumCollection</b>
+        /// in this AlbumCollection
         /// </value>
-        /// <param name="index">Index of the Album to get.</param>
+        /// <param name="index">Index of the <see cref="Album"/> to get.</param>
         public Album this[int index]
         {
             get
@@ -83,9 +83,7 @@ namespace Microsoft.Xna.Framework.Media
             }
         }
 
-        /// <summary>
-        /// Immediately releases the unmanaged resources used by this object.
-        /// </summary>
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
             foreach (var album in this.albumCollection)

--- a/MonoGame.Framework/Media/Artist.cs
+++ b/MonoGame.Framework/Media/Artist.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Xna.Framework.Media
     /// The <see cref="Artist"/> class provides information about an artist, including the artist's <see cref="Name"/>, <see cref="Albums"/>, and <see cref="Songs"/>
     /// </para>
     /// <para>
-    /// You can obtain an <b>Artist</b> through the <see cref="Album.Artist"/> and <see cref="Song.Artist"/> properties.
+    /// You can obtain an <b>Artist</b> through the <see cref="Album.Artist">Album.Artist</see>
+    /// and <see cref="Song.Artist">Song.Artist</see> properties.
     /// </para>
     /// </remarks>
     public sealed class Artist : IDisposable
@@ -22,7 +23,7 @@ namespace Microsoft.Xna.Framework.Media
         private string artist;
 
         /// <summary>
-        /// Gets the AlbumCollection for the Artist.
+        /// Gets the <see cref="AlbumCollection">AlbumCollection</see> for the Artist.
         /// </summary>
         public AlbumCollection Albums
         {
@@ -55,7 +56,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Gets the SongCollection for the Artist.
+        /// Gets the <see cref="SongCollection"/> for the Artist.
         /// </summary>
         public SongCollection Songs
         {
@@ -66,7 +67,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Creates a new instance of <see cref="Artist"/> class.
+        /// Creates a new instance of Artist class.
         /// </summary>
         /// <param name="artist">Name of the artist.</param>
         public Artist(string artist)
@@ -74,9 +75,7 @@ namespace Microsoft.Xna.Framework.Media
             this.artist = artist;
         }
 
-        /// <summary>
-        /// Immediately releases the unmanaged resources used by this object.
-        /// </summary>
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
         }

--- a/MonoGame.Framework/Media/Genre.cs
+++ b/MonoGame.Framework/Media/Genre.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Xna.Framework.Media
     /// and the <see cref="Albums"/> and <see cref="Songs"/> in that genre that are on the device.
     /// </para>
     /// <para>
-    /// You can obtain a <b>Genre</b> object through the <see cref="Album.Genre"/> and <see cref="Song.Genre"/> properties.
+    /// You can obtain a <see cref="Genre"/> object through the
+    /// <see cref="Album.Genre"/> and <see cref="Song.Genre"/> properties.
     /// </para>
     /// </remarks>
     public sealed class Genre : IDisposable
@@ -23,7 +24,7 @@ namespace Microsoft.Xna.Framework.Media
         private string genre;
 
         /// <summary>
-        /// Gets the AlbumCollection for the Genre.
+        /// Gets the <see cref="AlbumCollection"/> for the Genre.
         /// </summary>
         public AlbumCollection Albums
         {
@@ -56,7 +57,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Gets the SongCollection for the Genre.
+        /// Gets the <see cref="SongCollection"/> for the Genre.
         /// </summary>
         public SongCollection Songs
         {
@@ -83,7 +84,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Returns a String representation of the Genre.
+        /// Returns a String representation of the <see cref="Genre"/>.
         /// </summary>
         public override string ToString()
         {

--- a/MonoGame.Framework/Media/Genre.cs
+++ b/MonoGame.Framework/Media/Genre.cs
@@ -6,6 +6,18 @@ using System;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// Provides access to genre information in the media library.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="Genre"/> class provides information about a genre, including the genre's <see cref="Name"/>,
+    /// and the <see cref="Albums"/> and <see cref="Songs"/> in that genre that are on the device.
+    /// </para>
+    /// <para>
+    /// You can obtain a <b>Genre</b> object through the <see cref="Album.Genre"/> and <see cref="Song.Genre"/> properties.
+    /// </para>
+    /// </remarks>
     public sealed class Genre : IDisposable
     {
         private string genre;
@@ -54,6 +66,10 @@ namespace Microsoft.Xna.Framework.Media
             }
         }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="Genre"/> class.
+        /// </summary>
+        /// <param name="genre">Name of the genre.</param>
         public Genre(string genre)
         {
             this.genre = genre;

--- a/MonoGame.Framework/Media/Genre.cs
+++ b/MonoGame.Framework/Media/Genre.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Xna.Framework.Media
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The <see cref="Genre"/> class provides information about a genre, including the genre's <see cref="Name"/>,
+    /// The Genre class provides information about a genre, including the genre's <see cref="Name"/>,
     /// and the <see cref="Albums"/> and <see cref="Songs"/> in that genre that are on the device.
     /// </para>
     /// <para>
-    /// You can obtain a <see cref="Genre"/> object through the
-    /// <see cref="Album.Genre"/> and <see cref="Song.Genre"/> properties.
+    /// You can obtain a Genre object through the
+    /// <see cref="Album.Genre">Album.Genre</see> and <see cref="Song.Genre">Song.Genre</see> properties.
     /// </para>
     /// </remarks>
     public sealed class Genre : IDisposable
@@ -68,7 +68,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Creates a new instance of <see cref="Genre"/> class.
+        /// Creates a new instance of Genre class.
         /// </summary>
         /// <param name="genre">Name of the genre.</param>
         public Genre(string genre)
@@ -76,15 +76,13 @@ namespace Microsoft.Xna.Framework.Media
             this.genre = genre;
         }
 
-        /// <summary>
-        /// Immediately releases the unmanaged resources used by this object.
-        /// </summary>
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
         }
 
         /// <summary>
-        /// Returns a String representation of the <see cref="Genre"/>.
+        /// Returns a String representation of the Genre.
         /// </summary>
         public override string ToString()
         {

--- a/MonoGame.Framework/Media/MediaLibrary.cs
+++ b/MonoGame.Framework/Media/MediaLibrary.cs
@@ -6,6 +6,12 @@ using System;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// Provides access to songs, playlists, and pictures in the device's media library.
+    /// </summary>
+    /// <remarks>
+    /// 
+    /// </remarks>
 	public partial class MediaLibrary : IDisposable
 	{
         public AlbumCollection Albums { get { return PlatformGetAlbums();  } }

--- a/MonoGame.Framework/Media/MediaLibrary.cs
+++ b/MonoGame.Framework/Media/MediaLibrary.cs
@@ -10,18 +10,36 @@ namespace Microsoft.Xna.Framework.Media
     /// Provides access to songs, playlists, and pictures in the device's media library.
     /// </summary>
     /// <remarks>
-    /// 
+    /// <see cref="MediaLibrary"/> provides the following properties that return media collections:
+    /// <see cref="Albums"/>, <see cref="Songs"/>.
+    /// Each property returns a collection object that can be enumerated and indexed.
+    /// The collection object represents all media of that type in the device's media library.
     /// </remarks>
 	public partial class MediaLibrary : IDisposable
 	{
+        /// <summary>
+        /// Gets the <see cref="AlbumCollection"/> that contains all albums in the media library.
+        /// </summary>
         public AlbumCollection Albums { get { return PlatformGetAlbums();  } }
         //public ArtistCollection Artists { get; private set; }
         //public GenreCollection Genres { get; private set; }
+        /// <summary>
+        /// Gets a value indicating whether the object is disposed.
+        /// </summary>
         public bool IsDisposed { get; private set; }
+        /// <summary>
+        /// Gets the <see cref="MediaSource"/> with which this media library was constructed.
+        /// </summary>
         public MediaSource MediaSource { get { return null; } }
-		//public PlaylistCollection Playlists { get; private set; }
+        //public PlaylistCollection Playlists { get; private set; }
+        /// <summary>
+        /// Gets the <see cref="SongCollection"/> that contains all songs in the media library.
+        /// </summary>
         public SongCollection Songs { get { return PlatformGetSongs(); } }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="MediaLibrary"/>.
+        /// </summary>
 		public MediaLibrary()
 		{
 		}
@@ -34,12 +52,21 @@ namespace Microsoft.Xna.Framework.Media
 	    {
 	        PlatformLoad(progressCallback);
 	    }
-		
+
+        /// <summary>
+        /// Creates a new instance of <see cref="MediaLibrary"/> from a supplie <see cref="MediaSource"/>.
+        /// </summary>
+        /// <remarks>
+        /// Current implenetation will always throw <see cref="NotSupportedException"/>
+        /// </remarks>
 		public MediaLibrary(MediaSource mediaSource)
 		{
             throw new NotSupportedException("Initializing from MediaSource is not supported");
 		}
-		
+
+        /// <summary>
+        /// Immediately releases the unmanaged resources used by this object.
+        /// </summary>
 		public void Dispose()
 		{
 		    PlatformDispose();

--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Xna.Framework.Media
 {
     /// <summary>
     /// Provides methods and properties to play, pause, resume, and stop songs.
-    /// <see cref="MediaPlayer"/> also exposes shuffle, repeat, volume, play position, and visualization capabilities.
+    /// MediaPlayer also exposes shuffle, repeat, volume, play position, and visualization capabilities.
     /// </summary>
     public static partial class MediaPlayer
     {
@@ -274,7 +274,7 @@ namespace Microsoft.Xna.Framework.Media
 		}
 
         /// <summary>
-        /// Stops currently playing song, moves to the previous song in the queue of playing songs and plays it.
+        /// Stops currently playing song, moves to the next song in the queue of playing songs and plays it.
         /// </summary>
         /// <remarks>
         /// <para>

--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -122,8 +122,6 @@ namespace Microsoft.Xna.Framework.Media
         /// calls to <see cref="Play(Song)"/>, <see cref="Stop()"/>, <see cref="Pause()"/>,
         /// <see cref="Resume()"/>, <see cref="MoveNext()"/>, and <see cref="MovePrevious"/>
         /// might have no effect, depending on the platform.
-        /// If another application's background music is playing, your game will need to call
-        /// in order to pause the other application's background music in order to play the game's music.
         /// </remarks>
         public static bool GameHasControl
         {

--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Xna.Framework.Media
 		private static readonly MediaQueue _queue = new MediaQueue();
 
         /// <summary>
-        /// Raised when the active song changes due to active playback or due to explicit calls to the <see cref="MoveNext()"/> or <see cref="MovePrevious()"/> methods.
+        /// Raised when the active song changes due to active playback or due to explicit calls to the
+        /// <see cref="MoveNext()"/> or <see cref="MovePrevious()"/> methods.
         /// </summary>
 		public static event EventHandler<EventArgs> ActiveSongChanged;
         /// <summary>
@@ -56,7 +57,8 @@ namespace Microsoft.Xna.Framework.Media
         /// Gets or sets the repeat setting for the media player.
         /// </summary>
         /// <remarks>
-        /// When set to <see langword="true"/>, the playback queue will begin playing again after all songs in the queue have been played.
+        /// When set to <see langword="true"/>, the playback queue will begin
+        /// playing again after all songs in the queue have been played.
         /// </remarks>
         public static bool IsRepeating 
         {
@@ -68,7 +70,8 @@ namespace Microsoft.Xna.Framework.Media
         /// Gets or sets the shuffle setting for the media player.
         /// </summary>
         /// <remarks>
-        /// When set to <see langword="true"/>, songs in the playback queue are played in random order rather than from first to last.
+        /// When set to <see langword="true"/>, songs in the playback queue are
+        /// played in random order rather than from first to last.
         /// </remarks>
         public static bool IsShuffled
         {
@@ -115,10 +118,10 @@ namespace Microsoft.Xna.Framework.Media
         /// Determines whether the game has control of the background music.
         /// </summary>
         /// <remarks>
-        /// A gamer can play their own music as the background to your game by using the Xbox 360 dashboard.
-        /// If the game is currently playing custom background music (specified by the gamer using the Xbox 360 dashboard),
+        /// If a gamer is currently playing their own music as the background to your game,
         /// calls to <see cref="Play(Song)"/>, <see cref="Stop()"/>, <see cref="Pause()"/>,
-        /// <see cref="Resume()"/>, <see cref="MoveNext()"/>, and <see cref="MovePrevious"/> have no effect.
+        /// <see cref="Resume()"/>, <see cref="MoveNext()"/>, and <see cref="MovePrevious"/>
+        /// might have no effect, depending on the platform.
         /// If another application's background music is playing, your game will need to call
         /// in order to pause the other application's background music in order to play the game's music.
         /// </remarks>
@@ -139,7 +142,8 @@ namespace Microsoft.Xna.Framework.Media
         /// <remarks>
         /// <para>
         /// Volume adjustment is based on a decibel, not multiplicative, scale.
-        /// Setting <see cref="Volume"/> to 0.0 subtracts 96 dB from the volume. Setting <see cref="Volume"/> to 1.0 subtracts 0 dB from the volume.
+        /// Setting <see cref="Volume"/> to 0.0 subtracts 96 dB from the volume.
+        /// Setting <see cref="Volume"/> to 1.0 subtracts 0 dB from the volume.
         /// Values in between 0.0f and 1.0f subtract dB from the volume proportionally.
         /// </para>
         /// </remarks>

--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -6,6 +6,10 @@ using System;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// Provides methods and properties to play, pause, resume, and stop songs.
+    /// <see cref="MediaPlayer"/> also exposes shuffle, repeat, volume, play position, and visualization capabilities.
+    /// </summary>
     public static partial class MediaPlayer
     {
 		// Need to hold onto this to keep track of how many songs
@@ -18,7 +22,13 @@ namespace Microsoft.Xna.Framework.Media
         private static bool _isShuffled;
 		private static readonly MediaQueue _queue = new MediaQueue();
 
+        /// <summary>
+        /// Raised when the active song changes due to active playback or due to explicit calls to the <see cref="MoveNext()"/> or <see cref="MovePrevious()"/> methods.
+        /// </summary>
 		public static event EventHandler<EventArgs> ActiveSongChanged;
+        /// <summary>
+        /// Raised when the media player play state changes.
+        /// </summary>
         public static event EventHandler<EventArgs> MediaStateChanged;
 
         static MediaPlayer()
@@ -28,28 +38,55 @@ namespace Microsoft.Xna.Framework.Media
 
         #region Properties
 
+        /// <summary>
+        /// Gets the media playback queue, <see cref="MediaQueue"/>.
+        /// </summary>
         public static MediaQueue Queue { get { return _queue; } }
-		
+
+        /// <summary>
+        /// Gets or set the muted setting for the media player.
+        /// </summary>
 		public static bool IsMuted
         {
             get { return PlatformGetIsMuted(); }
             set { PlatformSetIsMuted(value); }
         }
 
+        /// <summary>
+        /// Gets or sets the repeat setting for the media player.
+        /// </summary>
+        /// <remarks>
+        /// When set to <see langword="true"/>, the playback queue will begin playing again after all songs in the queue have been played.
+        /// </remarks>
         public static bool IsRepeating 
         {
             get { return PlatformGetIsRepeating(); }
             set { PlatformSetIsRepeating(value); }
         }
 
+        /// <summary>
+        /// Gets or sets the shuffle setting for the media player.
+        /// </summary>
+        /// <remarks>
+        /// When set to <see langword="true"/>, songs in the playback queue are played in random order rather than from first to last.
+        /// </remarks>
         public static bool IsShuffled
         {
             get { return PlatformGetIsShuffled(); }
             set { PlatformSetIsShuffled(value); }
         }
 
+        /// <summary>
+        /// Gets or sets the visualization enabled setting for the media player.
+        /// </summary>
+        /// <remarks>
+        /// Always returns <see langword="false"/>
+        /// </remarks>
         public static bool IsVisualizationEnabled { get { return false; } }
 
+        /// <summary>
+        /// Gets the play position within the currently playing song.
+        /// </summary>
         public static TimeSpan PlayPosition
         {
             get { return PlatformGetPlayPosition(); }
@@ -58,6 +95,9 @@ namespace Microsoft.Xna.Framework.Media
 #endif
         }
 
+        /// <summary>
+        /// Gets the media playback state, <see cref="MediaState"/>
+        /// </summary>
         public static MediaState State
         {
             get { return PlatformGetState(); }
@@ -71,6 +111,17 @@ namespace Microsoft.Xna.Framework.Media
             }
         }
 
+        /// <summary>
+        /// Determines whether the game has control of the background music.
+        /// </summary>
+        /// <remarks>
+        /// A gamer can play their own music as the background to your game by using the Xbox 360 dashboard.
+        /// If the game is currently playing custom background music (specified by the gamer using the Xbox 360 dashboard),
+        /// calls to <see cref="Play(Song)"/>, <see cref="Stop()"/>, <see cref="Pause()"/>,
+        /// <see cref="Resume()"/>, <see cref="MoveNext()"/>, and <see cref="MovePrevious"/> have no effect.
+        /// If another application's background music is playing, your game will need to call
+        /// in order to pause the other application's background music in order to play the game's music.
+        /// </remarks>
         public static bool GameHasControl
         {
             get
@@ -78,8 +129,20 @@ namespace Microsoft.Xna.Framework.Media
                 return PlatformGetGameHasControl();
             }
         }
-		
 
+        /// <summary>
+        /// Gets or sets the media player volume
+        /// </summary>
+        /// <value>
+        /// Media player volume, from 0.0f (silence) to 1.0f (full volume relative to the current device volume)
+        /// </value>
+        /// <remarks>
+        /// <para>
+        /// Volume adjustment is based on a decibel, not multiplicative, scale.
+        /// Setting <see cref="Volume"/> to 0.0 subtracts 96 dB from the volume. Setting <see cref="Volume"/> to 1.0 subtracts 0 dB from the volume.
+        /// Values in between 0.0f and 1.0f subtract dB from the volume proportionally.
+        /// </para>
+        /// </remarks>
         public static float Volume
         {
             get { return PlatformGetVolume(); }
@@ -91,8 +154,11 @@ namespace Microsoft.Xna.Framework.Media
             }
         }
 
-		#endregion
-		
+        #endregion
+
+        /// <summary>
+        /// Pauses the currently playing song.
+        /// </summary>
         public static void Pause()
         {
             if (State != MediaState.Playing || _queue.ActiveSong == null)
@@ -133,7 +199,11 @@ namespace Microsoft.Xna.Framework.Media
                 EventHelpers.Raise(null, ActiveSongChanged, EventArgs.Empty);
         }
 
-		public static void Play(SongCollection collection, int index = 0)
+        /// <summary>
+        /// Play clears the current playback queue, and then queues up the specified song collection for playback. 
+        /// Playback starts immediately at the beginning of the song, specified by song collection index.
+        /// </summary>
+        public static void Play(SongCollection collection, int index = 0)
 		{
             if (collection == null)
                 throw new ArgumentNullException("collection", "This method does not accept null for this parameter.");
@@ -177,6 +247,9 @@ namespace Microsoft.Xna.Framework.Media
 			MoveNext();
 		}
 
+        /// <summary>
+        /// Resumes a paused song.
+        /// </summary>
         public static void Resume()
         {
             if (State != MediaState.Paused)
@@ -186,6 +259,9 @@ namespace Microsoft.Xna.Framework.Media
 			State = MediaState.Playing;
         }
 
+        /// <summary>
+        /// Stops playing a song.
+        /// </summary>
         public static void Stop()
         {
             if (State == MediaState.Stopped)
@@ -194,13 +270,29 @@ namespace Microsoft.Xna.Framework.Media
             PlatformStop();
 			State = MediaState.Stopped;
 		}
-		
+
+        /// <summary>
+        /// Stops currently playing song, moves to the previous song in the queue of playing songs and plays it.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the current song is the last song in the queue, <see cref="MoveNext()"/> will stay on current song
+        /// </para>
+        /// </remarks>
 		public static void MoveNext()
 		{
 			NextSong(1);
 		}
-		
-		public static void MovePrevious()
+
+        /// <summary>
+        /// Stops currently playing song, moves to the previous song in the queue of playing songs and plays it.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the current song is the first song in the queue, <see cref="MovePrevious()"/> will stay on current song
+        /// </para>
+        /// </remarks>
+        public static void MovePrevious()
 		{
 			NextSong(-1);
 		}

--- a/MonoGame.Framework/Media/MediaQueue.cs
+++ b/MonoGame.Framework/Media/MediaQueue.cs
@@ -7,17 +7,33 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// Provides methods and properties to access and control the queue of playing songs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="MediaQueue"/> is a read-only queue of songs.
+    /// With <see cref="MediaQueue"/>, you can control which song is playing in the queue, but you cannot add or remove songs from the queue.
+    /// Either <see cref="MediaPlayer.Play(Song)"/> or the songs already queued up when the game starts determine the songs that are in the queue of playing songs.
+    /// </para>
+    /// </remarks>
 	public sealed class MediaQueue
 	{
         List<Song> songs = new List<Song>();
 		private int _activeSongIndex = -1;
 		private Random random = new Random();
 
+        /// <summary>
+        /// Creates a new instance of <see cref="MediaQueue"/>.
+        /// </summary>
 		public MediaQueue()
 		{
 			
 		}
-		
+
+        /// <summary>
+        /// Gets the current <see cref="Song"/> in the queue of playing songs.
+        /// </summary>
 		public Song ActiveSong
 		{
 			get
@@ -28,7 +44,13 @@ namespace Microsoft.Xna.Framework.Media
 				return songs[_activeSongIndex];
 			}
 		}
-		
+
+        /// <summary>
+        /// Gets or sets the index of the current (active) song in the queue of playing songs.
+        /// </summary>
+        /// <remarks>
+        /// Changing the active song index does not alter the current media state (playing, paused, or stopped).
+        /// </remarks>
 		public int ActiveSongIndex
 		{
 		    get
@@ -41,6 +63,9 @@ namespace Microsoft.Xna.Framework.Media
 		    }
 		}
 
+        /// <summary>
+        /// Gets the count of songs in the <see cref="MediaQueue"/>.
+        /// </summary>
         internal int Count
         {
             get
@@ -49,6 +74,9 @@ namespace Microsoft.Xna.Framework.Media
             }
         }
 
+        /// <summary>
+        /// Gets the <see cref="Song"/> at the specified index in the MediaQueue
+        /// </summary>
         public Song this[int index]
         {
             get

--- a/MonoGame.Framework/Media/MediaQueue.cs
+++ b/MonoGame.Framework/Media/MediaQueue.cs
@@ -13,8 +13,10 @@ namespace Microsoft.Xna.Framework.Media
     /// <remarks>
     /// <para>
     /// <see cref="MediaQueue"/> is a read-only queue of songs.
-    /// With <see cref="MediaQueue"/>, you can control which song is playing in the queue, but you cannot add or remove songs from the queue.
-    /// Either <see cref="MediaPlayer.Play(Song)"/> or the songs already queued up when the game starts determine the songs that are in the queue of playing songs.
+    /// With <see cref="MediaQueue"/>, you can control which song is playing in the queue,
+    /// but you cannot add or remove songs from the queue.
+    /// Either <see cref="MediaPlayer.Play(Song)"/> or the songs already queued up when the game
+    /// starts determine the songs that are in the queue of playing songs.
     /// </para>
     /// </remarks>
 	public sealed class MediaQueue

--- a/MonoGame.Framework/Media/MediaQueue.cs
+++ b/MonoGame.Framework/Media/MediaQueue.cs
@@ -12,11 +12,11 @@ namespace Microsoft.Xna.Framework.Media
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <see cref="MediaQueue"/> is a read-only queue of songs.
-    /// With <see cref="MediaQueue"/>, you can control which song is playing in the queue,
+    /// MediaQueue is a read-only queue of songs.
+    /// With MediaQueue, you can control which song is playing in the queue,
     /// but you cannot add or remove songs from the queue.
-    /// Either <see cref="MediaPlayer.Play(Song)"/> or the songs already queued up when the game
-    /// starts determine the songs that are in the queue of playing songs.
+    /// Either <see cref="MediaPlayer.Play(Song)">MediaPlayer.Play(Song)</see> or the songs already queued up
+    /// when the game starts determine the songs that are in the queue of playing songs.
     /// </para>
     /// </remarks>
 	public sealed class MediaQueue
@@ -33,9 +33,9 @@ namespace Microsoft.Xna.Framework.Media
 
 		}
 
-    /// <summary>
-    /// Gets the current <see cref="Song"/> in the queue of playing songs.
-    /// </summary>
+        /// <summary>
+        /// Gets the current <see cref="Song"/> in the queue of playing songs.
+        /// </summary>
 		public Song ActiveSong
 		{
 			get
@@ -47,12 +47,12 @@ namespace Microsoft.Xna.Framework.Media
 			}
 		}
 
-    /// <summary>
-    /// Gets or sets the index of the current (active) song in the queue of playing songs.
-    /// </summary>
-    /// <remarks>
-    /// Changing the active song index does not alter the current media state (playing, paused, or stopped).
-    /// </remarks>
+        /// <summary>
+        /// Gets or sets the index of the current (active) song in the queue of playing songs.
+        /// </summary>
+        /// <remarks>
+        /// Changing the active song index does not alter the current media state (playing, paused, or stopped).
+        /// </remarks>
 		public int ActiveSongIndex
 		{
 		    get
@@ -66,7 +66,7 @@ namespace Microsoft.Xna.Framework.Media
 		}
 
         /// <summary>
-        /// Gets the count of songs in the <see cref="MediaQueue"/>.
+        /// Gets the count of songs in the MediaQueue.
         /// </summary>
         internal int Count
         {

--- a/MonoGame.Framework/Media/MediaSource.cs
+++ b/MonoGame.Framework/Media/MediaSource.cs
@@ -17,10 +17,6 @@ namespace Microsoft.Xna.Framework.Media
     /// <para>
     /// <see cref="MediaSource"/> provides access to the source or sources from which the media will be read.
     /// A source can be either the local device, or a device connected through Windows Media Connect.
-    /// On Windows and Windows Phone, the only available **MediaSource** is the local device.
-    /// On Xbox 360, a **MediaSource** can either be the local device or a device connected through Windows Media Connect.
-    /// Windows Media Connect is software that lets you connect your Windows Phone to a computer running Microsoft Windows.
-    /// Connecting this way enables you to view media on the connected computer in the Xbox 360 dashboard.
     /// </para>
     /// </remarks>
 	public sealed class MediaSource

--- a/MonoGame.Framework/Media/MediaSource.cs
+++ b/MonoGame.Framework/Media/MediaSource.cs
@@ -10,6 +10,19 @@ using UIKit;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// Provides methods and properties to access the source or sources from which the media will be read.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="MediaSource"/> provides access to the source or sources from which the media will be read.
+    /// A source can be either the local device, or a device connected through Windows Media Connect.
+    /// On Windows and Windows Phone, the only available **MediaSource** is the local device.
+    /// On Xbox 360, a **MediaSource** can either be the local device or a device connected through Windows Media Connect.
+    /// Windows Media Connect is software that lets you connect your Windows Phone to a computer running Microsoft Windows.
+    /// Connecting this way enables you to view media on the connected computer in the Xbox 360 dashboard.
+    /// </para>
+    /// </remarks>
 	public sealed class MediaSource
     {
 		private MediaSourceType _type;
@@ -19,7 +32,10 @@ namespace Microsoft.Xna.Framework.Media
 			_name = name;
 			_type = type;
 		}
-				
+
+        /// <summary>
+        /// Gets the <see cref="MediaSourceType"/> of this media source.
+        /// </summary>
         public Microsoft.Xna.Framework.Media.MediaSourceType MediaSourceType
         {
             get
@@ -28,6 +44,9 @@ namespace Microsoft.Xna.Framework.Media
             }
         }
 
+        /// <summary>
+        /// Gets the name of this media source.
+        /// </summary>
         public string Name
         {
             get
@@ -35,7 +54,11 @@ namespace Microsoft.Xna.Framework.Media
 				return _name;
             }
         }
-	
+
+        /// <summary>
+        /// Gets the available media sources with which a media library can be constructed.
+        /// </summary>
+        /// <returns>This method will always return a single media source: the local device.</returns>
 		public static IList<MediaSource> GetAvailableMediaSources()
         {
 #if IOS

--- a/MonoGame.Framework/Media/MediaSource.cs
+++ b/MonoGame.Framework/Media/MediaSource.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Xna.Framework.Media
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <see cref="MediaSource"/> provides access to the source or sources from which the media will be read.
+    /// MediaSource provides access to the source or sources from which the media will be read.
     /// A source can be either the local device, or a device connected through Windows Media Connect.
     /// </para>
     /// </remarks>

--- a/MonoGame.Framework/Media/MediaSourceType.cs
+++ b/MonoGame.Framework/Media/MediaSourceType.cs
@@ -6,9 +6,22 @@ using System;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// Type of the media source.
+    /// </summary>
+    /// <remarks>
+    /// Indicates the type of the current media source.
+    /// The type can be either a local device, or a device connected through Windows Media Connect.
+    /// </remarks>
  	public enum MediaSourceType
     {
+        /// <summary>
+        /// A local device.
+        /// </summary>
         LocalDevice = 0,
+        /// <summary>
+        /// A Windows Media Connect device.
+        /// </summary>
         WindowsMediaConnect = 4
     }
 }

--- a/MonoGame.Framework/Media/MediaState.cs
+++ b/MonoGame.Framework/Media/MediaState.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Xna.Framework.Media
         /// </summary>
         Stopped,
         /// <summary>
-        /// Media is currently playing.
+        /// Media is currently playing and not paused.
         /// </summary>
         Playing,
         /// <summary>

--- a/MonoGame.Framework/Media/MediaState.cs
+++ b/MonoGame.Framework/Media/MediaState.cs
@@ -6,10 +6,22 @@ using System;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// Media playback state
+    /// </summary>
     public enum MediaState
     {
+        /// <summary>
+        /// Media playback is stopped.
+        /// </summary>
         Stopped,
+        /// <summary>
+        /// Media is currently playing.
+        /// </summary>
         Playing,
+        /// <summary>
+        /// Media playback is paused.
+        /// </summary>
         Paused
     }
 }

--- a/MonoGame.Framework/Media/Playlist.cs
+++ b/MonoGame.Framework/Media/Playlist.cs
@@ -6,20 +6,35 @@ using System;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// Provides access to a playlist in the media library.
+    /// </summary>
+    /// <remarks>
+    /// Obtain <see cref="Playlist"/> objects through the <see cref="PlaylistCollection.this"/> indexer.
+    /// </remarks>
     public sealed class Playlist : IDisposable
     {
+        /// <summary>
+        /// Gets the duration of the <see cref="Playlist"/>.
+        /// </summary>
         public TimeSpan Duration
         {
             get;
 			internal set;
         }
 
+        /// <summary>
+        /// Gets the name of the <see cref="Playlist"/>.
+        /// </summary>
         public string Name
         {
             get;
 			internal set;
         }
 
+        /// <summary>
+        /// Immediately releases the unmanaged resources used by this object.
+        /// </summary>
 		public void Dispose()
         {
         }

--- a/MonoGame.Framework/Media/Playlist.cs
+++ b/MonoGame.Framework/Media/Playlist.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Xna.Framework.Media
     /// Provides access to a playlist in the media library.
     /// </summary>
     /// <remarks>
-    /// Obtain <see cref="Playlist"/> objects through the <see cref="PlaylistCollection.this"/> indexer.
+    /// Obtain Playlist objects through the <see cref="PlaylistCollection.this">PlaylistCollection.this</see> indexer.
     /// </remarks>
     public sealed class Playlist : IDisposable
     {
         /// <summary>
-        /// Gets the duration of the <see cref="Playlist"/>.
+        /// Gets the duration of the Playlist.
         /// </summary>
         public TimeSpan Duration
         {
@@ -24,7 +24,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Gets the name of the <see cref="Playlist"/>.
+        /// Gets the name of the Playlist.
         /// </summary>
         public string Name
         {
@@ -32,9 +32,7 @@ namespace Microsoft.Xna.Framework.Media
 			internal set;
         }
 
-        /// <summary>
-        /// Immediately releases the unmanaged resources used by this object.
-        /// </summary>
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
 		public void Dispose()
         {
         }

--- a/MonoGame.Framework/Media/PlaylistCollection.cs
+++ b/MonoGame.Framework/Media/PlaylistCollection.cs
@@ -130,11 +130,13 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Searches for the specified <see cref="Playlist"/> and returns the zero-based index of the first occurence within the entire <see cref="PlaylistCollection"/>.
+        /// Searches for the specified <see cref="Playlist"/> and returns the zero-based index
+        /// of the first occurence within the entire <see cref="PlaylistCollection"/>.
         /// </summary>
         /// <param name="item">The <see cref="Playlist"/> to locate</param>
         /// <returns>
-        /// The zero-based index of the first occurence of <paramref name="item"/> within the entire <see cref="PlaylistCollection"/>, if found. otherwise, -1.
+        /// The zero-based index of the first occurence of <paramref name="item"/> within
+        /// the entire <see cref="PlaylistCollection"/>, if found. otherwise, -1.
         /// </returns>
 		public int IndexOf(Playlist item)
         {
@@ -147,8 +149,8 @@ namespace Microsoft.Xna.Framework.Media
         /// <param name="item">The object to remove from the <see cref="PlaylistCollection"/>.</param>
         /// <returns>
         /// <see langword="true"/> if item was successfully removed from the <see cref="PlaylistCollection"/>;
-        /// otherwise, <see langword="false"/>. This method also returns <see langword="false"/> if item is not found in the
-        /// original <see cref="PlaylistCollection"/>.
+        /// otherwise, <see langword="false"/>. This method also returns <see langword="false"/>
+        /// if item is not found in the original <see cref="PlaylistCollection"/>.
         /// </returns>
         public bool Remove(Playlist item)
         {

--- a/MonoGame.Framework/Media/PlaylistCollection.cs
+++ b/MonoGame.Framework/Media/PlaylistCollection.cs
@@ -16,9 +16,7 @@ namespace Microsoft.Xna.Framework.Media
 		private bool isReadOnly = false;
 		private List<Playlist> innerlist = new List<Playlist>();
 
-        /// <summary>
-        /// Immediately releases the unmanaged resources used by this object.
-        /// </summary>
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
         }

--- a/MonoGame.Framework/Media/PlaylistCollection.cs
+++ b/MonoGame.Framework/Media/PlaylistCollection.cs
@@ -8,16 +8,22 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Media
 {
-
+    /// <summary>
+    /// A collection of playlists in the media library.
+    /// </summary>
     public sealed class PlaylistCollection : ICollection<Playlist>, IEnumerable<Playlist>, IEnumerable, IDisposable
     {
 		private bool isReadOnly = false;
 		private List<Playlist> innerlist = new List<Playlist>();
-		
+
+        /// <summary>
+        /// Immediately releases the unmanaged resources used by this object.
+        /// </summary>
         public void Dispose()
         {
         }
 
+        /// <inheritdoc/>
         public IEnumerator<Playlist> GetEnumerator()
         {
             return innerlist.GetEnumerator();
@@ -28,6 +34,9 @@ namespace Microsoft.Xna.Framework.Media
             return innerlist.GetEnumerator();
         }
 
+        /// <summary>
+        /// Gets the number of <see cref="Playlist"/> objects in the <see cref="PlaylistCollection"/>.
+        /// </summary>
         public int Count
         {
             get
@@ -35,12 +44,18 @@ namespace Microsoft.Xna.Framework.Media
 				return innerlist.Count;
             }
         }
-		
+
+        /// <summary>
+        /// Gets whether this collection is read-only,
+        /// </summary>
 		public bool IsReadOnly
         {
             get { return this.isReadOnly; }
         }
 
+        /// <summary>
+        /// Gets the <see cref="Playlist"/> at the specified index in the <see cref="PlaylistCollection"/>.
+        /// </summary>
         public Playlist this[int index]
         {
             get
@@ -48,7 +63,10 @@ namespace Microsoft.Xna.Framework.Media
 				return this.innerlist[index];
             }
         }
-		
+
+        /// <summary>
+        /// Adds a <see cref="Playlist"/> to this <see cref="PlaylistCollection"/>.
+        /// </summary>
 		public void Add(Playlist item)
         {
             if (item == null)
@@ -71,12 +89,16 @@ namespace Microsoft.Xna.Framework.Media
 
             this.innerlist.Add(item);
         }
-		
+
+        /// <summary>
+        /// Removes all items from this <see cref="PlaylistCollection"/>.
+        /// </summary>
 		public void Clear()
         {
             innerlist.Clear();
         }
-        
+
+        /// <inheritdoc cref="ICloneable.Clone"/>
         public PlaylistCollection Clone()
         {
             PlaylistCollection plc = new PlaylistCollection();
@@ -84,22 +106,50 @@ namespace Microsoft.Xna.Framework.Media
                 plc.Add(playlist);
             return plc;
         }
-        
+
+        /// <summary>
+        /// Determines whether the collection contains specified <see cref="Playlist"/>
+        /// </summary>
         public bool Contains(Playlist item)
         {
             return innerlist.Contains(item);
         }
-        
+
+        /// <summary>
+        /// Copies the elements of the collection to an <see cref="Array"/>,
+        /// starting at a particular <see cref="Array"/> index.
+        /// </summary>
+        /// <param name="array">
+        /// The one-dimensional <see cref="Array"/> that is the destination of the elements copied
+        /// from collection. The <see cref="Array"/> must have zero-based indexing.
+        /// </param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         public void CopyTo(Playlist[] array, int arrayIndex)
         {
             innerlist.CopyTo(array, arrayIndex);
         }
-		
+
+        /// <summary>
+        /// Searches for the specified <see cref="Playlist"/> and returns the zero-based index of the first occurence within the entire <see cref="PlaylistCollection"/>.
+        /// </summary>
+        /// <param name="item">The <see cref="Playlist"/> to locate</param>
+        /// <returns>
+        /// The zero-based index of the first occurence of <paramref name="item"/> within the entire <see cref="PlaylistCollection"/>, if found. otherwise, -1.
+        /// </returns>
 		public int IndexOf(Playlist item)
         {
             return innerlist.IndexOf(item);
         }
-        
+
+        /// <summary>
+        /// Removes the first occurrence of a <see cref="Playlist"/> from the <see cref="PlaylistCollection"/>.
+        /// </summary>
+        /// <param name="item">The object to remove from the <see cref="PlaylistCollection"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if item was successfully removed from the <see cref="PlaylistCollection"/>;
+        /// otherwise, <see langword="false"/>. This method also returns <see langword="false"/> if item is not found in the
+        /// original <see cref="PlaylistCollection"/>.
+        /// </returns>
         public bool Remove(Playlist item)
         {
             return innerlist.Remove(item);

--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Xna.Framework.Media
         private TimeSpan _duration = TimeSpan.Zero;
         bool disposed;
         /// <summary>
-        /// Gets the Album on which the Song appears.
+        /// Gets the <see cref="Album"/> on which the Song appears.
         /// </summary>
         public Album Album
         {
@@ -84,7 +84,7 @@ namespace Microsoft.Xna.Framework.Media
         /// <summary>
         /// Returns a song that can be played via <see cref="MediaPlayer"/>.
         /// </summary>
-        /// <param name="name">The name for the song. See <see cref="Song.Name"/>.</param>
+        /// <param name="name">The name for the song. See <see cref="Song.Name">Song.Name</see>.</param>
         /// <param name="uri">The path to the song file.</param>
         /// <returns></returns>
         public static Song FromUri(string name, Uri uri)
@@ -94,9 +94,7 @@ namespace Microsoft.Xna.Framework.Media
             return song;
         }
 
-        /// <summary>
-        /// Immediately releases the unmanaged resources used by this object.
-        /// </summary>
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
 		public void Dispose()
         {
             Dispose(true);

--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -4,9 +4,14 @@
 
 using System;
 using System.IO;
+using static Sdl.Joystick;
+using static Sdl;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// Provides access to a song in the song library.
+    /// </summary>
     public sealed partial class Song : IEquatable<Song>, IDisposable
     {
         private string _name;
@@ -39,7 +44,10 @@ namespace Microsoft.Xna.Framework.Media
         {
             get { return PlatformGetGenre(); }
         }
-        
+
+        /// <summary>
+        /// Gets a value indicating whether the object is disposed.
+        /// </summary>
         public bool IsDisposed
         {
             get { return disposed; }
@@ -64,6 +72,10 @@ namespace Microsoft.Xna.Framework.Media
             PlatformInitialize(fileName);
         }
 
+        /// <summary>
+        /// Allows this object to attempt to free resources and perform other
+        /// cleanup operations before garbage collection reclaims the object.
+        /// </summary>
         ~Song()
         {
             Dispose(false);
@@ -86,7 +98,10 @@ namespace Microsoft.Xna.Framework.Media
             song._name = name;
             return song;
         }
-		
+
+        /// <summary>
+        /// Immediately releases the unmanaged resources used by this object.
+        /// </summary>
 		public void Dispose()
         {
             Dispose(true);
@@ -106,11 +121,19 @@ namespace Microsoft.Xna.Framework.Media
             }
         }
 
+        /// <summary>
+        /// Gets the hash code for this instance.
+        /// </summary>
         public override int GetHashCode ()
 		{
 			return base.GetHashCode ();
 		}
 
+        /// <summary>
+        /// Determines whether two instances of <see cref="Song"/> are equal.
+        /// </summary>
+        /// <param name="song">The <see cref="Song"/> to compare with the current object</param>
+        /// <returns><see langword="true"/> if the specified <see cref="Song"/> is equal to the current object; otherwise, <see langword="false"/></returns>
         public bool Equals(Song song)
         {
 #if DIRECTX
@@ -119,9 +142,9 @@ namespace Microsoft.Xna.Framework.Media
 			return ((object)song != null) && (Name == song.Name);
 #endif
 		}
-		
-		
-		public override bool Equals(Object obj)
+
+        /// <inheritdoc/>
+        public override bool Equals(Object obj)
 		{
 			if(obj == null)
 			{
@@ -130,7 +153,10 @@ namespace Microsoft.Xna.Framework.Media
 			
 			return Equals(obj as Song);  
 		}
-		
+
+        /// <summary>
+        /// Determines whether the specified Song instances are equal.
+        /// </summary>
 		public static bool operator ==(Song song1, Song song2)
 		{
 			if((object)song1 == null)
@@ -140,42 +166,73 @@ namespace Microsoft.Xna.Framework.Media
 
 			return song1.Equals(song2);
 		}
-		
-		public static bool operator !=(Song song1, Song song2)
+
+        /// <summary>
+        /// Determines whether the specified Song instances are not equal.
+        /// </summary>
+        public static bool operator !=(Song song1, Song song2)
 		{
-		  return ! (song1 == song2);
+		    return !(song1 == song2);
 		}
 
+        /// <summary>
+        /// Gets the duration of the <see cref="Song"/>.
+        /// </summary>
         public TimeSpan Duration
         {
             get { return PlatformGetDuration(); }
-        }	
+        }
 
+        /// <summary>
+        /// Gets a value that indicates whether the song is DRM protected content.
+        /// </summary>
         public bool IsProtected
         {
             get { return PlatformIsProtected(); }
         }
 
+        /// <summary>
+        /// Gets a value that indicates whether the song has been rated by the user.
+        /// </summary>
         public bool IsRated
         {
             get { return PlatformIsRated(); }
         }
 
+        /// <summary>
+        /// Gets the name of the <see cref="Song"/>.
+        /// </summary>
         public string Name
         {
             get { return PlatformGetName(); }
         }
 
+        /// <summary>
+        /// Gets the song play count.
+        /// </summary>
         public int PlayCount
         {
             get { return PlatformGetPlayCount(); }
         }
 
+        /// <summary>
+        /// Gets the user's rating for the <see cref="Song"/>.
+        /// </summary>
+        /// <value>
+        /// User's rating for this <see cref="Song"/>, or 0 if the song is unrated.
+        /// Ratings range from 1 (dislike the most) to 10 (like the most).
+        /// </value>
         public int Rating
         {
             get { return PlatformGetRating(); }
         }
 
+        /// <summary>
+        /// Gets the track number of the song on the song's <see cref="Album"/>.
+        /// </summary>
+        /// <value>
+        /// Track number of this <see cref="Song"/> on the song's <see cref="Album"/>.
+        /// </value>
         public int TrackNumber
         {
             get { return PlatformGetTrackNumber(); }

--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.IO;
-using static Sdl.Joystick;
-using static Sdl;
 
 namespace Microsoft.Xna.Framework.Media
 {

--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Gets the Artist of the Song.
+        /// Gets the <see cref="Media.Artist"/> of the Song.
         /// </summary>
         public Artist Artist
         {
@@ -36,7 +36,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Gets the Genre of the Song.
+        /// Gets the <see cref="Media.Genre"/> of the Song.
         /// </summary>
         public Genre Genre
         {
@@ -70,10 +70,7 @@ namespace Microsoft.Xna.Framework.Media
             PlatformInitialize(fileName);
         }
 
-        /// <summary>
-        /// Allows this object to attempt to free resources and perform other
-        /// cleanup operations before garbage collection reclaims the object.
-        /// </summary>
+        /// <summary/>
         ~Song()
         {
             Dispose(false);
@@ -131,7 +128,8 @@ namespace Microsoft.Xna.Framework.Media
         /// Determines whether two instances of <see cref="Song"/> are equal.
         /// </summary>
         /// <param name="song">The <see cref="Song"/> to compare with the current object</param>
-        /// <returns><see langword="true"/> if the specified <see cref="Song"/> is equal to the current object; otherwise, <see langword="false"/></returns>
+        /// <returns><see langword="true"/> if the specified <see cref="Song"/> is equal to the current object;
+        /// otherwise, <see langword="false"/></returns>
         public bool Equals(Song song)
         {
 #if DIRECTX

--- a/MonoGame.Framework/Media/SongCollection.cs
+++ b/MonoGame.Framework/Media/SongCollection.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Xna.Framework.Media
     /// </remarks>
 	public class SongCollection : ICollection<Song>, IEnumerable<Song>, IEnumerable, IDisposable
 	{
-    public static readonly SongCollection Empty = new SongCollection();
+        public static readonly SongCollection Empty = new SongCollection();
 		private bool isReadOnly = false;
 		private List<Song> innerlist = new List<Song>();
 
@@ -48,11 +48,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <inheritdoc/>
-        public IEnumerator<Song> GetEnumerator()
-
-        }
-
-		    public IEnumerator<Song> GetEnumerator()
+		public IEnumerator<Song> GetEnumerator()
         {
             return innerlist.GetEnumerator();
         }

--- a/MonoGame.Framework/Media/SongCollection.cs
+++ b/MonoGame.Framework/Media/SongCollection.cs
@@ -136,7 +136,8 @@ namespace Microsoft.Xna.Framework.Media
         /// <summary>
         /// Determines whether a <see cref="Song"/> is in the <see cref="SongCollection"/>
         /// </summary>
-        /// <returns><see langword="true"/> if <paramref name="item"/> is found in the <see cref="SongCollection"/>; otherwise, <see langword="false"/>.</returns>
+        /// <returns><see langword="true"/> if <paramref name="item"/> is found in the <see cref="SongCollection"/>;
+        /// otherwise, <see langword="false"/>.</returns>
         public bool Contains(Song item)
         {
             return innerlist.Contains(item);
@@ -157,11 +158,13 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Searches for the specified <see cref="Song"/> and returns the zero-based index of the first occurence within the entire <see cref="SongCollection"/>.
+        /// Searches for the specified <see cref="Song"/> and returns the zero-based index of the
+        /// first occurence within the entire <see cref="SongCollection"/>.
         /// </summary>
         /// <param name="item">The <see cref="Song"/> to locate</param>
         /// <returns>
-        /// The zero-based index of the first occurence of <paramref name="item"/> within the entire <see cref="SongCollection"/>, if found. otherwise, -1.
+        /// The zero-based index of the first occurence of <paramref name="item"/> within
+        /// the entire <see cref="SongCollection"/>, if found. otherwise, -1.
         /// </returns>
         public int IndexOf(Song item)
         {
@@ -174,8 +177,9 @@ namespace Microsoft.Xna.Framework.Media
         /// <param name="item">The object to remove from the <see cref="SongCollection"/>.</param>
         /// <returns>
         /// <see langword="true"/> if item was successfully removed from the <see cref="SongCollection"/>;
-        /// otherwise, <see langword="false"/>. This method also returns <see langword="false"/> if item is not found in the
-        /// original <see cref="SongCollection"/>.
+        /// otherwise, <see langword="false"/>.
+        /// This method also returns <see langword="false"/> if item
+        /// is not found in the original <see cref="SongCollection"/>.
         /// </returns>
         public bool Remove(Song item)
         {

--- a/MonoGame.Framework/Media/SongCollection.cs
+++ b/MonoGame.Framework/Media/SongCollection.cs
@@ -25,13 +25,16 @@ namespace Microsoft.Xna.Framework.Media
     /// </remarks>
 	public class SongCollection : ICollection<Song>, IEnumerable<Song>, IEnumerable, IDisposable
 	{
+        /// <summary>
+        /// Returns a <see cref="SongCollection"/> with no contents.
+        /// </summary>
         public static readonly SongCollection Empty = new SongCollection();
 		private bool isReadOnly = false;
 		private List<Song> innerlist = new List<Song>();
 
         internal SongCollection()
         {
-
+            
         }
 
         internal SongCollection(List<Song> songs)

--- a/MonoGame.Framework/Media/SongCollection.cs
+++ b/MonoGame.Framework/Media/SongCollection.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.Intrinsics.X86;
 
 namespace Microsoft.Xna.Framework.Media
 {
@@ -134,7 +133,10 @@ namespace Microsoft.Xna.Framework.Media
             return sc;
         }
 
-        /// <inheritdoc cref="ICloneable.Clone"/>
+        /// <summary>
+        /// Determines whether a <see cref="Song"/> is in the <see cref="SongCollection"/>
+        /// </summary>
+        /// <returns><see langword="true"/> if <paramref name="item"/> is found in the <see cref="SongCollection"/>; otherwise, <see langword="false"/>.</returns>
         public bool Contains(Song item)
         {
             return innerlist.Contains(item);

--- a/MonoGame.Framework/Media/SongCollection.cs
+++ b/MonoGame.Framework/Media/SongCollection.cs
@@ -5,9 +5,25 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Intrinsics.X86;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// A collection of songs in the song library.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="SongCollection"/> class provides access to songs in the device's song library.
+    /// </para>
+    /// <para>
+    /// Use the <see cref="MediaLibrary.Songs"/> property to obtain the following collections:
+    /// All songs in the media library; 
+    /// Songs on a particular album; 
+    /// Songs associated with a particular artist; 
+    /// Songs associated with a particular genre; 
+    /// </para>
+    /// </remarks>
 	public class SongCollection : ICollection<Song>, IEnumerable<Song>, IEnumerable, IDisposable
 	{
 		private bool isReadOnly = false;
@@ -23,11 +39,15 @@ namespace Microsoft.Xna.Framework.Media
             this.innerlist = songs;
         }
 
+        /// <summary>
+        /// Immediately releases the unmanaged resources used by this object.
+        /// </summary>
 		public void Dispose()
         {
         }
-		
-		public IEnumerator<Song> GetEnumerator()
+
+        /// <inheritdoc/>
+        public IEnumerator<Song> GetEnumerator()
         {
             return innerlist.GetEnumerator();
         }
@@ -37,6 +57,9 @@ namespace Microsoft.Xna.Framework.Media
             return innerlist.GetEnumerator();
         }
 
+        /// <summary>
+        /// Gets the number of <see cref="Song"/> objects in the <see cref="SongCollection"/>.
+        /// </summary>
         public int Count
         {
             get
@@ -44,8 +67,11 @@ namespace Microsoft.Xna.Framework.Media
 				return innerlist.Count;
             }
         }
-		
-		public bool IsReadOnly
+
+        /// <summary>
+        /// Gets whether this collection is read-only,
+        /// </summary>
+        public bool IsReadOnly
         {
 		    get
 		    {
@@ -53,6 +79,9 @@ namespace Microsoft.Xna.Framework.Media
 		    }
         }
 
+        /// <summary>
+        /// Gets the <see cref="Song"/> at the specified index in the <see cref="SongCollection"/>.
+        /// </summary>
         public Song this[int index]
         {
             get
@@ -60,7 +89,10 @@ namespace Microsoft.Xna.Framework.Media
 				return this.innerlist[index];
             }
         }
-		
+
+        /// <summary>
+        /// Adds a <see cref="Song"/> to this <see cref="SongCollection"/>.
+        /// </summary>
 		public void Add(Song item)
         {
 
@@ -84,12 +116,16 @@ namespace Microsoft.Xna.Framework.Media
 
             this.innerlist.Add(item);
         }
-		
-		public void Clear()
+
+        /// <summary>
+        /// Removes all items from this <see cref="SongCollection"/>.
+        /// </summary>
+        public void Clear()
         {
             innerlist.Clear();
         }
-        
+
+        /// <inheritdoc cref="ICloneable.Clone"/>
         public SongCollection Clone()
         {
             SongCollection sc = new SongCollection();
@@ -97,22 +133,48 @@ namespace Microsoft.Xna.Framework.Media
                 sc.Add(song);
             return sc;
         }
-        
+
+        /// <inheritdoc cref="ICloneable.Clone"/>
         public bool Contains(Song item)
         {
             return innerlist.Contains(item);
         }
-        
+
+        /// <summary>
+        /// Copies the elements of the collection to an <see cref="Array"/>,
+        /// starting at a particular <see cref="Array"/> index.
+        /// </summary>
+        /// <param name="array">
+        /// The one-dimensional <see cref="Array"/> that is the destination of the elements copied
+        /// from collection. The <see cref="Array"/> must have zero-based indexing.
+        /// </param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         public void CopyTo(Song[] array, int arrayIndex)
         {
             innerlist.CopyTo(array, arrayIndex);
         }
-		
-		public int IndexOf(Song item)
+
+        /// <summary>
+        /// Searches for the specified <see cref="Song"/> and returns the zero-based index of the first occurence within the entire <see cref="SongCollection"/>.
+        /// </summary>
+        /// <param name="item">The <see cref="Song"/> to locate</param>
+        /// <returns>
+        /// The zero-based index of the first occurence of <paramref name="item"/> within the entire <see cref="SongCollection"/>, if found. otherwise, -1.
+        /// </returns>
+        public int IndexOf(Song item)
         {
             return innerlist.IndexOf(item);
         }
-        
+
+        /// <summary>
+        /// Removes the first occurrence of a <see cref="Song"/> from the <see cref="SongCollection"/>.
+        /// </summary>
+        /// <param name="item">The object to remove from the <see cref="SongCollection"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if item was successfully removed from the <see cref="SongCollection"/>;
+        /// otherwise, <see langword="false"/>. This method also returns <see langword="false"/> if item is not found in the
+        /// original <see cref="SongCollection"/>.
+        /// </returns>
         public bool Remove(Song item)
         {
             return innerlist.Remove(item);

--- a/MonoGame.Framework/Media/SongCollection.cs
+++ b/MonoGame.Framework/Media/SongCollection.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Xna.Framework.Media
         /// <summary>
         /// Adds a <see cref="Song"/> to this <see cref="SongCollection"/>.
         /// </summary>
-		    public void Add(Song item)
+		public void Add(Song item)
         {
 
             if (item == null)

--- a/MonoGame.Framework/Media/SongCollection.cs
+++ b/MonoGame.Framework/Media/SongCollection.cs
@@ -42,9 +42,7 @@ namespace Microsoft.Xna.Framework.Media
             this.innerlist = songs;
         }
 
-        /// <summary>
-        /// Immediately releases the unmanaged resources used by this object.
-        /// </summary>
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
 		public void Dispose()
         {
 

--- a/MonoGame.Framework/Media/Video.cs
+++ b/MonoGame.Framework/Media/Video.cs
@@ -74,9 +74,7 @@ namespace Microsoft.Xna.Framework.Media
         #endregion
 
         #region IDisposable Implementation
-        /// <summary>
-        /// Immediately releases the unmanaged resources used by this object.
-        /// </summary>
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
             Dispose(true);

--- a/MonoGame.Framework/Media/Video.cs
+++ b/MonoGame.Framework/Media/Video.cs
@@ -65,6 +65,10 @@ namespace Microsoft.Xna.Framework.Media
 #endif
         }
 
+        /// <summary>
+        /// Allows this object to attempt to free resources and perform other
+        /// cleanup operations before garbage collection reclaims the object.
+        /// </summary>
         ~Video()
         {
             Dispose(false);
@@ -73,7 +77,9 @@ namespace Microsoft.Xna.Framework.Media
         #endregion
 
         #region IDisposable Implementation
-
+        /// <summary>
+        /// Immediately releases the unmanaged resources used by this object.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);

--- a/MonoGame.Framework/Media/Video.cs
+++ b/MonoGame.Framework/Media/Video.cs
@@ -65,10 +65,7 @@ namespace Microsoft.Xna.Framework.Media
 #endif
         }
 
-        /// <summary>
-        /// Allows this object to attempt to free resources and perform other
-        /// cleanup operations before garbage collection reclaims the object.
-        /// </summary>
+        /// <summary/>
         ~Video()
         {
             Dispose(false);

--- a/MonoGame.Framework/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.cs
@@ -12,6 +12,10 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Media
 {
+    /// <summary>
+    /// Provides methods and properties to play back, pause, resume, and stop video.
+    /// <see cref="VideoPlayer"/> also exposes repeat, volume, and play position information.
+    /// </summary>
     public sealed partial class VideoPlayer : IDisposable
     {
         #region Fields
@@ -119,6 +123,9 @@ namespace Microsoft.Xna.Framework.Media
 
         #region Public API
 
+        /// <summary>
+        /// Creates a new instance of <see cref="VideoPlayer"/> class.
+        /// </summary>
         public VideoPlayer()
         {
             _state = MediaState.Stopped;

--- a/MonoGame.Framework/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.cs
@@ -13,7 +13,7 @@ using Microsoft.Xna.Framework.Graphics;
 namespace Microsoft.Xna.Framework.Media
 {
     /// <summary>
-    /// Provides methods and properties to play back, pause, resume, and stop video.
+    /// Provides methods and properties to play back, pause, resume, and stop <see cref="Video"/>.
     /// <see cref="VideoPlayer"/> also exposes repeat, volume, and play position information.
     /// </summary>
     public sealed partial class VideoPlayer : IDisposable
@@ -82,7 +82,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Gets the media playback state, MediaState.
+        /// Gets the media playback state, <see cref="MediaState"/>.
         /// </summary>
         public MediaState State
         { 
@@ -96,7 +96,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Gets the Video that is currently playing.
+        /// Gets the <see cref="Media.Video"/> that is currently playing.
         /// </summary>
         public Video Video { get { return _currentVideo; } }
 
@@ -187,7 +187,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Plays a Video.
+        /// Plays a <see cref="Video"/>.
         /// </summary>
         /// <param name="video">Video to play.</param>
         public void Play(Video video)

--- a/MonoGame.Framework/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.cs
@@ -287,9 +287,7 @@ namespace Microsoft.Xna.Framework.Media
 
         #region IDisposable Implementation
 
-        /// <summary>
-        /// Immediately releases the unmanaged resources used by this object.
-        /// </summary>
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
             Dispose(true);

--- a/MonoGame.Framework/Platform/Media/Song.NVorbis.cs
+++ b/MonoGame.Framework/Platform/Media/Song.NVorbis.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <summary>
-        /// Gets the duration of the <see cref="Song"/>.
+        /// Gets the position of the Song.
         /// </summary>
         public TimeSpan Position
         {

--- a/MonoGame.Framework/Platform/Media/Song.NVorbis.cs
+++ b/MonoGame.Framework/Platform/Media/Song.NVorbis.cs
@@ -98,6 +98,9 @@ namespace Microsoft.Xna.Framework.Media
             }
         }
 
+        /// <summary>
+        /// Gets the duration of the <see cref="Song"/>.
+        /// </summary>
         public TimeSpan Position
         {
             get


### PR DESCRIPTION
This PR **is quite big** and adds the documentation for `Microsoft.Xna.Framework.Media` namespace. 
**A review is probably needed**

## Changes
### Media
- `Genre`
- `MediaLibrary`
- `MediaPlayer`
- `MediaQueue`
- `MediaSource`
- `MediaSourceType` (enum)
- `MediaState` (enum)

### Playlist
- `Playlist`
- `PlaylistCollection`

### Song
- `Song`
- `SongCollection`
- `Platform/Media/Song.NVorbis`

### Video
- `Video`
- `VideoPlayer`

## Notes
- `MediaSource`, `MediaSourceType` docs were heavily modified because the original XNA docs did not match with actual MG implementation (Thanks to **Aristurtle** for help)
- `SongCollection` and `PlaylistCollection` didn't have the docs for most members. Original C# docs were reused, where possible (for `ICollection.Clear()`, `ICloneable.Clone()`, `operator==` etc.)
- GitHub diff shows some lines as deleted. Not sure why, probably different line endings.

## Reference:
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)