### PR TITLE
[Documentation]: Add missing XML docs for various custom vertices types

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/IVertexType.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IVertexType.cs
@@ -1,7 +1,13 @@
 ﻿namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Vertex type interface which is implemented by a custom vertex type structure.
+    /// </summary>
     public interface IVertexType
     {
+        /// <summary>
+        /// Vertex declaration, which defines per-vertex data.
+        /// </summary>
         VertexDeclaration VertexDeclaration
         {
             get;

--- a/MonoGame.Framework/Graphics/Vertices/VertexPosition.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPosition.cs
@@ -7,16 +7,26 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Describes a custom vertex format structure that contains position.
+    /// </summary>
     [DataContract]
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
 	public struct VertexPosition : IVertexType
 	{
+        /// <summary>
+        /// The XYZ vertex position.
+        /// </summary>
         [DataMember]
 		public Vector3 Position;
-
+        /// <inheritdoc cref="IVertexType.VertexDeclaration"/>
 		public static readonly VertexDeclaration VertexDeclaration;
 
-		public VertexPosition(Vector3 position)
+        /// <summary>
+        /// Creates an instance of <see cref="VertexPosition"/>.
+        /// </summary>
+        /// <param name="position">Position of the vertex.</param>
+        public VertexPosition(Vector3 position)
 		{
 			Position = position;
 		}
@@ -26,26 +36,52 @@ namespace Microsoft.Xna.Framework.Graphics
 			get { return VertexDeclaration; }
 		}
 
-	    public override int GetHashCode()
+        /// <inheritdoc/>
+        public override int GetHashCode()
 	    {
 	        return Position.GetHashCode();
 	    }
 
-		public override string ToString()
+        /// <summary>
+        /// Retrieves a string representation of this object.
+        /// </summary>
+        /// <returns>String representation of this object.</returns>
+        public override string ToString()
 		{
             return "{{Position:" + Position + "}}";
 		}
 
-		public static bool operator == (VertexPosition left, VertexPosition right)
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPosition"/> are equal
+        /// </summary>
+        /// <param name="left">The vertex on the left of the equality operator.</param>
+        /// <param name="right">The vertex on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the vertices are the same; <see langword="false"/> otherwise.
+        /// </returns>
+        public static bool operator == (VertexPosition left, VertexPosition right)
 		{
 			return left.Position == right.Position;
 		}
 
-		public static bool operator != (VertexPosition left, VertexPosition right)
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPosition"/> are different
+        /// </summary>
+        /// <param name="left">The vertex on the left of the equality operator.</param>
+        /// <param name="right">The vertex on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the vertices are different; <see langword="false"/> otherwise.
+        /// </returns>
+        public static bool operator != (VertexPosition left, VertexPosition right)
 		{
 			return !(left == right);
 		}
 
+        /// <summary>
+        /// Compares an object with the vertex.
+        /// </summary>
+        /// <param name="obj">The object to compare.</param>
+        /// <returns><see langword="true"/> if the object is equal to the vertex; <see langword="false"/> otherwise.</returns>
         public override bool Equals(object obj)
         {
             if (obj == null)

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
@@ -4,19 +4,32 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Describes a custom vertex format structure that contains position and color.
+    /// </summary>
     [DataContract]
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
 	public struct VertexPositionColor : IVertexType
 	{
+        /// <inheritdoc cref="VertexPosition.Position"/>
         [DataMember]
 		public Vector3 Position;
-        
+
+        /// <summary>
+        /// The vertex color.
+        /// </summary>
         [DataMember]
 		public Color Color;
 
+        /// <inheritdoc cref="IVertexType.VertexDeclaration"/>
 		public static readonly VertexDeclaration VertexDeclaration;
 
-		public VertexPositionColor(Vector3 position, Color color)
+        /// <summary>
+        /// Creates an instance of <see cref="VertexPositionColor"/>.
+        /// </summary>
+        /// <param name="position">Position of the vertex.</param>
+        /// <param name="color">Color of the vertex.</param>
+        public VertexPositionColor(Vector3 position, Color color)
 		{
 			this.Position = position;
 			Color = color;
@@ -30,6 +43,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
+        /// <inheritdoc/>
 	    public override int GetHashCode()
 	    {
 	        unchecked
@@ -38,21 +52,39 @@ namespace Microsoft.Xna.Framework.Graphics
 	        }
 	    }
 
+        /// <inheritdoc cref="VertexPosition.ToString()"/>
 	    public override string ToString()
 		{
             return "{{Position:" + this.Position + " Color:" + this.Color + "}}";
 		}
 
-		public static bool operator == (VertexPositionColor left, VertexPositionColor right)
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionColor"/> are equal
+        /// </summary>
+        /// <param name="left">The object on the left of the equality operator.</param>
+        /// <param name="right">The object on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
+        /// </returns>
+        public static bool operator == (VertexPositionColor left, VertexPositionColor right)
 		{
 			return ((left.Color == right.Color) && (left.Position == right.Position));
 		}
 
-		public static bool operator != (VertexPositionColor left, VertexPositionColor right)
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionColor"/> are different
+        /// </summary>
+        /// <param name="left">The object on the left of the inequality operator.</param>
+        /// <param name="right">The object on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
+        /// </returns>
+        public static bool operator != (VertexPositionColor left, VertexPositionColor right)
 		{
 			return !(left == right);
 		}
 
+        /// <inheritdoc cref="VertexPosition.Equals(object)"/>
 		public override bool Equals(object obj)
 		{
 			if (obj == null) {

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormal.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormal.cs
@@ -2,14 +2,27 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Describes a custom vertex format structure that contains position, color and normal data\\.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct VertexPositionColorNormal : IVertexType
     {
+        /// <inheritdoc cref="VertexPosition.Position"/>
         public Vector3 Position;
+        /// <inheritdoc cref="VertexPositionColor.Color"/>
         public Color Color;
+        /// <inheritdoc cref="VertexPositionNormalTexture.Normal"/>
         public Vector3 Normal;
+        /// <inheritdoc cref="IVertexType.VertexDeclaration"/>
         public static readonly VertexDeclaration VertexDeclaration;
 
+        /// <summary>
+        /// Creates an instance of <see cref="VertexPositionColorNormal"/>.
+        /// </summary>
+        /// <param name="position">Position of the vertex.</param>
+        /// <param name="color">Color of the vertex.</param>
+        /// <param name="normal">The vertex normal.</param>
         public VertexPositionColorNormal(Vector3 position, Color color, Vector3 normal)
         {
             Position = position;
@@ -25,6 +38,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked
@@ -36,21 +50,39 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc cref="VertexPosition.ToString()"/>
         public override string ToString()
         {
             return "{{Position:" + this.Position + " Color:" + this.Color + " Normal:" + this.Normal + "}}";
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionColorNormal"/> are equal
+        /// </summary>
+        /// <param name="left">The object on the left of the equality operator.</param>
+        /// <param name="right">The object on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator ==(VertexPositionColorNormal left, VertexPositionColorNormal right)
         {
             return (((left.Position == right.Position) && (left.Color == right.Color)) && (left.Normal == right.Normal));
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionColorNormal"/> are different
+        /// </summary>
+        /// <param name="left">The object on the left of the inequality operator.</param>
+        /// <param name="right">The object on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator !=(VertexPositionColorNormal left, VertexPositionColorNormal right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc cref="VertexPosition.Equals(object)"/>
         public override bool Equals(object obj)
         {
             if (obj == null)

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormalTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormalTexture.cs
@@ -2,15 +2,30 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Describes a custom vertex format structure that contains position, color, normal data, and one set of texture coordinates.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct VertexPositionColorNormalTexture : IVertexType
     {
+        /// <inheritdoc cref="VertexPosition.Position"/>
         public Vector3 Position;
+        /// <inheritdoc cref="VertexPositionColor.Color"/>
         public Color Color;
+        /// <inheritdoc cref="VertexPositionNormalTexture.Normal"/>
         public Vector3 Normal;
+        /// <inheritdoc cref="VertexPositionTexture.TextureCoordinate"/>
         public Vector2 TextureCoordinate;
+        /// <inheritdoc cref="IVertexType.VertexDeclaration"/>
         public static readonly VertexDeclaration VertexDeclaration;
 
+        /// <summary>
+        /// Creates an instance of <see cref="VertexPositionColorTexture"/>.
+        /// </summary>
+        /// <param name="position">Position of the vertex.</param>
+        /// <param name="color">Color of the vertex.</param>
+        /// <param name="normal">The vertex normal.</param>
+        /// <param name="textureCoordinate">Texture coordinate of the vertex.</param>
         public VertexPositionColorNormalTexture(Vector3 position, Color color, Vector3 normal, Vector2 textureCoordinate)
         {
             Position = position;
@@ -27,6 +42,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked
@@ -39,21 +55,39 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc cref="VertexPosition.ToString()"/>
         public override string ToString()
         {
             return "{{Position:" + this.Position + " Color:" + this.Color + " Normal:" + this.Normal + " TextureCoordinate:" + this.TextureCoordinate + "}}";
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionColorNormalTexture"/> are equal
+        /// </summary>
+        /// <param name="left">The object on the left of the equality operator.</param>
+        /// <param name="right">The object on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator ==(VertexPositionColorNormalTexture left, VertexPositionColorNormalTexture right)
         {
             return (((left.Position == right.Position) && (left.Color == right.Color)) && (left.Normal == right.Normal) && (left.TextureCoordinate == right.TextureCoordinate));
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionColorNormalTexture"/> are different
+        /// </summary>
+        /// <param name="left">The object on the left of the inequality operator.</param>
+        /// <param name="right">The object on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator !=(VertexPositionColorNormalTexture left, VertexPositionColorNormalTexture right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc cref="VertexPosition.Equals(object)"/>
         public override bool Equals(object obj)
         {
             if (obj == null)

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
@@ -2,14 +2,27 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Describes a custom vertex format structure that contains position, color, and one set of texture coordinates.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct VertexPositionColorTexture : IVertexType
     {
+        /// <inheritdoc cref="VertexPosition.Position"/>
         public Vector3 Position;
+        /// <inheritdoc cref="VertexPositionColor.Color"/>
         public Color Color;
+        /// <inheritdoc cref="VertexPositionTexture.TextureCoordinate"/>
         public Vector2 TextureCoordinate;
+        /// <inheritdoc cref="IVertexType.VertexDeclaration"/>
         public static readonly VertexDeclaration VertexDeclaration;
 
+        /// <summary>
+        /// Creates an instance of <see cref="VertexPositionColorTexture"/>.
+        /// </summary>
+        /// <param name="position">Position of the vertex.</param>
+        /// <param name="color">Color of the vertex.</param>
+        /// <param name="textureCoordinate">Texture coordinate of the vertex.</param>
         public VertexPositionColorTexture(Vector3 position, Color color, Vector2 textureCoordinate)
         {
             Position = position;
@@ -25,6 +38,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked
@@ -36,21 +50,39 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc cref="VertexPosition.ToString()"/>
         public override string ToString()
         {
             return "{{Position:" + this.Position + " Color:" + this.Color + " TextureCoordinate:" + this.TextureCoordinate + "}}";
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionColorTexture"/> are equal
+        /// </summary>
+        /// <param name="left">The object on the left of the equality operator.</param>
+        /// <param name="right">The object on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator ==(VertexPositionColorTexture left, VertexPositionColorTexture right)
         {
             return (((left.Position == right.Position) && (left.Color == right.Color)) && (left.TextureCoordinate == right.TextureCoordinate));
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionColorTexture"/> are different
+        /// </summary>
+        /// <param name="left">The object on the left of the inequality operator.</param>
+        /// <param name="right">The object on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator !=(VertexPositionColorTexture left, VertexPositionColorTexture right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc cref="VertexPosition.Equals(object)"/>
         public override bool Equals(object obj)
         {
             if (obj == null)

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
@@ -2,13 +2,29 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Describes a custom vertex format structure that contains position, normal data, and one set of texture coordinates.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct VertexPositionNormalTexture : IVertexType
     {
+        /// <inheritdoc cref="VertexPosition.Position"/>
         public Vector3 Position;
+        /// <summary>
+        /// The XYZ surface normal.
+        /// </summary>
         public Vector3 Normal;
+        /// <inheritdoc cref="VertexPositionTexture.TextureCoordinate"/>
         public Vector2 TextureCoordinate;
+        /// <inheritdoc cref="IVertexType.VertexDeclaration"/>
         public static readonly VertexDeclaration VertexDeclaration;
+
+        /// <summary>
+        /// Creates an instance of <see cref="VertexPositionTexture"/>.
+        /// </summary>
+        /// <param name="position">Position of the vertex.</param>
+        /// <param name="normal">The vertex normal.</param>
+        /// <param name="textureCoordinate">Texture coordinate of the vertex.</param>
         public VertexPositionNormalTexture(Vector3 position, Vector3 normal, Vector2 textureCoordinate)
         {
             this.Position = position;
@@ -24,6 +40,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked
@@ -35,21 +52,39 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc cref="VertexPosition.ToString()"/>
         public override string ToString()
         {
             return "{{Position:" + this.Position + " Normal:" + this.Normal + " TextureCoordinate:" + this.TextureCoordinate + "}}";
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionNormalTexture"/> are equal
+        /// </summary>
+        /// <param name="left">The object on the left of the equality operator.</param>
+        /// <param name="right">The object on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator ==(VertexPositionNormalTexture left, VertexPositionNormalTexture right)
         {
             return (((left.Position == right.Position) && (left.Normal == right.Normal)) && (left.TextureCoordinate == right.TextureCoordinate));
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionNormalTexture"/> are different
+        /// </summary>
+        /// <param name="left">The object on the left of the inequality operator.</param>
+        /// <param name="right">The object on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator !=(VertexPositionNormalTexture left, VertexPositionNormalTexture right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc cref="VertexPosition.Equals(object)"/>
         public override bool Equals(object obj)
         {
             if (obj == null)

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
@@ -2,12 +2,26 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Describes a custom vertex format structure that contains position and one set of texture coordinates.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack=1)]
     public struct VertexPositionTexture : IVertexType
     {
+        /// <inheritdoc cref="VertexPosition.Position"/>
         public Vector3 Position;
+        /// <summary>
+        /// UV texture coordinates.
+        /// </summary>
         public Vector2 TextureCoordinate;
+        /// <inheritdoc cref="IVertexType.VertexDeclaration"/>
         public static readonly VertexDeclaration VertexDeclaration;
+
+        /// <summary>
+        /// Creates an instance of <see cref="VertexPositionTexture"/>.
+        /// </summary>
+        /// <param name="position">Position of the vertex.</param>
+        /// <param name="textureCoordinate">Texture coordinate of the vertex.</param>
         public VertexPositionTexture(Vector3 position, Vector2 textureCoordinate)
         {
             this.Position = position;
@@ -22,6 +36,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc cref="VertexPosition.GetHashCode()"/>
         public override int GetHashCode()
         {
             unchecked
@@ -30,21 +45,39 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc cref="VertexPosition.ToString()"/>
         public override string ToString()
         {
             return "{{Position:" + this.Position + " TextureCoordinate:" + this.TextureCoordinate + "}}";
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionTexture"/> are equal
+        /// </summary>
+        /// <param name="left">The vertex on the left of the equality operator.</param>
+        /// <param name="right">The vertex on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the vertices are the same; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator ==(VertexPositionTexture left, VertexPositionTexture right)
         {
             return ((left.Position == right.Position) && (left.TextureCoordinate == right.TextureCoordinate));
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether two <see cref="VertexPositionTexture"/> are different
+        /// </summary>
+        /// <param name="left">The vertex on the left of the equality operator.</param>
+        /// <param name="right">The vertex on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if the vertices are different; <see langword="false"/> otherwise.
+        /// </returns>
         public static bool operator !=(VertexPositionTexture left, VertexPositionTexture right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc cref="VertexPosition.Equals(object)"/>
         public override bool Equals(object obj)
         {
             if (obj == null)


### PR DESCRIPTION
This PR adds the documentation for the following structures in `Microsoft.Xna.Framework.Graphics` namespace:

- `IVertexType` (interface)
- `VertexPosition`
- `VertexPositionColor`
- `VertexPositionTexture`
- `VertexPositionNormalTexture`
- `VertexPositionColorNormal`
- `VertexPositionColorTexture`
- `VertexPositionColorNormalTexture`

## Notes
Each structure lower in the list reuses documentation from structures earlier in the list, where possible, using `<inheritdoc/>`:
![image](https://github.com/MonoGame/MonoGame/assets/157877453/d496d1b9-5795-4d05-b1ab-2e644d10d585)
