### PR TITLE
[Documentation]: Add missing XML docs to various EventArgs

### DIFF
--- a/MonoGame.Framework/FileDropEventArgs.cs
+++ b/MonoGame.Framework/FileDropEventArgs.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Xna.Framework
     /// </summary>
     public struct FileDropEventArgs
     {
+        /// <summary>
+        /// Creates an instance of <see cref="FileDropEventArgs"/>.
+        /// </summary>
+        /// <param name="files">Array of paths to dropped files.</param>
         public FileDropEventArgs(string[] files)
         {
             Files = files;

--- a/MonoGame.Framework/Graphics/ResourceCreatedEventArgs.cs
+++ b/MonoGame.Framework/Graphics/ResourceCreatedEventArgs.cs
@@ -2,6 +2,9 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Provides data for the <see cref="GraphicsDevice.ResourceCreated"/> event. This class cannot be inherited.
+    /// </summary>
     public sealed class ResourceCreatedEventArgs : EventArgs
     {
         /// <summary>

--- a/MonoGame.Framework/Graphics/ResourceDestroyedEventArgs.cs
+++ b/MonoGame.Framework/Graphics/ResourceDestroyedEventArgs.cs
@@ -2,6 +2,9 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Provides data for the <see cref="GraphicsDevice.ResourceDestroyed"/> event. This class cannot be inherited.
+    /// </summary>
     public sealed class ResourceDestroyedEventArgs : EventArgs
     {
         /// <summary>

--- a/MonoGame.Framework/Platform/Input/InputKeyEventArgs.cs
+++ b/MonoGame.Framework/Platform/Input/InputKeyEventArgs.cs
@@ -7,6 +7,9 @@ using Microsoft.Xna.Framework.Input;
 
 namespace Microsoft.Xna.Framework
 {
+    /// <summary>
+    /// Provides data for the <see cref="GameWindow.KeyUp"/> and <see cref="GameWindow.KeyDown"/> events.
+    /// </summary>
     public struct InputKeyEventArgs
     {
         /// <summary>

--- a/MonoGame.Framework/TextInputEventArgs.cs
+++ b/MonoGame.Framework/TextInputEventArgs.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Xna.Framework
     /// </summary>
     public struct TextInputEventArgs
     {
+        /// <summary>
+        /// Creates an instance of <see cref="TextInputEventArgs"/>.
+        /// </summary>
+        /// <param name="character">Character for the key that was pressed.</param>
+        /// <param name="key">The pressed key.</param>
         public TextInputEventArgs(char character, Keys key = Keys.None)
         {
             Character = character;


### PR DESCRIPTION
This PR adds documentation for the following classes and structs with their namespaces:
- `Microsoft.Xna.Framework.FileDropEventArgs`
- `Microsoft.Xna.Framework.InputKeyEventArgs`
- `Microsoft.Xna.Framework.TextInputEventArgs`
- `Microsoft.Xna.Framework.Graphics.ResourceCreatedEventArgs`
- `Microsoft.Xna.Framework.Graphics.ResourceDestroyedEventArgs`

## Notes
- "`This class cannot be inherited.`" part was added to the `sealed` classes, similar to how it's documented in C# lang docs.

## Reference:
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)