### PR TITLE
[Documentation] Adds and Updates ContentReaderExtensions XML Documentation

### DIFF
--- a/MonoGame.Framework/Content/ContentReaderExtensions.cs
+++ b/MonoGame.Framework/Content/ContentReaderExtensions.cs
@@ -10,9 +10,14 @@ namespace Microsoft.Xna.Framework.Content
     public static class ContentReaderExtensions
     {
         /// <summary>
-        /// Gets the GraphicsDevice from the ContentManager.ServiceProvider.
+        /// Returns the <see cref="GraphicsDevice"/> instance from the service provider of the
+        /// <see cref="ContentManager"/> associated with this content reader.
         /// </summary>
         /// <returns>The <see cref="GraphicsDevice"/>.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The <see cref="ContentManager.ServiceProvider">ContentManager.ServiceProvider</see> does not contain a
+        /// <see cref="GraphicsDevice"/> instance.
+        /// </exception>
         public static GraphicsDevice GetGraphicsDevice(this ContentReader contentReader)
         {
             var serviceProvider = contentReader.ContentManager.ServiceProvider;

--- a/MonoGame.Framework/Content/ContentReaderExtensions.cs
+++ b/MonoGame.Framework/Content/ContentReaderExtensions.cs
@@ -7,6 +7,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    /// <summary>
+    /// Helper extension methods for <see cref="ContentReader"/>.
+    /// </summary>
     public static class ContentReaderExtensions
     {
         /// <summary>


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to several members of the `ContentReaderExtensions` class and updates existing documentation to align with the new guidelines and provide more contextual information.

## Reference
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)