### PR TITLE
[Documentation] Adds and Updates ContentSerializerAttribute XML Documentation

### DIFF
--- a/MonoGame.Framework/Content/ContentSerializerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerAttribute.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Xna.Framework.Content
         public bool AllowNull { get; set; }
 
         /// <summary>
-        /// Returns the overriden XML element name or the default "Item".
+        /// Returns the overridden XML element name or the default "Item".
         /// </summary>
         public string CollectionItemName
         {
             get
             {
-                // Return the defaul if unset.
+                // Return the default if unset.
                 if (string.IsNullOrEmpty(_collectionItemName))
                     return "Item";
 

--- a/MonoGame.Framework/Content/ContentSerializerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerAttribute.cs
@@ -78,6 +78,10 @@ namespace Microsoft.Xna.Framework.Content
         /// </summary>
         public bool SharedResource { get; set; }
 
+        /// <summary>
+        /// Creates a copy of this content serializer attribute.
+        /// </summary>
+        /// <returns>The copy of this content serializer attribute.</returns>
         public ContentSerializerAttribute Clone()
         {
             var clone = new ContentSerializerAttribute ();

--- a/MonoGame.Framework/Content/ContentSerializerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerAttribute.cs
@@ -48,6 +48,10 @@ namespace Microsoft.Xna.Framework.Content
         /// </summary>
         public string ElementName { get; set; }
 
+        /// <summary>
+        /// Gets or Sets a value indicating whether to write member contents directly into the current XML context
+        /// rather than wrapping the member in a new XML element (default is false).
+        /// </summary>
         public bool FlattenContent { get; set; }
 
         /// <summary>

--- a/MonoGame.Framework/Content/ContentSerializerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerAttribute.cs
@@ -5,7 +5,11 @@
 using System;
 
 namespace Microsoft.Xna.Framework.Content
-{	
+{
+    /// <summary>
+    /// Defines a custom <see cref="Attribute"/> that marks a field or property to control how it is serialized or to
+    /// indicate that protected or private data should be included in serialization.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
     public sealed class ContentSerializerAttribute : Attribute
     {

--- a/MonoGame.Framework/Content/ContentSerializerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerAttribute.cs
@@ -72,6 +72,10 @@ namespace Microsoft.Xna.Framework.Content
         /// </summary>
         public bool Optional { get; set; }
 
+        /// <summary>
+        /// Gets or Sets a value indicating whether this member is reference from multiple parents and should be
+        /// serialized as a unique ID reference (default is false).
+        /// </summary>
         public bool SharedResource { get; set; }
 
         public ContentSerializerAttribute Clone()

--- a/MonoGame.Framework/Content/ContentSerializerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerAttribute.cs
@@ -43,6 +43,9 @@ namespace Microsoft.Xna.Framework.Content
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the XML element name (default is the name of the managed type member).
+        /// </summary>
         public string ElementName { get; set; }
 
         public bool FlattenContent { get; set; }

--- a/MonoGame.Framework/Content/ContentSerializerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerAttribute.cs
@@ -66,6 +66,10 @@ namespace Microsoft.Xna.Framework.Content
             }
         }
 
+        /// <summary>
+        /// Gets or Sets a value indicating whether to write this element if the member is null and skip past it if not
+        /// found when deserializing XML (default is false).
+        /// </summary>
         public bool Optional { get; set; }
 
         public bool SharedResource { get; set; }

--- a/MonoGame.Framework/Content/ContentSerializerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerAttribute.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Xna.Framework.Content
         private string _collectionItemName;
 
         /// <summary>
-        /// Creates an instance of the attribute.
+        /// Initializes a new instance of the content serializer attribute.
         /// </summary>
         public ContentSerializerAttribute()
         {

--- a/MonoGame.Framework/Content/ContentSerializerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerAttribute.cs
@@ -55,7 +55,8 @@ namespace Microsoft.Xna.Framework.Content
         public bool FlattenContent { get; set; }
 
         /// <summary>
-        /// Returns true if the default CollectionItemName value was overridden.
+        /// Gets a value that indicates whether an explicit <see cref="CollectionItemName"/> is being used or the
+        /// default value.
         /// </summary>
         public bool HasCollectionItemName
         {

--- a/MonoGame.Framework/Content/ContentSerializerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerAttribute.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Xna.Framework.Content
             AllowNull = true;
         }
 
+        /// <summary>
+        /// Gets or Sets a value that indicates whether this member can have a null value (default is true).
+        /// </summary>
         public bool AllowNull { get; set; }
 
         /// <summary>

--- a/MonoGame.Framework/Content/ContentSerializerAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerAttribute.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Xna.Framework.Content
         public bool AllowNull { get; set; }
 
         /// <summary>
-        /// Returns the overridden XML element name or the default "Item".
+        /// Gets or Sets the XML element name for each item in a collection (default is "Item"). 
         /// </summary>
         public string CollectionItemName
         {


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to several members of the `ContentSerializerAttribute` class and updates existing documentation to align with the new guidelines and provide more contextual information.

## Reference
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)