### PR TITLE
 [Documentation] Adds and Updates ContentTypeReader XML Documentation

### DIFF
--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Xna.Framework.Content
             // Do nothing. Are we supposed to add ourselves to the manager?
         }
 
+        /// <summary />
         protected internal abstract object Read(ContentReader input, object existingInstance);
     }
 

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Xna.Framework.Content
 			return Read(input, (T)existingInstance);
         }
 
-        /// <inheritdoc />
+        /// <summary />
         protected internal abstract T Read(ContentReader input, T existingInstance);
     }
 }

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -56,6 +56,12 @@ namespace Microsoft.Xna.Framework.Content
         protected internal abstract object Read(ContentReader input, object existingInstance);
     }
 
+    /// <summary>
+    /// Defines the core behavior of content type readers used for reading a specific managed type from an .xnb binary
+    /// format and provides a base for derived classes.  Derive from this class to add new data types to the content
+    /// pipeline system.
+    /// </summary>
+    /// <typeparam name="T">The managed type to read.</typeparam>
     public abstract class ContentTypeReader<T> : ContentTypeReader
     {
         /// <summary />

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Xna.Framework.Content
             get { return false; }
         }
 
+        /// <summary>
+        /// Gets the type handled by this reader component.
+        /// </summary>
         public Type TargetType
         {
             get { return _targetType; }

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Xna.Framework.Content
 
     public abstract class ContentTypeReader<T> : ContentTypeReader
     {
+        /// <summary />
         protected ContentTypeReader()
             : base(typeof(T))
         {

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Xna.Framework.Content
             // Nothing
         }
 
+        /// <inheritdoc />
         protected internal override object Read(ContentReader input, object existingInstance)
         {
 			// as per the documentation http://msdn.microsoft.com/en-us/library/microsoft.xna.framework.content.contenttypereader.read.aspx

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Xna.Framework.Content
             _targetType = targetType;
         }
 
+        /// <summary />
         protected internal virtual void Initialize(ContentTypeReaderManager manager)
         {
             // Do nothing. Are we supposed to add ourselves to the manager?

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Xna.Framework.Content
     {
         private Type _targetType;
 
+        /// <summary>
+        /// Gets a value that indicates whether this content type read can deserialize into an object with the same
+        /// type ad defined in the <see cref="TargetType"/> property.
+        /// </summary>
         public virtual bool CanDeserializeIntoExistingObject
         {
             get { return false; }

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Xna.Framework.Content
             get { return _targetType; }
         }
 
+        /// <summary>
+        /// Gets the format version number for this type.
+        /// </summary>
         public virtual int TypeVersion
         {
             get { return 0; }   // The default version (unless overridden) is zero

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Xna.Framework.Content
             get { return 0; }   // The default version (unless overridden) is zero
         }
 
+        /// <summary />
         protected ContentTypeReader(Type targetType)
         {
             _targetType = targetType;

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Xna.Framework.Content
 			return Read(input, (T)existingInstance);
         }
 
+        /// <inheritdoc />
         protected internal abstract T Read(ContentReader input, T existingInstance);
     }
 }

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -7,6 +7,10 @@ using System.IO;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    /// <summary>
+    /// Defines the core behavior of content type readers used for reading a specific managed type from an .xnb binary
+    /// format and provides a base for derived classes.
+    /// </summary>
     public abstract class ContentTypeReader
     {
         private Type _targetType;


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to several members of the `ContentTypeReader` class and updates existing documentation to align with the new guidelines and provide more contextual information.

## Reference
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)