### PR TITLE
Updates WineHelper.cs Error Text To State .NET 8 instead of .NET 6

### DIFF
--- a/Tools/MonoGame.Effect.Compiler/WineHelper.cs
+++ b/Tools/MonoGame.Effect.Compiler/WineHelper.cs
@@ -21,7 +21,7 @@ namespace MonoGame.Effect.Compiler
                 Console.Error.WriteLine("Setup instructions:");
                 Console.Error.WriteLine("- Create 64 bit wine prefix");
                 Console.Error.WriteLine("- Install d3dcompiler_47 using winetricks");
-                Console.Error.WriteLine("- Install .NET 6");
+                Console.Error.WriteLine("- Install .NET 8");
                 Console.Error.WriteLine("- Setup MGFXC_WINE_PATH environmental variable to point to a valid wine prefix");
                 Console.Error.WriteLine("");
                 return -1;


### PR DESCRIPTION
## Description
This PR updates the error message that is output by **WineHelper.cs** to correctly state that .NET 8 needs to be installed instead of .NET 6

## Reference
[Issue #8103: .NET 8 Update Issues On Linux ](https://github.com/MonoGame/MonoGame/issues/8103)
[Issue #8124: macOS and Linux setup experience](https://github.com/MonoGame/MonoGame/issues/8124)