### PR TITLE
Updates DOTNET_URL In Wine Setup To .NET 8

### DIFF
--- a/Tools/MonoGame.Effect.Compiler/mgfxc_wine_setup.sh
+++ b/Tools/MonoGame.Effect.Compiler/mgfxc_wine_setup.sh
@@ -36,7 +36,7 @@ wine64 regedit crashdialog.reg
 popd
 
 # get dotnet
-DOTNET_URL="https://download.visualstudio.microsoft.com/download/pr/44d08222-aaa9-4d35-b24b-d0db03432ab7/52a4eb5922afd19e8e0d03e0dbbb41a0/dotnet-sdk-6.0.302-win-x64.zip"
+DOTNET_URL="https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.201/dotnet-sdk-8.0.201-win-x64.zip"
 curl $DOTNET_URL --output "$SCRIPT_DIR/dotnet-sdk.zip"
 7z x "$SCRIPT_DIR/dotnet-sdk.zip" -o"$WINEPREFIX/drive_c/windows/system32/"
 


### PR DESCRIPTION
## Description
This updates the `DOTNET_URL` environment variable in the **mgfxc_wine_setup.sh** script to point to 

```
https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.201/dotnet-sdk-8.0.201-win-x64.zip
``` 

so that it correctly installs .NET 8.

## Notes
The download link was determined by running the **dotnet-install.ps1** script with the following command

```powershell
dotnet-install.ps1 -DryRun
```

which outputs 

```powershell
PS C:\Users\Aristurtle\Downloads> .\dotnet-install.ps1 -DryRun  
dotnet-install: Payload URLs:
dotnet-install: URL #0 - aka.ms: https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.201/dotnet-sdk-8.0.201-win-x64.zip
dotnet-install: Repeatable invocation: .\dotnet-install.ps1 -Version "8.0.201" -InstallDir "C:\Users\Aristurtle\AppData\Local\Microsoft\dotnet" -Architecture "x64"
```

## References
- [dotnet-install scripts reference](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script)
- [Issue #8103: .NET 8 Update Issues On Linux ](https://github.com/MonoGame/MonoGame/issues/8103)
- [Issue #8124: macOS and Linux setup experience](https://github.com/MonoGame/MonoGame/issues/8124)