### PR TITLE
 Add /waitfordebugger argument to MGCB.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,20 @@
             "cwd": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Mac/Debug",
             "console": "internalConsole",
             "stopAtEntry": false
+        },
+        {
+            "name": "Attach to Process",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${input.processid}",
+        }
+    ],
+    "inputs": [
+        {
+            "id": "processid",
+            "type": "promptString",
+            "default": "0",
+            "description": "Enter Process Id of process to attach to."
         }
     ]
 }

--- a/Tools/MonoGame.Content.Builder/BuildContent.cs
+++ b/Tools/MonoGame.Content.Builder/BuildContent.cs
@@ -17,8 +17,14 @@ namespace MonoGame.Content.Builder
         [CommandLineParameter(
             Name = "launchdebugger",
             Flag = "d",
-            Description = "Wait for debugger to attach before building content.")]
+            Description = "Launch the debugger before building content.")]
         public bool LaunchDebugger = false;
+
+        [CommandLineParameter(
+            Name = "waitfordebugger",
+            Flag = "w",
+            Description = "Wait for debugger to attach before building content.")]
+        public bool WaitForDebuggerToAttach = false;
 
         [CommandLineParameter(
             Name = "quiet",

--- a/Tools/MonoGame.Content.Builder/BuildContent.cs
+++ b/Tools/MonoGame.Content.Builder/BuildContent.cs
@@ -22,7 +22,7 @@ namespace MonoGame.Content.Builder
 
         [CommandLineParameter(
             Name = "waitfordebugger",
-            Flag = "w",
+            Flag = "a",
             Description = "Wait for debugger to attach before building content.")]
         public bool WaitForDebuggerToAttach = false;
 

--- a/Tools/MonoGame.Content.Builder/BuildContent.cs
+++ b/Tools/MonoGame.Content.Builder/BuildContent.cs
@@ -305,7 +305,7 @@ namespace MonoGame.Content.Builder
 
             // If the intent is to debug build, break at the original location
             // of any exception, eg, within the actual importer/processor.
-            if (LaunchDebugger)
+            if (LaunchDebugger || WaitForDebuggerToAttach)
                 _manager.RethrowExceptions = false;
 
             // Feed all the assembly references to the pipeline manager
@@ -456,10 +456,12 @@ namespace MonoGame.Content.Builder
                         var dstTime = File.GetLastWriteTimeUtc(dest);
                         if (srcTime <= dstTime)
                         {
-                            if (string.IsNullOrEmpty(c.Link))
-                                Console.WriteLine("Skipping {0}", c.SourceFile);
-                            else
-                                Console.WriteLine("Skipping {0} => {1}", c.SourceFile, c.Link);
+                            if (!Quiet) {
+                                if (string.IsNullOrEmpty(c.Link))
+                                    Console.WriteLine("Skipping {0}", c.SourceFile);
+                                else
+                                    Console.WriteLine("Skipping {0} => {1}", c.SourceFile, c.Link);
+                            }
 
                             // Copy the stats from the previous stats collection.
                             _manager.ContentStats.CopyPreviousStats(c.SourceFile);
@@ -483,10 +485,12 @@ namespace MonoGame.Content.Builder
 
                     var buildTime = DateTime.UtcNow - startTime;
 
-                    if (string.IsNullOrEmpty(c.Link))
-                        Console.WriteLine("{0}", c.SourceFile);
-                    else
-                        Console.WriteLine("{0} => {1}", c.SourceFile, c.Link);
+                    if (!Quiet) {
+                        if (string.IsNullOrEmpty(c.Link))
+                            Console.WriteLine("{0}", c.SourceFile);
+                        else
+                            Console.WriteLine("{0} => {1}", c.SourceFile, c.Link);
+                    }
 
                     // Record content stats on the copy.
                     _manager.ContentStats.RecordStats(c.SourceFile, dest, "CopyItem", typeof(File), (float)buildTime.TotalSeconds);

--- a/Tools/MonoGame.Content.Builder/BuildContent.cs
+++ b/Tools/MonoGame.Content.Builder/BuildContent.cs
@@ -456,7 +456,8 @@ namespace MonoGame.Content.Builder
                         var dstTime = File.GetLastWriteTimeUtc(dest);
                         if (srcTime <= dstTime)
                         {
-                            if (!Quiet) {
+                            if (!Quiet)
+                            {
                                 if (string.IsNullOrEmpty(c.Link))
                                     Console.WriteLine("Skipping {0}", c.SourceFile);
                                 else
@@ -485,7 +486,8 @@ namespace MonoGame.Content.Builder
 
                     var buildTime = DateTime.UtcNow - startTime;
 
-                    if (!Quiet) {
+                    if (!Quiet)
+                    {
                         if (string.IsNullOrEmpty(c.Link))
                             Console.WriteLine("{0}", c.SourceFile);
                         else

--- a/Tools/MonoGame.Content.Builder/Program.cs
+++ b/Tools/MonoGame.Content.Builder/Program.cs
@@ -3,6 +3,8 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics;
+using System.Threading;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -47,9 +49,9 @@ namespace MonoGame.Content.Builder
             }
             if (content.WaitForDebuggerToAttach)
             {
-                var currentProcess = System.Diagnostics.Process.GetCurrentProcess();
+                var currentProcess = Process.GetCurrentProcess();
                 Console.WriteLine($"Waiting for debugger to attach ({currentProcess.MainModule.FileName} PID {currentProcess.Id}).  Press any key to continue without debugger.");
-                while (!System.Diagnostics.Debugger.IsAttached) {
+                while (!Debugger.IsAttached) {
                     if (Console.KeyAvailable) {
                         break;
                     }

--- a/Tools/MonoGame.Content.Builder/Program.cs
+++ b/Tools/MonoGame.Content.Builder/Program.cs
@@ -47,9 +47,14 @@ namespace MonoGame.Content.Builder
             }
             if (content.WaitForDebuggerToAttach)
             {
-                Process currentProcess = System.Diagnostics.Process.GetCurrentProcess();
-                Console.WriteLine($"Waiting for debugger to attach ({currentProcess.MainModule.FileName} PID {currentProcess.Id}).  Press enter to continue...");
-                Console.ReadLine();
+                var currentProcess = System.Diagnostics.Process.GetCurrentProcess();
+                Console.WriteLine($"Waiting for debugger to attach ({currentProcess.MainModule.FileName} PID {currentProcess.Id}).  Press any key to continue without debugger.");
+                while (!System.Diagnostics.Debugger.IsAttached) {
+                    if (Console.KeyAvailable) {
+                        break;
+                    }
+                    Thread.Sleep(100);
+                }
             }
 
             // Print a startup message.            

--- a/Tools/MonoGame.Content.Builder/Program.cs
+++ b/Tools/MonoGame.Content.Builder/Program.cs
@@ -45,6 +45,12 @@ namespace MonoGame.Content.Builder
                     Console.Error.WriteLine("The debugger is not implemented under Mono and thus is not supported on your platform.");
                 }
             }
+            if (content.WaitForDebuggerToAttach)
+            {
+                Process currentProcess = System.Diagnostics.Process.GetCurrentProcess();
+                Console.WriteLine($"Waiting for debugger to attach ({currentProcess.MainModule.FileName} PID {currentProcess.Id}).  Press enter to continue...");
+                Console.ReadLine();
+            }
 
             // Print a startup message.            
             var buildStarted = DateTime.Now;

--- a/Tools/MonoGame.Content.Builder/Program.cs
+++ b/Tools/MonoGame.Content.Builder/Program.cs
@@ -51,8 +51,10 @@ namespace MonoGame.Content.Builder
             {
                 var currentProcess = Process.GetCurrentProcess();
                 Console.WriteLine($"Waiting for debugger to attach ({currentProcess.MainModule.FileName} PID {currentProcess.Id}).  Press any key to continue without debugger.");
-                while (!Debugger.IsAttached) {
-                    if (Console.KeyAvailable) {
+                while (!Debugger.IsAttached)
+                {
+                    if (Console.KeyAvailable)
+                    {
                         break;
                     }
                     Thread.Sleep(100);


### PR DESCRIPTION
The call to `System.Diagnostics.Debugger.Launch` is
not supported on Unix based platforms. This makes
debugging `MGCB.exe` and Content Pipeline extensions
difficult.

So lets add a new argument which will make `MGCB.exe`
wait for a debugger to attach. Also add a extra
update to the `launch.json` to demonstrate how to
attach the `dotnet` debugger to an existing process.

This new system will also work on Windows.

To use this in VSCode you can add the following to the
`launch.json`

```json
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Attach to Process",
            "type": "coreclr",
            "request": "attach",
            "processId": "${input.processid}",
        }
    ],
    "inputs": [
        {
            "id": "processid",
            "type": "promptString",
            "default": "0",
            "description": "Enter Process Id of process to attach to."
        }
    ]
}
```

you can then add the following to your `csproj`.

```
<MonoGameMGCBAdditionalArguments>/waitfordebugger</MonoGameMGCBAdditionalArguments>
```

This will cause the `MGCB.exe` to print the ProcessId
to the console during the build and wait for the debugger
to attach. Once you have the ProcessId you can run the
VSCode `Attach to Process` and enter the ProcessId when prompted.
The debugger should then attach.

If you want to prcess without attaching the debugger just hit any
key in the console or terminal windows where `MGCB.exe` is running.