### PR TITLE
[Documentation] Adds and Updates DefaultColorProcessor XML Documentation

### DIFF
--- a/MonoGame.Framework/Graphics/DefaultColorProcessors.cs
+++ b/MonoGame.Framework/Graphics/DefaultColorProcessors.cs
@@ -2,11 +2,18 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Represents the default processors used in processing color values.
+    /// This class cannot be inherited.
+    /// </summary>
     public unsafe static class DefaultColorProcessors
     {
         /// <summary>
-        /// Zeroes RGB of pixels having zero alpha(standard XNA behavior)
+        /// Sets the RGB component values of each color to zero if the alpha component is zero.
         /// </summary>
+        /// <remarks>
+        /// This is standard XNA behavior.
+        /// </remarks>
         public static readonly Action<byte[]> ZeroTransparentPixels = data =>
         {
             fixed (byte* b = &data[0])
@@ -23,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
         };
 
         /// <summary>
-        /// Premultiplies RGB of pixels by its alpha
+        /// Premultiplies the RGB component value of each color by the its alpha component.
         /// </summary>
         public static readonly Action<byte[]> PremultiplyAlpha = data =>
         {


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to `DefaultColorProcessor` class and updates existing documentation to align with the new guidelines and provide more contextual information.

## Reference
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)