### PR TITLE
[Documentation] Adds and Updates DepthStencilState XML Documentation

### DIFF
--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -83,6 +83,19 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the stencil operation to perform if the stencil test passes and the depth-buffer test fails
+        /// for a counterclockwise triangle.
+        /// The default value is <see cref="StencilOperation.Keep">StencilOperation.Keep</see>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public StencilOperation CounterClockwiseStencilDepthBufferFail
         {
             get { return _counterClockwiseStencilDepthBufferFail; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -197,6 +197,30 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets a reference value to use for the stencil test.
+        /// The default is 0.
+        /// </summary>
+        /// <remarks>
+        /// The reference value is compared, by the comparison function specified by the <see cref="StencilFunction"/>
+        /// property, to the stencil buffer entry of a pixel.  This can be illustrated by a simple equation:
+        ///
+        /// <code>
+        /// ReferenceStencil StencilFunction (stencil buffer entry)
+        /// </code>
+        ///
+        /// This comparison applies only to the bits in the reference value and stencil buffer entry that are set in
+        /// the stencil mask by this property.  If the comparison is true, the stencil test passes and the pass
+        /// operation (specified by the <see cref="StencilPass"/> property) is performed.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public int ReferenceStencil
         {
             get { return _referenceStencil; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -30,6 +30,9 @@ namespace Microsoft.Xna.Framework.Graphics
         private int _stencilWriteMask;
         private bool _twoSidedStencilMode;
 
+        /// <summary>
+        /// Gets or Sets a value that indicates if depth buffering is enabled.
+        /// </summary>
         public bool DepthBufferEnable
         {
             get { return _depthBufferEnable; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -503,6 +503,18 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </code>
         /// </remarks>
         public static readonly DepthStencilState DepthRead;
+
+        /// <summary>
+        /// A built in state object with settings for not using a depth stencil buffer.
+        /// </summary>
+        /// <remarks>
+        /// This built-int state object has the following settings:
+        ///
+        /// <code>
+        /// DepthBufferEnable = false,
+        /// DepthBufferWriteEnable = false
+        /// </code>
+        /// </remarks>
         public static readonly DepthStencilState None;
 
 		static DepthStencilState ()

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -6,6 +6,9 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Contains depth-stencil state for the device.
+    /// </summary>
     public partial class DepthStencilState : GraphicsResource
     {
         private readonly bool _defaultStateObject;

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -130,6 +130,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the comparison function to use for counterclockwise stencil tests.
+        /// The default value is <see cref="CompareFunction.Always">CompareFunction.Always</see>
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public CompareFunction CounterClockwiseStencilFunction
         {
             get { return _counterClockwiseStencilFunction; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -319,6 +319,19 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the mask applied to the reference value and each stencil buffer entry to determine the
+        /// significant bits for the stencil test.
+        /// The default mask is <see cref="Int32.MaxValue">Int32.MaxValue</see>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public int StencilMask
         {
             get { return _stencilMask; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -490,6 +490,18 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </code>
         /// </remarks>
         public static readonly DepthStencilState Default;
+
+        /// <summary>
+        /// A built-int state object with settings for enabling a read-only depth stencil buffer.
+        /// </summary>
+        /// <remarks>
+        /// This built-in state object has the following settings:
+        ///
+        /// <code>
+        /// DepthBufferEnable = true,
+        /// DepthBufferWriteEnable = false
+        /// </code>
+        /// </remarks>
         public static readonly DepthStencilState DepthRead;
         public static readonly DepthStencilState None;
 

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -175,6 +175,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the comparison function for the depth-buffer test.
+        /// The default value is <see cref="CompareFunction.LessEqual">CompareFunction.LessEqual</see>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public CompareFunction DepthBufferFunction
         {
             get { return _depthBufferFunction; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -297,6 +297,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the comparison function for the stencil test.
+        /// The default is <see cref="CompareFunction.Always">CompareFunction.Always</see>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public CompareFunction StencilFunction
         {
             get { return _stencilFunction; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -275,6 +275,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the stencil operation to perform if the stencil test fails.
+        /// The default is <see cref="StencilOperation.Keep">StencilOperation.Keep</see>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public StencilOperation StencilFail
         {
             get { return _stencilFail; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -481,6 +481,14 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// A built-in state object with default settings for using a depth stencil buffer.
         /// </summary>
+        /// <remarks>
+        /// This built-in state object has the following settings:
+        ///
+        /// <code>
+        /// DepthBufferEnable = true,
+        /// DepthBufferWriteEnable = true
+        /// </code>
+        /// </remarks>
         public static readonly DepthStencilState Default;
         public static readonly DepthStencilState DepthRead;
         public static readonly DepthStencilState None;

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -425,6 +425,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new InvalidOperationException("You cannot modify the depth stencil state after it has been bound to the graphics device!");
         }
 
+        /// <summary>
+        /// Creates a new instance of the DepthStencilState class with default values.
+        /// </summary>
         public DepthStencilState ()
 		{
             DepthBufferEnable = true;

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -386,6 +386,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets a value that indicates whether two-sided stenciling is enabled.
+        /// The default value is false.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public bool TwoSidedStencilMode
         {
             get { return _twoSidedStencilMode; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -43,6 +43,28 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets a value that indicates if writing to the depth buffer is enabled.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         This property enables an application to prevent the system from updating the depth buffer with new
+        ///         values.
+        ///     </para>
+        ///     <para>
+        ///         if false, depth comparisons are still made according to the render state
+        ///         <see cref="DepthBufferFunction"/>, assuming that depth buffering is taking place, but depth values
+        ///         are not written to the buffer.
+        ///     </para>
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public bool DepthBufferWriteEnable
         {
             get { return _depthBufferWriteEnable; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         /// <summary>
         /// Gets or Sets a value that indicates if writing to the depth buffer is enabled.
+        /// The default value is true.
         /// </summary>
         /// <remarks>
         ///     <para>

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         /// <summary>
         /// Gets or Sets a value that indicates if depth buffering is enabled.
+        /// The default value is true.
         /// </summary>
         /// <exception cref="InvalidOperationException">
         /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -253,6 +253,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets a value that indicates whether stenciling is enabled.
+        /// The default is false.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public bool StencilEnable
         {
             get { return _stencilEnable; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -478,6 +478,9 @@ namespace Microsoft.Xna.Framework.Graphics
             _twoSidedStencilMode = cloneSource._twoSidedStencilMode;
 	    }
 
+        /// <summary>
+        /// A built-in state object with default settings for using a depth stencil buffer.
+        /// </summary>
         public static readonly DepthStencilState Default;
         public static readonly DepthStencilState DepthRead;
         public static readonly DepthStencilState None;

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -108,6 +108,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the stencil operation to perform if the stencil test fails for the counterclockwise triangle.
+        /// The default value is <see cref="StencilOperation.Keep">StencilOperation.Keep</see>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public StencilOperation CounterClockwiseStencilFail
         {
             get { return _counterClockwiseStencilFail; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -531,6 +531,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         partial void PlatformDispose();
 
+        /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
             if (!IsDisposed)

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -152,6 +152,19 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the stencil operation to perform if the stencil and depth-tests pass for a counterclockwise
+        /// triangle.
+        /// The default value is <see cref="StencilOperation.Keep">StencilOperation.Keep</see>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public StencilOperation CounterClockwiseStencilPass
         {
             get { return _counterClockwiseStencilPass; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -342,6 +342,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the stencil operation to perform if the stencil test passes.
+        /// The default value is <see cref="StencilOperation.Keep">StencilOperation.Keep</see>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public StencilOperation StencilPass
         {
             get { return _stencilPass; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -33,6 +33,14 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Gets or Sets a value that indicates if depth buffering is enabled.
         /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public bool DepthBufferEnable
         {
             get { return _depthBufferEnable; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -231,6 +231,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the stencil operation to perform if the stencil test passes and the depth-test fails.
+        /// The default is <see cref="StencilOperation.Keep">StencilOperation.Keep</see>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public StencilOperation StencilDepthBufferFail
         {
             get { return _stencilDepthBufferFail; }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -364,6 +364,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or Sets the write mask applied to values written into the stencil buffer.
+        /// The default mask is <see cref="Int32.MaxValue">Int32.MaxValue</see>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// When setting this value for one of the default DepthStencilState instances; <see cref="Default"/>,
+        /// <see cref="DepthRead"/>, or <see cref="None"/>.
+        ///
+        /// -or-
+        ///
+        /// When setting this value after this DepthStencilState has already been bound to the graphics device.
+        /// </exception>
         public int StencilWriteMask
         {
             get { return _stencilWriteMask; }


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to the `DepthStencilState` class.

## Reference
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)