### PR TITLE
[Documentation] Adds DisplayMode XML Documentation

### DIFF
--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -112,6 +112,13 @@ namespace Microsoft.Xna.Framework.Graphics
             return !(left == right);
         }
 
+        /// <summary>
+        /// Compares the current instance of the DisplayMode class to another instance to determine whether they are
+        /// equal.
+        /// </summary>
+        /// <param name="left">The DisplayMode object on the left of the equality operator.</param>
+        /// <param name="right">The DisplayMode object on the right of the equality operator.</param>
+        /// <returns>true if the objects are equal; otherwise, false.</returns>
         public static bool operator ==(DisplayMode left, DisplayMode right)
         {
             if (ReferenceEquals(left, right)) //Same object or both are null

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -100,6 +100,13 @@ namespace Microsoft.Xna.Framework.Graphics
 
         #region Operators
 
+        /// <summary>
+        /// Compares the current instance of the DisplayMode class to another instance to determine whether they are
+        /// different.
+        /// </summary>
+        /// <param name="left">The DisplayMode object on the left of the inequality operator.</param>
+        /// <param name="right">The DisplayMode object on the right of the inequality operator.</param>
+        /// <returns>true if the objects are different; otherwise, false.</returns>
         public static bool operator !=(DisplayMode left, DisplayMode right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -34,6 +34,9 @@ using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Describes the display mode.
+    /// </summary>
     [DataContract]
     public class DisplayMode
     {

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Xna.Framework.Graphics
             return (this.width.GetHashCode() ^ this.height.GetHashCode() ^ this.format.GetHashCode());
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return "{Width:" + this.width + " Height:" + this.height + " Format:" + this.Format + " AspectRatio:" + this.AspectRatio + "}";

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -138,6 +138,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         #region Public Methods
 
+        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             return obj is DisplayMode && this == (DisplayMode)obj;

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -77,7 +77,10 @@ namespace Microsoft.Xna.Framework.Graphics
         public int Width {
             get { return this.width; }
         }
-        
+
+        /// <summary>
+        /// Gets the bounds of the display that is guaranteed to be visible by the users screen.
+        /// </summary>
         public Rectangle TitleSafeArea {
             get { return GraphicsDevice.GetTitleSafeArea(0, 0, width, height); }
         }

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -144,6 +144,7 @@ namespace Microsoft.Xna.Framework.Graphics
             return obj is DisplayMode && this == (DisplayMode)obj;
         }
 
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             return (this.width.GetHashCode() ^ this.height.GetHashCode() ^ this.format.GetHashCode());

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -49,7 +49,10 @@ namespace Microsoft.Xna.Framework.Graphics
         #endregion Fields
 
         #region Properties
-        
+
+        /// <summary>
+        /// Gets a value indicating the aspect ratio of the display mode
+        /// </summary>
         public float AspectRatio {
             get { return (float)width / (float)height; }
         }

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -54,6 +54,9 @@ namespace Microsoft.Xna.Framework.Graphics
             get { return (float)width / (float)height; }
         }
 
+        /// <summary>
+        /// Gets a value indicating the surface format of the display mode.
+        /// </summary>
         public SurfaceFormat Format {
             get { return format; }
         }

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -61,6 +61,9 @@ namespace Microsoft.Xna.Framework.Graphics
             get { return format; }
         }
 
+        /// <summary>
+        /// Gets a value indicating the screen height, in pixels.
+        /// </summary>
         public int Height {
             get { return this.height; }
         }

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -68,6 +68,9 @@ namespace Microsoft.Xna.Framework.Graphics
             get { return this.height; }
         }
 
+        /// <summary>
+        /// Gets a value indicating the screen width, in pixels.
+        /// </summary>
         public int Width {
             get { return this.width; }
         }


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to the `DisplayMode` class.

## Reference
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)