### PR TITLE
[Documentation] Adds and Corrects Documentation for Collection classes

### DIFF
--- a/MonoGame.Framework/GameComponentCollection.cs
+++ b/MonoGame.Framework/GameComponentCollection.cs
@@ -37,6 +37,15 @@ namespace Microsoft.Xna.Framework
             base.ClearItems();
         }
 
+        /// <summary>
+        /// Inserts an element into the collection at the specified index.
+        /// Triggers <see cref="OnComponentAdded(GameComponentCollectionEventArgs)"/>.
+        /// </summary>
+        /// <param name="index">The zero-based index at which item should be inserted.</param>
+        /// <param name="item">The object to insert.</param>
+        /// <exception cref="ArgumentException">
+        /// Specified <see cref="IGameComponent"/> is already present in the collection.
+        /// </exception>
         protected override void InsertItem(int index, IGameComponent item)
         {
             if (base.IndexOf(item) != -1)
@@ -60,6 +69,11 @@ namespace Microsoft.Xna.Framework
             EventHelpers.Raise(this, ComponentRemoved, eventArgs);
         }
 
+        /// <summary>
+        /// Removes the element at the specified index of the <see cref="GameComponentCollection"/>.
+        /// Triggers <see cref="OnComponentRemoved(GameComponentCollectionEventArgs)"/>.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to remove.</param>
         protected override void RemoveItem(int index)
         {
             IGameComponent gameComponent = base[index];
@@ -70,6 +84,15 @@ namespace Microsoft.Xna.Framework
             }
         }
 
+        /// <summary>
+        /// Replaces the element at the specified index.
+        /// </summary>
+        /// <remarks>
+        /// This method is not supported and will always throw <see cref="NotSupportedException"/>
+        /// </remarks>
+        /// <param name="index">The zero-based index of the element to replace.</param>
+        /// <param name="item">The new value for the element at the specified index.</param>
+        /// <exception cref="NotSupportedException">Thrown always</exception>
         protected override void SetItem(int index, IGameComponent item)
         {
             throw new NotSupportedException();

--- a/MonoGame.Framework/Graphics/Effect/EffectAnnotationCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectAnnotationCollection.cs
@@ -2,7 +2,10 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	public class EffectAnnotationCollection : IEnumerable<EffectAnnotation>
+    /// <summary>
+    /// Represents a collection of <see cref="EffectAnnotation"/> objects.
+    /// </summary>
+    public class EffectAnnotationCollection : IEnumerable<EffectAnnotation>
 	{
         internal static readonly EffectAnnotationCollection Empty = new EffectAnnotationCollection(new EffectAnnotation[0]);
 
@@ -13,17 +16,27 @@ namespace Microsoft.Xna.Framework.Graphics
             _annotations = annotations;
         }
 
+        /// <summary>
+        /// Gets the number of elements contained in the collection.
+        /// </summary>
 		public int Count 
         {
 			get { return _annotations.Length; }
 		}
-		
-		public EffectAnnotation this[int index]
+
+        /// <summary>
+        /// Retrieves the <see cref="EffectAnnotation"/> at the specified index in the collection.
+        /// </summary>
+        public EffectAnnotation this[int index]
         {
             get { return _annotations[index]; }
         }
-		
-		public EffectAnnotation this[string name]
+
+        /// <summary>
+        /// Retrieves a <see cref="EffectAnnotation"/> from the collection, given the name of the annotation.
+        /// </summary>
+        /// <param name="name">The name of the annotation to retrieve.</param>
+        public EffectAnnotation this[string name]
         {
             get 
             {
@@ -35,7 +48,8 @@ namespace Microsoft.Xna.Framework.Graphics
 				return null;
 			}
         }
-		
+
+        /// <inheritdoc/>
 		public IEnumerator<EffectAnnotation> GetEnumerator()
         {
             return ((IEnumerable<EffectAnnotation>)_annotations).GetEnumerator();

--- a/MonoGame.Framework/Graphics/Effect/EffectParameterCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectParameterCollection.cs
@@ -2,6 +2,9 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Represents a collection of <see cref="EffectParameter"/> objects.
+    /// </summary>
     public class EffectParameterCollection : IEnumerable<EffectParameter>
     {
         internal static readonly EffectParameterCollection Empty = new EffectParameterCollection(new EffectParameter[0]);
@@ -39,17 +42,27 @@ namespace Microsoft.Xna.Framework.Graphics
             return new EffectParameterCollection(parameters, _indexLookup);
         }
 
+        /// <summary>
+        /// Gets the number of elements contained in the collection.
+        /// </summary>
         public int Count
         {
             get { return _parameters.Length; }
         }
-		
-		public EffectParameter this[int index]
+
+        /// <summary>
+        /// Retrieves the <see cref="EffectParameter"/> at the specified index in the collection.
+        /// </summary>
+        public EffectParameter this[int index]
 		{
 			get { return _parameters[index]; }
 		}
-		
-		public EffectParameter this[string name]
+
+        /// <summary>
+        /// Retrieves a <see cref="EffectParameter"/> from the collection, given the name of the parameter.
+        /// </summary>
+        /// <param name="name">The name of the parameter to retrieve.</param>
+        public EffectParameter this[string name]
         {
             get
             {
@@ -60,6 +73,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
         }
 
+        /// <inheritdoc/>
         public IEnumerator<EffectParameter> GetEnumerator()
         {
             return ((IEnumerable<EffectParameter>)_parameters).GetEnumerator();

--- a/MonoGame.Framework/Graphics/Effect/EffectPassCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectPassCollection.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Represents a collection of <see cref="EffectPass"/> objects.
+    /// </summary>
     public class EffectPassCollection : IEnumerable<EffectPass>
     {
 		private readonly EffectPass[] _passes;
@@ -21,11 +24,18 @@ namespace Microsoft.Xna.Framework.Graphics
             return new EffectPassCollection(passes);
         }
 
+        /// <summary>
+        /// Retrieves the <see cref="EffectPass"/> at the specified index in the collection.
+        /// </summary>
         public EffectPass this[int index]
         {
             get { return _passes[index]; }
         }
 
+        /// <summary>
+        /// Retrieves a <see cref="EffectPass"/> from the collection, given the name of the pass.
+        /// </summary>
+        /// <param name="name">The name of the pass to retrieve.</param>
         public EffectPass this[string name]
         {
             get 
@@ -40,11 +50,18 @@ namespace Microsoft.Xna.Framework.Graphics
 		    }
         }
 
+        /// <summary>
+        /// Gets the number of elements contained in the collection.
+        /// </summary>
         public int Count
         {
             get { return _passes.Length; }
         }
 
+        /// <summary>
+        /// Returns a <see cref="EffectPassCollection.Enumerator">EffectPassCollection.Enumerator</see>
+        /// that can iterate through a collection.
+        /// </summary>
         public Enumerator GetEnumerator()
         {
             return new Enumerator(_passes);
@@ -60,6 +77,9 @@ namespace Microsoft.Xna.Framework.Graphics
             return _passes.GetEnumerator();
         }
 
+        /// <summary>
+        /// Enumerator to iterate through the <see cref="EffectPassCollection"/>
+        /// </summary>
         public struct Enumerator : IEnumerator<EffectPass>
         {
             private readonly EffectPass[] _array;
@@ -73,6 +93,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 _current = null;
             }
 
+            /// <inheritdoc/>
             public bool MoveNext()
             {
                 if (_index < _array.Length)
@@ -86,11 +107,13 @@ namespace Microsoft.Xna.Framework.Graphics
                 return false;
             }
 
+            /// <inheritdoc/>
             public EffectPass Current
             {
                 get { return _current; }
             }
 
+            /// <inheritdoc cref="IDisposable.Dispose()"/>
             public void Dispose()
             {
 

--- a/MonoGame.Framework/Graphics/Effect/EffectTechniqueCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectTechniqueCollection.cs
@@ -2,10 +2,16 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Represents a collection of <see cref="EffectTechnique"/> objects.
+    /// </summary>
     public class EffectTechniqueCollection : IEnumerable<EffectTechnique>
     {
 		private readonly EffectTechnique[] _techniques;
 
+        /// <summary>
+        /// Gets the number of elements contained in the collection.
+        /// </summary>
         public int Count { get { return _techniques.Length; } }
 
         internal EffectTechniqueCollection(EffectTechnique[] techniques)
@@ -21,12 +27,19 @@ namespace Microsoft.Xna.Framework.Graphics
 
             return new EffectTechniqueCollection(techniques);
         }
-        
+
+        /// <summary>
+        /// Retrieves the <see cref="EffectTechnique"/> at the specified index in the collection.
+        /// </summary>
         public EffectTechnique this[int index]
         {
             get { return _techniques [index]; }
         }
 
+        /// <summary>
+        /// Retrieves a <see cref="EffectTechnique"/> from the collection, given the name of the technique.
+        /// </summary>
+        /// <param name="name">The name of the technique to retrieve.</param>
         public EffectTechnique this[string name]
         {
             get 
@@ -42,6 +55,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		    }
         }
 
+        /// <inheritdoc/>
         public IEnumerator<EffectTechnique> GetEnumerator()
         {
             return ((IEnumerable<EffectTechnique>)_techniques).GetEnumerator();

--- a/MonoGame.Framework/Graphics/ModelBoneCollection.cs
+++ b/MonoGame.Framework/Graphics/ModelBoneCollection.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Xna.Framework.Graphics
     /// </summary>
     public class ModelBoneCollection : ReadOnlyCollection<ModelBone>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelBoneCollection"/>
+        /// class that is a read-only wrapper around the specified list.
+        /// </summary>
+        /// <param name="list">The list to wrap.</param>
         public ModelBoneCollection(IList<ModelBone> list)
             : base(list)
         {
@@ -21,7 +26,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Retrieves a ModelBone from the collection, given the name of the bone.
+        /// Retrieves a <see cref="ModelBone"/> from the collection, given the name of the bone.
         /// </summary>
         /// <param name="boneName">The name of the bone to retrieve.</param>
         public ModelBone this[string boneName]
@@ -60,7 +65,8 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Returns a ModelMeshCollection.Enumerator that can iterate through a ModelMeshCollection.
+        /// Returns a <see cref="ModelBoneCollection.Enumerator">ModelBoneCollection.Enumerator</see>
+        /// that can iterate through a collection.
         /// </summary>
         /// <returns></returns>
         public new Enumerator GetEnumerator()
@@ -69,7 +75,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Provides the ability to iterate through the bones in an ModelMeshCollection.
+        /// Provides the ability to iterate through the bones in an ModelBoneCollection.
         /// </summary>
         public struct Enumerator : IEnumerator<ModelBone>
         {
@@ -84,12 +90,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
 
             /// <summary>
-            /// Gets the current element in the ModelMeshCollection.
+            /// Gets the current element in the ModelBoneCollection.
             /// </summary>
             public ModelBone Current { get { return _collection[_position]; } }
 
             /// <summary>
-            /// Advances the enumerator to the next element of the ModelMeshCollection.
+            /// Advances the enumerator to the next element of the ModelBoneCollection.
             /// </summary>
             public bool MoveNext()
             {
@@ -115,6 +121,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 get { return _collection[_position]; }
             }
 
+            /// <inheritdoc/>
             public void Reset()
             {
                 _position = -1;

--- a/MonoGame.Framework/Graphics/ModelEffectCollection.cs
+++ b/MonoGame.Framework/Graphics/ModelEffectCollection.cs
@@ -5,9 +5,10 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	// Summary:
-	//     Represents a collection of effects associated with a model.
-	public sealed class ModelEffectCollection : ReadOnlyCollection<Effect>
+    /// <summary>
+    /// Represents a collection of effects associated with a model.
+    /// </summary>
+    public sealed class ModelEffectCollection : ReadOnlyCollection<Effect>
 	{
 		internal ModelEffectCollection(IList<Effect> list)
 			: base(list)
@@ -29,16 +30,19 @@ namespace Microsoft.Xna.Framework.Graphics
 			Items.Remove (item);
 		}
 
-	    // Summary:
-	    //     Returns a ModelEffectCollection.Enumerator that can iterate through a ModelEffectCollection.
-	    public new ModelEffectCollection.Enumerator GetEnumerator()
+        /// <summary>
+        /// Returns a <see cref="ModelEffectCollection.Enumerator">ModelEffectCollection.Enumerator</see>
+        /// that can iterate through a collection.
+        /// </summary>
+        public new ModelEffectCollection.Enumerator GetEnumerator()
 		{
 			return new ModelEffectCollection.Enumerator((List<Effect>)Items);
 		}
 
-	    // Summary:
-	    //     Provides the ability to iterate through the bones in an ModelEffectCollection.
-	    public struct Enumerator : IEnumerator<Effect>, IDisposable, IEnumerator
+        /// <summary>
+        /// Enumerator to iterate through the <see cref="ModelEffectCollection"/>
+        /// </summary>
+        public struct Enumerator : IEnumerator<Effect>, IDisposable, IEnumerator
 	    {
 			List<Effect>.Enumerator enumerator;
             bool disposed;
@@ -49,12 +53,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 disposed = false;
 			}
 
-	        // Summary:
-	        //     Gets the current element in the ModelEffectCollection.
-	        public Effect Current { get { return enumerator.Current; } }
+	        /// <inheritdoc/>
+            public Effect Current { get { return enumerator.Current; } }
 
-	        // Summary:
-	        //     Immediately releases the unmanaged resources used by this object.
+	        /// <inheritdoc cref="IDisposable.Dispose()"/>
 	        public void Dispose()
             {
                 if (!disposed)
@@ -63,9 +65,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     disposed = true;
                 }
             }
-	        //
-	        // Summary:
-	        //     Advances the enumerator to the next element of the ModelEffectCollection.
+
+	        /// <inheritdoc/>
 	        public bool MoveNext() { return enumerator.MoveNext(); }
 
 	        #region IEnumerator Members

--- a/MonoGame.Framework/Graphics/ModelMeshCollection.cs
+++ b/MonoGame.Framework/Graphics/ModelMeshCollection.cs
@@ -10,7 +10,7 @@ using System.Collections.ObjectModel;
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
-    /// Represents a collection of ModelMesh objects.
+    /// Represents a collection of <see cref="ModelMesh"/> objects.
     /// </summary>
     public sealed class ModelMeshCollection : ReadOnlyCollection<ModelMesh>
     {
@@ -21,7 +21,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Retrieves a ModelMesh from the collection, given the name of the mesh.
+        /// Retrieves a <see cref="ModelMesh"/> from the collection, given the name of the mesh.
         /// </summary>
         /// <param name="meshName">The name of the mesh to retrieve.</param>
         public ModelMesh this[string meshName]
@@ -60,9 +60,9 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Returns a ModelMeshCollection.Enumerator that can iterate through a ModelMeshCollection.
+        /// Returns a <see cref="ModelMeshCollection.Enumerator">ModelMeshCollection.Enumerator</see>
+        /// that can iterate through a collection.
         /// </summary>
-        /// <returns></returns>
         public new Enumerator GetEnumerator()
         {
             return new Enumerator(this);
@@ -115,6 +115,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 get { return _collection[_position]; }
             }
 
+            /// <inheritdoc/>
             public void Reset()
             {
                 _position = -1;

--- a/MonoGame.Framework/Graphics/ModelMeshPartCollection.cs
+++ b/MonoGame.Framework/Graphics/ModelMeshPartCollection.cs
@@ -5,9 +5,16 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-
+    /// <summary>
+    /// Represents a collection of <see cref="ModelMeshPart"/> objects.
+    /// </summary>
 	public sealed class ModelMeshPartCollection : ReadOnlyCollection<ModelMeshPart>
 	{
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelMeshPartCollection"/>
+        /// class that is a read-only wrapper around the specified list.
+        /// </summary>
+        /// <param name="list">The list to wrap.</param>
 		public ModelMeshPartCollection(IList<ModelMeshPart> list)
 			: base(list)
 		{

--- a/MonoGame.Framework/Graphics/SamplerStateCollection.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.cs
@@ -6,6 +6,9 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Represents a collection of <see cref="SamplerState"/> objects,
+    /// </summary>
     public sealed partial class SamplerStateCollection
 	{
         private readonly GraphicsDevice _graphicsDevice;
@@ -39,7 +42,10 @@ namespace Microsoft.Xna.Framework.Graphics
 		    Clear();
         }
 
-		public SamplerState this [int index]
+        /// <summary>
+        /// Gets or sets the <see cref="SamplerState"/> at the specified index in the collection.
+        /// </summary>
+        public SamplerState this [int index]
         {
 			get
             {

--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -6,6 +6,9 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Represents a collection of <see cref="Texture"/> objects. This class cannot be inherited.
+    /// </summary>
     public sealed partial class TextureCollection
     {
         private readonly GraphicsDevice _graphicsDevice;
@@ -22,6 +25,9 @@ namespace Microsoft.Xna.Framework.Graphics
             PlatformInit();
         }
 
+        /// <summary>
+        /// Gets or sets the <see cref="Texture"/> at the specified sampler number.
+        /// </summary>
         public Texture this[int index]
         {
             get

--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -267,6 +267,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
                 get { return _collection[_position]; }
             }
 
+            /// <inheritdoc/>
             public void Reset()
             {
                 _position = -1;


### PR DESCRIPTION
This PR adds the documentation for the following classes:
- `Graphics/Effect/EffectAnnotationCollection`
- `Graphics/Effect/EffectParameterCollection`
- `Graphics/Effect/EffectPassCollection`
- `Graphics/Effect/EffectTechniqueCollection`
- `Graphics/ModelBoneCollection` **(with fixes)**
- `Graphics/ModelEffectCollection` **(with fixes)**
- `Graphics/ModelMeshCollection` (with minor improvements)
- `Graphics/ModelMeshPartCollection`
- `Graphics/SamplerStateCollection`
- `Graphics/TextureCollection`
- `Input/Touch/TouchCollection`
- `GameComponentCollection`

## Reference:
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)