### PR TITLE
[Documentation] Adds CurveKey XML Documentation 

### DIFF
--- a/MonoGame.Framework/CurveKey.cs
+++ b/MonoGame.Framework/CurveKey.cs
@@ -174,21 +174,25 @@ namespace Microsoft.Xna.Framework
 
         #region Inherited Methods
 
+        /// <inheritdoc/>
         public int CompareTo(CurveKey other)
         {
             return this._position.CompareTo(other._position);
         }
 
+        /// <inheritdoc/>
         public bool Equals(CurveKey other)
         {
             return (this == other);
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return (obj as CurveKey) != null && Equals((CurveKey)obj);
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this._position.GetHashCode() ^ this._value.GetHashCode() ^ this._tangentIn.GetHashCode() ^


### PR DESCRIPTION
This PR adds the documentation for the `CurveKey` class.

(i really didn't want to do PR for such small change, but I have nothing to link this change to.) 

## Reference:
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)