### PR TITLE
[Documentation] Adds DisplayModeCollection XML Documentation

### DIFF
--- a/MonoGame.Framework/Graphics/DisplayModeCollection.cs
+++ b/MonoGame.Framework/Graphics/DisplayModeCollection.cs
@@ -33,6 +33,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// A collection that manipulates <see cref="DisplayMode"/> instances.
+    /// </summary>
     public class DisplayModeCollection : IEnumerable<DisplayMode>
     {
         private readonly List<DisplayMode> _modes;

--- a/MonoGame.Framework/Graphics/DisplayModeCollection.cs
+++ b/MonoGame.Framework/Graphics/DisplayModeCollection.cs
@@ -40,6 +40,9 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         private readonly List<DisplayMode> _modes;
 
+        /// <summary>
+        /// Gets the <see cref="DisplayMode"/> instance with the specified format.
+        /// </summary>
         public IEnumerable<DisplayMode> this[SurfaceFormat format]
         {
             get 

--- a/MonoGame.Framework/Graphics/DisplayModeCollection.cs
+++ b/MonoGame.Framework/Graphics/DisplayModeCollection.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc />
         public IEnumerator<DisplayMode> GetEnumerator()
         {
             return _modes.GetEnumerator();


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to the `DisplayModeCollection` class.

## Reference
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)