### PR TITLE
Performance: Using newer Environment.CurrentManagedThreadId for UI/Main thread check

### DIFF
--- a/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Xna.Framework
 
         protected void WorkerThreadFrameDispatcher(SynchronizationContext uiThreadSyncContext)
         {
-            Threading.ResetThread(Thread.CurrentThread.ManagedThreadId);
+            Threading.ResetThread(Environment.CurrentManagedThreadId);
             try
             {
                 stopWatch = System.Diagnostics.Stopwatch.StartNew();
@@ -573,7 +573,7 @@ namespace Microsoft.Xna.Framework
         bool RunIteration(CancellationToken token)
         {
             // set main game thread global ID
-            Threading.ResetThread(Thread.CurrentThread.ManagedThreadId);
+            Threading.ResetThread(Environment.CurrentManagedThreadId);
 
             InternalState currentState = InternalState.Exited_GameThread;
 

--- a/MonoGame.Framework/Platform/Threading.cs
+++ b/MonoGame.Framework/Platform/Threading.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Xna.Framework
 
         static Threading()
         {
-            _mainThreadId = Thread.CurrentThread.ManagedThreadId;
+            _mainThreadId = Environment.CurrentManagedThreadId;
         }
 
 #if ANDROID
@@ -76,7 +76,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>true if the code is currently running on the UI thread.</returns>
         public static bool IsOnUIThread()
         {
-            return _mainThreadId == Thread.CurrentThread.ManagedThreadId;
+            return _mainThreadId == Environment.CurrentManagedThreadId;
         }
 
         /// <summary>


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1840

According to Microsoft, System.Environment.CurrentManagedThreadId is a 'compact and efficient replacement' to Thread.CurrentThread.ManagedThreadId.

 I've made this change in Platform/Threading.cs where the UI thread is checked. 