### PR TITLE
Respect Window.AllowAltF4 For SDLGamePlatform

### DIFF
--- a/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs
@@ -93,9 +93,25 @@ namespace Microsoft.Xna.Framework
                 Threading.Run();
                 GraphicsDevice.DisposeContexts();
 
-                if (_isExiting > 0)
+                if (_isExiting > 0 && ShouldExit())
+                {
                     break;
+                }
+                else
+                {
+                    _isExiting = 0;
+                }
             }
+        }
+
+        private bool ShouldExit()
+        {
+            if(_keys.Contains(Keys.F4) && (_keys.Contains(Keys.LeftAlt) || _keys.Contains(Keys.RightAlt)))
+            {
+                return Window.AllowAltF4;
+            }
+
+            return true;
         }
 
         private void SdlRunLoop()


### PR DESCRIPTION
## Description
Currently `Window.AllowAltF4` is not respected for `SDLGamePlatform`.  No matter the property setting `ALT+F4` will close the window.

This PR adds the check for `Alt+F4` during the exit check in the platform loop and handles exiting based on the keyboard key combination and the `Window.AllowAltF4` property.  If the keyboard combination was not pressed, then it falls back to the default behavior of allowing the exit to occur.

## Notes
Press `Alt+F4` will trigger `SDL.EventType.Quit`
https://github.com/MonoGame/MonoGame/blob/40452a45c261a4a32c63e1c6c35e5f2676c1dfc2/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs#L109-L111

However, `Alt+F4` can also trigger `Sdl.Window.EventId.Close`
https://github.com/MonoGame/MonoGame/blob/40452a45c261a4a32c63e1c6c35e5f2676c1dfc2/MonoGame.Framework/Platform/SDL/SDLGamePlatform.cs#L227-L229

It is inconsistent on which of these events is triggered first.  Regardless, when both events are triggered, they `_keys` collection does not contain both the `Keys.LeftAlt`/`Keys.RightAlt` and the `Keys.F4` due to the events firing before the keyboard update is performed.

Due to these reasons, this is why the check was moved into the platform loop and made during the `_isExiting` check.