### PR TITLE
[Documentation] Adds XML documentation to the Input namespace

### DIFF
--- a/MonoGame.Framework/Input/GamePadButtons.cs
+++ b/MonoGame.Framework/Input/GamePadButtons.cs
@@ -142,7 +142,12 @@ namespace Microsoft.Xna.Framework.Input
                 return ((_buttons & Buttons.BigButton) == Buttons.BigButton) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GamePadButtons"/> structure,
+        /// setting the specified buttons to pressed in.
+        /// </summary>
+        /// <param name="buttons">Buttons to be set as pressed in.</param>
         public GamePadButtons(Buttons buttons)
         {
             _buttons = buttons;

--- a/MonoGame.Framework/Input/GamePadDPad.cs
+++ b/MonoGame.Framework/Input/GamePadDPad.cs
@@ -4,6 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Input
 {
+    /// <summary>
+    /// A struct that represents which directions on the directional pad of a controller are being pressed.
+    /// </summary>
     public struct GamePadDPad
     {
         /// <summary>

--- a/MonoGame.Framework/Input/GamePadThumbSticks.cs
+++ b/MonoGame.Framework/Input/GamePadThumbSticks.cs
@@ -42,6 +42,12 @@ namespace Microsoft.Xna.Framework.Input
             get { return _right; }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GamePadThumbSticks"/> struct,
+        /// setting positions of the sticks. 
+        /// </summary>
+        /// <param name="leftPosition">Position of the left controller stick.</param>
+        /// <param name="rightPosition">Position of the right controller stick.</param>
         public GamePadThumbSticks(Vector2 leftPosition, Vector2 rightPosition)
             : this(leftPosition, rightPosition, GamePadDeadZone.None, GamePadDeadZone.None)
         {

--- a/MonoGame.Framework/Input/KeyboardInput.cs
+++ b/MonoGame.Framework/Input/KeyboardInput.cs
@@ -3,8 +3,14 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Xna.Framework.Input
 {
+    /// <summary>
+    /// Provides access to the keyboard input user interface.
+    /// </summary>
     public static partial class KeyboardInput
     {
+        /// <summary>
+        /// Determines if a keyboard user interface screen is active.
+        /// </summary>
         public static bool IsVisible { get; private set; }
 
         /// <summary>

--- a/MonoGame.Framework/Input/MessageBox.cs
+++ b/MonoGame.Framework/Input/MessageBox.cs
@@ -5,8 +5,14 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Xna.Framework.Input
 {
+    /// <summary>
+    /// Provides access to the message box user interface. 
+    /// </summary>
     public static partial class MessageBox
     {
+        /// <summary>
+        /// Determines if a message box user interface screen is active.
+        /// </summary>
         public static bool IsVisible { get; private set; }
 
         /// <summary>

--- a/MonoGame.Framework/Input/MouseCursor.cs
+++ b/MonoGame.Framework/Input/MouseCursor.cs
@@ -86,6 +86,9 @@ namespace Microsoft.Xna.Framework.Input
             return PlatformFromTexture2D(texture, originx, originy);
         }
 
+        /// <summary>
+        /// Gets a handle for this cursor.
+        /// </summary>
         public IntPtr Handle { get; private set; }
 
         private bool _disposed;
@@ -100,6 +103,7 @@ namespace Microsoft.Xna.Framework.Input
             Handle = handle;
         }
 
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
             if (_disposed)

--- a/MonoGame.Framework/Input/Touch/TouchLocation.cs
+++ b/MonoGame.Framework/Input/Touch/TouchLocation.cs
@@ -10,6 +10,9 @@ using System.Diagnostics;
 
 namespace Microsoft.Xna.Framework.Input.Touch
 {
+    /// <summary>
+    /// Provides methods and properties for interacting with a touch location on a touch screen device.
+    /// </summary>
     public struct TouchLocation : IEquatable<TouchLocation>
     {
 		/// <summary>
@@ -67,6 +70,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
             get { return _velocity; }
         }
 
+        /// <summary>
+        /// Gets the ID of the touch location.
+        /// </summary>
 		public int Id 
 		{ 
 			get
@@ -75,6 +81,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
 	        }
 		}
 
+        /// <summary>
+        /// Gets the position of the touch location.
+        /// </summary>
         public Vector2 Position 
 		{ 
 			get
@@ -82,7 +91,11 @@ namespace Microsoft.Xna.Framework.Input.Touch
 	            return _position;
 	        }
 		}
-		
+
+        /// <summary>
+        /// Gets the pressure of the touch location.
+        /// </summary>
+        /// <remarks>Only used in Android devices</remarks>
 		public float Pressure 
 		{ 
 			get
@@ -90,7 +103,10 @@ namespace Microsoft.Xna.Framework.Input.Touch
             	return _pressure;
         	}
 		}
-								
+
+        /// <summary>
+        /// Gets the current state of the touch location.
+        /// </summary>
         public TouchLocationState State 
 		{ 
 			get
@@ -98,17 +114,26 @@ namespace Microsoft.Xna.Framework.Input.Touch
 	            return _state;
 	        } 
 		}
-		
-		#endregion
-		
-		#region Constructors
 
+        #endregion
+
+        #region Constructors
+
+        /// <inheritdoc cref="TouchLocation(int, TouchLocationState, Vector2, TouchLocationState, Vector2)"/>
         public TouchLocation(int id, TouchLocationState state, Vector2 position)
             : this(id, state, position, TouchLocationState.Invalid, Vector2.Zero)
         {
         }
 
-        public TouchLocation(   int id, TouchLocationState state, Vector2 position, 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TouchLocation"/> structure.
+        /// </summary>
+        /// <param name="id">ID of the touch location.</param>
+        /// <param name="state">Current state of the touch location.</param>
+        /// <param name="position">Position of the touch location.</param>
+        /// <param name="previousState">Previous state of this touch location.</param>
+        /// <param name="previousPosition">Previous position of this touch location.</param>
+        public TouchLocation(int id, TouchLocationState state, Vector2 position, 
                                 TouchLocationState previousState, Vector2 previousPosition)
             : this(id, state, position, previousState, previousPosition, TimeSpan.Zero, false)
         {
@@ -234,6 +259,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
             return _isHighFrequency;
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
 			if (obj is TouchLocation)
@@ -242,6 +268,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			return false;
 		}
 
+        /// <inheritdoc/>
         public bool Equals(TouchLocation other)
         {
             return  _id.Equals(other._id) &&
@@ -250,17 +277,24 @@ namespace Microsoft.Xna.Framework.Input.Touch
         }
 
 
-
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return _id;
         }
 
+        /// <summary>
+        /// Gets a string representation of the <see cref="TouchLocation"/>.
+        /// </summary>
         public override string ToString()
         {
             return "Touch id:"+_id+" state:"+_state + " position:" + _position + " pressure:" + _pressure +" prevState:"+_previousState+" prevPosition:"+ _previousPosition + " previousPressure:" + _previousPressure;
         }
 
+        /// <summary>
+        /// Attempts to get the previous location of this touch location object.
+        /// </summary>
+        /// <param name="aPreviousLocation">Previous location data, as a <see cref="TouchLocation"/>.</param>
         public bool TryGetPreviousLocation(out TouchLocation aPreviousLocation)
         {
 			if (_previousState == TouchLocationState.Invalid)
@@ -297,6 +331,12 @@ namespace Microsoft.Xna.Framework.Input.Touch
             return true;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the two values are not equal.
+        /// </summary>
+        /// <param name="value1">The value on the left of the inequality operator.</param>
+        /// <param name="value2">The value on the right of the inequality operator.</param>
+        /// <returns><see langword="true"/> if the two values are not equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(TouchLocation value1, TouchLocation value2)
         {
 			return  value1._id != value2._id || 
@@ -306,6 +346,12 @@ namespace Microsoft.Xna.Framework.Input.Touch
 			        value1._previousPosition != value2._previousPosition;
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the two values are equal.
+        /// </summary>
+        /// <param name="value1">The value on the left of the equality operator.</param>
+        /// <param name="value2">The value on the right of the equality operator.</param>
+        /// <returns><see langword="true"/> if the two values are equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator ==(TouchLocation value1, TouchLocation value2)
         {
             return  value1._id == value2._id && 

--- a/MonoGame.Framework/Input/Touch/TouchPanel.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanel.cs
@@ -22,11 +22,18 @@ namespace Microsoft.Xna.Framework.Input.Touch
             return PrimaryWindow.TouchPanelState.GetState();
         }
 
+        /// <summary>
+        /// Gets the current state of the touch panel.
+        /// </summary>
+        /// <param name="window">Game windows to get state from</param>
         public static TouchPanelState GetState(GameWindow window)
         {
             return window.TouchPanelState;
         }
 
+        /// <summary>
+        /// Gets the touch panel capabilities for an available device.
+        /// </summary>
         public static TouchPanelCapabilities GetCapabilities()
         {
             return PrimaryWindow.TouchPanelState.GetCapabilities();
@@ -102,12 +109,18 @@ namespace Microsoft.Xna.Framework.Input.Touch
             set { PrimaryWindow.TouchPanelState.EnabledGestures = value; }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable the mouse touch point.
+        /// </summary>
         public static bool EnableMouseTouchPoint
         {
             get { return PrimaryWindow.TouchPanelState.EnableMouseTouchPoint; }
             set { PrimaryWindow.TouchPanelState.EnableMouseTouchPoint = value; }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable mouse gestures.
+        /// </summary>
         public static bool EnableMouseGestures
         {
             get { return PrimaryWindow.TouchPanelState.EnableMouseGestures; }

--- a/MonoGame.Framework/Input/Touch/TouchPanelCapabilities.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanelCapabilities.cs
@@ -72,6 +72,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
             }
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if a touch device supports pressure.
+        /// </summary>
         public bool HasPressure
         {
             get

--- a/MonoGame.Framework/Input/Touch/TouchPanelState.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanelState.cs
@@ -7,6 +7,10 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Input.Touch
 {
+    /// <summary>
+    /// Represents specific information about the state of the touch panel,
+    /// including the current state of touch locations and gestures.
+    /// </summary>
     public class TouchPanelState
     {
         /// <summary>
@@ -141,6 +145,9 @@ namespace Microsoft.Xna.Framework.Input.Touch
             }
         }
 
+        /// <summary>
+        /// Returns the current touch panel state
+        /// </summary>
         public TouchCollection GetState()
         {
             //Clear out touches from previous frames that were released on the same frame they were touched that haven't been seen
@@ -331,8 +338,14 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// </summary>
         public GestureType EnabledGestures { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether mouse touch points are enabled.
+        /// </summary>
         public bool EnableMouseTouchPoint { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether mouse gestures are enabled.
+        /// </summary>
         public bool EnableMouseGestures { get; set; }
 
         /// <summary>

--- a/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.SDL.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Xna.Framework.Input
         private static readonly Dictionary<int, GamePadInfo> Gamepads = new Dictionary<int, GamePadInfo>();
         private static readonly Dictionary<int, int> _translationTable = new Dictionary<int, int>();
 
+        /// <summary>
+        /// Initialies the internal database of gamepad mappings for an SDL context
+        /// </summary>
         public static void InitDatabase()
         {
             using (var stream = ReflectionHelpers.GetAssembly(typeof(GamePad)).GetManifestResourceStream("gamecontrollerdb.txt"))


### PR DESCRIPTION
This PR adds the documentation for the following classes in the `Input` namespace:
- `GamePadButtons`
- `GamePadDPad`
- `GamePadThumbSticks`
- `KeyboardInput` 
- `MessageBox` 
- `MouseCursor` 
- `Touch/TouchLocation`
- `Touch/TouchPanel`
- `Touch/TouchPanelState`
- `Touch/TouchPanelCapabilities`
- `Platform/Input/GamePad.SDL`

## Notes
In some classes there is an added newline at the end of file. This is forced by VS and i'm not sure how to disable this.

## Reference:
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)