### PR TITLE
[Documentation] Miscellaneous XML documentation

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Xna.Framework
 
         }
 
+        /// <summary/>
         ~Game()
         {
             Dispose(false);
@@ -101,6 +102,7 @@ namespace Microsoft.Xna.Framework
         #region IDisposable Implementation
 
         private bool _isDisposed;
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
             Dispose(true);
@@ -108,6 +110,7 @@ namespace Microsoft.Xna.Framework
             EventHelpers.Raise(this, Disposed, EventArgs.Empty);
         }
 
+        /// <summary/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_isDisposed)
@@ -193,6 +196,9 @@ namespace Microsoft.Xna.Framework
             get { return _components; }
         }
 
+        /// <summary>
+        /// Gets or sets time to sleep between frames when the game is not active
+        /// </summary>
         public TimeSpan InactiveSleepTime
         {
             get { return _inactiveSleepTime; }

--- a/MonoGame.Framework/GameComponent.cs
+++ b/MonoGame.Framework/GameComponent.cs
@@ -20,6 +20,10 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public Game Game { get; private set; }
 
+        /// <summary>
+        /// Indicates whether <see cref="Update(GameTime)">GameComponent.Update(GameTime)</see> should be
+        /// called when <see cref="Game.Update(GameTime)">Game.Update(GameTime)</see> is called.
+        /// </summary>
         public bool Enabled
         {
             get { return _enabled; }
@@ -33,6 +37,11 @@ namespace Microsoft.Xna.Framework
             }
         }
 
+        /// <summary>
+        /// Indicates the order in which the <see cref="GameComponent"/>
+        /// should be updated relative to other <see cref="GameComponent"/> instances.
+        /// Lower values are updated first.
+        /// </summary>
         public int UpdateOrder
         {
             get { return _updateOrder; }
@@ -61,11 +70,15 @@ namespace Microsoft.Xna.Framework
             this.Game = game;
         }
 
+        /// <summary/>
         ~GameComponent()
         {
             Dispose(false);
         }
 
+        /// <summary>
+        /// Called when the <see cref="GameComponent"/> needs to be initialized.
+        /// </summary>
         public virtual void Initialize() { }
 
         /// <summary>

--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -218,6 +218,9 @@ namespace Microsoft.Xna.Framework
             EventHelpers.Raise(this, OrientationChanged, EventArgs.Empty);
 		}
 
+        /// <summary>
+        /// Called when the window needs to be painted.
+        /// </summary>
 		protected void OnPaint ()
 		{
 		}
@@ -254,6 +257,10 @@ namespace Microsoft.Xna.Framework
             EventHelpers.Raise(this, FileDrop, e);
         }
 
+        /// <summary>
+        /// Sets the supported display orientations.
+        /// </summary>
+        /// <param name="orientations">Supported display orientations</param>
         protected internal abstract void SetSupportedOrientations (DisplayOrientation orientations);
 
 	    /// <summary>

--- a/MonoGame.Framework/Graphics/Effect/SkinnedEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/SkinnedEffect.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Xna.Framework.Graphics
     /// </summary>
     public class SkinnedEffect : Effect, IEffectMatrices, IEffectLights, IEffectFog, IEffectBones
     {
+        /// <summary>
+        /// The maximum number of bones.
+        /// </summary>
         public const int MaxBones = 72;
         
         #region Effect Parameters

--- a/MonoGame.Framework/Graphics/GraphicsDebug.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDebug.cs
@@ -4,6 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Represents a class for debugging graphics.
+    /// </summary>
     public partial class GraphicsDebug
     {
         /// <summary>

--- a/MonoGame.Framework/Graphics/OcclusionQuery.cs
+++ b/MonoGame.Framework/Graphics/OcclusionQuery.cs
@@ -6,6 +6,9 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Used to perform an occlusion query against the latest drawn objects.
+    /// </summary>
     public partial class OcclusionQuery : GraphicsResource
     {
         private bool _inBeginEndPair;  // true if Begin was called and End was not yet called.

--- a/MonoGame.Framework/Graphics/PresentationParameters.cs
+++ b/MonoGame.Framework/Graphics/PresentationParameters.cs
@@ -15,10 +15,16 @@ using Microsoft.Xna.Framework.Input.Touch;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Contains graphics presentation parameters.
+    /// </summary>
     public class PresentationParameters
     {
         #region Constants
 
+        /// <summary>
+        /// Default presentation rate 
+        /// </summary>
         public const int DefaultPresentRate = 60;
 
         #endregion Constants

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -11,7 +11,9 @@ using System.Text;
 
 namespace Microsoft.Xna.Framework.Graphics 
 {
-
+    /// <summary>
+    /// Represents a font texture.
+    /// </summary>
 	public sealed class SpriteFont 
     {
 		internal static class Errors 
@@ -379,8 +381,14 @@ namespace Microsoft.Xna.Framework.Graphics
             /// </summary>
             public float WidthIncludingBearings;
 
-			public static readonly Glyph Empty = new Glyph();
+            /// <summary>
+            /// Returns an empty glyph.
+            /// </summary>
+            public static readonly Glyph Empty = new Glyph();
 
+            /// <summary>
+            /// Returns a string representation of this <see cref="Glyph"/>.
+            /// </summary>
 			public override string ToString ()
 			{
                 return "CharacterIndex=" + Character + ", Glyph=" + BoundsInTexture + ", Cropping=" + Cropping + ", Kerning=" + LeftSideBearing + "," + Width + "," + RightSideBearing;

--- a/MonoGame.Framework/Platform/Graphics/IWindowInfo.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/IWindowInfo.OpenGL.cs
@@ -6,8 +6,14 @@ using System;
 
 namespace MonoGame.OpenGL
 {
+    /// <summary>
+    /// Represents an interface for retrieving window information.
+    /// </summary>
     public interface IWindowInfo
     {
+        /// <summary>
+        /// Gets the handle of the window.
+        /// </summary>
         IntPtr Handle { get; }
     }
 }

--- a/MonoGame.Framework/Platform/Graphics/OcclusionQuery.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OcclusionQuery.OpenGL.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Xna.Framework.Graphics
             return true;
         }
 
+        /// <summary/>
         protected override void Dispose(bool disposing)
         {
             if (!IsDisposed)

--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.OpenGL.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
         }
 
+        /// <summary/>
         protected override void Dispose(bool disposing)
         {
             if (!IsDisposed)

--- a/MonoGame.Framework/Platform/Graphics/RenderTargetCube.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTargetCube.OpenGL.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Xna.Framework.Graphics
             });
         }
 
+        /// <summary/>
         protected override void Dispose(bool disposing)
         {
             if (!IsDisposed)

--- a/MonoGame.Framework/Platform/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture.OpenGL.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Xna.Framework.Graphics
             glLastSamplerState = null;
         }
 
+        /// <summary/>
         protected override void Dispose(bool disposing)
         {
             if (!IsDisposed)

--- a/MonoGame.Framework/Platform/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -142,6 +142,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary/>
         protected override void Dispose(bool disposing)
         {
             if (!IsDisposed)

--- a/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -187,6 +187,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         }
 
+        /// <summary/>
         protected override void Dispose(bool disposing)
         {
             if (!IsDisposed)

--- a/MonoGame.Framework/Quaternion.cs
+++ b/MonoGame.Framework/Quaternion.cs
@@ -1016,10 +1016,10 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Deconstruction method for <see cref="Quaternion"/>.
         /// </summary>
-        /// <param name="x"></param>
-        /// <param name="y"></param>
-        /// <param name="z"></param>
-        /// <param name="w"></param>
+        /// <param name="x">The x coordinate in 3d-space.</param>
+        /// <param name="y">The y coordinate in 3d-space.</param>
+        /// <param name="z">The z coordinate in 3d-space.</param>
+        /// <param name="w">The rotation component.</param>
         public void Deconstruct(out float x, out float y, out float z, out float w)
         {
             x = X;

--- a/MonoGame.Framework/Quaternion.cs
+++ b/MonoGame.Framework/Quaternion.cs
@@ -1013,6 +1013,13 @@ namespace Microsoft.Xna.Framework
             return new Vector4(X,Y,Z,W);
         }
 
+        /// <summary>
+        /// Deconstruction method for <see cref="Quaternion"/>.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="z"></param>
+        /// <param name="w"></param>
         public void Deconstruct(out float x, out float y, out float z, out float w)
         {
             x = X;


### PR DESCRIPTION
This PR adds documentation in these members:
- `Game`
- `GameComponent`
- `GameWindow`
- `Quaternion`
- `Graphics/SpriteFont`
- `Graphics/GraphicsDebug`
- `Graphics/OcclusionQuery`
- `Graphics/PresentationParameters`
- `Graphics/Effect/SkinnedEffect`
- `Platform/Graphics/Texture.OpenGL`
- `Platform/Graphics/OcclusionQuery.OpenGL`
- `Platform/Graphics/RenderTarget2D.OpenGL`
- `Platform/Graphics/RenderTargetCube.OpenGL`
- `Platform/Graphics/Vertices/IndexBuffer.OpenGL`
- `Platform/Graphics/Vertices/VertexBuffer.OpenGL`
- **[Added 25.04.2024]**: `Platform/Graphics/IWindowInfo.OpenGL`

## Notes
Some classes required very minor changes to be considered documentation-complete. 
This PR binds together all "minor fixes", which means that only classes that require a lot of changes now are missing XML documentation.

## Reference:
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)