### PR TITLE
[Documentation] Add XML documentation to ResourceContentManager

### DIFF
--- a/MonoGame.Framework/Content/ResourceContentManager.cs
+++ b/MonoGame.Framework/Content/ResourceContentManager.cs
@@ -5,10 +5,22 @@ using System.Resources;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    /// <summary>
+    /// Subclass of <see cref="ContentManager"/>, which is specialized to read
+    /// from <i>.resx</i> resource files rather than directly from individual files on disk.
+    /// </summary>
     public class ResourceContentManager : ContentManager
     {
         private ResourceManager resource;
 
+        /// <summary>
+        /// Creates a new instance of <see cref="ResourceContentManager"/>.
+        /// </summary>
+        /// <param name="servicesProvider">
+        /// The service provider the <b>ResourceContentManager</b> should use to locate services.
+        /// </param>
+        /// <param name="resource">The resource manager for the <b>ResourceContentManager</b> to read from.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="resource"/> is <see langword="null"/>.</exception>
         public ResourceContentManager(IServiceProvider servicesProvider, ResourceManager resource)
             : base(servicesProvider)
         {
@@ -19,6 +31,15 @@ namespace Microsoft.Xna.Framework.Content
             this.resource = resource;
         }
 
+        /// <summary>
+        /// Opens a stream for reading the specified resource.
+        /// Derived classes can replace this to implement pack files or asset compression.
+        /// </summary>
+        /// <param name="assetName">The name of the asset being read.</param>
+        /// <exception cref="ContentLoadException">
+        /// Error loading <paramref name="assetName"/>.
+        /// The resource was not a binary resource, or the resource was not found.
+        /// </exception>
         protected override System.IO.Stream OpenStream(string assetName)
         {
             object obj = this.resource.GetObject(assetName);


### PR DESCRIPTION
This PR adds the documentation for the single class - `ResourceContentManager`.

## Reference:
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)