### PR TITLE
[Documentation] Adds XML documentation for Graphics related classes

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -12,6 +12,10 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Performs primitive-based rendering, creates resources,
+    /// handles system-level variables, adjusts gamma ramp levels, and creates shaders.
+    /// </summary>
     public partial class GraphicsDevice : IDisposable
     {
         /// <summary>
@@ -86,12 +90,26 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal GraphicsCapabilities GraphicsCapabilities { get; private set; }
 
+        /// <summary>
+        /// Gets the collection of vertex textures that support texture lookup
+        /// in the vertex shader using the texldl statement.
+        /// The vertex engine contains four texture sampler stages.
+        /// </summary>
         public TextureCollection VertexTextures { get; private set; }
 
+        /// <summary>
+        /// Returns the collection of vertex sampler states.
+        /// </summary>
         public SamplerStateCollection VertexSamplerStates { get; private set; }
 
+        /// <summary>
+        /// Returns the collection of textures that have been assigned to the texture stages of the device.
+        /// </summary>
         public TextureCollection Textures { get; private set; }
 
+        /// <summary>
+        /// Retrieves a collection of <see cref="SamplerState"/> objects for the current <see cref="GraphicsDevice"/>.
+        /// </summary>
         public SamplerStateCollection SamplerStates { get; private set; }
 
         /// <summary>
@@ -138,12 +156,32 @@ namespace Microsoft.Xna.Framework.Graphics
         // collected by holding a strong reference to it in this list.
         private readonly List<WeakReference> _resources = new List<WeakReference>();
 
-		// TODO Graphics Device events need implementing
-		public event EventHandler<EventArgs> DeviceLost;
+        // TODO Graphics Device events need implementing
+        /// <summary>
+        /// Occurs when a GraphicsDevice is about to be lost (for example, immediately before a reset).
+        /// </summary>
+        public event EventHandler<EventArgs> DeviceLost;
+        /// <summary>
+        /// Occurs after a GraphicsDevice is reset, allowing an application to recreate all resources.
+        /// </summary>
 		public event EventHandler<EventArgs> DeviceReset;
+        /// <summary>
+        /// Occurs when a GraphicsDevice is resetting,
+        /// allowing the application to cancel the default handling of the reset.
+        /// </summary>
 		public event EventHandler<EventArgs> DeviceResetting;
+        /// <summary>
+        /// Occurs when a resource is created.
+        /// </summary>
 		public event EventHandler<ResourceCreatedEventArgs> ResourceCreated;
+        /// <summary>
+        /// Occurs when a resource is destroyed.
+        /// </summary>
 		public event EventHandler<ResourceDestroyedEventArgs> ResourceDestroyed;
+        /// <summary>
+        /// Occurs when <see cref="Dispose()"/> is called
+        /// or when this object is finalized and collected by the garbage collector.
+        /// </summary>
         public event EventHandler<EventArgs> Disposing;
 
         internal event EventHandler<PresentationEventArgs> PresentationChanged;
@@ -152,6 +190,9 @@ namespace Microsoft.Xna.Framework.Graphics
         internal int MaxTextureSlots;
         internal int MaxVertexTextureSlots;
 
+        /// <summary>
+        /// Gets a value that indicates whether the object is disposed.
+        /// </summary>
         public bool IsDisposed
         {
             get
@@ -160,6 +201,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets a value that indicates whether the associated content was lost.
+        /// </summary>
 		public bool IsContentLost {
 			get {
 				// We will just return IsDisposed for now
@@ -186,6 +230,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets the graphics adapter.
+        /// </summary>
         public GraphicsAdapter Adapter
         {
             get;
@@ -324,6 +371,7 @@ namespace Microsoft.Xna.Framework.Graphics
             EffectCache = new Dictionary<int, Effect>();
         }
 
+        /// <summary/>
         ~GraphicsDevice()
         {
             Dispose(false);
@@ -388,6 +436,10 @@ namespace Microsoft.Xna.Framework.Graphics
             ApplyRenderTargets(null);
         }
 
+        /// <summary>
+        /// Gets or sets rasterizer state.
+        /// The default value is <see cref="RasterizerState.CullCounterClockwise"/>.
+        /// </summary>
         public RasterizerState RasterizerState
         {
             get
@@ -446,6 +498,10 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets or sets a system-defined instance of a blend state object initialized for alpha blending.
+        /// The default value is <see cref="BlendState.Opaque"/>.
+        /// </summary>
         public BlendState BlendState
         {
 			get { return _blendState; }
@@ -487,6 +543,10 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 		}
 
+        /// <summary>
+        /// Gets or sets a system-defined instance of a depth-stencil state object.
+        /// The default value is <see cref="DepthStencilState.Default"/>.
+        /// </summary>
         public DepthStencilState DepthStencilState
         {
             get { return _depthStencilState; }
@@ -540,6 +600,10 @@ namespace Microsoft.Xna.Framework.Graphics
             PlatformApplyState(applyShaders);
         }
 
+        /// <summary>
+        /// Clears resource buffers.
+        /// </summary>
+        /// <param name="color">Set this color value in all buffers.</param>
         public void Clear(Color color)
         {
             var options = ClearOptions.Target;
@@ -553,6 +617,11 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritdoc cref="Clear(Color)"/>
+        /// <param name="color">Set this color value in all buffers.</param>
+        /// <param name="options">Options for clearing a buffer.</param>
+        /// <param name="depth">Set this depth value in the buffer.</param>
+        /// <param name="stencil">Set this stencil value in the buffer.</param>
         public void Clear(ClearOptions options, Color color, float depth, int stencil)
         {
             PlatformClear(options, color.ToVector4(), depth, stencil);
@@ -563,7 +632,8 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-		public void Clear(ClearOptions options, Vector4 color, float depth, int stencil)
+        /// <inheritdoc cref="Clear(ClearOptions, Color, float, int)"/>
+        public void Clear(ClearOptions options, Vector4 color, float depth, int stencil)
 		{
             PlatformClear(options, color, depth, stencil);
 
@@ -573,12 +643,14 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <inheritoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
+        /// <summary/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_isDisposed)
@@ -643,6 +715,11 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Presents the display with the contents of the next buffer
+        /// in the sequence of back buffers owned by the <see cref="GraphicsDevice"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">A render target is active.</exception>
         public void Present()
         {
             // We cannot present with a RT set on the device.
@@ -662,6 +739,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
         partial void PlatformReset();
 
+        /// <summary>
+        /// Resets the presentation parameters for the current <see cref="GraphicsDevice"/>.
+        /// </summary>
         public void Reset()
         {
             PlatformReset();
@@ -675,6 +755,13 @@ namespace Microsoft.Xna.Framework.Graphics
             EventHelpers.Raise(this, DeviceReset, EventArgs.Empty);
        }
 
+        /// <summary>
+        /// Resets the current <see cref="GraphicsDevice"/> with the specified <see cref="PresentationParameters"/>.
+        /// </summary>
+        /// <param name="presentationParameters">Presentation parameters to set.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="presentationParameters"/> is <see langword="null"/>
+        /// </exception>
         public void Reset(PresentationParameters presentationParameters)
         {
             if (presentationParameters == null)
@@ -715,6 +802,9 @@ namespace Microsoft.Xna.Framework.Graphics
             EventHelpers.Raise(this, DeviceReset, EventArgs.Empty);
         }
 
+        /// <summary>
+        /// Retrieves the display mode's spatial resolution, color resolution, and refresh frequency.
+        /// </summary>
         public DisplayMode DisplayMode
         {
             get
@@ -723,6 +813,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Retrieves the status of the device.
+        /// </summary>
         public GraphicsDeviceStatus GraphicsDeviceStatus
         {
             get
@@ -731,12 +824,18 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets the presentation parameters associated with this graphics device.
+        /// </summary>
         public PresentationParameters PresentationParameters
         {
             get;
             private set;
         }
 
+        /// <summary>
+        /// Gets or sets a viewport identifying the portion of the render target to receive draw calls.
+        /// </summary>
         public Viewport Viewport
         {
             get
@@ -752,11 +851,18 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         private readonly GraphicsProfile _graphicsProfile;
+        /// <summary>
+        /// Gets the graphics profile.
+        /// The default value is <see cref="GraphicsProfile.Reach"/>.
+        /// </summary>
         public GraphicsProfile GraphicsProfile
         {
             get { return _graphicsProfile; }
         }
 
+        /// <summary>
+        /// Gets or sets the rectangle used for scissor testing. By default, the size matches the render target size.
+        /// </summary>
         public Rectangle ScissorRectangle
         {
             get
@@ -774,6 +880,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Gets the amount of render targets bound to this device.
+        /// </summary>
         public int RenderTargetCount
         {
             get
@@ -782,6 +891,13 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Sets a new render target for this <see cref="GraphicsDevice"/>.
+        /// </summary>
+        /// <param name="renderTarget">
+        /// A new render target for the device, or <see langword="null"/>
+        /// to set the device render target to the back buffer of the device.
+        /// </param>
 		public void SetRenderTarget(RenderTarget2D renderTarget)
 		{
 			if (renderTarget == null)
@@ -795,6 +911,9 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
+        /// <inheritdoc cref="SetRenderTarget(RenderTarget2D)"/>
+        /// <param name="renderTarget"/>
+        /// <param name="cubeMapFace">The cube map face type.</param>
         public void SetRenderTarget(RenderTargetCube renderTarget, CubeMapFace cubeMapFace)
         {
             if (renderTarget == null)
@@ -808,6 +927,10 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Sets an array of render targets.
+        /// </summary>
+        /// <param name="renderTargets">An array of render targets.</param>
 		public void SetRenderTargets(params RenderTargetBinding[] renderTargets)
 		{
             // Avoid having to check for null and zero length.
@@ -906,6 +1029,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 Clear(DiscardColor);
         }
 
+        /// <summary>
+        /// Gets render target surfaces.
+        /// </summary>
+        /// <returns>An array of bound render targets.</returns>
 		public RenderTargetBinding[] GetRenderTargets()
 		{
             // Return a correctly sized copy our internal array.
@@ -914,12 +1041,23 @@ namespace Microsoft.Xna.Framework.Graphics
             return bindings;
 		}
 
+        /// <summary>
+        /// Gets render target surfaces.
+        /// </summary>
+        /// <param name="outTargets">
+        /// When this method returns, contains an array of that description of bound render targets.
+        /// This parameter is treated as uninitialized.
+        /// </param>
         public void GetRenderTargets(RenderTargetBinding[] outTargets)
         {
             Debug.Assert(outTargets.Length == _currentRenderTargetCount, "Invalid outTargets array length!");
             Array.Copy(_currentRenderTargetBindings, outTargets, _currentRenderTargetCount);
         }
 
+        /// <summary>
+        /// Sets or binds a vertex buffer to a device. 
+        /// </summary>
+        /// <param name="vertexBuffer">A vertex buffer.</param>
         public void SetVertexBuffer(VertexBuffer vertexBuffer)
         {
             _vertexBuffersDirty |= (vertexBuffer == null)
@@ -927,6 +1065,13 @@ namespace Microsoft.Xna.Framework.Graphics
                                    : _vertexBuffers.Set(vertexBuffer, 0);
         }
 
+        /// <inheritdoc cref="SetVertexBuffer(VertexBuffer)"/>
+        /// <param name="vertexBuffer"/>
+        /// <param name="vertexOffset">The offset (in bytes) from the beginning of the buffer.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="vertexOffset"/> is less than 0
+        /// OR is greater than or equal to <paramref name="vertexBuffer"/>.VertexCount.
+        /// </exception>
         public void SetVertexBuffer(VertexBuffer vertexBuffer, int vertexOffset)
         {
             // Validate vertexOffset.
@@ -942,6 +1087,13 @@ namespace Microsoft.Xna.Framework.Graphics
                                    : _vertexBuffers.Set(vertexBuffer, vertexOffset);
         }
 
+        /// <summary>
+        /// Sets the vertex buffers.
+        /// </summary>
+        /// <param name="vertexBuffers">An array of vertex buffers.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Length of <paramref name="vertexBuffers"/> is more than max allowed number of vertex buffers. 
+        /// </exception>
         public void SetVertexBuffers(params VertexBufferBinding[] vertexBuffers)
         {
             if (vertexBuffers == null || vertexBuffers.Length == 0)
@@ -969,6 +1121,9 @@ namespace Microsoft.Xna.Framework.Graphics
             _indexBufferDirty = true;
         }
 
+        /// <summary>
+        /// Gets or sets index data. The default value is <see langword="null"/>.
+        /// </summary>
         public IndexBuffer Indices { set { SetIndexBuffer(value); } get { return _indexBuffer; } }
 
         internal Shader VertexShader
@@ -1009,6 +1164,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 _pixelConstantBuffers[slot] = buffer;
         }
 
+        /// <summary>
+        /// Gets a value that indicates whether the resources were lost.
+        /// </summary>
         public bool ResourcesLost { get; set; }
 
         /// <summary>
@@ -1370,6 +1528,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// The format is whatever the current format of the backbuffer is.
         /// </summary>
         /// <typeparam name="T">A byte[] of size (ViewPort.Width * ViewPort.Height * 4)</typeparam>
+        /// <param name="data">Array of data.</param>
         public void GetBackBufferData<T>(T[] data) where T : struct
         {
             if (data == null)
@@ -1377,11 +1536,29 @@ namespace Microsoft.Xna.Framework.Graphics
             GetBackBufferData(null, data, 0, data.Length);
         }
 
+        /// <inheritdoc cref="GetBackBufferData{T}(T[])"/>
+        /// <typeparam name="T"/>
+        /// <param name="data"/>
+        /// <param name="startIndex">The first element to use.</param>
+        /// <param name="elementCount">The number of elements to use.</param>
         public void GetBackBufferData<T>(T[] data, int startIndex, int elementCount) where T : struct
         {
             GetBackBufferData(null, data, startIndex, elementCount);
         }
 
+        /// <inheritdoc cref="GetBackBufferData{T}(T[], int, int)"/>
+        /// <typeparam name="T"/>
+        /// <param name="rect">
+        /// The section of the back buffer to copy.
+        /// <see langword="null"/> indicates the data will be copied from the entire back buffer.
+        /// </param>
+        /// <param name="data"/>
+        /// <param name="startIndex"/>
+        /// <param name="elementCount"/>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="data"/> is <see langword="null"/>
+        /// </exception>
+        /// <exception cref="ArgumentException"/>
         public void GetBackBufferData<T>(Rectangle? rect, T[] data, int startIndex, int elementCount)
             where T : struct
         {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -161,23 +161,28 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Occurs when a GraphicsDevice is about to be lost (for example, immediately before a reset).
         /// </summary>
         public event EventHandler<EventArgs> DeviceLost;
+
         /// <summary>
         /// Occurs after a GraphicsDevice is reset, allowing an application to recreate all resources.
         /// </summary>
 		public event EventHandler<EventArgs> DeviceReset;
+
         /// <summary>
         /// Occurs when a GraphicsDevice is resetting,
         /// allowing the application to cancel the default handling of the reset.
         /// </summary>
 		public event EventHandler<EventArgs> DeviceResetting;
+
         /// <summary>
         /// Occurs when a resource is created.
         /// </summary>
 		public event EventHandler<ResourceCreatedEventArgs> ResourceCreated;
+
         /// <summary>
         /// Occurs when a resource is destroyed.
         /// </summary>
 		public event EventHandler<ResourceDestroyedEventArgs> ResourceDestroyed;
+
         /// <summary>
         /// Occurs when <see cref="Dispose()"/> is called
         /// or when this object is finalized and collected by the garbage collector.
@@ -337,8 +342,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
 
             // Initialize the main viewport
-            _viewport = new Viewport (0, 0,
-			                         DisplayMode.Width, DisplayMode.Height);
+            _viewport = new Viewport (0, 0, DisplayMode.Width, DisplayMode.Height);
 			_viewport.MaxDepth = 1.0f;
 
             PlatformSetup();
@@ -1537,8 +1541,8 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <inheritdoc cref="GetBackBufferData{T}(T[])"/>
-        /// <typeparam name="T"/>
-        /// <param name="data"/>
+        /// <typeparam name="T">A byte[] of size (ViewPort.Width * ViewPort.Height * 4)</typeparam>
+        /// <param name="data">Array of data.</param>
         /// <param name="startIndex">The first element to use.</param>
         /// <param name="elementCount">The number of elements to use.</param>
         public void GetBackBufferData<T>(T[] data, int startIndex, int elementCount) where T : struct
@@ -1547,14 +1551,14 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <inheritdoc cref="GetBackBufferData{T}(T[], int, int)"/>
-        /// <typeparam name="T"/>
+        /// <typeparam name="T">A byte[] of size (ViewPort.Width * ViewPort.Height * 4)</typeparam>
         /// <param name="rect">
         /// The section of the back buffer to copy.
         /// <see langword="null"/> indicates the data will be copied from the entire back buffer.
         /// </param>
-        /// <param name="data"/>
-        /// <param name="startIndex"/>
-        /// <param name="elementCount"/>
+        /// <param name="data">Array of data.</param>
+        /// <param name="startIndex">The first element to use.</param>
+        /// <param name="elementCount">The number of elements to use.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="data"/> is <see langword="null"/>
         /// </exception>

--- a/MonoGame.Framework/Graphics/GraphicsResource.cs
+++ b/MonoGame.Framework/Graphics/GraphicsResource.cs
@@ -7,6 +7,9 @@ using System.Diagnostics;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Queries and prepares resources.
+    /// </summary>
     public abstract class GraphicsResource : IDisposable
     {
         bool disposed;
@@ -23,6 +26,7 @@ namespace Microsoft.Xna.Framework.Graphics
             
         }
 
+        /// <summary/>
         ~GraphicsResource()
         {
             // Pass false so the managed objects are not released
@@ -40,6 +44,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         }
 
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
             // Dispose of managed objects as well
@@ -80,8 +85,15 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Occurs when <see cref="Dispose()"/> is called
+        /// or when this object is finalized and collected by the garbage collector.
+        /// </summary>
 		public event EventHandler<EventArgs> Disposing;
-		
+
+        /// <summary>
+        /// Gets the <see cref="Graphics.GraphicsDevice"/> associated with this <see cref="GraphicsResource"/>.
+        /// </summary>
 		public GraphicsDevice GraphicsDevice
 		{
 			get
@@ -110,7 +122,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 graphicsDevice.AddResourceReference(_selfReference);
             }
 		}
-		
+
+        /// <summary>
+        /// Gets a value that indicates whether the object is disposed.
+        /// </summary>
 		public bool IsDisposed
 		{
 			get
@@ -118,11 +133,20 @@ namespace Microsoft.Xna.Framework.Graphics
 				return disposed;
 			}
 		}
-		
+
+        /// <summary>
+        /// Gets the name of the resource.
+        /// </summary>
 		public string Name { get; set; }
-		
+
+        /// <summary>
+        /// Gets the resource tags for this resource.
+        /// </summary>
 		public Object Tag { get; set; }
 
+        /// <summary>
+        /// Gets a string representation of the current instance.
+        /// </summary>
         public override string ToString()
         {
             return string.IsNullOrEmpty(Name) ? base.ToString() : Name;

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Xna.Framework
             _game.Services.AddService(typeof(IGraphicsDeviceService), this);
         }
 
+        /// <summary/>
         ~GraphicsDeviceManager()
         {
             Dispose(false);
@@ -149,6 +150,13 @@ namespace Microsoft.Xna.Framework
             CreateDevice();
         }
 
+        /// <summary>
+        /// Begins the drawing process.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if the drawing process begins successfully;
+        /// <see langword="false"/> otherwise.
+        /// </returns>
         public bool BeginDraw()
         {
             if (_graphicsDevice == null)
@@ -158,6 +166,9 @@ namespace Microsoft.Xna.Framework
             return true;
         }
 
+        /// <summary>
+        /// Ends the drawing process and calls <see cref="GraphicsDevice.Present()"/> for the current graphics device.
+        /// </summary>
         public void EndDraw()
         {
             if (_graphicsDevice != null && _drawBegun)
@@ -259,12 +270,14 @@ namespace Microsoft.Xna.Framework
 
         #region IDisposable Members
 
+        /// <inheritdoc cref="IDisposable.Dispose()"/>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
+        /// <summary/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Xna.Framework
         private readonly Game _game;
         private GraphicsDevice _graphicsDevice;
         private bool _initialized = false;
-
         private int _preferredBackBufferHeight;
         private int _preferredBackBufferWidth;
         private SurfaceFormat _preferredBackBufferFormat;
@@ -30,6 +29,7 @@ namespace Microsoft.Xna.Framework
         private bool _preferHalfPixelOffset = false;
         private bool _wantFullScreen;
         private GraphicsProfile _graphicsProfile;
+        
         // dirty flag for ApplyChanges
         private bool _shouldApplyChanges;
 


### PR DESCRIPTION
This PR adds the documentation for the following classes:
- `GraphicsDeviceManager`
- `Graphics/GraphicsDevice`
- `Graphics/GraphicsResource`

## Notes
- I tried my best to match the documentation with the actual implementation, but due to the size of the classes, I might have missed some errors.

## Reference:
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)