### PR TITLE
Update Link to View Frustum Culling Tutorial In Comment

### DIFF
--- a/MonoGame.Framework/BoundingBox.cs
+++ b/MonoGame.Framework/BoundingBox.cs
@@ -666,7 +666,7 @@ namespace Microsoft.Xna.Framework
         /// </param>
         public void Intersects(ref Plane plane, out PlaneIntersectionType result)
         {
-            // See http://zach.in.tu-clausthal.de/teaching/cg_literatur/lighthouse3d_view_frustum_culling/index.html
+            // See https://cgvr.informatik.uni-bremen.de/teaching/cg_literatur/lighthouse3d_view_frustum_culling/index.html
 
             Vector3 positiveVertex;
             Vector3 negativeVertex;


### PR DESCRIPTION
## Description
Updates the reference link to the view frustum culling tutorial.  Original link is no longer valid.  Original link was validated using wayback machine at https://web.archive.org/web/20160321050150/http://zach.in.tu-clausthal.de/teaching/cg_literatur/lighthouse3d_view_frustum_culling/index.html to ensure that the new link is the same document.

Reference:
This closes issue #8262