### PR TITLE
Issue #4804: Documented that graphics driver settings may overwrite vsync settings

### DIFF
--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -595,7 +595,9 @@ namespace Microsoft.Xna.Framework
         /// <remarks>
         /// Vsync limits the frame rate of the game to the monitor referesh rate to prevent screen tearing.
         /// When called at startup this will automatically set the vsync mode during initialization.  If
-        /// set after startup you must call ApplyChanges() for the vsync mode to be changed.
+        /// set after startup you must call ApplyChanges() for the vsync mode to be changed.  Depending on
+        /// a user's video card settings, vsync settings can be ignored and cause unexpected behaviour in
+        /// frame rate.
         /// </remarks>
         public bool SynchronizeWithVerticalRetrace
         {


### PR DESCRIPTION
Solution for issue #4804
Updates the remarks comment on GraphicsDeviceManager.SynchronizeWithVerticalRetrace to include warning of possible unexpected behavior caused by user driver settings.