### PR TITLE
Update doc links to docs.monogame.net

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Xna.Framework.Content
         ///     <para>
         ///         Before a ContentManager can load an asset, you need to add the asset to your game project using
         ///         the steps described in
-        ///         <see href="https://monogame.net/articles/content_pipeline/index.html">Adding Content - MonoGame</see>.
+        ///         <see href="https://docs.monogame.net/articles/content_pipeline/index.html">Adding Content - MonoGame</see>.
         ///     </para>
         /// </remarks>
         /// <typeparam name="T">
@@ -299,7 +299,7 @@ namespace Microsoft.Xna.Framework.Content
         /// <remarks>
         /// Before a ContentManager can load an asset, you need to add the asset to your game project using
         /// the steps described in
-        /// <see href="https://monogame.net/articles/content_pipeline/index.html">Adding Content - MonoGame</see>.
+        /// <see href="https://docs.monogame.net/articles/content_pipeline/index.html">Adding Content - MonoGame</see>.
         /// </remarks>
         /// <typeparam name="T">
         ///     <para>

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A high level breakdown of the components of the framework:
 * Our [issue tracker](https://github.com/MonoGame/MonoGame/issues) is on GitHub.
 * Use our [community forums](http://community.monogame.net/) for support questions.
 * You can [join the Discord server](https://discord.gg/monogame) and chat live with the core developers and other users.
-* The [official documentation](https://monogame.net/articles/index.html) is on our website.
+* The [official documentation](https://docs.monogame.net/articles/index.html) is on our website.
 * Download [release](https://github.com/MonoGame/MonoGame/releases) and [development](https://github.com/orgs/MonoGame/packages) packages.
 * Follow [@MonoGameTeam](https://twitter.com/monogameteam) on Twitter.
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,4 +1,4 @@
-Depending on the [platform](https://monogame.net/articles/platforms) that you are targeting, MonoGame has different sets of requirements.
+Depending on the [platform](https://docs.monogame.net/articles/platforms) that you are targeting, MonoGame has different sets of requirements.
 
 For desktop platforms
 ====================

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,4 +1,4 @@
-Depending on the [platform](https://docs.monogame.net/articles/platforms) that you are targeting, MonoGame has different sets of requirements.
+Depending on the [platform](https://docs.monogame.net/articles/platforms.html) that you are targeting, MonoGame has different sets of requirements.
 
 For desktop platforms
 ====================

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -569,7 +569,7 @@ namespace MonoGame.Tools.Pipeline
 
         private void CmdHelp_Executed(object sender, EventArgs e)
         {
-            Process.Start(new ProcessStartInfo() { FileName = "https://monogame.net/articles/tools/mgcb_editor.html", UseShellExecute = true, Verb = "open" });
+            Process.Start(new ProcessStartInfo() { FileName = "https://docs.monogame.net/articles/tools/mgcb_editor.html", UseShellExecute = true, Verb = "open" });
         }
 
         private void CmdAbout_Executed(object sender, EventArgs e)


### PR DESCRIPTION
Fixing some 404s on doc references by pointing them at the new/old subdomain.