### PR TITLE
Issue #8084: DesktopGL GraphicsDevice.ScissorRectangle Fix

### DIFF
--- a/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
@@ -299,9 +299,16 @@ namespace Microsoft.Xna.Framework
                 _game.GraphicsDevice.PresentationParameters.BackBufferHeight == height) {
                 return;
             }
+
+            Viewport prevViewport = _game.GraphicsDevice.Viewport;
+            Rectangle prevScissorRect = _game.GraphicsDevice.ScissorRectangle;
+
             _game.GraphicsDevice.PresentationParameters.BackBufferWidth = width;
             _game.GraphicsDevice.PresentationParameters.BackBufferHeight = height;
             _game.GraphicsDevice.Viewport = new Viewport(0, 0, width, height);
+
+            if (_game.GraphicsDevice.RasterizerState.ScissorTestEnable && prevScissorRect == prevViewport.Bounds)
+                _game.GraphicsDevice.ScissorRectangle = new Rectangle(0, 0, width, height);
 
             Sdl.Window.GetSize(Handle, out _width, out _height);
 

--- a/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
@@ -300,15 +300,12 @@ namespace Microsoft.Xna.Framework
                 return;
             }
 
-            Viewport prevViewport = _game.GraphicsDevice.Viewport;
-            Rectangle prevScissorRect = _game.GraphicsDevice.ScissorRectangle;
+            if (_game.GraphicsDevice.RasterizerState.ScissorTestEnable && _game.GraphicsDevice.ScissorRectangle == _game.GraphicsDevice.Viewport.Bounds)
+                _game.GraphicsDevice.ScissorRectangle = new Rectangle(0, 0, width, height);
 
             _game.GraphicsDevice.PresentationParameters.BackBufferWidth = width;
             _game.GraphicsDevice.PresentationParameters.BackBufferHeight = height;
             _game.GraphicsDevice.Viewport = new Viewport(0, 0, width, height);
-
-            if (_game.GraphicsDevice.RasterizerState.ScissorTestEnable && prevScissorRect == prevViewport.Bounds)
-                _game.GraphicsDevice.ScissorRectangle = new Rectangle(0, 0, width, height);
 
             Sdl.Window.GetSize(Handle, out _width, out _height);
 


### PR DESCRIPTION
Solution for issue [#8084](https://github.com/MonoGame/MonoGame/issues/8084).

Updates ClientResize function in order to update the ScissorRectangle when the viewport is resized. This change mimics the behavior found on other platforms such as WindowsDX.