### PR TITLE
Added error detection for effect content files

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
     [ContentProcessor(DisplayName = "Effect - MonoGame")]
     public class EffectProcessor : ContentProcessor<EffectContent, CompiledEffectContent>
     {
+        private static readonly Regex errorOrWarning = new(@"(.*)\((\d*,\d*(?>,\d*,\d*)?)\):\s*(.*)", RegexOptions.Compiled);
         EffectProcessorDebugMode debugMode;
         string defines;
 
@@ -107,7 +108,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             var errorsAndWarningArray = shaderErrorsAndWarnings.Split(new[] { "\n", "\r", Environment.NewLine },
                                                                       StringSplitOptions.RemoveEmptyEntries);
 
-            var errorOrWarning = new Regex(@"(.*)\((\d*,\d*)-?\d*\):\s*(.*)", RegexOptions.Compiled);
             ContentIdentity identity = null;
             var allErrorsAndWarnings = new System.Text.StringBuilder();
 

--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 
                 if (groups.Count != 4)
                 {
+                    // Just log anything we don't recognize as a warning.
                     if (buildFailed)
                         allErrorsAndWarnings.AppendLine(errorOrWarningLine);
                     else
@@ -132,6 +133,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                 var errorOrWarningMessage = groups[3].Value;
 
                 var newIdentity = new ContentIdentity(filename, input.Identity.SourceTool, lineAndColumn);
+
+                // If we got an exception then we'll be throwing an exception
+                // below, so just gather the lines to throw later.
                 if (buildFailed)
                 {
                     if (identity == null)
@@ -140,7 +144,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                         allErrorsAndWarnings.AppendLine(errorOrWarningMessage);
                     }
                     else
-                        allErrorsAndWarnings.Append(errorOrWarningLine);
+                        allErrorsAndWarnings.AppendLine(errorOrWarningLine);
                 }
                 else
                     context.Logger.LogWarning(string.Empty, newIdentity, errorOrWarningMessage);

--- a/Tools/MonoGame.Content.Builder.Editor/Common/OutputParser.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/OutputParser.cs
@@ -43,7 +43,7 @@ namespace MonoGame.Tools.Pipeline
         Regex _reFileError = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\W*?: (?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildEnd = new Regex(@"^(Build)\W+(?<buildInfo>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildTime = new Regex(@"^(Time elapsed)\W+(?<buildElapsedTime>.*?)\.\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
+        
 
         public OutputParser()
         {
@@ -61,7 +61,7 @@ namespace MonoGame.Tools.Pipeline
         }
 
         internal void Parse(string text)
-        {
+        {   
             ParseLine(text);
         }
 
@@ -90,7 +90,7 @@ namespace MonoGame.Tools.Pipeline
             var prevFilename = Filename;
 
             State = OutputState.Unknown;
-            Filename = null;
+            Filename = null;            
             BuildBeginTime = null;
             BuildInfo = null;
             BuildElapsedTime = null;

--- a/Tools/MonoGame.Content.Builder.Editor/Common/OutputParser.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/OutputParser.cs
@@ -39,12 +39,11 @@ namespace MonoGame.Tools.Pipeline
         Regex _reSkipping = new Regex(@"^(Skipping)\W(?<filename>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildAsset = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildError = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\W*?:\W*?error\W*?:\W*(?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        Regex _reFileErrorWithLineNum   = new Regex(@"^(?<filename>.+?)(\((?<line>[0-9]+),(?<column>[0-9]+)(-(?<columnEnd>[0-9]+))?\))?:\W*?(error)\W*(?<errorCode>[A-Z][0-9]+):\W*(?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        Regex _reFileWarningWithLineNum = new Regex(@"^(?<filename>.+?)(\((?<line>[0-9]+),(?<column>[0-9]+)(-(?<columnEnd>[0-9]+))?\))?:\W*?(warning)\W*(?<warningCode>[A-Z][0-9]+):\W*(?<warningMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reFileErrorOrWarningWithLineNum = new Regex(@"^(?<filename>.+?)(\((?<line>\d+),(?<column>\d+)(((-|(,\d+,)))(?<columnEnd>\d+))?\))?:\W*?(?<type>(error|warning))\W*(?<code>[A-Z]+[0-9]+):\s*(?<message>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reFileError = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\W*?: (?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildEnd = new Regex(@"^(Build)\W+(?<buildInfo>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildTime = new Regex(@"^(Time elapsed)\W+(?<buildElapsedTime>.*?)\.\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        
+
 
         public OutputParser()
         {
@@ -62,7 +61,7 @@ namespace MonoGame.Tools.Pipeline
         }
 
         internal void Parse(string text)
-        {   
+        {
             ParseLine(text);
         }
 
@@ -91,7 +90,7 @@ namespace MonoGame.Tools.Pipeline
             var prevFilename = Filename;
 
             State = OutputState.Unknown;
-            Filename = null;            
+            Filename = null;
             BuildBeginTime = null;
             BuildInfo = null;
             BuildElapsedTime = null;
@@ -138,33 +137,20 @@ namespace MonoGame.Tools.Pipeline
                 Filename = m.Groups["filename"].Value;
                 ErrorMessage = m.Groups["errorMessage"].Value;
             }
-            else if (_reFileErrorWithLineNum.IsMatch(line))
+            else if (_reFileErrorOrWarningWithLineNum.IsMatch(line))
             {
-                State = OutputState.BuildError;
-                var m = _reFileErrorWithLineNum.Match(line);
+                var m = _reFileErrorOrWarningWithLineNum.Match(line);
                 var lineNum = m.Groups["line"];
                 var columnBegin = m.Groups["column"];
                 var columnEnd = m.Groups["columnEnd"];
                 var column = columnBegin.Value;
-                if(columnEnd.Success)
+                if (columnEnd.Success)
                     column += "-" + columnEnd.Value;
-                var errorCode = m.Groups["errorCode"];
-                Filename = m.Groups["filename"].Value.Replace("\\\\","/").Replace("\\", "/");
-                ErrorMessage = string.Format("{0} ({1},{2}): {3}", errorCode, lineNum, column, m.Groups["errorMessage"].Value);
-            }
-            else if (_reFileWarningWithLineNum.IsMatch(line))
-            {
-                State = OutputState.BuildWarning;
-                var m = _reFileWarningWithLineNum.Match(line);
-                var lineNum = m.Groups["line"];
-                var columnBegin = m.Groups["column"];
-                var columnEnd = m.Groups["columnEnd"];                
-                var column = columnBegin.Value;
-                if(columnEnd.Success)
-                    column += "-" + columnEnd.Value;
-                var errorCode = m.Groups["warningCode"];
+                var type = m.Groups["type"];
+                var errorCode = m.Groups["code"];
+                State = type.Value.Equals("error", StringComparison.OrdinalIgnoreCase) ? OutputState.BuildError : OutputState.BuildWarning;
                 Filename = m.Groups["filename"].Value.Replace("\\\\", "/").Replace("\\", "/");
-                ErrorMessage = string.Format("{0} ({1},{2}): {3}", errorCode, lineNum, column, m.Groups["warningMessage"].Value);
+                ErrorMessage = string.Format("{0} {1} ({2},{3}): {4}", type, errorCode, lineNum, column, m.Groups["message"].Value);
             }
             else if (_reFileError.IsMatch(line))
             {

--- a/Tools/MonoGame.Effect.Compiler/Program.cs
+++ b/Tools/MonoGame.Effect.Compiler/Program.cs
@@ -3,12 +3,21 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace MonoGame.Effect.Compiler
 {
     public static class Program
     {
+        private static bool usingWine;
+
+        private static readonly List<(string, string)> sourceFiles = new();
+
+        private static readonly Regex lineColumnRegex = new(@"\((\d+),(\d+)-?\d*\)", RegexOptions.Compiled);
+
         public static int Main(string[] args)
         {
             if (!Environment.Is64BitProcess && Environment.OSVersion.Platform != PlatformID.Unix)
@@ -23,19 +32,30 @@ namespace MonoGame.Effect.Compiler
 
             if (!parser.ParseCommandLine(args))
                 return 1;
-            
+
             // We don't support running MGFXC on Unix platforms
             // however Wine can be used to make it work so lets try that.
             if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                Environment.SetEnvironmentVariable("MGFXC_USE_WINE", "1");
                 return WineHelper.Run(options);
+            }
+
+            usingWine = Environment.GetEnvironmentVariable("MGFXC_USE_WINE") == "1";
+
+            var sourceFilepath = Path.GetFullPath(options.SourceFile);
+
+            var nativeSourceFilepath = ConvertToNative(sourceFilepath);
+
+            sourceFiles.Add((sourceFilepath, nativeSourceFilepath));
 
             // Validate the input file exits.
-            if (!File.Exists(options.SourceFile))
+            if (!File.Exists(sourceFilepath))
             {
-                Console.Error.WriteLine("The input file '{0}' was not found!", options.SourceFile);
+                Console.Error.WriteLine("The input file '{0}' was not found!", nativeSourceFilepath);
                 return 1;
             }
-            
+
             // TODO: This would be where we would decide the user
             // is trying to convert an FX file to a MGFX glsl file.
             //
@@ -45,15 +65,20 @@ namespace MonoGame.Effect.Compiler
             ShaderResult shaderResult;
             try
             {
-                shaderResult = ShaderResult.FromFile(options.SourceFile, options, new ConsoleEffectCompilerOutput());
+                shaderResult = ShaderResult.FromFile(sourceFilepath, options, new ConsoleEffectCompilerOutput());
 
                 foreach (var dependency in shaderResult.Dependencies)
-                    Console.WriteLine("Dependency: " + dependency);
+                {
+                    var dependencyNativeFilename = ConvertToNative(dependency);
+                    Console.WriteLine("Dependency: " + dependencyNativeFilename);
+
+                    sourceFiles.Add((dependency, dependencyNativeFilename));
+                }
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine(ex.Message);
-                Console.Error.WriteLine("Failed to parse '{0}'!", options.SourceFile);
+                Console.Error.WriteLine(ConvertMessage(ex.Message));
+                Console.Error.WriteLine("Failed to parse '{0}'!", nativeSourceFilepath);
                 return 1;
             }
 
@@ -65,63 +90,93 @@ namespace MonoGame.Effect.Compiler
                 effect = EffectObject.CompileEffect(shaderResult, out shaderErrorsAndWarnings);
 
                 if (!string.IsNullOrEmpty(shaderErrorsAndWarnings))
-                    Console.Error.WriteLine(shaderErrorsAndWarnings);
+                    Console.Error.WriteLine(ConvertMessage(shaderErrorsAndWarnings));
             }
             catch (ShaderCompilerException)
             {
                 // Write the compiler errors and warnings and let the user know what happened.
-                Console.Error.WriteLine(shaderErrorsAndWarnings);
-                Console.Error.WriteLine("Failed to compile '{0}'!", options.SourceFile);
+                Console.Error.WriteLine(ConvertMessage(shaderErrorsAndWarnings));
+                Console.Error.WriteLine("Failed to compile '{0}'!", nativeSourceFilepath);
                 return 1;
             }
             catch (Exception ex)
             {
                 // First write all the compiler errors and warnings.
                 if (!string.IsNullOrEmpty(shaderErrorsAndWarnings))
-                    Console.Error.WriteLine(shaderErrorsAndWarnings);
+                    Console.Error.WriteLine(ConvertMessage(shaderErrorsAndWarnings));
 
                 // If we have an exception message then write that.
                 if (!string.IsNullOrEmpty(ex.Message))
-                    Console.Error.WriteLine(ex.Message);
+                    Console.Error.WriteLine(ConvertMessage(ex.Message));
 
                 // Let the user know what happened.
-                Console.Error.WriteLine("Unexpected error compiling '{0}'!", options.SourceFile);
+                Console.Error.WriteLine("Unexpected error compiling '{0}'!", nativeSourceFilepath);
                 return 1;
             }
-            
+
             // Get the output file path.
             if (options.OutputFile == string.Empty)
-                options.OutputFile = Path.GetFileNameWithoutExtension(options.SourceFile) + ".mgfxo";
+                options.OutputFile = Path.GetFileNameWithoutExtension(sourceFilepath) + ".mgfxo";
+
+            var outputFilepath = Path.GetFullPath(options.OutputFile);
+            var nativeOutputFilepath = ConvertToNative(outputFilepath);
 
             // Write out the effect to a runtime format.
             try
             {
-                using (var stream = new FileStream(options.OutputFile, FileMode.Create, FileAccess.Write))
+                using (var stream = new FileStream(outputFilepath, FileMode.Create, FileAccess.Write))
                 using (var writer = new BinaryWriter(stream))
                     effect.Write(writer, options);
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine(ex.Message);
-                Console.Error.WriteLine("Failed to write '{0}'!", options.OutputFile);
+                Console.Error.WriteLine(ConvertMessage(ex.Message));
+                Console.Error.WriteLine("Failed to write '{0}'!", nativeOutputFilepath);
                 return 1;
             }
 
             // We finished succesfully.
-            Console.WriteLine("Compiled '{0}' to '{1}'.", options.SourceFile, options.OutputFile);
+            Console.WriteLine("Compiled '{0}' to '{1}'.", nativeSourceFilepath, nativeOutputFilepath);
             return 0;
+        }
+
+        private static string ConvertToNative(string path)
+        {
+            if (!usingWine)
+                return path.Replace('\\', '/');
+
+            var proc = new Process();
+            proc.StartInfo.FileName = "winepath.exe";
+            proc.StartInfo.Arguments = "-u \"" + path + "\"";
+            proc.StartInfo.UseShellExecute = false;
+            proc.StartInfo.RedirectStandardOutput = true;
+            proc.Start();
+
+            return proc.StandardOutput.ReadToEnd().Trim('\n');
+        }
+
+        private static string ConvertMessage(string sourceString)
+        {
+            sourceString = sourceString.Replace("\\\\", "\\");
+
+            foreach (var (originalFilename, newFilename) in sourceFiles)
+                sourceString = sourceString.Replace(originalFilename, newFilename);
+
+            sourceString = lineColumnRegex.Replace(sourceString, "($1,$2)");
+
+            return sourceString;
         }
 
         private class ConsoleEffectCompilerOutput : IEffectCompilerOutput
         {
             public void WriteWarning(string file, int line, int column, string message)
             {
-                Console.WriteLine("Warning: {0}({1},{2}): {3}" , file, line, column, message);
+                Console.WriteLine("Warning: {0}({1},{2}): {3}", ConvertToNative(file), line, column, ConvertMessage(message));
             }
 
             public void WriteError(string file, int line, int column, string message)
             {
-                throw new Exception(string.Format("Error: {0}({1},{2}): {3}", file, line, column, message));
+                throw new Exception(string.Format("Error: {0}({1},{2}): {3}", ConvertToNative(file), line, column, ConvertMessage(message)));
             }
         }
     }


### PR DESCRIPTION
MSBuild can detect warnings and errors from standard output of `<Exec>` task, which is used to build content with `mgcb`, and these detected warnings and errors will be displayed by IDE or text editor.

This is how it looks:
![warning and errors](https://github.com/MonoGame/MonoGame/assets/69744837/fd0a0c1d-a9ee-4410-b83c-6c44733ea1c8)
