### PR TITLE
Fix Visual Studio extension build issue

### DIFF
--- a/Templates/MonoGame.Templates.VSExtension/MonoGame.Templates.VSExtension.csproj
+++ b/Templates/MonoGame.Templates.VSExtension/MonoGame.Templates.VSExtension.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.*" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.*" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.9.*" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Templates.pkgdef">


### PR DESCRIPTION
This is to resolve #8300 I have some options in the discussion in order to get the builds working. This is the simplest one.

We could instead add this line to the csproj to override the version of the child dependency:

PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="16.*" ExcludeAssets="runtime"

And maybe we want to cap both to 17.9 for right now if the current solution is the accepted one?