### PR TITLE
Update MeshHelper to fix #8140

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/MeshHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/MeshHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -71,8 +71,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
                 var aa = geom.Vertices.Positions[ia];
                 var bb = geom.Vertices.Positions[ib];
-                var cc = geom.Vertices.Positions[ic];                
-                
+                var cc = geom.Vertices.Positions[ic];
+
                 var faceNormal = Vector3.Cross(cc - bb, bb - aa);
                 var len = faceNormal.Length();
                 if (len > 0.0f)
@@ -95,9 +95,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     // by Shuangshuang Jin, Robert R. Lewis, David West.
                     //
 
-                    normals[positionIndices[ia]] += faceNormal;
-                    normals[positionIndices[ib]] += faceNormal;
-                    normals[positionIndices[ic]] += faceNormal;
+                    normals[ia] += faceNormal;
+                    normals[ib] += faceNormal;
+                    normals[ic] += faceNormal;
                 }
             }
 
@@ -115,7 +115,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
                     // TODO: We could maybe void this by a better algorithm
                     // above for generating the normals.
-                    
+
                     // We have a zero length normal.  You can argue that putting
                     // anything here is better than nothing, but by leaving it to
                     // zero it allows the caller to detect this and react to it.
@@ -125,7 +125,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             // Set the new normals on the vertex channel.
             for (var i = 0; i < channel.Count; i++)
-                channel[i] = normals[geom.Vertices.PositionIndices[i]];
+                channel[i] = normals[i];
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         public static void CalculateTangentFrames(MeshContent mesh, string textureCoordinateChannelName, string tangentChannelName, string binormalChannelName)
         {
             foreach (var geom in mesh.Geometry)
-                CalculateTangentFrames(geom, textureCoordinateChannelName, tangentChannelName, binormalChannelName);                            
+                CalculateTangentFrames(geom, textureCoordinateChannelName, tangentChannelName, binormalChannelName);
         }
 
         /// <summary>
@@ -344,7 +344,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 foreach (var nodeContent in node.Children)
                 {
                     var bone = nodeContent as BoneContent;
-                    if (bone == null) 
+                    if (bone == null)
                         continue;
 
                     // If we found a bone
@@ -456,7 +456,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     PositionIndex = verts.PositionIndices[vIndex],
                     ChannelData = new object[verts.Channels.Count]
                 };
-                
+
                 for (var channel = 0; channel < verts.Channels.Count; channel++)
                     iData.ChannelData[channel] = verts.Channels[channel][vIndex];
 
@@ -513,7 +513,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         {
             // We don't throw here as non-optimized still works.
         }
-        
+
         /// <summary>
         /// Reverses the triangle winding order of the mesh.
         /// </summary>
@@ -646,7 +646,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
                 for (var i = 0; i < ChannelData.Length; i++)
                 {
-                        if (!Equals(ChannelData[i], other.ChannelData[i]))
+                    if (!Equals(ChannelData[i], other.ChannelData[i]))
                         return false;
                 }
 


### PR DESCRIPTION
Hello,

I've modified MeshHelper to address the issue mentioned in #8140 .
 Based on my understanding, the values in each of the VertexContent "Channels" should be indexed to match their corresponding vertex in the "Positions" index.
The previous code incorrectly indexed them using the vertex positions in the parent Mesh collection.