### PR TITLE
Re-enable 17.* wildcard for extension project

### DIFF
--- a/Templates/MonoGame.Templates.VSExtension/MonoGame.Templates.VSExtension.csproj
+++ b/Templates/MonoGame.Templates.VSExtension/MonoGame.Templates.VSExtension.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.*" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.9.*" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.*" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Templates.pkgdef">


### PR DESCRIPTION
Looks like Microsoft has been releasing the problem packages for the 17.10 set of VS tools in the last 24 hours (including 17.7.22 of the SDK analyzer from the original issue where it was looking for 17.7.20). The builds were failing again, because of another new package that should be there now.

Testing locally I am able to use the 17.* wildcards successfully, so basically resetting this to what it was before all of the broken packages. The GitHub action build is successful again as well.