### PR TITLE
[Documentation] Fix Invalid `<see cref>` tags

### DIFF
--- a/MonoGame.Framework/GameComponentCollection.cs
+++ b/MonoGame.Framework/GameComponentCollection.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Xna.Framework
 
         /// <summary>
         /// Removes every <see cref="GameComponent"/> from this <see cref="GameComponentCollection"/>.
-        /// Triggers <see cref="OnComponentRemoved"/> once for each <see cref="GameComponent"/> removed.
+        /// Triggers <see cref="ComponentRemoved"/> once for each <see cref="GameComponent"/> removed.
         /// </summary>
         protected override void ClearItems()
         {
@@ -39,7 +39,7 @@ namespace Microsoft.Xna.Framework
 
         /// <summary>
         /// Inserts an element into the collection at the specified index.
-        /// Triggers <see cref="OnComponentAdded(GameComponentCollectionEventArgs)"/>.
+        /// Triggers <see cref="ComponentAdded"/>.
         /// </summary>
         /// <param name="index">The zero-based index at which item should be inserted.</param>
         /// <param name="item">The object to insert.</param>
@@ -71,7 +71,7 @@ namespace Microsoft.Xna.Framework
 
         /// <summary>
         /// Removes the element at the specified index of the <see cref="GameComponentCollection"/>.
-        /// Triggers <see cref="OnComponentRemoved(GameComponentCollectionEventArgs)"/>.
+        /// Triggers <see cref="ComponentRemoved"/>.
         /// </summary>
         /// <param name="index">The zero-based index of the element to remove.</param>
         protected override void RemoveItem(int index)

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Xna.Framework
         private bool _preferHalfPixelOffset = false;
         private bool _wantFullScreen;
         private GraphicsProfile _graphicsProfile;
-        
+
         // dirty flag for ApplyChanges
         private bool _shouldApplyChanges;
 
@@ -64,7 +64,7 @@ namespace Microsoft.Xna.Framework
             _preferredDepthStencilFormat = DepthFormat.Depth24;
             _synchronizedWithVerticalRetrace = true;
 
-            // Assume the window client size as the default back 
+            // Assume the window client size as the default back
             // buffer resolution in the landscape orientation.
             var clientBounds = _game.Window.ClientBounds;
             if (clientBounds.Width >= clientBounds.Height)
@@ -231,9 +231,8 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Raised by <see cref="CreateDevice()"/> or <see cref="ApplyChanges"/>. Allows users
-        /// to override the <see cref="PresentationParameters"/> to pass to the
-        /// <see cref="Graphics.GraphicsDevice"/>.
+        /// Raised by <see cref="ApplyChanges"/>. Allows users to override the <see cref="PresentationParameters"/> to
+        /// pass to the <see cref="Graphics.GraphicsDevice">GraphicsDevice</see>.
         /// </summary>
         public event EventHandler<PreparingDeviceSettingsEventArgs> PreparingDeviceSettings;
 


### PR DESCRIPTION
## Description
This PR is to resolve invalid `cref` links in `<see>` tags of XML documentation in the repository. Various `cref` links were referencing private methods, which do not get included in documentation, which creates broken links for the documentation website build.

## Reference
- https://github.com/MonoGame/docs.monogame.github.io/pull/14