### PR TITLE
Fixed XML (45,85)  NormalizedShort4.cs

### DIFF
--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// </summary>
         /// <param name="a">The value on the left of the inequality operator.</param>
         /// <param name="b">The value on the right of the inequality operator.</param>
-        /// <returns>true if the two value are not equal; otherwise, false.</returns
+        /// <returns>true if the two value are not equal; otherwise, false.</returns>
         public static bool operator !=(NormalizedShort4 a, NormalizedShort4 b)
 		{
 			return !a.Equals (b);


### PR DESCRIPTION
This is my first time submitting anything here, so I apologize in advance if there's something I haven't done correctly. I saw this warning while building earlier and wanted to fix it:

> MonoGame/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs(45,85): warning CS1570: XML comment has badly formed XML -- 'The character(s) '' cannot be used at this location.'

line was missing a '>' at eol