### PR TITLE
Error on creating Effect with byte array and range #7794

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/Effect.cs
+++ b/MonoGame.Framework/Graphics/Effect/Effect.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Xna.Framework.Graphics
             header.Version = (int)effectCode[index++];
             header.Profile = (int)effectCode[index++];
             header.EffectKey = BitConverter.ToInt32(effectCode, index); index += 4;
-            header.HeaderSize = index;
+            header.HeaderSize = 10;
 
             if (header.Signature != MGFXHeader.MGFXSignature)
                 throw new Exception("This does not appear to be a MonoGame MGFX file!");

--- a/Tests/Framework/Graphics/EffectTest.cs
+++ b/Tests/Framework/Graphics/EffectTest.cs
@@ -11,6 +11,17 @@ namespace MonoGame.Tests.Graphics
     [TestFixture]
     internal class EffectTest : GraphicsDeviceTestFixtureBase
     {
+        [Test]
+        public void EffectConstructorShouldAllowIndexAndCount()
+        {
+            byte[] mgfxo = EffectResource.BasicEffect.Bytecode;
+            var index = 100000;
+            var byteArray = new byte[index + mgfxo.Length];
+            mgfxo.CopyTo(byteArray, index);
+            Effect effect = null;
+            Assert.DoesNotThrow(() => { effect = new Effect(game.GraphicsDevice, byteArray, index, mgfxo.Length); });
+            effect.Dispose();
+        }
 
         [Test]
         public void EffectPassShouldSetTexture()


### PR DESCRIPTION
see #7794

`header.HeaderSize` should always be read as 10 bytes and is only ever used in L128

EDIT: wrong Line number