### PR TITLE
[Documentation] Update XML documentation for `Texture2D`

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -5,24 +5,47 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
 using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Represents a 2D grid of texels.
+    /// </summary>
+    /// <remarks>
+    /// A texel represents the smallest unit of a texture that can be read from or written to by the GPU. A texel is
+    /// composed of 1 to 4 components. Specifically, a texel may be any one of the available texture formats represented
+    /// in the SurfaceFormat enumeration.
+    /// </remarks>
     public partial class Texture2D : Texture
     {
+        /// <summary>
+        /// Defines the values for the surface type of a <b>Texture2D</b>
+        /// </summary>
         internal protected enum SurfaceType
         {
+            /// <summary>
+            /// Describes that the surface type is a texture.
+            /// </summary>
             Texture,
+
+            /// <summary>
+            /// Describes that the surface type is a render target.
+            /// </summary>
             RenderTarget,
+
+            /// <summary>
+            /// Describes that the surface type is a swap chain render target.
+            /// </summary>
             SwapChainRenderTarget,
         }
 
 		internal int width;
 		internal int height;
         internal int ArraySize;
-                
+
         internal float TexelWidth { get; private set; }
         internal float TexelHeight { get; private set; }
 
@@ -38,59 +61,160 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Creates a new texture of the given size
+        /// Creates an uninitialized <b>Texture2D</b> resource with the specified parameters.
         /// </summary>
-        /// <param name="graphicsDevice"></param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
+        /// <remarks>
+        ///     <para>
+        ///         To initialize the texture with data after creating, you can use one of the
+        ///         <see cref="SetData{T}(T[])">SetData</see> method.
+        ///     </para>
+        ///     <para>
+        ///         To initialize a <b>Texture2D</b> from an existing file use the
+        ///         <see cref="ContentManager.Load{T}(string)">ContentManager.Load</see> method if loading a pipeline
+        ///         preprocessed <b>Texture2D</b> from an .xnb file or <see cref="FromFile(GraphicsDevice, string)">Texture2D.FromFile</see>
+        ///         to load directly from a file.
+        ///     </para>
+        /// </remarks>
+        /// <param name="graphicsDevice">The graphics device used to display the texture.</param>
+        /// <param name="width">The width, in pixels, of the texture.</param>
+        /// <param name="height">The height, in pixels, of the texture.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="graphicsDevice"/> parameter is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The <paramref name="width"/> and/or <paramref name="height"/> less than or equal to zero.
+        /// </exception>
         public Texture2D(GraphicsDevice graphicsDevice, int width, int height)
             : this(graphicsDevice, width, height, false, SurfaceFormat.Color, SurfaceType.Texture, false, 1)
         {
         }
 
         /// <summary>
-        /// Creates a new texture of a given size with a surface format and optional mipmaps 
+        /// Creates an uninitialized <b>Texture2D</b> resource with the specified parameters.
         /// </summary>
-        /// <param name="graphicsDevice"></param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
-        /// <param name="mipmap"></param>
-        /// <param name="format"></param>
+        /// <remarks>
+        ///     <para>
+        ///         To initialize the texture with data after creating, you can use one of the
+        ///         <see cref="SetData{T}(T[])">SetData</see> method.
+        ///     </para>
+        ///     <para>
+        ///         To initialize a <b>Texture2D</b> from an existing file use the
+        ///         <see cref="ContentManager.Load{T}(string)">ContentManager.Load</see> method if loading a pipeline
+        ///         preprocessed <b>Texture2D</b> from an .xnb file or <see cref="FromFile(GraphicsDevice, string)">Texture2D.FromFile</see>
+        ///         to load directly from a file.
+        ///     </para>
+        /// </remarks>
+        /// <param name="graphicsDevice">The graphics device used to display the texture.</param>
+        /// <param name="width">The width, in pixels, of the texture.</param>
+        /// <param name="height">The height, in pixels, of the texture.</param>
+        /// <param name="mipmap"><b>true</b> if mimapping is enabled for the texture; otherwise, <b>false</b>.</param>
+        /// <param name="format">The surface format of the texture.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="graphicsDevice"/> parameter is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The <paramref name="width"/> and/or <paramref name="height"/> less than or equal to zero.
+        /// </exception>
         public Texture2D(GraphicsDevice graphicsDevice, int width, int height, bool mipmap, SurfaceFormat format)
             : this(graphicsDevice, width, height, mipmap, format, SurfaceType.Texture, false, 1)
         {
         }
 
         /// <summary>
-        /// Creates a new texture array of a given size with a surface format and optional mipmaps.
-        /// Throws ArgumentException if the current GraphicsDevice can't work with texture arrays
+        /// Creates an uninitialized <b>Texture2D</b> resource with the specified parameters.
         /// </summary>
-        /// <param name="graphicsDevice"></param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
-        /// <param name="mipmap"></param>
-        /// <param name="format"></param>
-        /// <param name="arraySize"></param>
+        /// <remarks>
+        ///     <para>
+        ///         To initialize the texture with data after creating, you can use one of the
+        ///         <see cref="SetData{T}(T[])">SetData</see> method.
+        ///     </para>
+        ///     <para>
+        ///         To initialize a <b>Texture2D</b> from an existing file use the
+        ///         <see cref="ContentManager.Load{T}(string)">ContentManager.Load</see> method if loading a pipeline
+        ///         preprocessed <b>Texture2D</b> from an .xnb file or <see cref="FromFile(GraphicsDevice, string)">Texture2D.FromFile</see>
+        ///         to load directly from a file.
+        ///     </para>
+        /// </remarks>
+        /// <param name="graphicsDevice">The graphics device used to display the texture.</param>
+        /// <param name="width">The width, in pixels, of the texture.</param>
+        /// <param name="height">The height, in pixels, of the texture.</param>
+        /// <param name="mipmap"><b>true</b> if mimapping is enabled for the texture; otherwise, <b>false</b>.</param>
+        /// <param name="format">The surface format of the texture.</param>
+        /// <param name="arraySize">The size of the texture array.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="graphicsDevice"/> parameter is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The <paramref name="width"/> and/or <paramref name="height"/> less than or equal to zero.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The <paramref name="arraySize"/> parameter is greater than 1 and the graphics device does not support
+        /// texture arrays.
+        /// </exception>
         public Texture2D(GraphicsDevice graphicsDevice, int width, int height, bool mipmap, SurfaceFormat format, int arraySize)
             : this(graphicsDevice, width, height, mipmap, format, SurfaceType.Texture, false, arraySize)
         {
-            
+
         }
 
         /// <summary>
-        ///  Creates a new texture of a given size with a surface format and optional mipmaps.
+        /// Creates an uninitialized <b>Texture2D</b> resource with the specified parameters.
         /// </summary>
-        /// <param name="graphicsDevice"></param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
-        /// <param name="mipmap"></param>
-        /// <param name="format"></param>
-        /// <param name="type"></param>
+        /// <remarks>
+        ///     <para>
+        ///         To initialize the texture with data after creating, you can use one of the
+        ///         <see cref="SetData{T}(T[])">SetData</see> method.
+        ///     </para>
+        ///     <para>
+        ///         To initialize a <b>Texture2D</b> from an existing file use the
+        ///         <see cref="ContentManager.Load{T}(string)">ContentManager.Load</see> method if loading a pipeline
+        ///         preprocessed <b>Texture2D</b> from an .xnb file or <see cref="FromFile(GraphicsDevice, string)">Texture2D.FromFile</see>
+        ///         to load directly from a file.
+        ///     </para>
+        /// </remarks>
+        /// <param name="graphicsDevice">The graphics device used to display the texture.</param>
+        /// <param name="width">The width, in pixels, of the texture.</param>
+        /// <param name="height">The height, in pixels, of the texture.</param>
+        /// <param name="mipmap"><b>true</b> if mimapping is enabled for the texture; otherwise, <b>false</b>.</param>
+        /// <param name="format">The surface format of the texture.</param>
+        /// <param name="type">The surface type of the texture</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="graphicsDevice"/> parameter is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The <paramref name="width"/> and/or <paramref name="height"/> less than or equal to zero.
+        /// </exception>
         internal Texture2D(GraphicsDevice graphicsDevice, int width, int height, bool mipmap, SurfaceFormat format, SurfaceType type)
             : this(graphicsDevice, width, height, mipmap, format, type, false, 1)
         {
         }
-        
+
+        /// <summary>
+        /// Creates an uninitialized <b>Texture2D</b> resource with the specified parameters.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         To initialize the texture with data after creating, you can use one of the
+        ///         <see cref="SetData{T}(T[])">SetData</see> method.
+        ///     </para>
+        ///     <para>
+        ///         To initialize a <b>Texture2D</b> from an existing file use the
+        ///         <see cref="ContentManager.Load{T}(string)">ContentManager.Load</see> method if loading a pipeline
+        ///         preprocessed <b>Texture2D</b> from an .xnb file or <see cref="FromFile(GraphicsDevice, string)">Texture2D.FromFile</see>
+        ///         to load directly from a file.
+        ///     </para>
+        /// </remarks>
+        /// <param name="graphicsDevice">The graphics device used to display the texture.</param>
+        /// <param name="width">The width, in pixels, of the texture.</param>
+        /// <param name="height">The height, in pixels, of the texture.</param>
+        /// <param name="mipmap"><b>true</b> if mimapping is enabled for the texture; otherwise, <b>false</b>.</param>
+        /// <param name="format">The surface format of the texture.</param>
+        /// <param name="type">The surface type of the texture</param>
+        /// <param name="shared">
+        /// Whether this render target resource should be a shared resource accessible on another device.
+        /// This property is only valid for DirectX targets.
+        /// </param>
+        /// <param name="arraySize">The size of the texture array.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="graphicsDevice"/> parameter is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The <paramref name="width"/> and/or <paramref name="height"/> less than or equal to zero.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The <paramref name="arraySize"/> parameter is greater than 1 and the graphics device does not support
+        /// texture arrays.
+        /// </exception>
         protected Texture2D(GraphicsDevice graphicsDevice, int width, int height, bool mipmap, SurfaceFormat format, SurfaceType type, bool shared, int arraySize)
 		{
             if (graphicsDevice == null)
@@ -142,17 +266,67 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Changes the pixels of the texture
-        /// Throws ArgumentNullException if data is null
-        /// Throws ArgumentException if arraySlice is greater than 0, and the GraphicsDevice does not support texture arrays
+        /// Copies an array of data to the texture.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="level">Layer of the texture to modify</param>
+        /// <typeparam name="T">The type of the elements in the array.</typeparam>
+        /// <param name="level">The mipmap level where the data will be placed.</param>
         /// <param name="arraySlice">Index inside the texture array</param>
-        /// <param name="rect">Area to modify</param>
-        /// <param name="data">New data for the texture</param>
-        /// <param name="startIndex">Start position of data</param>
-        /// <param name="elementCount"></param>
+        /// <param name="rect">
+        /// The section of the texture where the data will be placed.  null indicates the data will be copied over the
+        /// entire texture.
+        /// </param>
+        /// <param name="data">
+        /// The array of data to copy.  If <paramref name="rect"/> is null, the number of elements in the array must be
+        /// equal to the size of the texture, which is <see cref="Width"/> x <see cref="Height"/>; otherwise, the number
+        /// of elements in the array should be equal to the size of the rectangle.
+        /// </param>
+        /// <param name="startIndex">The index of the element in the array at which to start copying.</param>
+        /// <param name="elementCount">The number of elements to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="level"/> parameter is larger than the number of levels in this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="arraySlice"/> parameter is greater than zero and the texture arrays are not
+        ///             supported on the graphics device.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="arraySlice"/> parameter is less than zero or is greater than or equal to the
+        ///             <see cref="ArraySize"/> of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="rect"/> is outside the bounds of the texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="startIndex"/> parameter is less than zero or is greater than or equal to the
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void SetData<T>(int level, int arraySlice, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct
         {
             Rectangle checkedRect;
@@ -161,15 +335,55 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Changes the pixels of the texture
+        /// Copies an array of data to the texture.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="level">Layer of the texture to modify</param>
-        /// <param name="rect">Area to modify</param>
-        /// <param name="data">New data for the texture</param>
-        /// <param name="startIndex">Start position of data</param>
-        /// <param name="elementCount"></param>
-        public void SetData<T>(int level, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct 
+        /// <typeparam name="T">The type of the elements in the array.</typeparam>
+        /// <param name="level">The mipmap level where the data will be placed.</param>
+        /// <param name="rect">
+        /// The section of the texture where the data will be placed.  null indicates the data will be copied over the
+        /// entire texture.
+        /// </param>
+        /// <param name="data">
+        /// The array of data to copy.  If <paramref name="rect"/> is null, the number of elements in the array must be
+        /// equal to the size of the texture, which is <see cref="Width"/> x <see cref="Height"/>; otherwise, the number
+        /// of elements in the array should be equal to the size of the rectangle.
+        /// </param>
+        /// <param name="startIndex">The index of the element in the array at which to start copying.</param>
+        /// <param name="elementCount">The number of elements to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="level"/> parameter is larger than the number of levels in this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="rect"/> is outside the bounds of the texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="startIndex"/> parameter is less than zero or is greater than or equal to the
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
+        public void SetData<T>(int level, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct
         {
             Rectangle checkedRect;
             ValidateParams(level, 0, rect, data, startIndex, elementCount, out checkedRect);
@@ -180,12 +394,35 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Changes the texture's pixels
+        /// Copies an array of data to the texture.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="data">New data for the texture</param>
-        /// <param name="startIndex">Start position of data</param>
-        /// <param name="elementCount"></param>
+        /// <typeparam name="T">The type of the elements in the array.</typeparam>
+        /// <param name="data"> The array of data to copy.</param>
+        /// <param name="startIndex">The index of the element in the array at which to start copying.</param>
+        /// <param name="elementCount">The number of elements to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="startIndex"/> parameter is less than zero or is greater than or equal to the
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
 		public void SetData<T>(T[] data, int startIndex, int elementCount) where T : struct
         {
             Rectangle checkedRect;
@@ -193,11 +430,28 @@ namespace Microsoft.Xna.Framework.Graphics
             PlatformSetData(0, data, startIndex, elementCount);
         }
 
-		/// <summary>
-        /// Changes the texture's pixels
+        /// <summary>
+        /// Copies an array of data to the texture.
         /// </summary>
-        /// <typeparam name="T">New data for the texture</typeparam>
-        /// <param name="data"></param>
+        /// <typeparam name="T">The type of the elements in the array.</typeparam>
+        /// <param name="data">The array of data to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
 		public void SetData<T>(T[] data) where T : struct
 		{
             Rectangle checkedRect;
@@ -206,17 +460,67 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Retrieves the contents of the texture
-        /// Throws ArgumentException if data is null, data.length is too short or
-        /// if arraySlice is greater than 0 and the GraphicsDevice doesn't support texture arrays
+        /// Copies texture data into an array
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="level">Layer of the texture</param>
+        /// <typeparam name="T">The type of the elements in the array.</typeparam>
+        /// <param name="level">The mipmap level to copy from.</param>
         /// <param name="arraySlice">Index inside the texture array</param>
-        /// <param name="rect">Area of the texture to retrieve</param>
-        /// <param name="data">Destination array for the data</param>
-        /// <param name="startIndex">Starting index of data where to write the pixel data</param>
-        /// <param name="elementCount">Number of pixels to read</param>
+        /// <param name="rect">
+        /// The section of the texture where the data will be copied from.  null indicates the data will be copied over
+        /// the entire texture.
+        /// </param>
+        /// <param name="data">
+        /// The array to receive texture data.  If <paramref name="rect"/> is null, the number of elements in the array
+        /// must be equal to the size of the texture, which is <see cref="Width"/> x <see cref="Height"/>; otherwise,
+        /// the number of elements in the array should be equal to the size of the rectangle.
+        /// </param>
+        /// <param name="startIndex">The index of the element in the array at which to start copying.</param>
+        /// <param name="elementCount">The number of elements to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="level"/> parameter is larger than the number of levels in this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="arraySlice"/> parameter is greater than zero and the texture arrays are not
+        ///             supported on the graphics device.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="arraySlice"/> parameter is less than zero or is greater than or equal to the
+        ///             <see cref="ArraySize"/> of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="rect"/> is outside the bounds of the texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="startIndex"/> parameter is less than zero or is greater than or equal to the
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void GetData<T>(int level, int arraySlice, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct
         {
             Rectangle checkedRect;
@@ -225,42 +529,116 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Retrieves the contents of the texture
-        /// Throws ArgumentException if data is null, data.length is too short or
-        /// if arraySlice is greater than 0 and the GraphicsDevice doesn't support texture arrays
+        /// Copies texture data into an array
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="level">Layer of the texture</param>
-        /// <param name="rect">Area of the texture</param>
-        /// <param name="data">Destination array for the texture data</param>
-        /// <param name="startIndex">First position in data where to write the pixel data</param>
-        /// <param name="elementCount">Number of pixels to read</param>
+        /// <typeparam name="T">The type of the elements in the array.</typeparam>
+        /// <param name="level">The mipmap level to copy from.</param>
+        /// <param name="rect">
+        /// The section of the texture where the data will be copied from.  null indicates the data will be copied over
+        /// the entire texture.
+        /// </param>
+        /// <param name="data">
+        /// The array to receive texture data.  If <paramref name="rect"/> is null, the number of elements in the array
+        /// must be equal to the size of the texture, which is <see cref="Width"/> x <see cref="Height"/>; otherwise,
+        /// the number of elements in the array should be equal to the size of the rectangle.
+        /// </param>
+        /// <param name="startIndex">The index of the element in the array at which to start copying.</param>
+        /// <param name="elementCount">The number of elements to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="level"/> parameter is larger than the number of levels in this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="rect"/> is outside the bounds of the texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="startIndex"/> parameter is less than zero or is greater than or equal to the
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void GetData<T>(int level, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct
         {
             this.GetData(level, 0, rect, data, startIndex, elementCount);
         }
 
         /// <summary>
-        /// Retrieves the contents of the texture
-        /// Throws ArgumentException if data is null, data.length is too short or
-        /// if arraySlice is greater than 0 and the GraphicsDevice doesn't support texture arrays
+        /// Copies texture data into an array
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="data">Destination array for the texture data</param>
-        /// <param name="startIndex">First position in data where to write the pixel data</param>
-        /// <param name="elementCount">Number of pixels to read</param>
+        /// <typeparam name="T">The type of the elements in the array.</typeparam>
+        /// <param name="data">The array to receive texture data.</param>
+        /// <param name="startIndex">The index of the element in the array at which to start copying.</param>
+        /// <param name="elementCount">The number of elements to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="startIndex"/> parameter is less than zero or is greater than or equal to the
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
 		public void GetData<T>(T[] data, int startIndex, int elementCount) where T : struct
 		{
 			this.GetData(0, null, data, startIndex, elementCount);
 		}
 
         /// <summary>
-        /// Retrieves the contents of the texture
-        /// Throws ArgumentException if data is null, data.length is too short or
-        /// if arraySlice is greater than 0 and the GraphicsDevice doesn't support texture arrays
+        /// Copies texture data into an array
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="data">Destination array for the texture data</param>
+        /// <typeparam name="T">The type of the elements in the array.</typeparam>
+        /// <param name="data">The array to receive texture data.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void GetData<T> (T[] data) where T : struct
 		{
 		    if (data == null)
@@ -271,13 +649,13 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Creates a <see cref="Texture2D"/> from a file, supported formats bmp, gif, jpg, png, tif and dds (only for simple textures).
         /// May work with other formats, but will not work with tga files.
-        /// This internally calls <see cref="FromStream"/>.
+        /// This internally calls <see cref="FromFile(GraphicsDevice, string, Action{byte[]})"/>.
         /// </summary>
         /// <param name="graphicsDevice">The graphics device to use to create the texture.</param>
         /// <param name="path">The path to the image file.</param>
         /// <param name="colorProcessor">Function that is applied to the data in RGBA format before the texture is sent to video memory. Could be null(no processing then).</param>
         /// <returns>The <see cref="Texture2D"/> created from the given file.</returns>
-        /// <remarks>Note that different image decoders may generate slight differences between platforms, but perceptually 
+        /// <remarks>Note that different image decoders may generate slight differences between platforms, but perceptually
         /// the images should be identical.
         /// </remarks>
         public static Texture2D FromFile(GraphicsDevice graphicsDevice, string path, Action<byte[]> colorProcessor)
@@ -292,12 +670,12 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Creates a <see cref="Texture2D"/> from a file, supported formats bmp, gif, jpg, png, tif and dds (only for simple textures).
         /// May work with other formats, but will not work with tga files.
-        /// This internally calls <see cref="FromStream"/>.
+        /// This internally calls <see cref="FromStream(GraphicsDevice, Stream, Action{byte[]})"/>.
         /// </summary>
         /// <param name="graphicsDevice">The graphics device to use to create the texture.</param>
         /// <param name="path">The path to the image file.</param>
         /// <returns>The <see cref="Texture2D"/> created from the given file.</returns>
-        /// <remarks>Note that different image decoders may generate slight differences between platforms, but perceptually 
+        /// <remarks>Note that different image decoders may generate slight differences between platforms, but perceptually
         /// the images should be identical.  This call does not premultiply the image alpha, but areas of zero alpha will
         /// result in black color data.
         /// </remarks>
@@ -314,7 +692,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="stream">The stream from which to read the image data.</param>
         /// <param name="colorProcessor">Function that is applied to the data in RGBA format before the texture is sent to video memory. Could be null(no processing then).</param>
         /// <returns>The <see cref="Texture2D"/> created from the image stream.</returns>
-        /// <remarks>Note that different image decoders may generate slight differences between platforms, but perceptually 
+        /// <remarks>Note that different image decoders may generate slight differences between platforms, but perceptually
         /// the images should be identical.
         /// </remarks>
         public static Texture2D FromStream(GraphicsDevice graphicsDevice, Stream stream, Action<byte[]> colorProcessor)
@@ -341,7 +719,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="graphicsDevice">The graphics device to use to create the texture.</param>
         /// <param name="stream">The stream from which to read the image data.</param>
         /// <returns>The <see cref="Texture2D"/> created from the image stream.</returns>
-        /// <remarks>Note that different image decoders may generate slight differences between platforms, but perceptually 
+        /// <remarks>Note that different image decoders may generate slight differences between platforms, but perceptually
         /// the images should be identical.  This call does not premultiply the image alpha, but areas of zero alpha will
         /// result in black color data.
         /// </remarks>
@@ -354,8 +732,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Converts the texture to a JPG image
         /// </summary>
         /// <param name="stream">Destination for the image</param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
+        /// <param name="width">The width, in pixels, of the image.</param>
+        /// <param name="height">The height, in pixels, of the image.</param>
         public void SaveAsJpeg(Stream stream, int width, int height)
         {
             PlatformSaveAsJpeg(stream, width, height);
@@ -365,15 +743,20 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Converts the texture to a PNG image
         /// </summary>
         /// <param name="stream">Destination for the image</param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
+        /// <param name="width">The width, in pixels, of the image.</param>
+        /// <param name="height">The height, in pixels, of the image.</param>
         public void SaveAsPng(Stream stream, int width, int height)
         {
             PlatformSaveAsPng(stream, width, height);
         }
 
-        // This method allows games that use Texture2D.FromStream 
-        // to reload their textures after the GL context is lost.
+        /// <summary>
+        /// Reloads the texture
+        /// </summary>
+        /// <remarks>
+        /// This method allows games that use <see cref="FromStream(GraphicsDevice, Stream)">Texture2D.FromStream</see>
+        /// to reload their textures after the GL context is lost.
+        /// </remarks>
         public void Reload(Stream textureStream)
         {
             PlatformReload(textureStream);


### PR DESCRIPTION
## Description
This PR adds missing and updates existing XML documentation to the `Texture2D` class.

## Reference
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)