### PR TITLE
[Documentation] Update XML documentation for `Texture3D`

### DIFF
--- a/MonoGame.Framework/Graphics/Texture3D.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.cs
@@ -5,36 +5,92 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Microsoft.Xna.Framework.Content;
 using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Represents a 3D volume of texels.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A texel represents the smallest unit of a texture that can be read from or written to by the GPU. A
+    ///         texel is composed of 1 to 4 components. Specifically, a texel may be any one of the available texture
+    ///         formats represented in the <see cref="SurfaceFormat"/> enumeration.
+    ///     </para>
+    ///     <para>
+    ///         A <b>Texture3D</b> resource (also known as a volume texture) contains a 3D volume of texels. Since it is
+    ///         a texture resource, it may contain mipmap levels.
+    ///     </para>
+    ///     <para>
+    ///         When a <b>Texture3D</b> mipmap slice is bound as a render target output (by creating a
+    ///         <see cref="RenderTargetCube"/>), the <b>Texture3D</b> behaves identically to an array of
+    ///         <see cref="Texture2D"/> objects with <i>n</i> array slices, where <i>n</i> is the depth (third dimension)
+    ///         of the <b>Texture3D</b>.
+    ///     </para>
+    /// </remarks>
 	public partial class Texture3D : Texture
 	{
         private int _width;
         private int _height;
         private int _depth;
 
+        /// <summary>
+        /// Gets the width, in pixels, of this texture resource.
+        /// </summary>
         public int Width
         {
             get { return _width; }
         }
 
+        /// <summary>
+        /// Gets the height, in pixels, of this texture resource.
+        /// </summary>
         public int Height
         {
             get { return _height; }
         }
 
+        /// <summary>
+        /// Gets the depth, in pixels, of this texture resource.
+        /// </summary>
         public int Depth
         {
             get { return _depth; }
         }
 
+        /// <summary>
+        /// Creates an uninitialized <b>Texture3D</b> resource with the specified parameters.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         To initialize the texture with data after creating, you can use one of the
+        ///         <see cref="SetData{T}(T[])">SetData</see> methods.
+        ///     </para>
+        ///     <para>
+        ///         To initialize a <b>Texture3D</b> from an existing file use the
+        ///         <see cref="ContentManager.Load{T}(string)">ContentManager.Load</see> method if loading a pipeline
+        ///         preprocessed <b>Texture3D</b> from an .xnb file.
+        ///     </para>
+        /// </remarks>
+        /// <param name="graphicsDevice">The graphics device used to display the texture.</param>
+        /// <param name="width">The width, in pixels, of the texture.</param>
+        /// <param name="height">The height, in pixels, of the texture.</param>
+        /// <param name="depth">The depth, in pixels, of the texture.</param>
+        /// <param name="mipMap"><b>true</b> if mimapping is enabled for the texture; otherwise, <b>false</b>.</param>
+        /// <param name="format">The surface format of the texture.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="graphicsDevice"/> parameter is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The <paramref name="width"/>, <paramref name="height"/>, and/or <paramref name="depth"/> parameters are less
+        /// than or equal to zero.
+        /// </exception>
 		public Texture3D(GraphicsDevice graphicsDevice, int width, int height, int depth, bool mipMap, SurfaceFormat format)
             : this(graphicsDevice, width, height, depth, mipMap, format, false)
 		{
 		}
 
+        /// <summary />
 		protected Texture3D (GraphicsDevice graphicsDevice, int width, int height, int depth, bool mipMap, SurfaceFormat format, bool renderTarget)
 		{
 		    if (graphicsDevice == null)
@@ -56,6 +112,27 @@ namespace Microsoft.Xna.Framework.Graphics
             PlatformConstruct(graphicsDevice, width, height, depth, mipMap, format, renderTarget);
         }
 
+        /// <summary>
+        /// Copies an array of data to the texture.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements in the array.</typeparam>
+        /// <param name="data">The array of data to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void SetData<T>(T[] data) where T : struct
 		{
             if (data == null)
@@ -63,11 +140,107 @@ namespace Microsoft.Xna.Framework.Graphics
 			SetData(data, 0, data.Length);
 		}
 
+        /// <summary>
+        /// Copies an array of data to the texture.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements in the array.</typeparam>
+        /// <param name="data">The array of data to copy.</param>
+        /// <param name="startIndex">The index of the element in the array at which to start copying.</param>
+        /// <param name="elementCount">The number of elements to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="startIndex"/> parameter is less than zero or is greater than or equal to the
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
 		public void SetData<T> (T[] data, int startIndex, int elementCount) where T : struct
 		{
 			SetData(0, 0, 0, Width, Height, 0, Depth, data, startIndex, elementCount);
 		}
 
+        /// <summary>
+        /// Copies an array of data to the texture.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements in the array.</typeparam>
+        /// <param name="level">The mipmap level where the data will be placed.</param>
+        /// <param name="left">Position of the left side of the box on the x-axis.</param>
+        /// <param name="top">Position of the top of the box on the y-axis.</param>
+        /// <param name="right">Position of the right side of the box on the x-axis.</param>
+        /// <param name="bottom">Position of the bottom of the box on the y-axis.</param>
+        /// <param name="front">Position of the front of the box on the z-axis.</param>
+        /// <param name="back">Position of the back of the box on the z-axis.</param>
+        /// <param name="data">The array of data to copy.</param>
+        /// <param name="startIndex">The index of the element in the array at which to start copying.</param>
+        /// <param name="elementCount">The number of elements to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="level"/> parameter is larger than the number of levels in this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="startIndex"/> parameter is less than zero or is greater than or equal to the
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="left"/>, <paramref name="top"/>, <paramref name="back"/>, and/or <paramref name="right"/>
+        ///             parameters are less than zero.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="right"/> parameter is greater than the width of the texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="bottom"/> parameter is greater than the height of the texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="top"/> parameter is greater than the depth of the texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="elementCount"/> parameter is the incorrect size.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
 		public void SetData<T> (int level,
 		                        int left, int top, int right, int bottom, int front, int back,
 		                        T[] data, int startIndex, int elementCount) where T : struct
@@ -82,19 +255,72 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
         /// <summary>
-        /// Gets a copy of 3D texture data, specifying a mipmap level, source box, start index, and number of elements.
+        /// Copies texture data into an array.
         /// </summary>
         /// <typeparam name="T">The type of the elements in the array.</typeparam>
-        /// <param name="level">Mipmap level.</param>
+        /// <param name="level">The mipmap level where the data will be placed.</param>
         /// <param name="left">Position of the left side of the box on the x-axis.</param>
         /// <param name="top">Position of the top of the box on the y-axis.</param>
         /// <param name="right">Position of the right side of the box on the x-axis.</param>
         /// <param name="bottom">Position of the bottom of the box on the y-axis.</param>
         /// <param name="front">Position of the front of the box on the z-axis.</param>
         /// <param name="back">Position of the back of the box on the z-axis.</param>
-        /// <param name="data">Array of data.</param>
-        /// <param name="startIndex">Index of the first element to get.</param>
-        /// <param name="elementCount">Number of elements to get.</param>
+        /// <param name="data">The array of data to copy.</param>
+        /// <param name="startIndex">The index of the element in the array at which to start copying.</param>
+        /// <param name="elementCount">The number of elements to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="level"/> parameter is larger than the number of levels in this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="startIndex"/> parameter is less than zero or is greater than or equal to the
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="left"/>, <paramref name="top"/>, <paramref name="back"/>, and/or <paramref name="right"/>
+        ///             parameters are less than zero.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="right"/> parameter is greater than the width of the texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="bottom"/> parameter is greater than the height of the texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="top"/> parameter is greater than the depth of the texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="elementCount"/> parameter is the incorrect size.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void GetData<T>(int level, int left, int top, int right, int bottom, int front, int back, T[] data, int startIndex, int elementCount) where T : struct
         {
             ValidateParams(level, left, top, right, bottom, front, back, data, startIndex, elementCount);
@@ -102,22 +328,65 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Gets a copy of 3D texture data, specifying a start index and number of elements.
+        /// Copies texture data into an array.
         /// </summary>
         /// <typeparam name="T">The type of the elements in the array.</typeparam>
-        /// <param name="data">Array of data.</param>
-        /// <param name="startIndex">Index of the first element to get.</param>
-        /// <param name="elementCount">Number of elements to get.</param>
+        /// <param name="data">The array of data to copy.</param>
+        /// <param name="startIndex">The index of the element in the array at which to start copying.</param>
+        /// <param name="elementCount">The number of elements to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="startIndex"/> parameter is less than zero or is greater than or equal to the
+        ///             length of the data array.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="elementCount"/> parameter is the incorrect size.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void GetData<T>(T[] data, int startIndex, int elementCount) where T : struct
         {
             GetData(0, 0, 0, _width, _height, 0, _depth, data, startIndex, elementCount);
         }
 
         /// <summary>
-        /// Gets a copy of 3D texture data.
+        /// Copies texture data into an array.
         /// </summary>
         /// <typeparam name="T">The type of the elements in the array.</typeparam>
-        /// <param name="data">Array of data.</param>
+        /// <param name="data">The array of data to copy.</param>
+        /// <exception cref="ArgumentException">
+        /// One of the following conditions is true:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>
+        ///             The <typeparamref name="T"/> type size is invalid for the format of this texture.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <description>
+        ///             The <paramref name="data"/> array parameter is too small.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void GetData<T>(T[] data) where T : struct
         {
             if (data == null)


### PR DESCRIPTION
## Description
This PR adds missing and updates existing XML documentation to the `Texture3D` class.

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)