### PR TITLE
Fix a TargetPlatform rethrow warning

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
+++ b/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
@@ -121,12 +121,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             {
                 return base.ConvertFrom(context, culture, value);
             }
-            catch (FormatException fex)
+            catch (FormatException)
             { 
                 // convert legacy Platforms
                 if (value.Equals("Linux") || value.Equals("WindowsGL"))
                     return TargetPlatform.DesktopGL;
-                else throw fex;
+                else
+                    throw;
             }
         }
     }


### PR DESCRIPTION
This PR fixes a [CA2200](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2200) warning in `TargetPlatform.cs` file.

Issue in tracker: https://github.com/AristurtleDev/monogame-build-warning-tracker/issues/192