### PR TITLE
[Documentation] Update XML documentation for `ModelMeshPartContent`

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/ModelMeshPartContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/ModelMeshPartContent.cs
@@ -7,6 +7,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 {
+    /// <summary>
+    /// Stores design-time data for a <see cref="ModelMeshPart"/> asset.
+    /// </summary>
     public sealed class ModelMeshPartContent
     {
         private IndexCollection _indexBuffer;
@@ -30,39 +33,64 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             _primitiveCount = primitiveCount;
         }
 
+
+        /// <summary>
+        /// Gets the collection of indices for this mesh part.
+        /// </summary>
         public IndexCollection IndexBuffer
         {
             get { return _indexBuffer; }
         }
 
+        /// <summary>
+        /// Gets the material of this mesh part.
+        /// </summary>
         public MaterialContent Material
         {
             get { return _material; }
             set { _material = value; }
         }
 
+        /// <summary>
+        /// Gets the number of vertices used in this mesh part.
+        /// </summary>
         public int NumVertices
         {
             get { return _numVertices; }
         }
 
+        /// <summary>
+        /// Gets the number of primitives to render for this mesh part.
+        /// </summary>
         public int PrimitiveCount
         {
             get { return _primitiveCount; }
         }
 
+        /// <summary>
+        /// Gets the location in the index buffer at which to start reading vertices.
+        /// </summary>
         public int StartIndex
         {
             get { return _startIndex; }
         }
 
+        /// <summary>
+        /// Gets a user-defined tag object.
+        /// </summary>
         public object Tag { get; set; }
 
+        /// <summary>
+        /// Gets the collection of vertices for this mesh part.
+        /// </summary>
         public VertexBufferContent VertexBuffer
         {
             get { return _vertexBuffer; }
         }
 
+        /// <summary>
+        /// Gets the offset from the start of the index buffer to the first vertex index.
+        /// </summary>
         public int VertexOffset
         {
             get { return _vertexOffset; }


### PR DESCRIPTION
## Description
This PR adds missing and updates existing XML documentation to the `ModelMeshPartContent` class.

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)