### PR TITLE
[Documentation] Update XML documentation for `ModelMeshContentCollection`

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/ModelMeshContentCollection.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/ModelMeshContentCollection.cs
@@ -7,6 +7,9 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 {
+    /// <summary>
+    /// A collection of <see cref="ModelMeshPartContent"/> objects.
+    /// </summary>
     public sealed class ModelMeshContentCollection : ReadOnlyCollection<ModelMeshContent>
     {
         internal ModelMeshContentCollection(IList<ModelMeshContent> list)


### PR DESCRIPTION
## Description
This PR adds missing and updates existing XML documentation to the `ModelMeshContentCollection` class.

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)