### PR TITLE
Small change to XmlColor and filled XML documentation.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/XmlColor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/XmlColor.cs
@@ -14,25 +14,50 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
     {
         private Color _color;
 
+        /// <summary>
+        /// Creates a new instance of XmlColor with <see cref="Color.Empty"/> color.
+        /// </summary>
         public XmlColor()
         {            
         }
 
+        /// <summary>
+        /// Creates a new instance of XmlColor with provided color
+        /// </summary>
+        /// <param name="c">Color to be stored</param>
         public XmlColor(Color c)
         {
             _color = c;
         }
 
+        /// <summary>
+        /// Implict XmlColor -> Color conversion
+        /// </summary>
         public static implicit operator Color(XmlColor x)
         {
             return x._color;
         }
 
+        /// <summary>
+        /// Implict Color -> XmlColor conversion
+        /// </summary>
         public static implicit operator XmlColor(Color c)
         {
             return new XmlColor(c);
         }
 
+        /// <summary>
+        /// Returns a string representation of the supplied <see cref="Color"/>.
+        /// </summary>
+        /// <remarks>
+        /// This string value can be used in <see cref="ToColor(string)"/> to get identical color object.
+        /// </remarks>
+        /// <param name="color">Color to be converted.</param>
+        /// <returns>
+        /// The predefined name of the color, if it's named,
+        /// or a string in the format <b>"R, G, B, A"</b>, if the color is not named,
+        /// with every component in the [0..255] range.
+        /// </returns>
         public static string FromColor(Color color)
         {
             if (color.IsNamedColor)
@@ -40,6 +65,13 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             return string.Format("{0}, {1}, {2}, {3}", color.R, color.G, color.B, color.A);
         }
 
+        /// <summary>
+        /// Returns a new <see cref="Color"/> object from its string representation.
+        /// </summary>
+        /// <param name="value">
+        /// A predefined color name,
+        /// OR a string in the format <b>"R, G, B, A"</b>, where each component is in the [0..255] range.<para/>
+        /// </param>
         public static Color ToColor(string value)
         {            
             if (!value.Contains(","))
@@ -55,6 +87,9 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             return Color.FromArgb(a, r, g, b);
         }
 
+        /// <summary>
+        /// Default color value as a string, used for serialization and deserialization.
+        /// </summary>
         [XmlText]
         public string Default
         {

--- a/MonoGame.Framework.Content.Pipeline/Builder/XmlColor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/XmlColor.cs
@@ -74,7 +74,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         /// </param>
         public static Color ToColor(string value)
         {            
-            if (!value.Contains(","))
+            if (!value.Contains(','))
                 return Color.FromName(value);
 
             int r, g, b, a;

--- a/MonoGame.Framework.Content.Pipeline/Builder/XmlColor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/XmlColor.cs
@@ -31,7 +31,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         }
 
         /// <summary>
-        /// Implict XmlColor -> Color conversion
+        /// Implicit XmlColor -> Color conversion
         /// </summary>
         public static implicit operator Color(XmlColor x)
         {
@@ -39,7 +39,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         }
 
         /// <summary>
-        /// Implict Color -> XmlColor conversion
+        /// Implicit Color -> XmlColor conversion
         /// </summary>
         public static implicit operator XmlColor(Color c)
         {


### PR DESCRIPTION
This PR:
- Fills documentation in `XmlColor` class
- Applies a recommended change ([CA1847](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1847)) to `XmlColor.ToColor` method, which should slightly improve performance.

Issue in tracker: https://github.com/AristurtleDev/monogame-build-warning-tracker/issues/191