### PR TITLE
[Documentation] Update XML documentation for `Vector2`

### DIFF
--- a/MonoGame.Framework/Utilities/System.Numerics.Vectors/Vector2.cs
+++ b/MonoGame.Framework/Utilities/System.Numerics.Vectors/Vector2.cs
@@ -5,9 +5,15 @@ namespace System.Numerics
     /// </summary>
     public struct Vector2
     {
+        /// <summary>The X component of the vector.</summary>
         public Single X;
+
+        /// <summary>The Y component of the vector.</summary>
         public Single Y;
- 
+
+        /// <summary>Creates a vector with the specified values.</summary>
+        /// <param name="x">The value assigned to the <see cref="X"/> field.</param>
+        /// <param name="y">The value assigned to the <see cref="Y"/> field.</param>
         public Vector2(Single x, Single y)
         {
             X = x;


### PR DESCRIPTION
## Description
This PR adds missing and updates existing XML documentation to the `Vector2` strut.
Specifically, MonoGame.Framework/Utilities/System.Numerics.Vectors/Vector2.cs

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)