### PR TITLE
Suppress warnings from UWP project

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
@@ -13,7 +13,7 @@
     <SharpDXVersion>4.0.1</SharpDXVersion>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <PackageOutputPath>..\Artifacts\NuGet</PackageOutputPath>
-    <NoWarn>$(NoWarn);CS0168;CS0219;CS0436;CS1574;CS1591;CS3021;CS4014;MSB4011;NU5128</NoWarn>
+    <NoWarn>$(NoWarn);CS0067;CS0168;CS0169;CS0219;CS0419;CS0436;CS0618;CS1574;CS1591;CS3021;CS4014;MSB4011;NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsUniversal.csproj
@@ -13,6 +13,7 @@
     <SharpDXVersion>4.0.1</SharpDXVersion>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <PackageOutputPath>..\Artifacts\NuGet</PackageOutputPath>
+    <NoWarn>$(NoWarn);CS0168;CS0219;CS0436;CS1574;CS1591;CS3021;CS4014;MSB4011;NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
UWP platform will be [dropped soon](https://github.com/MonoGame/MonoGame/pull/6285#issuecomment-2123244514), so warnings that exist only in that project can be suppressed