### PR TITLE
Suppress warnings in Utilities/System.Numerics.Vectors

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.Native.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Native.csproj
@@ -16,11 +16,13 @@
     <Compile Remove="obj\**\*" />
     <Compile Remove="Platform\**\*" />
     <Compile Remove="Properties\**\*" />
+    <Compile Remove="Utilities\System.Numerics.Vectors\**\*" />
     <Compile Include="Platform\Native\**\*" />
   </ItemGroup>
 
   <ItemGroup>
     <None Remove="Platform\**\*" />
+    <None Remove="Utilities\System.Numerics.Vectors\**\*" />
   </ItemGroup>
 
 </Project>

--- a/MonoGame.Framework/Utilities/System.Numerics.Vectors/Matrix4x4.cs
+++ b/MonoGame.Framework/Utilities/System.Numerics.Vectors/Matrix4x4.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS1591
 namespace System.Numerics
 {
     /// <summary>

--- a/MonoGame.Framework/Utilities/System.Numerics.Vectors/Plane.cs
+++ b/MonoGame.Framework/Utilities/System.Numerics.Vectors/Plane.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS1591
 namespace System.Numerics
 {
     /// <summary>

--- a/MonoGame.Framework/Utilities/System.Numerics.Vectors/Quaternion.cs
+++ b/MonoGame.Framework/Utilities/System.Numerics.Vectors/Quaternion.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS1591
 namespace System.Numerics
 {
     /// <summary>

--- a/MonoGame.Framework/Utilities/System.Numerics.Vectors/Vector2.cs
+++ b/MonoGame.Framework/Utilities/System.Numerics.Vectors/Vector2.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS1591
 namespace System.Numerics
 {
     /// <summary>

--- a/MonoGame.Framework/Utilities/System.Numerics.Vectors/Vector3.cs
+++ b/MonoGame.Framework/Utilities/System.Numerics.Vectors/Vector3.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS1591
 namespace System.Numerics
 {
     /// <summary>

--- a/MonoGame.Framework/Utilities/System.Numerics.Vectors/Vector4.cs
+++ b/MonoGame.Framework/Utilities/System.Numerics.Vectors/Vector4.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS1591
 namespace System.Numerics
 {
     /// <summary>


### PR DESCRIPTION
- Removed Utilities/System.Numerics.Vectors from Native project
- Added `#pragma warning disable` to files in Utilities/System.Numerics.Vectors