### PR TITLE
[Documentation] Update XML documentation for `Utilities.Vector4`

### DIFF
--- a/MonoGame.Framework/Utilities/System.Numerics.Vectors/Vector4.cs
+++ b/MonoGame.Framework/Utilities/System.Numerics.Vectors/Vector4.cs
@@ -5,11 +5,20 @@ namespace System.Numerics
     /// </summary>
     public struct Vector4
     {
+        /// <summary>The X component of the vector.</summary>
         public Single X;
+        /// <summary>The Y component of the vector.</summary>
         public Single Y;
+        /// <summary>The Z component of the vector.</summary>
         public Single Z;
+        /// <summary>The W component of the vector.</summary>
         public Single W;
- 
+
+        /// <summary>Creates a vector with the specified values.</summary>
+        /// <param name="x">The value assigned to the <see cref="X"/> field.</param>
+        /// <param name="y">The value assigned to the <see cref="Y"/> field.</param>
+        /// <param name="z">The value assigned to the <see cref="Z"/> field.</param>
+        /// <param name="w">The value assigned to the <see cref="W"/> field.</param>
         public Vector4(Single x, Single y, Single z, Single w)
         {
             X = x;


### PR DESCRIPTION
## Description
This PR adds missing and updates existing XML documentation to the `Utilities.Vector4` strut.

Would guess this might not be required after #8350 is merged, feel free to reject if this is the case

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)