### PR TITLE
[Documentation] Update XML documentation for `ContentPipeline/ContentStatsCollection`

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/ContentStatsCollection.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentStatsCollection.cs
@@ -22,6 +22,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         private readonly object _locker = new object();
         private readonly Dictionary<string, ContentStats> _statsBySource = new Dictionary<string, ContentStats>(1024);
 
+        /// <summary>
+        /// The file extension used by the content pipeline after building to store the content statistics.
+        /// <remarks><para>Read only - cannot be assigned to</para></remarks>
+        /// </summary>
         public static readonly string Extension = ".mgstats";
 
         /// <summary>

--- a/MonoGame.Framework.Content.Pipeline/ContentStatsCollection.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentStatsCollection.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                         collection._statsBySource.Add(stats.SourceFile, stats);
                 }
             }
-            catch (Exception ex)
+            catch
             {
                 // Assume the file didn't exist or was incorrectly
                 // formatted... either way we start from fresh data.


### PR DESCRIPTION
## Description
This PR
- Adds missing XML documentation to the `ContentPipeline/ContentStatsCollection` class
- Removes exception variable that is not used (CS0168 warning)

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)