### PR TITLE
[Documentation] Update XML documentation for `Content/ContentSerializerIgnoreAttribute`

### DIFF
--- a/MonoGame.Framework/Content/ContentSerializerIgnoreAttribute.cs
+++ b/MonoGame.Framework/Content/ContentSerializerIgnoreAttribute.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Xna.Framework.Content
 	// The class definition on msdn site shows: [AttributeUsageAttribute(384)]
 	// The following code var ff = (AttributeTargets)384; shows that ff is Field | Property
 	//  so that is what we use.
+    /// <summary>
+    /// Defines a custom <see cref="Attribute"/> that marks a field or property to indicate that it should
+    /// not be included in serialization.
+    /// </summary>
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
 	public sealed class ContentSerializerIgnoreAttribute : Attribute
 	{


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to the `Content/ContentSerializerIgnoreAttribute` class.

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)