### PR TITLE
[Documentation] Update XML documentation for 'GameWindow'

### DIFF
--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -270,6 +270,12 @@ namespace Microsoft.Xna.Framework
 		protected abstract void SetTitle (string title);
 
 #if DIRECTX && WINDOWS
+        /// <summary>
+        /// Create a <see cref="GameWindow"/> based on the given <see cref="Game"/> and a fixed starting size.
+        /// </summary>
+        /// <param name="game">The <see cref="Game"/> to create the <see cref="GameWindow"/> for.</param>
+        /// <param name="width">Initial pixel width to set for the <see cref="GameWindow"/>.</param>
+        /// <param name="height">Initial pixel height to set for the <see cref="GameWindow"/>.</param>
         public static GameWindow Create(Game game, int width, int height)
         {
             var window = new MonoGame.Framework.WinFormsGameWindow((MonoGame.Framework.WinFormsGamePlatform)game.Platform);


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to the `GameWindow` class.

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)