### PR TITLE
[Documentation] Update XML documentation for `Windows.Mouse`

### DIFF
--- a/MonoGame.Framework/Platform/Input/Mouse.Windows.cs
+++ b/MonoGame.Framework/Platform/Input/Mouse.Windows.cs
@@ -35,11 +35,12 @@ namespace Microsoft.Xna.Framework.Input
         {
             PrimaryWindow.MouseState.X = x;
             PrimaryWindow.MouseState.Y = y;
-            
+
             var pt = _window.PointToScreen(new System.Drawing.Point(x, y));
             SetCursorPos(pt.X, pt.Y);
         }
 
+        /// <inheritdoc cref="Mouse.SetCursor"/>
         public static void PlatformSetCursor(MouseCursor cursor)
         {
             _window.Cursor = cursor.Cursor;


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to the `Windows.Mouse` class.

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)