### PR TITLE
[Documentation] Update XML documentation for `SamplerState.DirectX`

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/States/SamplerState.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/States/SamplerState.DirectX.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         private SharpDX.Direct3D11.SamplerState _state;
 
+        /// <inheritdoc />
         protected internal override void GraphicsDeviceResetting()
         {
             SharpDX.Utilities.Dispose(ref _state);
@@ -45,7 +46,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // TODO: How do i do this?
                 desc.MinimumLod = 0.0f;
 
-                // To support feature level 9.1 these must 
+                // To support feature level 9.1 these must
                 // be set to these exact values.
                 desc.MaximumLod = float.MaxValue;
 


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to the `SamplerState.DirectX` class.

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)