### PR TITLE
[Documentation] Update XML documentation for `RenderTarget2D.DirectX`

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.DirectX.cs
@@ -104,6 +104,7 @@ namespace Microsoft.Xna.Framework.Graphics
             SharpDX.Utilities.Dispose(ref _depthStencilView);
         }
 
+        /// <summary />
         protected override void Dispose(bool disposing)
         {
             if (disposing)
@@ -146,6 +147,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary />
         protected internal override Texture2DDescription GetTexture2DDescription()
         {
             var desc = base.GetTexture2DDescription();


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to the `RenderTarget2D.DirectX` class.

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)