### PR TITLE
[Documentation] Update XML documentation for `VertexBuffer.DirectX`

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.DirectX.cs
@@ -211,6 +211,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary /
         protected override void Dispose(bool disposing)
         {
             if (disposing)


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to the `VertexBuffer.DirectX` class.

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)