### PR TITLE
[Documentation] Update XML documentation for `IndexBuffer.DirectX`

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/Vertices/IndexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Vertices/IndexBuffer.DirectX.cs
@@ -161,6 +161,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary />
         protected override void Dispose(bool disposing)
         {
             if (disposing)


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to the `IndexBuffer.DirectX` class.

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)