### PR TITLE
[Documentation] Update XML documentation for `Texture.DirectX`

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/Texture.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture.DirectX.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Xna.Framework.Graphics
             SharpDX.Utilities.Dispose(ref _texture);
         }
 
+        /// <summary />
         protected override void Dispose(bool disposing)
         {
             if (disposing)


### PR DESCRIPTION
## Description
This PR adds missing XML documentation to the `Texture.DirectX` class.

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)