### PR TITLE
Remove CLSCompliant attributes

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -177,7 +177,6 @@ namespace Microsoft.Xna.Framework
         #region Properties
 
 #if ANDROID
-        [CLSCompliant(false)]
         public static AndroidGameActivity Activity { get; internal set; }
 #endif
         private static Game _instance = null;
@@ -383,7 +382,6 @@ namespace Microsoft.Xna.Framework
         public event EventHandler<ExitingEventArgs> Exiting;
 
 #if WINDOWS_UAP
-        [CLSCompliant(false)]
         public ApplicationExecutionState PreviousExecutionState { get; internal set; }
 #endif
 

--- a/MonoGame.Framework/Graphics/PresentationParameters.cs
+++ b/MonoGame.Framework/Graphics/PresentationParameters.cs
@@ -102,7 +102,6 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
 #if WINDOWS_UAP
-        [CLSCompliant(false)]
         public SwapChainPanel SwapChainPanel { get; set; }
 #endif
 

--- a/MonoGame.Framework/Media/Album.cs
+++ b/MonoGame.Framework/Media/Album.cs
@@ -172,7 +172,6 @@ namespace Microsoft.Xna.Framework.Media
         }
         
 #if IOS && !TVOS
-        [CLSCompliant(false)]
         public UIImage GetAlbumArt(int width = 0, int height = 0)
         {
             if (width == 0)
@@ -183,7 +182,6 @@ namespace Microsoft.Xna.Framework.Media
 			return this.thumbnail.ImageWithSize(new CGSize(width, height));
         }
 #elif ANDROID
-        [CLSCompliant(false)]
         public Bitmap GetAlbumArt(int width = 0, int height = 0)
         {
             var albumArt = MediaStore.Images.Media.GetBitmap(MediaLibrary.Context.ContentResolver, this.thumbnail);
@@ -211,13 +209,11 @@ namespace Microsoft.Xna.Framework.Media
 #endif
 
 #if IOS && !TVOS
-        [CLSCompliant(false)]
         public UIImage GetThumbnail()
         {
             return this.GetAlbumArt(220, 220);
         }
 #elif ANDROID
-        [CLSCompliant(false)]
         public Bitmap GetThumbnail()
         {
             return this.GetAlbumArt(220, 220);

--- a/MonoGame.Framework/Platform/Android/AndroidGameActivity.cs
+++ b/MonoGame.Framework/Platform/Android/AndroidGameActivity.cs
@@ -10,7 +10,6 @@ using Android.Views;
 
 namespace Microsoft.Xna.Framework
 {
-	[CLSCompliant(false)]
     public class AndroidGameActivity : Activity
     {
         internal Game Game { private get; set; }
@@ -93,7 +92,6 @@ namespace Microsoft.Xna.Framework
 		}
     }
 
-	[CLSCompliant(false)]
 	public static class ActivityExtensions
     {
         public static ActivityAttribute GetActivityAttribute(this AndroidGameActivity obj)

--- a/MonoGame.Framework/Platform/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Platform/Android/AndroidGameWindow.cs
@@ -12,7 +12,6 @@ using MonoGame.OpenGL;
 
 namespace Microsoft.Xna.Framework
 {
-    [CLSCompliant(false)]
     public class AndroidGameWindow : GameWindow, IDisposable
     {
         internal MonoGameAndroidGameView GameView { get; private set; }

--- a/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
@@ -18,7 +18,6 @@ using Microsoft.Xna.Framework.Input.Touch;
 
 namespace Microsoft.Xna.Framework
 {
-    [CLSCompliant(false)]
     public class MonoGameAndroidGameView : SurfaceView, ISurfaceHolderCallback, View.IOnTouchListener
     {
         // What is the state of the app, for tracking surface recreation inside this class.

--- a/MonoGame.Framework/Platform/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffect.XAudio.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Xna.Framework.Audio
         private static Speakers _speakers = Speakers.Stereo;
 
         // XNA does not expose this, but it exists in X3DAudio.
-        [CLSCompliant(false)]
         public static Speakers Speakers
         {
             get { return _speakers; }

--- a/MonoGame.Framework/Platform/Graphics/RenderTargetCube.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTargetCube.DirectX.cs
@@ -85,14 +85,12 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <inheritdoc/>
-        [CLSCompliant(false)]
         public RenderTargetView GetRenderTargetView(int arraySlice)
         {
             return _renderTargetViews[arraySlice];
         }
 
         /// <inheritdoc/>
-        [CLSCompliant(false)]
         public DepthStencilView GetDepthStencilView()
         {
             return _depthStencilView;

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
@@ -286,19 +286,16 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
 #if IOS
-        [CLSCompliant(false)]
         public static Texture2D FromStream(GraphicsDevice graphicsDevice, UIImage uiImage)
         {
             return PlatformFromStream(graphicsDevice, uiImage.CGImage);
         }
 #elif ANDROID
-        [CLSCompliant(false)]
         public static Texture2D FromStream(GraphicsDevice graphicsDevice, Bitmap bitmap)
         {
             return PlatformFromStream(graphicsDevice, bitmap);
         }
 
-        [CLSCompliant(false)]
         public void Reload(Bitmap image)
         {
             var width = image.Width;

--- a/MonoGame.Framework/Platform/GraphicsDeviceManager.Legacy.cs
+++ b/MonoGame.Framework/Platform/GraphicsDeviceManager.Legacy.cs
@@ -397,7 +397,6 @@ namespace Microsoft.Xna.Framework
 
 
 #if WINDOWS_UAP
-        [CLSCompliant(false)]
         public SwapChainPanel SwapChainPanel { get; set; }
 #endif
 

--- a/MonoGame.Framework/Platform/GraphicsDeviceManager.WinRT.cs
+++ b/MonoGame.Framework/Platform/GraphicsDeviceManager.WinRT.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Xna.Framework
 {
     partial class GraphicsDeviceManager
     {
-        [CLSCompliant(false)] 
         public SwapChainPanel SwapChainPanel { get; set; }
 
         partial void PlatformPreparePresentationParameters(PresentationParameters presentationParameters)

--- a/MonoGame.Framework/Platform/Media/Song.Android.cs
+++ b/MonoGame.Framework/Platform/Media/Song.Android.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Xna.Framework.Media
         private TimeSpan position;
         private Android.Net.Uri assetUri;
 
-        [CLSCompliant(false)]
         public Android.Net.Uri AssetUri
         {
             get { return this.assetUri; }

--- a/MonoGame.Framework/Platform/Media/Song.WinRT.cs
+++ b/MonoGame.Framework/Platform/Media/Song.WinRT.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Xna.Framework.Media
         
 		private MusicProperties musicProperties;
 
-        [CLSCompliant(false)]
         public StorageFile StorageFile
         {
             get { return this.musicProperties.File; }

--- a/MonoGame.Framework/Platform/Media/Song.iOS.cs
+++ b/MonoGame.Framework/Platform/Media/Song.iOS.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Xna.Framework.Media
         private NSUrl assetUrl;
         private NSObject playToEndObserver;
 
-        [CLSCompliant(false)]
         public NSUrl AssetUrl
         {
             get { return this.assetUrl; }

--- a/MonoGame.Framework/Platform/Microsoft/Devices/Sensors/SensorBase.cs
+++ b/MonoGame.Framework/Platform/Microsoft/Devices/Sensors/SensorBase.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Devices.Sensors
 		where TSensorReading : ISensorReading
 	{
 #if IOS
-        [CLSCompliant(false)]
         protected static readonly CoreMotion.CMMotionManager motionManager = new CoreMotion.CMMotionManager();
 #endif
         bool disposed;

--- a/MonoGame.Framework/Platform/WindowsUniversal/GameFrameworkViewSource.cs
+++ b/MonoGame.Framework/Platform/WindowsUniversal/GameFrameworkViewSource.cs
@@ -20,7 +20,6 @@ namespace MonoGame.Framework
             this._gameConstructorCustomizationDelegate = gameConstructorCustomizationDelegate;
         }
 
-        [CLSCompliant(false)]
         public IFrameworkView CreateView()
         {
             return new UAPFrameworkView<T>(_gameConstructorCustomizationDelegate);

--- a/MonoGame.Framework/Platform/WindowsUniversal/XamlGame.cs
+++ b/MonoGame.Framework/Platform/WindowsUniversal/XamlGame.cs
@@ -14,7 +14,6 @@ namespace MonoGame.Framework
     /// Static class for initializing a Game object for a XAML application.
     /// </summary>
     /// <typeparam name="T">A class derived from Game with a public parameterless constructor.</typeparam>
-    [CLSCompliant(false)]
     public static class XamlGame<T>
         where T : Game, new()
     {

--- a/MonoGame.Framework/Platform/iOS/OrientationConverter.cs
+++ b/MonoGame.Framework/Platform/iOS/OrientationConverter.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Xna.Framework
 {
     public static class OrientationConverter
     {
-        [CLSCompliant(false)]
         public static DisplayOrientation UIDeviceOrientationToDisplayOrientation(UIDeviceOrientation orientation)
         {
             switch (orientation)
@@ -26,7 +25,6 @@ namespace Microsoft.Xna.Framework
             }
         }
 
-        [CLSCompliant(false)]
         public static DisplayOrientation ToDisplayOrientation(UIInterfaceOrientation orientation)
         {
             switch (orientation)
@@ -41,7 +39,6 @@ namespace Microsoft.Xna.Framework
             }
         }
 
-        [CLSCompliant(false)]
         public static UIInterfaceOrientationMask ToUIInterfaceOrientationMask (DisplayOrientation orientation)
         {
             switch (Normalize(orientation))


### PR DESCRIPTION
Should resolve all `Class.Method does not need a CLSCompliant attribute` warnings