### PR TITLE
Platform-specific launchers for MGCB Editor Build Task

### DIFF
--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -7,7 +7,8 @@ public enum ProjectType
     Tools,
     Templates,
     ContentPipeline,
-    MGCBEditor
+    MGCBEditor,
+    MGCBEditorLauncher
 }
 
 public class BuildContext : FrostingContext
@@ -126,6 +127,7 @@ public class BuildContext : FrostingContext
         ProjectType.Templates => $"Templates/{id}/{id}.csproj",
         ProjectType.ContentPipeline => "MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj",
         ProjectType.MGCBEditor => $"Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.{id}.csproj",
+		ProjectType.MGCBEditorLauncher => $"Tools/MonoGame.Content.Builder.Editor.Launcher/MonoGame.Content.Builder.Editor.Launcher.{id}.csproj",
         _ => throw new ArgumentOutOfRangeException(nameof(type))
     };
 

--- a/build/BuildToolsTasks/BuildMGCBEditorTask.cs
+++ b/build/BuildToolsTasks/BuildMGCBEditorTask.cs
@@ -24,5 +24,6 @@ public sealed class BuildMGCBEditorTask : FrostingTask<BuildContext>
 
         context.DotNetPublish(context.GetProjectPath(ProjectType.MGCBEditor, platform), context.DotNetPublishSettings);
         context.DotNetPack(context.GetProjectPath(ProjectType.Tools, "MonoGame.Content.Builder.Editor.Launcher.Bootstrap"), context.DotNetPackSettings);
+		context.DotNetPack(context.GetProjectPath(ProjectType.MGCBEditorLauncher, platform), context.DotNetPackSettings);
     }
 }


### PR DESCRIPTION
The current Nuget Build Task (develop) for the MGCB Editor does not create platform-specific launcher packages (e.g. mgcb-editor-windows), so the Nuget packages for Mac, Linux and Windows are missing. However, these are required for the bootstrap launcher and in the dotnet manifest files.

This leads to errors when creating the project and the editor cannot be opened.