### PR TITLE
[Documentation] Documentation Fixes For Warnings and Errors

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -58,11 +58,11 @@ namespace Microsoft.Xna.Framework.Content
             'G', // Google Stadia
             'b', // WebAssembly and Bridge.NET
 
-            // NOTE: There are additional identifiers for consoles that 
+            // NOTE: There are additional identifiers for consoles that
             // are not defined in this repository.  Be sure to ask the
             // console port maintainers to ensure no collisions occur.
 
-            
+
             // Legacy identifiers... these could be reused in the
             // future if we feel enough time has passed.
 
@@ -173,7 +173,6 @@ namespace Microsoft.Xna.Framework.Content
 		}
 
         /// <inheritdoc cref="ContentManager.ContentManager(IServiceProvider)"/>
-        /// <param name="serviceProvider" />
         /// <param name="rootDirectory">The root directory the ContentManager will search for content in.</param>
         public ContentManager(IServiceProvider serviceProvider, string rootDirectory)
 		{
@@ -255,15 +254,15 @@ namespace Microsoft.Xna.Framework.Content
         /// <exception cref="ContentLoadException">
         /// The type of the <paramref name="assetName"/> in the file does not match the type of asset requested as
         /// specified by <typeparamref name="T"/>.
-        /// 
+        ///
         /// -or-
-        /// 
+        ///
         /// A content file matching the <paramref name="assetName"/> parameter could not be found.
         ///
         /// -or-
         ///
         /// The specified path in the <paramref name="assetName"/> parameter is invalid (for example, a
-        /// directory in the path does not exist).        
+        /// directory in the path does not exist).
         ///
         /// -or-
         ///
@@ -324,15 +323,15 @@ namespace Microsoft.Xna.Framework.Content
         /// <exception cref="ContentLoadException">
         /// The type of the <paramref name="assetName"/> in the file does not match the type of asset requested as
         /// specified by <typeparamref name="T"/>.
-        /// 
+        ///
         /// -or-
-        /// 
+        ///
         /// A content file matching the <paramref name="assetName"/> parameter could not be found.
         ///
         /// -or-
         ///
         /// The specified path in the <paramref name="assetName"/> parameter is invalid (for example, a
-        /// directory in the path does not exist).        
+        /// directory in the path does not exist).
         ///
         /// -or-
         ///
@@ -350,11 +349,11 @@ namespace Microsoft.Xna.Framework.Content
             }
 
             T result = default(T);
-            
+
             // On some platforms, name and slash direction matter.
             // We store the asset by a /-separating key rather than how the
             // path to the file was passed to us to avoid
-            // loading "content/asset1.xnb" and "content\\ASSET1.xnb" as if they were two 
+            // loading "content/asset1.xnb" and "content\\ASSET1.xnb" as if they were two
             // different files. This matches stock XNA behavior.
             // The dictionary will ignore case differences
             var key = assetName.Replace('\\', '/');
@@ -384,14 +383,14 @@ namespace Microsoft.Xna.Framework.Content
             {
                 var assetPath = Path.Combine(RootDirectory, assetName) + ".xnb";
 
-                // This is primarily for editor support. 
+                // This is primarily for editor support.
                 // Setting the RootDirectory to an absolute path is useful in editor
-                // situations, but TitleContainer can ONLY be passed relative paths.                
+                // situations, but TitleContainer can ONLY be passed relative paths.
 #if DESKTOPGL || WINDOWS
-                if (Path.IsPathRooted(assetPath))                
-                    stream = File.OpenRead(assetPath);                
+                if (Path.IsPathRooted(assetPath))
+                    stream = File.OpenRead(assetPath);
                 else
-#endif                
+#endif
                 stream = TitleContainer.OpenStream(assetPath);
 #if ANDROID
                 // Read the asset into memory in one go. This results in a ~50% reduction
@@ -431,7 +430,7 @@ namespace Microsoft.Xna.Framework.Content
 			{
 				throw new ObjectDisposedException("ContentManager");
 			}
-						
+
 			string originalAssetName = assetName;
 			object result = null;
 
@@ -446,7 +445,7 @@ namespace Microsoft.Xna.Framework.Content
                         ((GraphicsResource)result).Name = originalAssetName;
                 }
             }
-            
+
 			if (result == null)
 				throw new ContentLoadException("Could not load " + originalAssetName + " asset!");
 
@@ -503,7 +502,7 @@ namespace Microsoft.Xna.Framework.Content
 
             var reader = new ContentReader(this, decompressedStream,
                                                         originalAssetName, version, recordDisposableObject);
-            
+
             return reader;
         }
 
@@ -528,14 +527,14 @@ namespace Microsoft.Xna.Framework.Content
         {
             foreach (var asset in LoadedAssets)
             {
-                // This never executes as asset.Key is never null.  This just forces the 
+                // This never executes as asset.Key is never null.  This just forces the
                 // linker to include the ReloadAsset function when AOT compiled.
                 if (asset.Key == null)
                     ReloadAsset(asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()));
 
                 var methodInfo = ReflectionHelpers.GetMethodInfo(typeof(ContentManager), "ReloadAsset");
                 var genericMethod = methodInfo.MakeGenericMethod(asset.Value.GetType());
-                genericMethod.Invoke(this, new object[] { asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()) }); 
+                genericMethod.Invoke(this, new object[] { asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()) });
             }
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         /// <summary>
         /// The rendering information for debugging and profiling.
-        /// The metrics are reset every frame after draw within <see cref="GraphicsDevice.Present"/>. 
+        /// The metrics are reset every frame after draw within <see cref="GraphicsDevice.Present"/>.
         /// </summary>
         public GraphicsMetrics Metrics { get { return _graphicsMetrics; } set { _graphicsMetrics = value; } }
 
@@ -621,9 +621,11 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        /// <inheritdoc cref="Clear(Color)"/>
-        /// <param name="color">Set this color value in all buffers.</param>
+        /// <summary>
+        /// Clears resource buffers.
+        /// </summary>
         /// <param name="options">Options for clearing a buffer.</param>
+        /// <param name="color">Set this color value in all buffers.</param>
         /// <param name="depth">Set this depth value in the buffer.</param>
         /// <param name="stencil">Set this stencil value in the buffer.</param>
         public void Clear(ClearOptions options, Color color, float depth, int stencil)
@@ -636,7 +638,13 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        /// <inheritdoc cref="Clear(ClearOptions, Color, float, int)"/>
+        /// <summary>
+        /// Clears resource buffers.
+        /// </summary>
+        /// <param name="options">Options for clearing a buffer.</param>
+        /// <param name="color">Set this color value in all buffers.</param>
+        /// <param name="depth">Set this depth value in the buffer.</param>
+        /// <param name="stencil">Set this stencil value in the buffer.</param>
         public void Clear(ClearOptions options, Vector4 color, float depth, int stencil)
 		{
             PlatformClear(options, color, depth, stencil);
@@ -754,7 +762,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Update the back buffer.
             OnPresentationChanged();
-            
+
             EventHelpers.Raise(this, PresentationChanged, new PresentationEventArgs(PresentationParameters));
             EventHelpers.Raise(this, DeviceReset, EventArgs.Empty);
        }
@@ -915,8 +923,13 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
-        /// <inheritdoc cref="SetRenderTarget(RenderTarget2D)"/>
-        /// <param name="renderTarget"/>
+        /// <summary>
+        /// Sets a new render target for this <see cref="GraphicsDevice"/>.
+        /// </summary>
+        /// <param name="renderTarget">
+        /// A new render target for the device, or <see langword="null"/>
+        /// to set the device render target to the back buffer of the device.
+        /// </param>
         /// <param name="cubeMapFace">The cube map face type.</param>
         public void SetRenderTarget(RenderTargetCube renderTarget, CubeMapFace cubeMapFace)
         {
@@ -1059,7 +1072,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <summary>
-        /// Sets or binds a vertex buffer to a device. 
+        /// Sets or binds a vertex buffer to a device.
         /// </summary>
         /// <param name="vertexBuffer">A vertex buffer.</param>
         public void SetVertexBuffer(VertexBuffer vertexBuffer)
@@ -1069,8 +1082,10 @@ namespace Microsoft.Xna.Framework.Graphics
                                    : _vertexBuffers.Set(vertexBuffer, 0);
         }
 
-        /// <inheritdoc cref="SetVertexBuffer(VertexBuffer)"/>
-        /// <param name="vertexBuffer"/>
+        /// <summary>
+        /// Sets or binds a vertex buffer to a device.
+        /// </summary>
+        /// <param name="vertexBuffer">A vertex buffer.</param>
         /// <param name="vertexOffset">The offset (in bytes) from the beginning of the buffer.</param>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="vertexOffset"/> is less than 0
@@ -1096,7 +1111,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         /// <param name="vertexBuffers">An array of vertex buffers.</param>
         /// <exception cref="ArgumentOutOfRangeException">
-        /// Length of <paramref name="vertexBuffers"/> is more than max allowed number of vertex buffers. 
+        /// Length of <paramref name="vertexBuffers"/> is more than max allowed number of vertex buffers.
         /// </exception>
         public void SetVertexBuffers(params VertexBufferBinding[] vertexBuffers)
         {
@@ -1454,7 +1469,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentOutOfRangeException("vertexDeclaration", "Vertex stride of vertexDeclaration should be at least as big as the stride of the actual vertices.");
 
             PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
-            
+
             unchecked
             {
                 _graphicsMetrics._drawCount++;
@@ -1540,7 +1555,10 @@ namespace Microsoft.Xna.Framework.Graphics
             GetBackBufferData(null, data, 0, data.Length);
         }
 
-        /// <inheritdoc cref="GetBackBufferData{T}(T[])"/>
+        /// <summary>
+        /// Gets the Pixel data of what is currently drawn on screen.
+        /// The format is whatever the current format of the backbuffer is.
+        /// </summary>
         /// <typeparam name="T">A byte[] of size (ViewPort.Width * ViewPort.Height * 4)</typeparam>
         /// <param name="data">Array of data.</param>
         /// <param name="startIndex">The first element to use.</param>
@@ -1550,7 +1568,10 @@ namespace Microsoft.Xna.Framework.Graphics
             GetBackBufferData(null, data, startIndex, elementCount);
         }
 
-        /// <inheritdoc cref="GetBackBufferData{T}(T[], int, int)"/>
+        /// <summary>
+        /// Gets the Pixel data of what is currently drawn on screen.
+        /// The format is whatever the current format of the backbuffer is.
+        /// </summary>
         /// <typeparam name="T">A byte[] of size (ViewPort.Width * ViewPort.Height * 4)</typeparam>
         /// <param name="rect">
         /// The section of the back buffer to copy.

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Xna.Framework.Graphics
         ///     <item>
         ///         <description>
         ///             The <paramref name="arraySlice"/> parameter is less than zero or is greater than or equal to the
-        ///             <see cref="ArraySize"/> of this texture.
+        ///             internal array buffer of this texture.
         ///         </description>
         ///     </item>
         ///     <item>
@@ -493,7 +493,7 @@ namespace Microsoft.Xna.Framework.Graphics
         ///     <item>
         ///         <description>
         ///             The <paramref name="arraySlice"/> parameter is less than zero or is greater than or equal to the
-        ///             <see cref="ArraySize"/> of this texture.
+        ///             internal array buffer of this texture.
         ///         </description>
         ///     </item>
         ///     <item>

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
@@ -56,17 +56,26 @@ namespace Microsoft.Xna.Framework.Graphics
             PlatformConstruct();
 		}
 
-        /// <inheritdoc cref="VertexBuffer(GraphicsDevice, VertexDeclaration, int, BufferUsage, bool)"/>
+        /// <summary>
+        /// Creates a new instance of <see cref="VertexBuffer"/>
+        /// </summary>
+        /// <param name="graphicsDevice">The graphics device.</param>
+        /// <param name="vertexDeclaration">The vertex declaration, which describes per-vertex data.</param>
+        /// <param name="vertexCount">The number of vertices.</param>
+        /// <param name="bufferUsage">Behavior options.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice"/> is <see langword="null"/></exception>
         public VertexBuffer(GraphicsDevice graphicsDevice, VertexDeclaration vertexDeclaration, int vertexCount, BufferUsage bufferUsage) :
 			this(graphicsDevice, vertexDeclaration, vertexCount, bufferUsage, false)
         {
         }
 
-        /// <inheritdoc cref="VertexBuffer(GraphicsDevice, VertexDeclaration, int, BufferUsage, bool)"/>
-        /// <param name="graphicsDevice"/>
-        /// <param name="type">The data type.</param>
-        /// <param name="vertexCount"/>
-        /// <param name="bufferUsage"/>
+        /// <summary>
+        /// Creates a new instance of <see cref="VertexBuffer"/>
+        /// </summary>
+        /// <param name="graphicsDevice">The graphics device.</param>
+        /// <param name="vertexCount">The number of vertices.</param>
+        /// <param name="bufferUsage">Behavior options.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice"/> is <see langword="null"/></exception>
         public VertexBuffer(GraphicsDevice graphicsDevice, Type type, int vertexCount, BufferUsage bufferUsage) :
 			this(graphicsDevice, VertexDeclaration.FromType(type), vertexCount, bufferUsage, false)
 		{
@@ -98,7 +107,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <remarks>
         /// <p>Using this operation it is easy to get certain vertex elements from a VertexBuffer.</p>
         /// <p>
-        /// For example to get the texture coordinates from a VertexBuffer of <see cref="VertexPositionTexture"/> you can call 
+        /// For example to get the texture coordinates from a VertexBuffer of <see cref="VertexPositionTexture"/> you can call
         /// GetData(4 * 3, data, elementCount, 20). 'data'should be an array of <see cref="Vector2"/> in this example.
         /// The offsetInBytes is the number of bytes taken up by the <see cref="VertexPositionTexture.Position"/> of the vertex.
         /// For vertexStride we pass the size of a <see cref="VertexPositionTexture"/>.
@@ -150,14 +159,14 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="startIndex">Index at which to start copying from <paramref name="data"/>.
         /// Must be within the <paramref name="data"/> array bounds.</param>
         /// <param name="elementCount">Number of elements to copy from <paramref name="data"/>.
-        /// The combination of <paramref name="startIndex"/> and <paramref name="elementCount"/> 
+        /// The combination of <paramref name="startIndex"/> and <paramref name="elementCount"/>
         /// must be within the <paramref name="data"/> array bounds.</param>
-        /// <param name="vertexStride">Specifies how far apart, in bytes, elements from <paramref name="data"/> should be when 
+        /// <param name="vertexStride">Specifies how far apart, in bytes, elements from <paramref name="data"/> should be when
         /// they are copied into the vertex buffer.
         /// In almost all cases this should be <c>sizeof(T)</c>, to create a tightly-packed vertex buffer.
-        /// If you specify <c>sizeof(T)</c>, elements from <paramref name="data"/> will be copied into the 
+        /// If you specify <c>sizeof(T)</c>, elements from <paramref name="data"/> will be copied into the
         /// vertex buffer with no padding between each element.
-        /// If you specify a value greater than <c>sizeof(T)</c>, elements from <paramref name="data"/> will be copied 
+        /// If you specify a value greater than <c>sizeof(T)</c>, elements from <paramref name="data"/> will be copied
         /// into the vertex buffer with padding between each element.
         /// If you specify <c>0</c> for this parameter, it will be treated as if you had specified <c>sizeof(T)</c>.
         /// With the exception of <c>0</c>, you must specify a value greater than or equal to <c>sizeof(T)</c>.</param>
@@ -168,7 +177,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Vector3[] positions = new Vector3[numVertices];
         /// vertexBuffer.SetData(0, positions, 0, numVertices, vertexBuffer.VertexDeclaration.VertexStride);
         /// </code>
-        /// 
+        ///
         /// Continuing from the previous example, if you want to set only the texture coordinate component of the vertex data,
         /// you would call this method as follows (note that <paramref name="offsetInBytes"/> is 12, the size of a Vector3,
         /// representing the position):
@@ -189,7 +198,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         /// <summary>
         /// Sets the vertex buffer data, specifying the index at which to start copying from the source data array,
-        /// and the number of elements to copy from the source data array. This is the same as calling 
+        /// and the number of elements to copy from the source data array. This is the same as calling
         /// <see cref="SetData{T}(int, T[], int, int, int)"/>  with <c>offsetInBytes</c> equal to <c>0</c>,
         /// and <c>vertexStride</c> equal to <c>sizeof(T)</c>.
         /// </summary>
@@ -198,7 +207,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="startIndex">Index at which to start copying from <paramref name="data"/>.
         /// Must be within the <paramref name="data"/> array bounds.</param>
         /// <param name="elementCount">Number of elements to copy from <paramref name="data"/>.
-        /// The combination of <paramref name="startIndex"/> and <paramref name="elementCount"/> 
+        /// The combination of <paramref name="startIndex"/> and <paramref name="elementCount"/>
         /// must be within the <paramref name="data"/> array bounds.</param>
 		public void SetData<T>(T[] data, int startIndex, int elementCount) where T : struct
         {
@@ -207,8 +216,8 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
         /// <summary>
-        /// Sets the vertex buffer data. This is the same as calling <see cref="SetData{T}(int, T[], int, int, int)"/> 
-        /// with <c>offsetInBytes</c> and <c>startIndex</c> equal to <c>0</c>, <c>elementCount</c> equal to <c>data.Length</c>, 
+        /// Sets the vertex buffer data. This is the same as calling <see cref="SetData{T}(int, T[], int, int, int)"/>
+        /// with <c>offsetInBytes</c> and <c>startIndex</c> equal to <c>0</c>, <c>elementCount</c> equal to <c>data.Length</c>,
         /// and <c>vertexStride</c> equal to <c>sizeof(T)</c>.
         /// </summary>
         /// <typeparam name="T">Type of elements in the data array.</typeparam>
@@ -240,7 +249,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (elementCount > 1 && (elementCount * vertexStride > bufferSize))
                 throw new InvalidOperationException("The vertex stride is larger than the vertex buffer.");
             if (vertexStride < elementSizeInBytes)
-                throw new ArgumentOutOfRangeException("The vertex stride must be greater than or equal to the size of the specified data (" + elementSizeInBytes + ").");            
+                throw new ArgumentOutOfRangeException("The vertex stride must be greater than or equal to the size of the specified data (" + elementSizeInBytes + ").");
 
             PlatformSetData<T>(offsetInBytes, data, startIndex, elementCount, vertexStride, options, bufferSize, elementSizeInBytes);
         }


### PR DESCRIPTION
## Description
The following errors were generated by docfx when building documentation

**Warnings**
```
MonoGame\MonoGame.Framework\Content\ContentManager.cs(177,1): warning: Duplicate parameter 'serviceProvider' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(628,1): warning: Duplicate parameter 'color' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(639,1): warning: Duplicate parameter 'color' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(920,1): warning: Duplicate parameter 'renderTarget' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(1078,1): warning: Duplicate parameter 'vertexBuffer' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(1547,1): warning: Duplicate parameter 'data' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(1547,1): warning: Duplicate type parameter 'T' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(1565,1): warning: Duplicate parameter 'data' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(1565,1): warning: Duplicate parameter 'data' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(1565,1): warning: Duplicate parameter 'startIndex' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(1565,1): warning: Duplicate parameter 'elementCount' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(1565,1): warning: Duplicate type parameter 'T' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs(1565,1): warning: Duplicate type parameter 'T' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\Vertices\VertexBuffer.cs(69,1): warning: Duplicate parameter 'graphicsDevice' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\Vertices\VertexBuffer.cs(69,1): warning: Duplicate parameter 'vertexCount' found in comments, the latter one is ignored.
MonoGame\MonoGame.Framework\Graphics\Vertices\VertexBuffer.cs(69,1): warning: Duplicate parameter 'bufferUsage' found in comments, the latter one is ignored.
```


**Errors**
```
Microsoft.Xna.Framework.Graphics.Texture2D.yml: error InvalidBookmark: Invalid link: '<a href="#Microsoft_Xna_Framework_Graphics_Texture2D_ArraySize">ArraySize</a>'. The file api/Microsoft.Xna.Framework.Graphics.Texture2D.yml doesn't contain a bookmark named 'Microsoft_Xna_Framework_Graphics_Texture2D_ArraySize'.
Microsoft.Xna.Framework.Graphics.Texture2D.yml: error InvalidBookmark: Invalid link: '<a href="#Microsoft_Xna_Framework_Graphics_Texture2D_ArraySize">ArraySize</a>'. The file api/Microsoft.Xna.Framework.Graphics.Texture2D.yml doesn't contain a bookmark named 'Microsoft_Xna_Framework_Graphics_Texture2D_ArraySize'.
```

This PR addresses these issues.