### PR TITLE
Update Joystick.LastConnectedIndex calculation for reconnected Joystick

### DIFF
--- a/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
+++ b/MonoGame.Framework/Platform/Input/Joystick.SDL.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Xna.Framework.Input
             while (Joysticks.ContainsKey(id))
                 id++;
 
-            if (id > _lastConnectedIndex)
+            if (id != _lastConnectedIndex)
                 _lastConnectedIndex = id;
 
             Joysticks.Add(id, jdevice);


### PR DESCRIPTION
fix for Joystick.LastConnectedIndex calculation when two joysticks connected and first are reconnected.
#8315 

With new changes algorithm will try to search first empty id for connected joystick and use them in dictionary of connected joysticks and in `LastConnectedIndex` variable. 
Old algo are correct only when new joystick connected but incorrect with reconnecting first joystick scenario.