### PR TITLE
Use specific wildcard to fix VS extension issue 

### DIFF
--- a/Templates/MonoGame.Templates.VSExtension/MonoGame.Templates.VSExtension.csproj
+++ b/Templates/MonoGame.Templates.VSExtension/MonoGame.Templates.VSExtension.csproj
@@ -58,8 +58,8 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.*" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.*" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.10.*" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.10.*" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Templates.pkgdef">


### PR DESCRIPTION
Currently Windows builds are failing with this:

D:\a\MonoGame\MonoGame\Templates\MonoGame.Templates.VSExtension\MonoGame.Templates.VSExtension.csproj : error NU1102: Unable to find package Microsoft.VisualStudio.SDK.Analyzers with version (>= 17.7.41)

This has happened previously in issue #8300 during the transition between 17.9 and 17.10. Now we have the same issue happening again as some Visual Studio SDK public NuGets are 17.10 and some are on 17.11  (and 17.11 pre-release) so we're running into compatibility issues when grabbing the latest. 

Not sure if you'd like me to track a new issue and discuss any longer term plans for this? Seems like this might keep happening.

