### PR TITLE
Upgrade Android to handle obsolete API's.

### DIFF
--- a/MonoGame.Framework/Media/Album.cs
+++ b/MonoGame.Framework/Media/Album.cs
@@ -10,6 +10,7 @@ using CoreGraphics;
 using MediaPlayer;
 using UIKit;
 #elif ANDROID
+using Android.Content;
 using Android.Graphics;
 using Android.Provider;
 #endif

--- a/MonoGame.Framework/Media/Album.cs
+++ b/MonoGame.Framework/Media/Album.cs
@@ -167,7 +167,13 @@ namespace Microsoft.Xna.Framework.Media
 #elif ANDROID
         public Bitmap GetAlbumArt(int width = 0, int height = 0)
         {
-            var albumArt = MediaStore.Images.Media.GetBitmap(MediaLibrary.Context.ContentResolver, this.thumbnail);
+            Bitmap albumArt;
+            if (!OperatingSystem.IsAndroidVersionAtLeast (29)) {
+                albumArt = MediaStore.Images.Media.GetBitmap(MediaLibrary.Context.ContentResolver, this.thumbnail);
+            } else {
+                var source = ImageDecoder.CreateSource (MediaLibrary.Context.ContentResolver, this.thumbnail);
+                albumArt = ImageDecoder.DecodeBitmap (source);
+            }
             if (width == 0 || height == 0)
                 return albumArt;
 

--- a/MonoGame.Framework/Platform/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Platform/Android/AndroidGameWindow.cs
@@ -36,10 +36,16 @@ namespace Microsoft.Xna.Framework
 
             Point size;
             // GetRealSize() was defined in JellyBeanMr1 / API 17 / Android 4.2
-            if (Build.VERSION.SdkInt < BuildVersionCodes.JellyBeanMr1)
+            if (!OperatingSystem.IsAndroidVersionAtLeast(17))
             {
                 size.X = activity.Resources.DisplayMetrics.WidthPixels;
                 size.Y = activity.Resources.DisplayMetrics.HeightPixels;
+            }
+            else if (OperatingSystem.IsAndroidVersionAtLeast(30)) // API 30 and Above
+            {
+                var rect = activity.WindowManager.CurrentWindowMetrics.Bounds;
+                size.X = rect.Width ();
+                size.Y = rect.Height ();
             }
             else
             {

--- a/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
@@ -98,7 +98,9 @@ namespace Microsoft.Xna.Framework
             mHolder = Holder;
             // Add callback to get the SurfaceCreated etc events
             mHolder.AddCallback(this);
+#pragma warning disable CS0618
             mHolder.SetType(SurfaceType.Gpu);
+#pragma warning restore CS0618
         }
 
         public void SurfaceChanged(ISurfaceHolder holder, global::Android.Graphics.Format format, int width, int height)
@@ -171,8 +173,8 @@ namespace Microsoft.Xna.Framework
         public virtual void ClearCurrent()
         {
             EnsureUndisposed();
-            if (!egl.EglMakeCurrent(eglDisplay, EGL10.EglNoSurface,
-                EGL10.EglNoSurface, EGL10.EglNoContext))
+            if (!egl.EglMakeCurrent(eglDisplay, IEGL10.EglNoSurface,
+                IEGL10.EglNoSurface, IEGL10.EglNoContext))
             {
                 System.Diagnostics.Debug.WriteLine("Error Clearing Current" + GetErrorAsString());
             }
@@ -770,10 +772,10 @@ namespace Microsoft.Xna.Framework
 
         protected void DestroyGLSurface()
         {
-            if (!(eglSurface == null || eglSurface == EGL10.EglNoSurface))
+            if (!(eglSurface == null || eglSurface == IEGL10.EglNoSurface))
             {
-                if (!egl.EglMakeCurrent(eglDisplay, EGL10.EglNoSurface,
-                        EGL10.EglNoSurface, EGL10.EglNoContext))
+                if (!egl.EglMakeCurrent(eglDisplay, IEGL10.EglNoSurface,
+                        IEGL10.EglNoSurface, IEGL10.EglNoContext))
                 {
                     Log.Verbose("AndroidGameView", "Could not unbind EGL surface" + GetErrorAsString());
                 }
@@ -804,47 +806,47 @@ namespace Microsoft.Xna.Framework
                 List<int> attribs = new List<int>();
                 if (Red != 0)
                 {
-                    attribs.Add(EGL11.EglRedSize);
+                    attribs.Add(IEGL11.EglRedSize);
                     attribs.Add(Red);
                 }
                 if (Green != 0)
                 {
-                    attribs.Add(EGL11.EglGreenSize);
+                    attribs.Add(IEGL11.EglGreenSize);
                     attribs.Add(Green);
                 }
                 if (Blue != 0)
                 {
-                    attribs.Add(EGL11.EglBlueSize);
+                    attribs.Add(IEGL11.EglBlueSize);
                     attribs.Add(Blue);
                 }
                 if (Alpha != 0)
                 {
-                    attribs.Add(EGL11.EglAlphaSize);
+                    attribs.Add(IEGL11.EglAlphaSize);
                     attribs.Add(Alpha);
                 }
                 if (Depth != 0)
                 {
-                    attribs.Add(EGL11.EglDepthSize);
+                    attribs.Add(IEGL11.EglDepthSize);
                     attribs.Add(Depth);
                 }
                 if (Stencil != 0)
                 {
-                    attribs.Add(EGL11.EglStencilSize);
+                    attribs.Add(IEGL11.EglStencilSize);
                     attribs.Add(Stencil);
                 }
                 if (SampleBuffers != 0)
                 {
-                    attribs.Add(EGL11.EglSampleBuffers);
+                    attribs.Add(IEGL11.EglSampleBuffers);
                     attribs.Add(SampleBuffers);
                 }
                 if (Samples != 0)
                 {
-                    attribs.Add(EGL11.EglSamples);
+                    attribs.Add(IEGL11.EglSamples);
                     attribs.Add(Samples);
                 }
-                attribs.Add(EGL11.EglRenderableType);
+                attribs.Add(IEGL11.EglRenderableType);
                 attribs.Add(4);
-                attribs.Add(EGL11.EglNone);
+                attribs.Add(IEGL11.EglNone);
 
                 return attribs.ToArray();
             }
@@ -860,14 +862,14 @@ namespace Microsoft.Xna.Framework
             {
                 return new SurfaceConfig()
                 {
-                    Red = GetAttribute(config, egl, eglDisplay, EGL11.EglRedSize),
-                    Green = GetAttribute(config, egl, eglDisplay, EGL11.EglGreenSize),
-                    Blue = GetAttribute(config, egl, eglDisplay, EGL11.EglBlueSize),
-                    Alpha = GetAttribute(config, egl, eglDisplay, EGL11.EglAlphaSize),
-                    Depth = GetAttribute(config, egl, eglDisplay, EGL11.EglDepthSize),
-                    Stencil = GetAttribute(config, egl, eglDisplay, EGL11.EglStencilSize),
-                    SampleBuffers = GetAttribute(config, egl, eglDisplay, EGL11.EglSampleBuffers),
-                    Samples = GetAttribute(config, egl, eglDisplay, EGL11.EglSamples)
+                    Red = GetAttribute(config, egl, eglDisplay, IEGL11.EglRedSize),
+                    Green = GetAttribute(config, egl, eglDisplay, IEGL11.EglGreenSize),
+                    Blue = GetAttribute(config, egl, eglDisplay, IEGL11.EglBlueSize),
+                    Alpha = GetAttribute(config, egl, eglDisplay, IEGL11.EglAlphaSize),
+                    Depth = GetAttribute(config, egl, eglDisplay, IEGL11.EglDepthSize),
+                    Stencil = GetAttribute(config, egl, eglDisplay, IEGL11.EglStencilSize),
+                    SampleBuffers = GetAttribute(config, egl, eglDisplay, IEGL11.EglSampleBuffers),
+                    Samples = GetAttribute(config, egl, eglDisplay, IEGL11.EglSamples)
                 };
             }
 
@@ -883,8 +885,8 @@ namespace Microsoft.Xna.Framework
 
             egl = EGLContext.EGL.JavaCast<IEGL10>();
 
-            eglDisplay = egl.EglGetDisplay(EGL10.EglDefaultDisplay);
-            if (eglDisplay == EGL10.EglNoDisplay)
+            eglDisplay = egl.EglGetDisplay(IEGL10.EglDefaultDisplay);
+            if (eglDisplay == IEGL10.EglNoDisplay)
                 throw new Exception("Could not get EGL display" + GetErrorAsString());
 
             int[] version = new int[2];
@@ -975,17 +977,17 @@ namespace Microsoft.Xna.Framework
             var createdVersion = new MonoGame.OpenGL.GLESVersion();
             foreach (var v in MonoGame.OpenGL.GLESVersion.GetSupportedGLESVersions ()) {
                 Log.Verbose("AndroidGameView", "Creating GLES {0} Context", v);
-                eglContext = egl.EglCreateContext(eglDisplay, results[0], EGL10.EglNoContext, v.GetAttributes());
-                if (eglContext == null || eglContext == EGL10.EglNoContext)
+                eglContext = egl.EglCreateContext(eglDisplay, results[0], IEGL10.EglNoContext, v.GetAttributes());
+                if (eglContext == null || eglContext == IEGL10.EglNoContext)
                 {
                     Log.Verbose("AndroidGameView", string.Format("GLES {0} Not Supported. {1}", v, GetErrorAsString()));
-                    eglContext = EGL10.EglNoContext;
+                    eglContext = IEGL10.EglNoContext;
                     continue;
                 }
                 createdVersion = v;
                 break;
             }
-            if (eglContext == null || eglContext == EGL10.EglNoContext)
+            if (eglContext == null || eglContext == IEGL10.EglNoContext)
             {
                 eglContext = null;
                 throw new Exception("Could not create EGL context" + GetErrorAsString());
@@ -999,35 +1001,35 @@ namespace Microsoft.Xna.Framework
         {
             switch (egl.EglGetError())
             {
-                case EGL10.EglSuccess:
+                case IEGL10.EglSuccess:
                     return "Success";
 
-                case EGL10.EglNotInitialized:
+                case IEGL10.EglNotInitialized:
                     return "Not Initialized";
 
-                case EGL10.EglBadAccess:
+                case IEGL10.EglBadAccess:
                     return "Bad Access";
-                case EGL10.EglBadAlloc:
+                case IEGL10.EglBadAlloc:
                     return "Bad Allocation";
-                case EGL10.EglBadAttribute:
+                case IEGL10.EglBadAttribute:
                     return "Bad Attribute";
-                case EGL10.EglBadConfig:
+                case IEGL10.EglBadConfig:
                     return "Bad Config";
-                case EGL10.EglBadContext:
+                case IEGL10.EglBadContext:
                     return "Bad Context";
-                case EGL10.EglBadCurrentSurface:
+                case IEGL10.EglBadCurrentSurface:
                     return "Bad Current Surface";
-                case EGL10.EglBadDisplay:
+                case IEGL10.EglBadDisplay:
                     return "Bad Display";
-                case EGL10.EglBadMatch:
+                case IEGL10.EglBadMatch:
                     return "Bad Match";
-                case EGL10.EglBadNativePixmap:
+                case IEGL10.EglBadNativePixmap:
                     return "Bad Native Pixmap";
-                case EGL10.EglBadNativeWindow:
+                case IEGL10.EglBadNativeWindow:
                     return "Bad Native Window";
-                case EGL10.EglBadParameter:
+                case IEGL10.EglBadParameter:
                     return "Bad Parameter";
-                case EGL10.EglBadSurface:
+                case IEGL10.EglBadSurface:
                     return "Bad Surface";
 
                 default:
@@ -1045,7 +1047,7 @@ namespace Microsoft.Xna.Framework
                     DestroyGLSurface();
 
                     eglSurface = egl.EglCreateWindowSurface(eglDisplay, eglConfig, (Java.Lang.Object)this.Holder, null);
-                    if (eglSurface == null || eglSurface == EGL10.EglNoSurface)
+                    if (eglSurface == null || eglSurface == IEGL10.EglNoSurface)
                         throw new Exception("Could not create EGL window surface" + GetErrorAsString());
 
                     if (!egl.EglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext))
@@ -1073,7 +1075,7 @@ namespace Microsoft.Xna.Framework
         {
             IEGL10 egl = EGLContext.EGL.JavaCast<IEGL10>();
             EGLSurface result = egl.EglCreatePbufferSurface(eglDisplay, config, attribList);
-            if (result == null || result == EGL10.EglNoSurface)
+            if (result == null || result == IEGL10.EglNoSurface)
                 throw new Exception("EglCreatePBufferSurface");
             return result;
         }
@@ -1308,21 +1310,21 @@ namespace Microsoft.Xna.Framework
                 this.view = view;
                 foreach (var v in MonoGame.OpenGL.GLESVersion.GetSupportedGLESVersions())
                 {
-                    eglContext = view.egl.EglCreateContext(view.eglDisplay, view.eglConfig, EGL10.EglNoContext, v.GetAttributes());
-                    if (eglContext == null || eglContext == EGL10.EglNoContext)
+                    eglContext = view.egl.EglCreateContext(view.eglDisplay, view.eglConfig, IEGL10.EglNoContext, v.GetAttributes());
+                    if (eglContext == null || eglContext == IEGL10.EglNoContext)
                     {
                         continue;
                     }
                     break;
                 }
-                if (eglContext == null || eglContext == EGL10.EglNoContext)
+                if (eglContext == null || eglContext == IEGL10.EglNoContext)
                 {
                     eglContext = null;
                     throw new Exception("Could not create EGL context" + view.GetErrorAsString());
                 }
-                int[] pbufferAttribList = new int[] { EGL10.EglWidth, 64, EGL10.EglHeight, 64, EGL10.EglNone };
+                int[] pbufferAttribList = new int[] { IEGL10.EglWidth, 64, IEGL10.EglHeight, 64, IEGL10.EglNone };
                 surface = view.CreatePBufferSurface(view.eglConfig, pbufferAttribList);
-                if (surface == EGL10.EglNoSurface)
+                if (surface == IEGL10.EglNoSurface)
                     throw new Exception("Could not create Pbuffer Surface" + view.GetErrorAsString());
             }
 

--- a/MonoGame.Framework/Platform/Android/ScreenReceiver.cs
+++ b/MonoGame.Framework/Platform/Android/ScreenReceiver.cs
@@ -24,8 +24,13 @@ namespace Microsoft.Xna.Framework
                 // and if not re-enable the game related functions.
                 // http://stackoverflow.com/questions/4260794/how-to-tell-if-device-is-sleeping
                 KeyguardManager keyguard = (KeyguardManager)context.GetSystemService(Context.KeyguardService);
-                if (!keyguard.InKeyguardRestrictedInputMode())
-                    OnUnlocked();
+                if (!OperatingSystem.IsAndroidVersionAtLeast (28)) {
+                    if (!keyguard.InKeyguardRestrictedInputMode())
+                        OnUnlocked();
+                } else {
+                    if (!keyguard.IsDeviceLocked)
+                        OnUnlocked();
+                }
 			}
 			else if(intent.Action == Intent.ActionUserPresent)
 			{

--- a/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Xna.Framework.Audio
                 int frequency = DEFAULT_FREQUENCY;
                 int updateSize = DEFAULT_UPDATE_SIZE;
                 int updateBuffers = DEFAULT_UPDATE_BUFFER_COUNT;
-                if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.JellyBeanMr1)
+                if (OperatingSystem.IsAndroidVersionAtLeast(17))
                 {
                     Android.Util.Log.Debug("OAL", Game.Activity.PackageManager.HasSystemFeature(PackageManager.FeatureAudioLowLatency) ? "Supports low latency audio playback." : "Does not support low latency audio playback.");
 
@@ -210,7 +210,7 @@ namespace Microsoft.Xna.Framework.Audio
 
                     // If 4.4 or higher, then we don't need to double buffer on the application side.
                     // See http://stackoverflow.com/a/15006327
-                    if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Kitkat)
+                    if (OperatingSystem.IsAndroidVersionAtLeast (19))
                     {
                         updateBuffers = 1;
                     }

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.Android.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.Android.cs
@@ -76,8 +76,8 @@ namespace MonoGame.OpenGL
 
         internal int[] GetAttributes()
         {
-            int minor = Minor > -1 ? EglContextMinorVersion : EGL10.EglNone;
-            return new int[] { EglContextClientVersion, Major, minor, Minor, EGL10.EglNone };
+            int minor = Minor > -1 ? EglContextMinorVersion : IEGL10.EglNone;
+            return new int[] { EglContextClientVersion, Major, minor, Minor, IEGL10.EglNone };
         }
 
         public override string ToString()

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
@@ -392,10 +392,14 @@ namespace Microsoft.Xna.Framework.Graphics
             using (Bitmap image = BitmapFactory.DecodeStream(stream, null, new BitmapFactory.Options
             {
                 InScaled = false,
+#pragma warning disable CA1422
                 InDither = false,
+#pragma warning restore CA1422
                 InJustDecodeBounds = false,
+#pragma warning disable CS0618
                 InPurgeable = true,
                 InInputShareable = true,
+#pragma warning restore CS0618
             }))
             {
                 var width = image.Width;

--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+using Android.OS;
 using Android.Views;
 
 namespace Microsoft.Xna.Framework.Input
@@ -35,7 +37,10 @@ namespace Microsoft.Xna.Framework.Input
             var capabilities = new GamePadCapabilities();
             capabilities.IsConnected = true;
             capabilities.GamePadType = GamePadType.GamePad;
-            capabilities.HasLeftVibrationMotor = capabilities.HasRightVibrationMotor = device.Vibrator.HasVibrator;
+            capabilities.HasLeftVibrationMotor = capabilities.HasRightVibrationMotor =
+                !OperatingSystem.IsAndroidVersionAtLeast (31) ?
+                    device.Vibrator.HasVibrator :
+                    device.VibratorManager.DefaultVibrator.HasVibrator;
 
             // build out supported inputs from what the gamepad exposes
             int[] keyMap = new int[16];
@@ -63,7 +68,7 @@ namespace Microsoft.Xna.Framework.Input
             // get a bool[] with indices matching the keyMap
             bool[] hasMap = new bool[16];
             // HasKeys() was defined in Kitkat / API19 / Android 4.4
-            if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.Kitkat)
+            if (!OperatingSystem.IsAndroidVersionAtLeast(19))
             {
                 var keyMap2 = new Keycode[keyMap.Length];
                 for(int i=0; i<keyMap.Length;i++)
@@ -178,10 +183,17 @@ namespace Microsoft.Xna.Framework.Input
             if (gamePad == null)
                 return false;
 
-            var vibrator = gamePad._device.Vibrator;
+            var vibrator = !OperatingSystem.IsAndroidVersionAtLeast (31) ? gamePad._device.Vibrator : gamePad._device.VibratorManager.DefaultVibrator;
             if (!vibrator.HasVibrator)
                 return false;
-            vibrator.Vibrate(500);
+            if (!OperatingSystem.IsAndroidVersionAtLeast (26))
+            {
+                vibrator.Vibrate(500);
+            }
+            else
+            {
+                vibrator.Vibrate (VibrationEffect.CreateOneShot(500, VibrationEffect.DefaultAmplitude));
+            }
             return true;
         }
 

--- a/MonoGame.Framework/Platform/Media/MediaLibrary.Android.cs
+++ b/MonoGame.Framework/Platform/Media/MediaLibrary.Android.cs
@@ -34,15 +34,15 @@ namespace Microsoft.Xna.Framework.Media
                     // See: https://code.google.com/p/android/issues/detail?id=1630
                     // Workaround: http://stackoverflow.com/questions/1954434/cover-art-on-android
 
-                    int albumNameColumn = musicCursor.GetColumnIndex(MediaStore.Audio.AlbumColumns.Album);
-                    int albumArtistColumn = musicCursor.GetColumnIndex(MediaStore.Audio.AlbumColumns.Artist);
-                    int albumIdColumn = musicCursor.GetColumnIndex(MediaStore.Audio.AlbumColumns.AlbumId);
-                    int genreColumn = musicCursor.GetColumnIndex(MediaStore.Audio.GenresColumns.Name); // Also broken :(
+                    int albumNameColumn = musicCursor.GetColumnIndex(MediaStore.Audio.IAlbumColumns.Album);
+                    int albumArtistColumn = musicCursor.GetColumnIndex(MediaStore.Audio.IAlbumColumns.Artist);
+                    int albumIdColumn = musicCursor.GetColumnIndex(MediaStore.Audio.IAlbumColumns.AlbumId);
+                    int genreColumn = musicCursor.GetColumnIndex(MediaStore.Audio.IGenresColumns.Name); // Also broken :(
 
-                    int artistColumn = musicCursor.GetColumnIndex(MediaStore.Audio.AudioColumns.Artist);
-                    int titleColumn = musicCursor.GetColumnIndex(MediaStore.Audio.AudioColumns.Title);
-                    int durationColumn = musicCursor.GetColumnIndex(MediaStore.Audio.AudioColumns.Duration);
-                    int assetIdColumn = musicCursor.GetColumnIndex(MediaStore.Audio.AudioColumns.Id);
+                    int artistColumn = musicCursor.GetColumnIndex(MediaStore.Audio.IAudioColumns.Artist);
+                    int titleColumn = musicCursor.GetColumnIndex(MediaStore.IMediaColumns.Title);
+                    int durationColumn = musicCursor.GetColumnIndex(MediaStore.Audio.IAudioColumns.Duration);
+                    int assetIdColumn = musicCursor.GetColumnIndex(IBaseColumns.Id);
 
                     if (titleColumn == -1 || durationColumn == -1 || assetIdColumn == -1)
                     {


### PR DESCRIPTION
As the underlying Android platform evolves they tend to obsolete many API's. We should be keeping on top of these so that the Android implementation stays current. However we cannot remove the old APi's completely due to the massive number of devices which Android supports.

So we need to make use of Runtime checks to make sure we call the correct "supported" API's on the correct versions of Android. Previously this had to be done by checking the `SdkInt` version. With .net 6 and beyond we can make use of the
`OperatingSystem.IsAndroidVersionAtLeast` utility method. This is a method which the compiler is aware of and it can hide the warnings about obsolete API's around the code it protects.

Also upgraded other obsolete API's which do not need runtime checks.