### PR TITLE
Fixes video playback (#8407 removed Video.PlatformInitialize)

### DIFF
--- a/MonoGame.Framework/Media/Video.cs
+++ b/MonoGame.Framework/Media/Video.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Xna.Framework.Media
         internal Video(string fileName)
         {
             FileName = fileName;
+
+            PlatformInitialize();
         }
 
         /// <summary/>


### PR DESCRIPTION
1) PR #8407 removed this which broke video playback on other platforms:
```
#if !WINDOWS_UAP
    PlatformInitialize();
#endif
```
https://github.com/MonoGame/MonoGame/pull/8407/files#diff-0842687d1e42c798e63c477dc22f4f361e99a5de14e59768123efb0cd3ae0b7eL62

2) The non-existent video tests within't MonoGame.Tests didn't prevent this video bug change which I suspect is likely due to their lack of existence.