### PR TITLE
Fix NuGet Package Security Issue

### DIFF
--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -32,6 +32,8 @@
   <ItemGroup>
     <PackageReference Include="Cake.FileHelpers" Version="7.0.0" />
     <PackageReference Include="Cake.Frosting" Version="4.0.0" />
+    <PackageReference Include="NuGet.Packaging" Version="6.10.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When buiilding dotnet is reporting the following security vulnerabilities.

```
error NU1904: Warning As Error: Package 'NuGet.Packaging' 6.7.0 has a known critical severity vulnerability, https://github.com/advisories/GHSA-68w7-72jg-6qpp
Warning As Error: Package 'System.Formats.Asn1' 6.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-447r-wph3-92pm
```

The Cake packages have not been updated so add references to the latest stable packages manually.