### PR TITLE
[CI] Improve versioning and allow upload to nuget.org

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,19 @@ jobs:
           - name: Expose GitHub Runtime
             uses: crazy-max/ghaction-github-runtime@v3
 
-          - name: Push GitHub Nugets
-            run: dotnet run --project build/Build.csproj -- --target=DeployNuGetsToGithub
+          - name: Push Nugets
+            run: dotnet run --project build/Build.csproj -- --target=Deploy
             env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+          - name: Make a Release
+            if: github.ref_type == 'tag'
+            uses: ncipollo/release-action@v1
+            with:
+              name: 'MonoGame ${{ github.ref_name }}'
+              tag: ${{ github.ref_name }}
+              allowUpdates: true
+              removeArtifacts: true
+              artifacts: "nugets/*.nupkg"
+              token: ${{ secrets.GITHUB_TOKEN }}

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Cake.FileHelpers" Version="7.0.0" />
     <PackageReference Include="Cake.Frosting" Version="4.0.0" />
+    <PackageReference Include="Cake.Git" Version="4.0.0" />
     <PackageReference Include="NuGet.Packaging" Version="6.10.1" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
   </ItemGroup>

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -47,8 +47,8 @@ public class BuildContext : FrostingContext
             }
             else if (workflow.RefType == GitHubActionsRefType.Tag)
             {
-                var baseVersion = workflow.RefName;
-                if (!Regex.IsMatch(baseVersion, @"v\d+.\d+.\d+"))
+                var baseVersion = workflow.RefName.Split('/')[^1];
+                if (!VersionRegex.IsMatch(baseVersion))
                     throw new Exception($"Invalid tag: {baseVersion}");
                 
                 VersionBase = baseVersion[1..];

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -52,7 +52,7 @@ public class BuildContext : FrostingContext
                     throw new Exception($"Invalid tag: {baseVersion}");
                 
                 VersionBase = baseVersion[1..];
-                Version = $"{VersionBase}.{workflow.RunNumber}";
+                Version = VersionBase;
             }
             else if (workflow.RefType == GitHubActionsRefType.Branch && workflow.RefName != "refs/heads/master")
             {

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -41,22 +41,18 @@ public class BuildContext : FrostingContext
             var workflow = context.BuildSystem().GitHubActions.Environment.Workflow;
             repositoryUrl = $"https://github.com/{workflow.Repository}";
 
-            if (workflow.RefType == GitHubActionsRefType.Tag)
-            {
-                var baseVersion = workflow.RefName;
-                if (Regex.IsMatch(baseVersion, @"v\d+.\d+.\d+"))
-                {
-                    VersionBase = baseVersion[1..];
-                }
-                else
-                {
-                    throw new Exception($"Invalid tag: {baseVersion}");
-                }
-            }
-
             if (workflow.Repository != "MonoGame/MonoGame")
             {
                 Version = $"{VersionBase}.{workflow.RunNumber}-{workflow.RepositoryOwner}";
+            }
+            else if (workflow.RefType == GitHubActionsRefType.Tag)
+            {
+                var baseVersion = workflow.RefName;
+                if (!Regex.IsMatch(baseVersion, @"v\d+.\d+.\d+"))
+                    throw new Exception($"Invalid tag: {baseVersion}");
+                
+                VersionBase = baseVersion[1..];
+                Version = $"{VersionBase}.{workflow.RunNumber}";
             }
             else if (workflow.RefType == GitHubActionsRefType.Branch && workflow.RefName != "refs/heads/master")
             {

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -1,3 +1,6 @@
+using Cake.Git;
+using Microsoft.VisualBasic;
+using System.Text.RegularExpressions;
 
 namespace BuildScripts;
 
@@ -13,34 +16,60 @@ public enum ProjectType
 
 public class BuildContext : FrostingContext
 {
+    public static string VersionBase = "1.0.0";
+    public static readonly Regex VersionRegex = new(@"^v\d+.\d+.\d+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     public static readonly string DefaultRepositoryUrl = "https://github.com/MonoGame/MonoGame";
-    public static readonly string DefaultBaseVersion = "3.8.2";
 
     public BuildContext(ICakeContext context) : base(context)
     {
         var repositoryUrl = context.Argument("build-repository", DefaultRepositoryUrl);
         var buildConfiguration = context.Argument("build-configuration", "Release");
         BuildOutput = context.Argument("build-output", "artifacts");
-        Version = context.Argument("build-version", DefaultBaseVersion + ".1-develop");
         NuGetsDirectory = $"{BuildOutput}/NuGet/";
+
+        var tags = GitAliases.GitTags(context, ".");
+        foreach (var tag in tags)
+        {
+            if (VersionRegex.IsMatch(tag.FriendlyName))
+            {
+                VersionBase = tag.FriendlyName[1..];
+            }
+        }
 
         if (context.BuildSystem().IsRunningOnGitHubActions)
         {
             var workflow = context.BuildSystem().GitHubActions.Environment.Workflow;
             repositoryUrl = $"https://github.com/{workflow.Repository}";
 
+            if (workflow.RefType == GitHubActionsRefType.Tag)
+            {
+                var baseVersion = workflow.RefName;
+                if (Regex.IsMatch(baseVersion, @"v\d+.\d+.\d+"))
+                {
+                    VersionBase = baseVersion[1..];
+                }
+                else
+                {
+                    throw new Exception($"Invalid tag: {baseVersion}");
+                }
+            }
+
             if (workflow.Repository != "MonoGame/MonoGame")
             {
-                Version = $"{DefaultBaseVersion}.{workflow.RunNumber}-{workflow.RepositoryOwner}";
+                Version = $"{VersionBase}.{workflow.RunNumber}-{workflow.RepositoryOwner}";
             }
             else if (workflow.RefType == GitHubActionsRefType.Branch && workflow.RefName != "refs/heads/master")
             {
-                Version = $"{DefaultBaseVersion}.{workflow.RunNumber}-develop";
+                Version = $"{VersionBase}.{workflow.RunNumber}-develop";
             }
             else
             {
-                Version = $"{DefaultBaseVersion}.{workflow.RunNumber}";
+                Version = $"{VersionBase}.{workflow.RunNumber}";
             }
+        }
+        else
+        {
+            Version = context.Argument("build-version", VersionBase + ".1-develop");
         }
 
         DotNetMSBuildSettings = new DotNetMSBuildSettings();

--- a/build/DeployTasks/DeployNuGetsToNuGetOrgTask.cs
+++ b/build/DeployTasks/DeployNuGetsToNuGetOrgTask.cs
@@ -1,0 +1,31 @@
+
+namespace BuildScripts;
+
+[TaskName("DeployNuGetsToNuGetOrgTask")]
+[IsDependentOn(typeof(DownloadArtifactsTask))]
+public sealed class DeployNuGetsToNuGetOrgTask : FrostingTask<BuildContext>
+{
+    public override bool ShouldRun(BuildContext context)
+    {
+        if (context.BuildSystem().IsRunningOnGitHubActions)
+        {
+            var workflow = context.BuildSystem().GitHubActions.Environment.Workflow;
+            if (workflow.RefType == GitHubActionsRefType.Tag &&
+                !string.IsNullOrWhiteSpace(context.EnvironmentVariable("NUGET_API_KEY")))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public override void Run(BuildContext context)
+    {
+        context.DotNetNuGetPush($"nugets/*.nupkg", new()
+        {
+            ApiKey = context.EnvironmentVariable("NUGET_API_KEY"),
+            Source = $"https://api.nuget.org/v3/index.json"
+        });
+    }
+}

--- a/build/Tasks.cs
+++ b/build/Tasks.cs
@@ -29,6 +29,11 @@ public sealed class BuildTemplatesTask : FrostingTask<BuildContext> { }
 [IsDependentOn(typeof(BuildTemplatesTask))]
 public sealed class BuildAllTask : FrostingTask<BuildContext> { }
 
+[TaskName("Deploy")]
+[IsDependentOn(typeof(DeployNuGetsToGitHubTask))]
+[IsDependentOn(typeof(DeployNuGetsToNuGetOrgTask))]
+public sealed class DeployTask : FrostingTask<BuildContext> { }
+
 [TaskName("Default")]
 [IsDependentOn(typeof(BuildAllTask))]
 public sealed class DefaultTask : FrostingTask<BuildContext> { }


### PR DESCRIPTION
Stuff done:
- Added deploy task for nuget.org
- Replaced the hardcoded version with loading version from the latest tag
- Automatically use the current tag as version if building from GitHub workloads
- Automatically make a release when tag is pushed
- Fully use the tags version when its created:
  - Non master branches can be tagged
  - Tags should be specified with 4 numbers, first 3 being our release, 4th being our attempt at releasing that one, ie. `3.8.0.1` and `3.8.0.0-rc1`