### PR TITLE
Fix edgecase where global tool may not be prefixed with `dotnet-`

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor.Launcher.Bootstrap/Program.cs
+++ b/Tools/MonoGame.Content.Builder.Editor.Launcher.Bootstrap/Program.cs
@@ -17,7 +17,18 @@ namespace MonoGame.Content.Builder.Editor.Launcher.Bootstrap
                 RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "mgcb-editor-linux" :
                 throw new NotImplementedException("Unsupported Operating System");
 
-            Process.Start(executable, $"\"{string.Join("\" \"", args)}\"");
+            // We invoke the tool directly without the `dotnet-` if it exists.
+            // See: https://github.com/MonoGame/MonoGame/pulls/8448.
+            var isInPath = Environment
+                .GetEnvironmentVariable("PATH")
+                .Split(Path.PathSeparator)
+                .Select(x => Path.Combine(x, executable))
+                .Any(File.Exists);
+
+            if (isInPath)
+                Process.Start(executable, $"\"{string.Join("\" \"", args)}\"");
+            else
+                Process.Start("dotnet", $"{executable} \"{string.Join("\" \"", args)}\"");
         }
     }
 }

--- a/Tools/MonoGame.Content.Builder.Editor.Launcher.Bootstrap/Program.cs
+++ b/Tools/MonoGame.Content.Builder.Editor.Launcher.Bootstrap/Program.cs
@@ -17,7 +17,7 @@ namespace MonoGame.Content.Builder.Editor.Launcher.Bootstrap
                 RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "mgcb-editor-linux" :
                 throw new NotImplementedException("Unsupported Operating System");
 
-            Process.Start("dotnet", $"{executable} \"{string.Join("\" \"", args)}\"");
+            Process.Start(executable, $"\"{string.Join("\" \"", args)}\"");
         }
     }
 }


### PR DESCRIPTION
### Problem
When running `dotnet tool install dotnet-mgcb-editor -g`, it can sometimes install the binary as `mgcb-editor` which causes the command `dotnet mgcb-editor` to fail since it doesn't have the required `dotnet-` prefix.
```
❯ mgcb-editor

~ 
❯ Could not execute because the specified command or file was not found.
Possible reasons for this include:
  * You misspelled a built-in dotnet command.
  * You intended to execute a .NET program, but dotnet-mgcb-editor-linux does not exist.
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
  ```

### Solution
This PR fixes that by first checking if the command without the `dotnet-` prefix resides in `PATH`, and invokes it directly if found. Otherwise, it uses the current implementation. I hope I've done everything correctly.

### Workarounds
Creating a symlink `dotnet-mgcb-editor-<OS>` that points to `mgcb-editor-<OS>` is a temporary solution.
```sh
# Windows
mklink "%DOTNET_ROOT%/tools/mgcb-editor-windows" "%DOTNET_ROOT%/tools/dotnet-mgcb-editor-windows"
```
```sh
# Mac
ln -s "$DOTNET_ROOT/tools/mgcb-editor-mac" "$DOTNET_ROOT/tools/dotnet-mgcb-editor-mac"
```
```sh
# Linux
ln -s "$DOTNET_ROOT/tools/mgcb-editor-linux" "$DOTNET_ROOT/tools/dotnet-mgcb-editor-linux"
```