### PR TITLE
Updating links to include getting_started subdomain

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Xna.Framework.Content
         ///     <para>
         ///         Before a ContentManager can load an asset, you need to add the asset to your game project using
         ///         the steps described in
-        ///         <see href="https://docs.monogame.net/articles/content_pipeline/index.html">Adding Content - MonoGame</see>.
+        ///         <see href="https://docs.monogame.net/articles/getting_started/content_pipeline/index.html">Adding Content - MonoGame</see>.
         ///     </para>
         /// </remarks>
         /// <typeparam name="T">
@@ -293,7 +293,7 @@ namespace Microsoft.Xna.Framework.Content
         /// <remarks>
         /// Before a ContentManager can load an asset, you need to add the asset to your game project using
         /// the steps described in
-        /// <see href="https://docs.monogame.net/articles/content_pipeline/index.html">Adding Content - MonoGame</see>.
+        /// <see href="https://docs.monogame.net/articles/getting_started/content_pipeline/index.html">Adding Content - MonoGame</see>.
         /// </remarks>
         /// <typeparam name="T">
         ///     <para>

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,4 +1,4 @@
-Depending on the [platform](https://docs.monogame.net/articles/platforms.html) that you are targeting, MonoGame has different sets of requirements.
+Depending on the [platform](https://docs.monogame.net/articles/getting_started/platforms.html) that you are targeting, MonoGame has different sets of requirements.
 
 For desktop platforms
 ====================

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.cs
@@ -579,7 +579,7 @@ namespace MonoGame.Tools.Pipeline
 
         private void CmdHelp_Executed(object sender, EventArgs e)
         {
-            Process.Start(new ProcessStartInfo() { FileName = "https://docs.monogame.net/articles/tools/mgcb_editor.html", UseShellExecute = true, Verb = "open" });
+            Process.Start(new ProcessStartInfo() { FileName = "https://docs.monogame.net/articles/getting_started/tools/mgcb_editor.html", UseShellExecute = true, Verb = "open" });
         }
 
         private void CmdAbout_Executed(object sender, EventArgs e)


### PR DESCRIPTION
Fixing some 404s when linking to docs that have the getting_started subdomain now.