### PR TITLE
Detect GamePad/Keyboard events on Android

### DIFF
--- a/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
@@ -1148,13 +1148,28 @@ namespace Microsoft.Xna.Framework
 
         #region Key and Motion
 
+        private bool IsKeyboard(InputDevice device)
+        {
+            if (device == null)
+                return false;
+            var sources = device.Sources;
+            return (sources & InputSourceType.Keyboard) == InputSourceType.Keyboard && device.VendorId != 0 && device.ProductId != 0;
+        }
+
+        private bool IsGamePad(InputDevice device) {
+            if (device == null)
+                return false;
+            var sources = device.Sources;
+            return ((sources & InputSourceType.Gamepad) == InputSourceType.Gamepad || (sources & InputSourceType.Joystick) == InputSourceType.Joystick) && device.VendorId != 0 && device.ProductId != 0 ;
+        }
+
         public override bool OnKeyDown(Keycode keyCode, KeyEvent e)
         {
             bool handled = false;
-            if (GamePad.OnKeyDown(keyCode, e))
+            if (IsGamePad (e.Device) && GamePad.OnKeyDown(keyCode, e))
                 return true;
 
-            handled = Keyboard.KeyDown(keyCode);
+            handled = IsKeyboard (e.Device) && Keyboard.KeyDown(keyCode);
 
             // we need to handle the Back key here because it doesn't work any other way
             if (keyCode == Keycode.Back)
@@ -1184,14 +1199,14 @@ namespace Microsoft.Xna.Framework
         {
             if (keyCode == Keycode.Back)
                 GamePad.Back = false;
-            if (GamePad.OnKeyUp(keyCode, e))
+            if (IsGamePad (e.Device) && GamePad.OnKeyUp(keyCode, e))
                 return true;
-            return Keyboard.KeyUp(keyCode);
+            return IsKeyboard (e.Device) && Keyboard.KeyUp(keyCode);
         }
 
         public override bool OnGenericMotionEvent(MotionEvent e)
         {
-            if (GamePad.OnGenericMotionEvent(e))
+            if (IsGamePad (e.Device) && GamePad.OnGenericMotionEvent(e))
                 return true;
 
             return base.OnGenericMotionEvent(e);


### PR DESCRIPTION
Fixes #8463

### Description of Change

This was a bug, we assumed that ALL KeyDown and KeyUp events were coming from a GamePad on Android! They might not, users can use USB or Bluetooth keyboards. As a result key presses would be passed to the GamePad not the keyboard.

So lets check the type of the device sending the data and route it to the correct place. This should allow keyboards to work.





