### PR TITLE
Fix OpenAL SoundEffectInstance Panning Issue on DesktopGL and Mobile

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.7" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="bin\**\*" />
     <Compile Remove="obj\**\*" />
     <Compile Remove="Platform\**\*" />
@@ -76,21 +80,6 @@
 
   <ItemGroup>
     <None Include="MonoGame.Framework.Android.targets" Pack="true" PackagePath="build" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedNativeLibrary Include="..\ThirdParty\Dependencies\openal-soft\libs\armeabi-v7a\libopenal32.so">
-      <Link>libs\armeabi-v7a\libopenal32.so</Link>
-    </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="..\ThirdParty\Dependencies\openal-soft\libs\arm64-v8a\libopenal32.so">
-      <Link>libs\arm64-v8a\libopenal32.so</Link>
-    </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="..\ThirdParty\Dependencies\openal-soft\libs\x86\libopenal32.so">
-      <Link>libs\x86\libopenal32.so</Link>
-    </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="..\ThirdParty\Dependencies\openal-soft\libs\x86_64\libopenal32.so">
-      <Link>libs\x86_64\libopenal32.so</Link>
-    </EmbeddedNativeLibrary>
   </ItemGroup>
 
   <Import Project="Platform\OpenGL.targets" />

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -18,6 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="MonoGame.Library.SDL" Version="2.26.5.5" />
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.7" />
     <PackageReference Include="NVorbis" Version="0.10.4" />
   </ItemGroup>
 
@@ -88,27 +89,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(CopyContentFiles)' == 'True'">
-    <Content Include="..\ThirdParty\Dependencies\openal-soft\Windows\x86\soft_oal.dll">
-      <Link>x86\soft_oal.dll</Link>
-      <PackagePath>runtimes\win-x86\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\openal-soft\Windows\x64\soft_oal.dll">
-      <Link>x64\soft_oal.dll</Link>
-      <PackagePath>runtimes\win-x64\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\openal-soft\Linux\x64\libopenal.so.1">
-      <Link>x64\libopenal.so.1</Link>
-      <PackagePath>runtimes\linux-x64\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\openal-soft\MacOS\Universal\libopenal.1.dylib">
-      <Link>libopenal.1.dylib</Link>
-      <PackagePath>runtimes\osx\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-
     <Content Include="MonoGame.Framework.DesktopGL.targets" PackagePath="build" />
   </ItemGroup>
 

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.7" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="bin\**\*" />
     <Compile Remove="obj\**\*" />
     <Compile Remove="Platform\**\*" />

--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -69,7 +69,8 @@ namespace MonoGame.OpenAL
     {
         Pitch = 0x1003,
         Gain = 0x100A,
-        ReferenceDistance = 0x1020
+        ReferenceDistance = 0x1020,
+        StereoAngles = 0x1030
     }
 
     internal enum ALGetSourcei
@@ -197,28 +198,31 @@ namespace MonoGame.OpenAL
         {
 #if DESKTOPGL
             if (CurrentPlatform.OS == OS.Windows)
-                return FuncLoader.LoadLibraryExt("soft_oal.dll");
+                return FuncLoader.LoadLibraryExt("openal.dll");
             else if (CurrentPlatform.OS == OS.Linux)
-                return FuncLoader.LoadLibraryExt("libopenal.so.1");
+                return FuncLoader.LoadLibraryExt("libopenal.so");
             else if (CurrentPlatform.OS == OS.MacOSX)
-                return FuncLoader.LoadLibraryExt("libopenal.1.dylib");
+                return FuncLoader.LoadLibraryExt("libopenal.dylib");
             else
                 return FuncLoader.LoadLibraryExt("openal");
 #elif ANDROID
-            var ret = FuncLoader.LoadLibrary("libopenal32.so");
+            var ret = FuncLoader.LoadLibrary("libopenal.so");
 
             if (ret == IntPtr.Zero)
             {
                 var appFilesDir = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
                 var appDir = Path.GetDirectoryName(appFilesDir);
-                var lib = Path.Combine(appDir, "lib", "libopenal32.so");
+                var lib = Path.Combine(appDir, "lib", "libopenal.so");
 
                 ret = FuncLoader.LoadLibrary(lib);
             }
 
             return ret;
 #else
-            return FuncLoader.LoadLibrary("/System/Library/Frameworks/OpenAL.framework/OpenAL");
+            var ret =  FuncLoader.LoadLibrary("libopenal.dylib");
+            if (ret ==IntPtr.Zero)
+                ret = FuncLoader.LoadLibrary(Path.Combine (Path.GetDirectoryName (typeof (AL).Assembly.Location), "libopenal.dylib"));
+            return ret;
 #endif
         }
 
@@ -421,6 +425,10 @@ namespace MonoGame.OpenAL
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_alsource3f(int sourceId, ALSource3f i, float x, float y, float z);
         internal static d_alsource3f alSource3f = FuncLoader.LoadFunction<d_alsource3f>(NativeLibrary, "alSource3f");
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void d_alsourcefv(int sourceId, ALSourcef i, float[] values);
+        internal static d_alsourcefv alSourcefv = FuncLoader.LoadFunction<d_alsourcefv>(NativeLibrary, "alSourcefv");
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void d_algetsourcei(int sourceId, ALGetSourcei i, out int state);

--- a/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Xna.Framework.Audio
         public bool SupportsEfx { get; private set; }
         public bool SupportsIeee { get; private set; }
 
+        public bool SupportsStereoAngles { get; private set;}
+
         /// <summary>
         /// Sets up the hardware resources used by the controller.
         /// </summary>
@@ -118,6 +120,8 @@ namespace Microsoft.Xna.Framework.Audio
 
             if (Alc.IsExtensionPresent(_device, "ALC_EXT_CAPTURE"))
                 Microphone.PopulateCaptureDevices();
+
+            SupportsStereoAngles = AL.IsExtensionPresent ("AL_EXT_STEREO_ANGLES");
 
             // We have hardware here and it is ready
 


### PR DESCRIPTION
Fixes #6876
Fixes #6543


### Description of Change

So OpenAL has an outstanding issue where is does not support stereo panning (see https://github.com/kcat/openal-soft/issues/194)

They do however have an extension `AL_EXT_STEREO_ANGLES` which can produce a similar effect. So lets make use of this extension if it is supported to support panning of stereo audio.
