### PR TITLE
Fix: Make SpriteFonts default to lossless compression

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/LocalizedFontProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/LocalizedFontProcessor.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         public LocalizedFontProcessor ()
         {
               PremultiplyAlpha = true;
-              textureFormat = TextureProcessorOutputFormat.Color;
+              TextureFormat = TextureProcessorOutputFormat.Color;
         }
 
         /// <summary>

--- a/MonoGame.Framework.Content.Pipeline/Processors/LocalizedFontProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/LocalizedFontProcessor.cs
@@ -36,13 +36,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         [DefaultValue(true)]
         public virtual bool PremultiplyAlpha { get; set; }
 
-        [DefaultValue(typeof(TextureProcessorOutputFormat), "Compressed")]
+        [DefaultValue(typeof(TextureProcessorOutputFormat), "Color")]
         public virtual TextureProcessorOutputFormat TextureFormat { get; set; }
 
         public LocalizedFontProcessor ()
         {
               PremultiplyAlpha = true;
-              TextureFormat = TextureProcessorOutputFormat.Compressed;
+              textureFormat = TextureProcessorOutputFormat.Color;
         }
 
         /// <summary>


### PR DESCRIPTION
Font textures default to "Color" instead of "Compressed" to make them more consistent to images
