### PR TITLE
Add GDK-related platforms to enums and csproj

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -174,5 +174,6 @@
   <Import Project="..\PlayStation4\MonoGame.Framework.Content.Pipeline.targets" Condition="exists('..\PlayStation4\MonoGame.Framework.Content.Pipeline.targets')" />
   <Import Project="..\PlayStation5\MonoGame.Framework.Content.Pipeline.targets" Condition="exists('..\PlayStation5\MonoGame.Framework.Content.Pipeline.targets')" />
   <Import Project="..\PSVita\MonoGame.Framework.Content.Pipeline.targets" Condition="exists('..\PSVita\MonoGame.Framework.Content.Pipeline.targets')" />
+  <Import Project="..\GDKX\MonoGame.Framework.Content.Pipeline.targets" Condition="exists('..\GDKX\MonoGame.Framework.Content.Pipeline.targets')" />
 
 </Project>

--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
@@ -97,6 +97,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                     return "OpenGL";
                 case TargetPlatform.DesktopVK:
                     return "Vulkan";
+                case TargetPlatform.WindowsGDK:
+                case TargetPlatform.XboxOne:
+                case TargetPlatform.XboxSeries:
+                    return "GDK";
             }
 
             return platform.ToString();

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
             'S', // Nintendo Switch
             'b', // WebAssembly and Bridge.NET
             'V', // DesktopVK (Vulkan)
+            'G', // Windows GDK
+            's', // Xbox Series
         };
 
         /// <summary>

--- a/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
+++ b/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
@@ -91,6 +91,15 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// All desktop versions using Vulkan.
         /// </summary>
         DesktopVK,
+        
+        /// Windows GDK
+        /// </summary>
+        WindowsGDK,
+
+        /// <summary>
+        /// Xbox Series
+        /// </summary>
+        XboxSeries
     }
 
 

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -50,6 +50,8 @@ namespace Microsoft.Xna.Framework.Content
             'S', // Nintendo Switch
             'b', // WebAssembly and Bridge.NET
             'V', // DesktopVK
+            'G', // Windows GDK
+            's', // Xbox Series
 
             // NOTE: There are additional identifiers for consoles that
             // are not defined in this repository.  Be sure to ask the

--- a/MonoGame.Framework/Platform/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Platform/Windows/WinFormsGamePlatform.cs
@@ -80,6 +80,11 @@ namespace MonoGame.Framework
 
         public override bool BeforeDraw(GameTime gameTime)
         {
+#if GDKX
+            var device = Game.GraphicsDevice;
+            if (device != null)
+                device.PlatformPrepare(); // maybe add a Prepare() to GraphicsDevice, could be useful for other backend?
+#endif
             return true;
         }
 
@@ -126,7 +131,9 @@ namespace MonoGame.Framework
                     _window = null;
                     Window = null;
                 }
+#if !GDKX
                 Microsoft.Xna.Framework.Media.MediaManagerState.CheckShutdown();
+#endif
             }
 
             base.Dispose(disposing);

--- a/MonoGame.Framework/Utilities/GraphicsBackend.cs
+++ b/MonoGame.Framework/Utilities/GraphicsBackend.cs
@@ -10,7 +10,7 @@ namespace MonoGame.Framework.Utilities
     public enum GraphicsBackend
     {
         /// <summary>
-        /// Represents the Microsoft DirectX graphics backend.
+        /// Represents the Microsoft DirectX 11 graphics backend.
         /// </summary>
         DirectX,
 
@@ -27,6 +27,11 @@ namespace MonoGame.Framework.Utilities
         /// <summary>
         /// Represents the Apple Metal graphics backend.
         /// </summary>
-        Metal
+        Metal,
+
+        /// <summary>
+        /// Represents the Microsoft DirectX 12 graphics backend. (GDKX only for now)
+        /// </summary>
+        DirectX12
     }
 }

--- a/MonoGame.Framework/Utilities/MonoGamePlatform.cs
+++ b/MonoGame.Framework/Utilities/MonoGamePlatform.cs
@@ -43,6 +43,16 @@ namespace MonoGame.Framework.Utilities
         /// MonoGame Xbox One platform.
         /// </summary>
         XboxOne,
+        
+        /// <summary>
+        /// MonoGame Windows GDK platform.
+        /// </summary>
+        WindowsGDK,
+
+        /// <summary>
+        /// MonoGame Xbox Series platform.
+        /// </summary>
+        XboxSeries,
 
         /// <summary>
         /// MonoGame PlayStation 4 platform.

--- a/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
+++ b/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
@@ -83,6 +83,7 @@
   <Import Project="..\..\XBoxOne\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\XBoxOne\MonoGame.Effect.Compiler.targets')" />
   <Import Project="..\..\PlayStation4\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\PlayStation4\MonoGame.Effect.Compiler.targets')" />
   <Import Project="..\..\PlayStation5\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\PlayStation5\MonoGame.Effect.Compiler.targets')" />
+  <Import Project="..\..\GDKX\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\GDKX\MonoGame.Effect.Compiler.targets')" />
 
   <Target Name="CopyNuGetToolFiles" AfterTargets="Build">
     <ItemGroup>


### PR DESCRIPTION
See #8195.

This PR add the GDK platforms to various enums, this is necessary to build the [GDK backend](https://github.com/MonoGame/MonoGame.XB1/pull/51).

Unfortunately this add two GDK-specific #ifdef to the code, one in Game.cs already present for DX11 and another one to WinFormsGamePlatform.cs in order to add a Prepare() call used by the DX12 backend and to avoid calling SharpDX related stuff. This could probably be removed when merging when #8242 is ready.