### PR TITLE
[Documentation] Minor docs fixes

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -167,6 +167,7 @@ namespace Microsoft.Xna.Framework.Content
 		}
 
         /// <inheritdoc cref="ContentManager.ContentManager(IServiceProvider)"/>
+        /// <param name="serviceProvider"/>
         /// <param name="rootDirectory">The root directory the ContentManager will search for content in.</param>
         public ContentManager(IServiceProvider serviceProvider, string rootDirectory)
 		{
@@ -230,8 +231,8 @@ namespace Microsoft.Xna.Framework.Content
         ///         The type of asset to load.
         ///     </para>
         ///     <para>
-        ///         <see cref="Effect"/>, <see cref="Model"/>, <see cref="SoundEffect"/>,
-        ///         <see cref="Song"/>, <see cref="SpriteFont"/>, <see cref="Texture"/>, <see cref="Texture2D"/>,
+        ///         <see cref="Effect"/>, <see cref="Model"/>, <see cref="Audio.SoundEffect"/>,
+        ///         <see cref="Media.Song"/>, <see cref="SpriteFont"/>, <see cref="Texture"/>, <see cref="Texture2D"/>,
         ///         and <see cref="TextureCube"/> are all supported by default by the standard Content Pipeline
         ///         processor, but additional types may be loaded by extending the processor.
         ///     </para>
@@ -299,8 +300,8 @@ namespace Microsoft.Xna.Framework.Content
         ///         The type of asset to load.
         ///     </para>
         ///     <para>
-        ///         <see cref="Effect"/>, <see cref="Model"/>, <see cref="SoundEffect"/>,
-        ///         <see cref="Song"/>, <see cref="SpriteFont"/>, <see cref="Texture"/>, <see cref="Texture2D"/>,
+        ///         <see cref="Effect"/>, <see cref="Model"/>, <see cref="Audio.SoundEffect"/>,
+        ///         <see cref="Media.Song"/>, <see cref="SpriteFont"/>, <see cref="Texture"/>, <see cref="Texture2D"/>,
         ///         and <see cref="TextureCube"/> are all supported by default by the standard Content Pipeline
         ///         processor, but additional types may be loaded by extending the processor.
         ///     </para>

--- a/MonoGame.Framework/Graphics/IGraphicsDeviceService.cs
+++ b/MonoGame.Framework/Graphics/IGraphicsDeviceService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Raised when the <see cref="GraphicsDevice"/> has reset.
         /// </summary>
-        /// <seealso cref="Microsoft.Xna.Framework.Graphics.GraphicsDevice.Reset"/>
+        /// <seealso cref="Microsoft.Xna.Framework.Graphics.GraphicsDevice.Reset()"/>
         event EventHandler<EventArgs> DeviceReset;
 
         /// <summary>

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
@@ -73,6 +73,10 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Creates a new instance of <see cref="VertexBuffer"/>
         /// </summary>
         /// <param name="graphicsDevice">The graphics device.</param>
+        /// <param name="type">
+        /// The data type.
+        /// Must be a value type which implements the <see cref="IVertexType"/> interface.
+        /// </param>
         /// <param name="vertexCount">The number of vertices.</param>
         /// <param name="bufferUsage">Behavior options.</param>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice"/> is <see langword="null"/></exception>


### PR DESCRIPTION
### Description of Change

This PR fixes a few missed/broken lines in documentation:
1) `ContentManager`:
- Added an empty docline for `serviceProvider` to suppress a warning related to using `<inheritdoc>`. [This is a Roslyn bug](https://github.com/dotnet/roslyn/issues/40325).
- Fixed links to SoundEffect and Song that could not be resolved.
2) `IGraphicsDeviceService` - fixed ambiguous reference to `Reset` method.
3) `VertexBuffer` - restored docline for `type` which was accidently removed in https://github.com/MonoGame/MonoGame/commit/d9c074d28491b5f20e44aae80be1fcbef0c64f0b.

## Reference:

[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)


