### PR TITLE
Fix MacOS Content directory location.

### DIFF
--- a/MonoGame.Framework/Platform/TitleContainer.Desktop.cs
+++ b/MonoGame.Framework/Platform/TitleContainer.Desktop.cs
@@ -16,8 +16,11 @@ namespace Microsoft.Xna.Framework
 #if DESKTOPGL
             // Check for the package Resources Folder first. This is where the assets
             // will be bundled.
-            if (CurrentPlatform.OS == OS.MacOSX)
+            if (CurrentPlatform.OS == OS.MacOSX) {
                 Location = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "..", "Resources");
+                if (!Directory.Exists (Location))
+                    Location = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "..", "..", "Resources");
+            }
             if (!Directory.Exists (Location))
 #endif
             Location = AppDomain.CurrentDomain.BaseDirectory;


### PR DESCRIPTION
According to the docs [1] we now have the arm64 and x64 platforms in a MacOS app bundle are now in their own subdirectories.

The problem is our code in the TitleContainer assumes the `Resources` directory is only one level above the `MacOS` directory.

```
Contents/
       MacOS/
       Resources/
```

However with the new platform specific code the recommendation is to place the arm64 and x64 code in their own folders.

```
Contents/
       MacOS/
          arm64/
          amd64/
       Resources/
```

The means that we can never find the `Resources` directory and it defaults to the current directory. Which will cause a crash.

So lets add another backup path check to handle this situation.

[1] https://docs.monogame.net/articles/getting_started/packaging_games.html?tabs=macos





