### PR TITLE
Fixed Matrix.GetHashCode() implementation

### DIFF
--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -1674,7 +1674,9 @@ namespace Microsoft.Xna.Framework
         /// <returns>Hash code of this <see cref="Matrix"/>.</returns>
         public override int GetHashCode()
         {
-            return (((((((((((((((this.M11.GetHashCode() + this.M12.GetHashCode()) + this.M13.GetHashCode()) + this.M14.GetHashCode()) + this.M21.GetHashCode()) + this.M22.GetHashCode()) + this.M23.GetHashCode()) + this.M24.GetHashCode()) + this.M31.GetHashCode()) + this.M32.GetHashCode()) + this.M33.GetHashCode()) + this.M34.GetHashCode()) + this.M41.GetHashCode()) + this.M42.GetHashCode()) + this.M43.GetHashCode()) + this.M44.GetHashCode());
+            int h1 = HashCode.Combine(M11, M12, M13, M14, M21, M22, M23, M24);
+            int h2 = HashCode.Combine(M31, M32, M33, M34, M41, M42, M43, M44);
+            return HashCode.Combine(h1, h2);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -1670,7 +1670,42 @@ namespace Microsoft.Xna.Framework
         /// <returns>Hash code of this <see cref="Matrix"/>.</returns>
         public override int GetHashCode()
         {
-            return (((((((((((((((this.M11.GetHashCode() + this.M12.GetHashCode()) + this.M13.GetHashCode()) + this.M14.GetHashCode()) + this.M21.GetHashCode()) + this.M22.GetHashCode()) + this.M23.GetHashCode()) + this.M24.GetHashCode()) + this.M31.GetHashCode()) + this.M32.GetHashCode()) + this.M33.GetHashCode()) + this.M34.GetHashCode()) + this.M41.GetHashCode()) + this.M42.GetHashCode()) + this.M43.GetHashCode()) + this.M44.GetHashCode());
+            unchecked
+            {
+                int hash1 = 17;
+                int hash2 = 17;
+                int hash3 = 17;
+                int hash4 = 17;
+
+                hash1 = hash1 * 31 + M11.GetHashCode();
+                hash2 = hash2 * 31 + M12.GetHashCode();
+                hash3 = hash3 * 31 + M13.GetHashCode();
+                hash4 = hash4 * 31 + M14.GetHashCode();
+
+                hash1 = hash1 * 31 + M21.GetHashCode();
+                hash2 = hash2 * 31 + M22.GetHashCode();
+                hash3 = hash3 * 31 + M23.GetHashCode();
+                hash4 = hash4 * 31 + M24.GetHashCode();
+
+                hash1 = hash1 * 31 + M31.GetHashCode();
+                hash2 = hash2 * 31 + M32.GetHashCode();
+                hash3 = hash3 * 31 + M33.GetHashCode();
+                hash4 = hash4 * 31 + M34.GetHashCode();
+
+                hash1 = hash1 * 31 + M41.GetHashCode();
+                hash2 = hash2 * 31 + M42.GetHashCode();
+                hash3 = hash3 * 31 + M43.GetHashCode();
+                hash4 = hash4 * 31 + M44.GetHashCode();
+
+                int mix = 17;
+
+                mix = mix * 31 + hash1;
+                mix = mix * 31 + hash2;
+                mix = mix * 31 + hash3;
+                mix = mix * 31 + hash4;
+
+                return mix;
+            }
         }
 
         /// <summary>

--- a/Tests/Framework/MatrixTest.cs
+++ b/Tests/Framework/MatrixTest.cs
@@ -8,13 +8,24 @@ namespace MonoGame.Tests.Framework
         [Test]
         public void Add()
         {
-            Matrix test = new Matrix(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
-            Matrix expected = new Matrix(2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32);
+            Matrix test = new Matrix(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+            Matrix expected = new Matrix(2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32);
             Matrix result;
-            Matrix.Add(ref test,ref test, out result);
+            Matrix.Add(ref test, ref test, out result);
             Assert.AreEqual(expected, result);
-            Assert.AreEqual(expected, Matrix.Add(test,test));
-            Assert.AreEqual(expected, test+test);
+            Assert.AreEqual(expected, Matrix.Add(test, test));
+            Assert.AreEqual(expected, test + test);
+        }
+
+        [Test]
+        public void GetHashCodeNotCommutative()
+        {
+            Matrix test = new Matrix(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+            int initalHashCode = test.GetHashCode();
+            (test.M11, test.M12) = (test.M12, test.M11);
+            int newHashCode = test.GetHashCode();
+
+            Assert.AreNotEqual(initalHashCode, newHashCode);
         }
     }
 }


### PR DESCRIPTION
The current `Matrix.GetHashCode()` uses addition to combine the hash codes of the float fields. This could easily lead to collisions, such as when just swapping two members of a matrix.
```csharp
//example
Matrix m1 = Matrix.Identity;
Matrix m2 = Matrix.Identity;

(m1.M11, m1.M12) = (m1.M12, m1.M11);

Debug.WriteLine(m1.GetHashCode());//these two return the same value
Debug.WriteLine(m2.GetHashCode());
Debug.WriteLine(m1 == m2);//False
```

To fix this, the only change was to use `HashCode.Combine()` to combine the hashcodes.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.