### PR TITLE
Add Self Hosted Runner for Tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
         run: dotnet run --project build/Build.csproj -- --target=Default
 
       - name: Test
-        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 1m -c Release --filter="TestCategory!=Audio & TestCategory!=Effects"
+        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 1m -c Release --filter="TestCategory!=Audio"
         env:
           DOTNET_ROOT: ${{github.workspace}}/dotnet64
           MGFXC_WINE_PATH: /home/runner/.winemonogame
@@ -83,7 +83,7 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Test
-        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 1m -c Release --filter="TestCategory!=Audio & TestCategory!=Effects"
+        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 1m -c Release --filter="TestCategory!=Audio"
         env:
           DOTNET_ROOT: ${{github.workspace}}/dotnet64
           MGFXC_WINE_PATH: /Users/runner/.winemonogame

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Setup Wine 
-        run: wget -qO- https://monogame.net/downloads/net8_mgfxc_wine_setup.sh | bash
+        run: wget -qO- https://monogame.net/downloads/net9_mgfxc_wine_setup.sh | bash
         if: runner.os != 'Windows'
 
       - name: Install required workloads
@@ -75,7 +75,7 @@ jobs:
         run: dotnet run --project build/Build.csproj -- --target=Default
 
       - name: Test
-        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 1m -c Release
+        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 1m -c Release --filter="TestCategory!=Audio & TestCategory!=Effects"
         env:
           DOTNET_ROOT: ${{github.workspace}}/dotnet64
           MGFXC_WINE_PATH: /home/runner/.winemonogame
@@ -83,7 +83,7 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Test
-        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 1m -c Release
+        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 1m -c Release --filter="TestCategory!=Audio & TestCategory!=Effects"
         env:
           DOTNET_ROOT: ${{github.workspace}}/dotnet64
           MGFXC_WINE_PATH: /Users/runner/.winemonogame
@@ -141,3 +141,291 @@ jobs:
               artifacts: "nugets/*.nupkg"
               token: ${{ secrets.GITHUB_TOKEN }}
 
+  tests:
+    name: tests-${{ matrix.os }}
+    needs: [ build ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows
+            platform: windows
+          - os: macos
+            platform: macos
+          - os: ubuntu-latest
+            platform: linux
+            filter: --where="Category != Audio"
+          # - os: linux
+          #   platform: linux
+      fail-fast: false
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: install wine64 on linux
+        run: |
+          sudo apt install p7zip-full curl
+          sudo dpkg --add-architecture i386 
+          sudo mkdir -pm755 /etc/apt/keyrings
+          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
+          sudo apt update && sudo apt install --install-recommends winehq-stable
+        if: runner.os == 'Linux' && runner.environment == 'github-hosted'
+
+      - name: Install Arial Font
+        run: |
+          echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | sudo debconf-set-selections
+          sudo apt install -y ttf-mscorefonts-installer
+          sudo fc-cache
+          fc-match Arial
+        if: runner.os == 'Linux' && runner.environment == 'github-hosted'
+
+      - name: Setup Wine 
+        run: wget -qO- https://monogame.net/downloads/net9_mgfxc_wine_setup.sh | bash
+        if: runner.os != 'Windows' && runner.environment == 'github-hosted'
+
+      - name: Download tests-tools-${{ matrix.platform }}
+        uses: actions/download-artifact@v3
+        with:
+          name: tests-tools-${{ matrix.platform }}
+          path: tests-tools
+
+      - name: Download tests-desktopgl-${{ matrix.platform }}
+        uses: actions/download-artifact@v3
+        with:
+          name: tests-desktopgl-${{ matrix.platform }}
+          path: tests-desktopgl
+          
+      - name: Download tests-windowsdx-${{ matrix.platform }}
+        uses: actions/download-artifact@v3
+        with:
+          name: tests-windowsdx-${{ matrix.platform }}
+          path: tests-windowsdx
+        if: runner.os == 'Windows'
+
+      - name: Install Tools
+        run: |
+          dotnet tool install --create-manifest-if-needed mgcb-basisu
+          dotnet tool install --create-manifest-if-needed mgcb-crunch
+
+      - name: Run Tools Tests
+        run: dotnet test tests-tools/MonoGame.Tools.Tests.dll --blame-hang-timeout 1m --filter="TestCategory!=Effects"
+        env:
+          CI: true
+
+      - name: Run DirectX Tests
+        shell: cmd
+        run: dotnet MonoGame.Tests.dll
+        env:
+          CI: true
+        working-directory: tests-windowsdx
+        if: runner.os == 'Windows'
+
+      # Run the DesktopGL tests on all platforms using NUnitLite runner not dotnet test
+      # We have to run this is bits because the tests crash if too many are run in one go?
+      - name: Run Framework Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Framework ${{matrix.filter}}
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+
+      - name: Run Audio Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Audio
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Input Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Input
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+
+      - name: Run Visual Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Visual
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+
+      - name: Run Game Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --where="Category = GameTest"
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+
+      - name: Run Graphics.BlendStateTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.BlendStateTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.DepthStencilStateTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.DepthStencilStateTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.EffectTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.EffectTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.GraphicsAdapterTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.GraphicsAdapterTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      # This test hangs on MacOS?
+      # - name: Run Graphics.GraphicsDeviceTest Tests
+      #   run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.GraphicsDeviceTest
+      #   env:
+      #     CI: true
+      #   working-directory: tests-desktopgl
+      #   if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.IndexBufferTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.IndexBufferTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.MiscellaneousTests Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.MiscellaneousTests
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.ModelTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.ModelTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.OcclusionQueryTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.OcclusionQueryTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.RasterizerStateTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.RasterizerStateTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.RenderTarget2DTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.RenderTarget2DTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.RenderTargetCubeTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.RenderTargetCubeTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.SamplerStateTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.SamplerStateTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.ScissorRectangleTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.ScissorRectangleTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.ShaderTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.ShaderTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.SpriteBatchTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.SpriteBatchTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.SpriteFontTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.SpriteFontTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.Texture2DNonVisualTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.Texture2DNonVisualTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.Texture2DTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.Texture2DTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.Texture3DNonVisualTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.Texture3DNonVisualTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.Texture3DTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.Texture3DTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.TextureCubeTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.TextureCubeTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.VertexBufferTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.VertexBufferTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'
+
+      - name: Run Graphics.ViewportTest Tests
+        run: dotnet MonoGame.Tests.dll --timeout=300000 --test MonoGame.Tests.Graphics.ViewportTest
+        env:
+          CI: true
+        working-directory: tests-desktopgl
+        if: runner.environment != 'github-hosted'

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ project.lock.json
 /MonoGame.Framework/MonoGame.Framework.Net.WindowsUniversal.project.lock.json
 /MonoGame.Framework/MonoGame.Framework.WindowsUniversal.project.lock.json
 artifacts/
+Artifacts/
 
 # JetBrains Rider
 .idea/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,20 @@
             "type": "coreclr",
             "request": "attach",
             "processId": "${input.processid}",
-        }
+        },
+        {
+            "name": "MonoGame.Tests",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-tests",
+            "program": "${workspaceFolder}/Artifacts/Tests/DesktopGL/Debug/MonoGame.Tests",
+            "args": [
+                "--test=MonoGame.Tests.Graphics.SpriteBatchTest.Draw_normal"
+            ],
+            "cwd": "${workspaceFolder}/Artifacts/Tests/DesktopGL/Debug/",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
     ],
     "inputs": [
         {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "dotnetCoreExplorer.searchpatterns": [
+        "Artifacts/Tests/**/MonoGame.Tests.dll",
+        "Artifacts/Tests/**/MonoGame.Tools.Tests.dll"
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,6 +12,18 @@
                 "/consoleloggerparameters:NoSummary"
             ],
             "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build-tests",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Tests/MonoGame.Tests.DesktopGL.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
@@ -99,10 +99,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         private static uint Pack(float x, float y, float z, float w)
         {
-            var byte4 = (((uint) MathF.Round(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) & 0xff) << 0;
-            var byte3 = (((uint) MathF.Round(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) & 0xff) << 8;
-            var byte2 = (((uint) MathF.Round(MathHelper.Clamp(z, -1.0f, 1.0f) * 127.0f)) & 0xff) << 16;
-            var byte1 = (((uint) MathF.Round(MathHelper.Clamp(w, -1.0f, 1.0f) * 127.0f)) & 0xff) << 24;
+            var byte4 = (uint)(((int) MathF.Round(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) & 0xff) << 0;
+            var byte3 = (uint)(((int) MathF.Round(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) & 0xff) << 8;
+            var byte2 = (uint)(((int) MathF.Round(MathHelper.Clamp(z, -1.0f, 1.0f) * 127.0f)) & 0xff) << 16;
+            var byte1 = (uint)(((int) MathF.Round(MathHelper.Clamp(w, -1.0f, 1.0f) * 127.0f)) & 0xff) << 24;
 
             return byte4 | byte3 | byte2 | byte1;
         }

--- a/MonoGame.Framework/Graphics/PackedVector/Short2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short2.cs
@@ -115,8 +115,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			const float minNeg = ~(int)maxPos; // two's complement
 
             // clamp the value between min and max values
-            var word2 = ((uint) MathF.Round(MathHelper.Clamp(vectorX, minNeg, maxPos)) & 0xFFFF);
-            var word1 = (((uint) MathF.Round(MathHelper.Clamp(vectorY, minNeg, maxPos)) & 0xFFFF) << 0x10);
+            var word2 = (uint)((int) MathF.Round(MathHelper.Clamp(vectorX, minNeg, maxPos)) & 0xFFFF);
+            var word1 = (uint)(((int) MathF.Round(MathHelper.Clamp(vectorY, minNeg, maxPos)) & 0xFFFF) << 0x10);
 
             return (word2 | word1);
 		}

--- a/MonoGame.Framework/Platform/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Platform/Audio/OALSoundBuffer.cs
@@ -67,7 +67,11 @@ namespace Microsoft.Xna.Framework.Audio
             ALHelper.CheckError("Failed to get buffer channels");
             AL.GetBuffer(openALDataBuffer, ALGetBufferi.Size, out unpackedSize);
             ALHelper.CheckError("Failed to get buffer size");
-            Duration = (float)(unpackedSize / ((bits / 8) * channels)) / (float)sampleRate;
+            if (format == ALFormat.MonoMSAdpcm || format == ALFormat.StereoMSAdpcm) {
+                Duration = (float)(unpackedSize * 2) / (channels * sampleRate);;
+            } else {
+                Duration = (float)(unpackedSize * 8) / (channels * bits * sampleRate);
+            }
         }
 
 		public void Dispose()

--- a/Tests/Assets/Projects/BuildSimpleProject.csproj
+++ b/Tests/Assets/Projects/BuildSimpleProject.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\..\..\..\Tools\MonoGame.Content.Builder.Task\MonoGame.Content.Builder.Task.props" />
+  <Import Project="../../MonoGame.Content.Builder.Task.props" Condition="Exists('../../MonoGame.Content.Builder.Task.props')" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
@@ -12,5 +12,5 @@
   <ItemGroup>
     <MonoGameContentReference Include="Content\Content.mgcb" />
   </ItemGroup>
-  <Import Project="..\..\..\..\..\..\Tools\MonoGame.Content.Builder.Task\MonoGame.Content.Builder.Task.targets" />
+  <Import Project="../../MonoGame.Content.Builder.Task.targets" Condition="Exists('../../MonoGame.Content.Builder.Task.targets')" />
 </Project>

--- a/Tests/Framework/Audio/DynamicSoundEffectInstanceTest.cs
+++ b/Tests/Framework/Audio/DynamicSoundEffectInstanceTest.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 
 namespace MonoGame.Tests.Audio
 {
+    [Category("Audio")]
     class DynamicSoundEffectInstanceTest
     {
         [SetUp]

--- a/Tests/Framework/Audio/SoundEffectInstanceTest.cs
+++ b/Tests/Framework/Audio/SoundEffectInstanceTest.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 
 namespace MonoGame.Tests.Audio
 {
+    [Category("Audio")]
     class SoundEffectInstanceTest
     {
         [SetUp]

--- a/Tests/Framework/Audio/SoundEffectTest.cs
+++ b/Tests/Framework/Audio/SoundEffectTest.cs
@@ -12,6 +12,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Tests.Audio
 {
+    [Category("Audio")]
     public class SoundEffectTests
     {
         [SetUp]

--- a/Tests/Framework/Audio/XactTest.cs
+++ b/Tests/Framework/Audio/XactTest.cs
@@ -12,7 +12,9 @@ using Microsoft.Xna.Framework;
 
 namespace MonoGame.Tests.Audio
 {
+
     [TestFixture]
+    [Category("Audio")]
     public class XactTests
     {
         private AudioEngine _audioEngine;
@@ -353,6 +355,30 @@ namespace MonoGame.Tests.Audio
             Assert.Throws<IndexOutOfRangeException>(() => cue.SetVariable("Cue Private", 1.0f));
 
             cue.Dispose();
+        }
+
+        [Test]
+        public void WaveBankPlays()
+        {
+            var waveBank = new WaveBank(_audioEngine, @"Assets\Audio\Win\Tests.xwb");
+            Assert.False(waveBank.IsInUse);
+            Assert.False(waveBank.IsDisposed);
+            Assert.True(waveBank.IsPrepared);
+
+            var sei = _soundBank.GetSoundEffectInstance (0, 0, out bool streaming);
+            sei.Play ();
+            Assert.True(sei.State == SoundState.Playing);
+            sei = _soundBank.GetSoundEffectInstance (0, 1, out streaming);
+            sei.Play ();
+            Assert.True(sei.State == SoundState.Playing);
+            sei = _soundBank.GetSoundEffectInstance (0, 2, out streaming);
+            sei.Play ();
+            Assert.True(sei.State == SoundState.Playing);
+
+            waveBank.Dispose();
+            Assert.True(waveBank.IsDisposed);
+            Assert.False(waveBank.IsInUse);
+            Assert.False(waveBank.IsPrepared);
         }
 
         private void SleepWhileAudioEngineUpdates(int ms)

--- a/Tests/Framework/FrameworkDispatcherTest.cs
+++ b/Tests/Framework/FrameworkDispatcherTest.cs
@@ -54,6 +54,7 @@ namespace MonoGame.Tests.Framework
 
 #if !XNA
         [Test]
+        [Category ("Audio")]
         public void UpdatesSoundEffectInstancePool()
         {
             FrameworkDispatcher.Update();

--- a/Tests/Framework/GameTest+Methods.cs
+++ b/Tests/Framework/GameTest+Methods.cs
@@ -13,6 +13,7 @@ namespace MonoGame.Tests {
 	partial class GameTest {
 		public static class Methods {
 			[TestFixture]
+			[Category("GameTest")]
 			public class Run : FixtureBase {
 				[Test, Ignore("Fix me!")]
 				public void Can_only_be_called_once ()

--- a/Tests/Framework/GameTest+Properties.cs
+++ b/Tests/Framework/GameTest+Properties.cs
@@ -23,6 +23,7 @@ namespace MonoGame.Tests
 		public static class Properties 
         {
 			[TestFixture]
+			[Category("GameTest")]
 			public class Components : ReadOnlyPropertyFixtureBase<GameComponentCollection> 
             {
 				public Components ()
@@ -39,6 +40,7 @@ namespace MonoGame.Tests
 			}
 
 			[TestFixture]
+			[Category("GameTest")]
 			public class Content : ReadWritePropertyFixtureBase<ContentManager> {
 				public Content ()
 					: base (g => g.Content)
@@ -70,6 +72,7 @@ namespace MonoGame.Tests
 			}
 
 			[TestFixture]
+			[Category("GameTest")]
 			public class GraphicsDevice_ : ReadOnlyPropertyFixtureBase<GraphicsDevice> {
 				public GraphicsDevice_ ()
 					: base (g => g.GraphicsDevice)
@@ -118,6 +121,7 @@ namespace MonoGame.Tests
 			}
 
 			[TestFixture]
+			[Category("GameTest")]
 			public class InactiveSleepTime : ReadWritePropertyFixtureBase<TimeSpan> {
 				public InactiveSleepTime ()
 					: base (g => g.InactiveSleepTime)
@@ -135,6 +139,7 @@ namespace MonoGame.Tests
 			}
 
 			[TestFixture]
+			[Category("GameTest")]
 			public class IsActive : ReadOnlyPropertyFixtureBase<bool> {
 				public IsActive ()
 					: base (g => g.IsActive)
@@ -144,6 +149,7 @@ namespace MonoGame.Tests
 			}
 
 			[TestFixture]
+			[Category("GameTest")]
 			public class IsFixedTimeStep : ReadWritePropertyFixtureBase<bool> {
 				public IsFixedTimeStep ()
 					: base (g => g.IsFixedTimeStep)
@@ -158,6 +164,7 @@ namespace MonoGame.Tests
 			}
 
 			[TestFixture]
+			[Category("GameTest")]
 			public class IsMouseVisible : ReadWritePropertyFixtureBase<bool> {
 				public IsMouseVisible ()
 					: base (g => g.IsMouseVisible)
@@ -172,6 +179,7 @@ namespace MonoGame.Tests
 			}
 
 			[TestFixture]
+			[Category("GameTest")]
 			public class LaunchParameters_ : ReadOnlyPropertyFixtureBase<LaunchParameters> {
 				public LaunchParameters_ ()
 					: base (g => g.LaunchParameters)
@@ -187,6 +195,7 @@ namespace MonoGame.Tests
 			}
 
 			[TestFixture]
+			[Category("GameTest")]
 			public class Services : ReadOnlyPropertyFixtureBase<GameServiceContainer> {
 				public Services ()
 					: base (g => g.Services)
@@ -202,6 +211,7 @@ namespace MonoGame.Tests
 			}
 
 			[TestFixture]
+			[Category("GameTest")]
 			public class TargetElapsedTime : ReadWritePropertyFixtureBase<TimeSpan> {
 				public TargetElapsedTime ()
 					: base (g => g.TargetElapsedTime)
@@ -218,6 +228,7 @@ namespace MonoGame.Tests
 			}
 
 			[TestFixture]
+			[Category("GameTest")]
 			public class Window : ReadOnlyPropertyFixtureBase<GameWindow> {
 				public Window ()
 					: base (g => g.Window)

--- a/Tests/Framework/GameTest.cs
+++ b/Tests/Framework/GameTest.cs
@@ -36,6 +36,7 @@ namespace MonoGame.Tests {
 		}
 
 		[TestFixture]
+		[Category("GameTest")]
 		public class Disposal : FixtureBase {
 			[TestCase ("Components")]
 			[TestCase ("Content")]
@@ -130,6 +131,7 @@ namespace MonoGame.Tests {
 		}
 
 		[TestFixture]
+		[Category("GameTest")]
 		public class Behaviors : FixtureBase {
 			[Test, Ignore("Fix me!")]
 			public void Nongraphical_run_succeeds ()
@@ -176,6 +178,7 @@ namespace MonoGame.Tests {
         }
 
         [TestFixture]
+		[Category("GameTest")]
         public class Misc
         {
             [Test]

--- a/Tests/Framework/Graphics/BlendStateTest.cs
+++ b/Tests/Framework/Graphics/BlendStateTest.cs
@@ -10,15 +10,18 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     internal class BlendStateTest : GraphicsDeviceTestFixtureBase
     {
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToSetNullBlendState()
         {
             Assert.Throws<ArgumentNullException>(() => game.GraphicsDevice.BlendState = null);
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToMutateStateObjectAfterBindingToGraphicsDevice()
         {
             var blendState = new BlendState();
@@ -38,6 +41,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToMutateDefaultStateObjects()
         {
             DoAsserts(BlendState.Additive, d => Assert.Throws<InvalidOperationException>(d));
@@ -83,6 +87,7 @@ namespace MonoGame.Tests.Graphics
 #if DESKTOPGL
         [Ignore("Fails similarity test. Needs Investigating")]
 #endif
+        [RunOnUI]
         public void VisualTests()
         {
             var blends = new[]

--- a/Tests/Framework/Graphics/DepthStencilStateTest.cs
+++ b/Tests/Framework/Graphics/DepthStencilStateTest.cs
@@ -11,15 +11,18 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     internal class DepthStencilStateTest : GraphicsDeviceTestFixtureBase
     {
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToSetNullDepthStencilState()
         {
             Assert.Throws<ArgumentNullException>(() => gd.DepthStencilState = null);
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToMutateStateObjectAfterBindingToGraphicsDevice()
         {
             var depthStencilState = new DepthStencilState();
@@ -39,6 +42,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToMutateDefaultStateObjects()
         {
             DoAsserts(DepthStencilState.Default, d => Assert.Throws<InvalidOperationException>(d));
@@ -68,6 +72,7 @@ namespace MonoGame.Tests.Graphics
 
         [TestCase(false)]
         [TestCase(true)]
+        [RunOnUI]
         public void VisualTestDepthBufferEnable(bool depthBufferEnable)
         {
             PrepareFrameCapture();
@@ -95,6 +100,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void VisualTestStencilBuffer()
         {
             PrepareFrameCapture();

--- a/Tests/Framework/Graphics/EffectTest.cs
+++ b/Tests/Framework/Graphics/EffectTest.cs
@@ -9,9 +9,11 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     internal class EffectTest : GraphicsDeviceTestFixtureBase
     {
         [Test]
+        [RunOnUI]
         public void EffectConstructorShouldAllowIndexAndCount()
         {
             byte[] mgfxo = EffectResource.BasicEffect.Bytecode;
@@ -24,6 +26,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void EffectPassShouldSetTexture()
         {
             var texture = new Texture2D(game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
@@ -45,6 +48,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void EffectPassShouldSetTextureOnSubsequentCalls()
         {
             var texture = new Texture2D(game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
@@ -73,6 +77,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void EffectPassShouldSetTextureEvenIfNull()
         {
             var texture = new Texture2D(game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
@@ -94,6 +99,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void EffectPassShouldOverrideTextureIfNotExplicitlySet()
         {
             var texture = new Texture2D(game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
@@ -117,6 +123,7 @@ namespace MonoGame.Tests.Graphics
 #if DESKTOPGL
         [Ignore("Fails under OpenGL!")]
 #endif
+        [RunOnUI]
         public void EffectParameterShouldBeSetIfSetByNameAndGetByIndex()
         {
             // This relies on the parameters permanently being on the same index.

--- a/Tests/Framework/Graphics/GraphicsAdapterTest.cs
+++ b/Tests/Framework/Graphics/GraphicsAdapterTest.cs
@@ -7,15 +7,15 @@ using System.Linq;
 using Microsoft.Xna.Framework.Graphics;
 using NUnit.Framework;
 
+namespace MonoGame.Tests.Graphics
+{
+    [TestFixture]
+    class GraphicsAdapterTest
+    {
 // HACK: Only enable for XNA and DirectX which are the 
 // only platforms which currently correctly implement 
 // the GraphicsAdapter API.
 #if XNA || DIRECTX
-
-namespace MonoGame.Tests.Graphics
-{
-    class GraphicsAdapterTest
-    {
         private static bool Equals(DisplayMode m1, DisplayMode m2)
         {
             return m1.Width == m2.Width &&
@@ -138,7 +138,8 @@ namespace MonoGame.Tests.Graphics
             Assert.AreEqual(selectedDepthFormat, DepthFormat.None);
             Assert.AreEqual(selectedMultiSampleCount, 0);
         }
+#endif // XNA || DIRECTX
     }
 }
 
-#endif // XNA || DIRECTX
+

--- a/Tests/Framework/Graphics/GraphicsDeviceManagerTest.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceManagerTest.cs
@@ -10,9 +10,11 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     internal class GraphicsDeviceManagerTest
     {
         [Test]
+        [RunOnUI]
         public void DefaultParameterValidation()
         {
             var game = new Game();
@@ -37,6 +39,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void InitializeEventCount()
         {
             var game = new TestGameBase();
@@ -72,6 +75,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void DoNotModifyPresentationParametersDirectly()
         {
             var game = new TestGameBase();
@@ -93,6 +97,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void PreparingDeviceSettings()
         {
             var game = new TestGameBase();
@@ -131,6 +136,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void PreparingDeviceSettingsEventChangeGraphicsProfile()
         {
             var game = new TestGameBase();
@@ -169,6 +175,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void PreparingDeviceSettingsArgsPresentationParametersAreApplied()
         {
             var game = new TestGameBase();
@@ -202,6 +209,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void PreparingDeviceSettingsArgsThrowsWhenPPSetToNull()
         {
             var game = new TestGameBase();
@@ -222,6 +230,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ApplyChangesReturnsWhenNoSetterCalled()
         {
             var game = new TestGameBase();
@@ -252,6 +261,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ApplyChangesInvokesPreparingDeviceSettings()
         {
             var game = new TestGameBase();
@@ -277,6 +287,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ApplyChangesResetsDevice()
         {
             var game = new TestGameBase();
@@ -296,6 +307,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void DeviceDisposingInvokedAfterDeviceDisposed()
         {
             var game = new TestGameBase();
@@ -326,6 +338,7 @@ namespace MonoGame.Tests.Graphics
     internal class GraphicsDeviceManagerFixtureTest : GraphicsDeviceTestFixtureBase
     {
         [Test]
+        [RunOnUI]
         public void ResettingDeviceTriggersResetEvents()
         {
             var resetCount = 0;
@@ -347,6 +360,7 @@ namespace MonoGame.Tests.Graphics
         }
         
         [Test]
+        [RunOnUI]
         public void NewDeviceDoesNotTriggerReset()
         {
             var resetCount = 0;
@@ -370,6 +384,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ClientSizeChangedOnDeviceReset()
         {
             var count = 0;
@@ -396,6 +411,7 @@ namespace MonoGame.Tests.Graphics
 #if DESKTOPGL
         [Ignore("Expected 2 but got 3. Needs Investigating")]
 #endif
+        [RunOnUI]
         public void MultiSampleCountRoundsDown()
         {
             gdm.PreferMultiSampling = true;
@@ -412,11 +428,13 @@ namespace MonoGame.Tests.Graphics
 
         }
 
+        [Test]
         [TestCase(false)]
         [TestCase(true)]
 #if DESKTOPGL
         [Ignore("Expected not 1024 but got 1024. Needs Investigating")]
 #endif
+        [RunOnUI]
         public void MSAAEnabled(bool enabled)
         {
             gdm.PreferMultiSampling = enabled;
@@ -492,6 +510,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void UnsupportedMultiSampleCountDoesNotThrowException()
         {
             gdm.PreferMultiSampling = true;
@@ -513,6 +532,7 @@ namespace MonoGame.Tests.Graphics
 
 #if DIRECTX
         [Test]
+        [RunOnUI]
         public void TooHighMultiSampleCountClampedToMaxSupported()
         {
             var maxMultiSampleCount = gd.GraphicsCapabilities.MaxMultiSampleCount;

--- a/Tests/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceTest.cs
@@ -15,9 +15,11 @@ using MonoGame.OpenGL;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     internal class GraphicsDeviceTest : GraphicsDeviceTestFixtureBase
     {
         [Test]
+        [RunOnUI]
         public void BlendFactor()
         {
             Assert.AreEqual(Color.White, gd.BlendFactor);
@@ -38,6 +40,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void CtorAdapterNull()
         {
             Assert.Throws<ArgumentNullException>(
@@ -45,6 +48,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void CtorPresentationParametersNull()
         {
             Assert.Throws<ArgumentNullException>(
@@ -52,6 +56,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void DisposedWhenDisposingInvoked()
         {
             var count = 0;
@@ -71,6 +76,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ResetDoesNotTriggerDeviceLost()
         {
             // TODO figure out exactly when a device is lost
@@ -96,6 +102,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ResetDoesNotClearState()
         {
             gd.RasterizerState = RasterizerState.CullNone;
@@ -119,6 +126,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test, Ignore("Make sure dynamic graphics resources are notified when graphics device is lost")]
+        [RunOnUI]
         public void ContentLostResources()
         {
             // https://blogs.msdn.microsoft.com/shawnhar/2007/12/12/virtualizing-the-graphicsdevice-in-xna-game-studio-2-0/
@@ -152,12 +160,14 @@ namespace MonoGame.Tests.Graphics
 #if DESKTOPGL
         [Ignore("Does not throw the exception. Needs Investigating")]
 #endif
+        [RunOnUI]
         public void ResetWindowHandleNullThrowsException()
         {
             Assert.Throws<ArgumentException>(() => gd.Reset(new PresentationParameters()));
         }
 
 		[Test]
+        [RunOnUI]
 		public void Clear()
 		{
 			var colors = new Color [] {
@@ -182,6 +192,7 @@ namespace MonoGame.Tests.Graphics
 		}
 
         [Test]
+        [RunOnUI]
         public void DrawPrimitivesParameterValidation()
         {
             var vertexBuffer = new VertexBuffer(
@@ -216,6 +227,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void DrawIndexedPrimitivesParameterValidation()
         {
             var vertexBuffer = new VertexBuffer(
@@ -276,6 +288,7 @@ namespace MonoGame.Tests.Graphics
         // This overload of DrawIndexedPrimitives is not supported on XNA.
 #if !XNA
         [Test]
+        [RunOnUI]
         public void DrawIndexedPrimitivesParameterValidation2()
         {
             var vertexBuffer = new VertexBuffer(
@@ -327,6 +340,7 @@ namespace MonoGame.Tests.Graphics
 
 #if XNA || DIRECTX
         [Test]
+        [RunOnUI]
         public void DrawInstancedPrimitivesParameterValidation()
         {
             var vertexBuffer = new VertexBuffer(
@@ -377,6 +391,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void DrawInstancedPrimitivesVisualTest()
         {
             VertexBuffer vertexBuffer = null;
@@ -456,6 +471,7 @@ namespace MonoGame.Tests.Graphics
 #endif
 
         [Test]
+        [RunOnUI]
         public void DrawUserPrimitivesParameterValidation()
         {
             var vertexDataNonEmpty = new[]
@@ -505,6 +521,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void DrawUserIndexedPrimitivesParameterValidation()
         {
             var vertexDataNonEmpty = new[]
@@ -597,6 +614,7 @@ namespace MonoGame.Tests.Graphics
 #if DESKTOPGL
         [Ignore("Vertex Textures are not implemented for OpenGL")]
 #endif
+        [RunOnUI]
         public void VertexTexturesGetSet()
         {
             // TODO: The availability of vertex textures should depend on GraphicsProfile.
@@ -650,6 +668,7 @@ namespace MonoGame.Tests.Graphics
 #if DESKTOPGL
         [Ignore("Vertex Textures are not implemented for OpenGL")]
 #endif
+        [RunOnUI]
         public void VertexTextureVisualTest()
         {
             // Implements an extremely simple terrain that reads from a heightmap in the vertex shader.
@@ -721,6 +740,7 @@ namespace MonoGame.Tests.Graphics
 #if DESKTOPGL
         [Ignore("Vertex samplers are not implemented for OpenGL")]
 #endif
+        [RunOnUI]
         public void VertexSamplerStatesGetSet()
         {
             var samplerState = new SamplerState { Filter = TextureFilter.Point };
@@ -733,6 +753,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void PresentInvalidOperationException()
         {
             // This should work else it means we had
@@ -754,6 +775,7 @@ namespace MonoGame.Tests.Graphics
 
 #if DESKTOPGL
         [Test]
+        [RunOnUI]
         public void DifferentVboGetsSet()
         {
             var vb1 = new VertexBuffer(gd, VertexPosition.VertexDeclaration, 6, BufferUsage.None);
@@ -790,7 +812,9 @@ namespace MonoGame.Tests.Graphics
             };
         }
 
+        [Test]
         [TestCaseSource("BackBufferRects")]
+        [RunOnUI]
         public void GetBackBufferData(Rectangle? rectangle)
         {
             gd.Clear(Color.CornflowerBlue);

--- a/Tests/Framework/Graphics/GraphicsDeviceTestFixtureBase.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceTestFixtureBase.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -13,6 +14,7 @@ using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Tests.Components;
 using MonoGame.Tests.Utilities;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 
 namespace MonoGame.Tests.Graphics
 {
@@ -162,7 +164,7 @@ namespace MonoGame.Tests.Graphics
             var referenceImageDirectory = Paths.ReferenceImage(folderName);
             var outputDirectory = Paths.CapturedFrame(folderName);
             var fileName = TestContext.CurrentContext.GetTestFrameFileNameFormat(_totalFramesExpected);
-            var capturedImagePath = Path.Combine(outputDirectory, fileName);
+            var capturedImagePath = Path.Combine(TestContext.CurrentContext.TestDirectory, outputDirectory, fileName);
             var referenceImagePath = Path.Combine(referenceImageDirectory, fileName);
             
             var allResults = new List<FrameComparisonResult>();

--- a/Tests/Framework/Graphics/IndexBufferTest.cs
+++ b/Tests/Framework/Graphics/IndexBufferTest.cs
@@ -9,9 +9,11 @@ using Microsoft.Xna.Framework.Graphics;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     class IndexBufferTest: GraphicsDeviceTestFixtureBase
     {
         [Test]
+        [RunOnUI]
         public void ShouldSetAndGetData()
         {   
             var savedData = new short[] { 1, 2, 3, 4 };
@@ -26,6 +28,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldSetAndGetData_elementCount()
         {
             var savedData = new short[] { 1, 2, 3, 4 };
@@ -43,6 +46,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldSetAndGetData_startIndex()
         {
             var savedData = new short[] { 1, 2, 3, 4 };
@@ -60,6 +64,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldSetAndGetData_offsetInBytes()
         {
             var savedData = new short[] { 1, 2, 3, 4 };
@@ -75,6 +80,7 @@ namespace MonoGame.Tests.Graphics
         }
         
         [Test]
+        [RunOnUI]
         public void NullDeviceShouldThrowArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => 

--- a/Tests/Framework/Graphics/MiscellaneousTests.cs
+++ b/Tests/Framework/Graphics/MiscellaneousTests.cs
@@ -3,9 +3,12 @@ using NUnit.Framework;
 
 namespace MonoGame.Tests.Graphics
 {
+    [TestFixture]
+    [NonParallelizable]
     internal class MiscellaneousTests : GraphicsDeviceTestFixtureBase
     {
         [Test]
+        [RunOnUI]
         public void Colored3DCube()
         {
             PrepareFrameCapture();

--- a/Tests/Framework/Graphics/ModelTest.cs
+++ b/Tests/Framework/Graphics/ModelTest.cs
@@ -13,6 +13,7 @@ namespace MonoGame.Tests.Graphics
 {
 
     [TestFixture]
+    [NonParallelizable]
     internal sealed class ModelTest : GraphicsDeviceTestFixtureBase
     {
         // model exported from default blender project.
@@ -32,6 +33,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldDrawSampleModel()
         {
             // model contains a bit more that only the cube, so let extract the cube
@@ -56,6 +58,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void MeshPartEffectReplacesOldOneOnParentModel()
         {
             // simple model used in test
@@ -72,6 +75,7 @@ namespace MonoGame.Tests.Graphics
 #if !XNA // Tests below are valid for Monogame only because of manual model creation.
 
         [Test]
+        [RunOnUI]
         public void ShouldConstructAndInitialize()
         {
             var actual = new Model(gd, new List<ModelBone>(), new List<ModelMesh>());
@@ -81,6 +85,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldNotConstructWhenParamsAreNotValid()
         {
             // simple empty collections to make code more readable.
@@ -94,6 +99,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldReadTransformationsFromBones()
         {
             var someBones = new[] { new ModelBone(), new ModelBone() }.ToList();
@@ -110,6 +116,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void CopyBoneTransformsFrom_Exceptions()
         {
             var someBones = new[] { new ModelBone() }.ToList();
@@ -120,6 +127,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void CopyBoneTransformsTo_Exceptions()
         {
             var someBones = new[] { new ModelBone() }.ToList();

--- a/Tests/Framework/Graphics/OcclusionQueryTest.cs
+++ b/Tests/Framework/Graphics/OcclusionQueryTest.cs
@@ -10,10 +10,12 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     internal class OcclusionQueryTest : GraphicsDeviceTestFixtureBase
     {
 
         [Test]
+        [RunOnUI]
         public void ConstructorsAndProperties()
         {
             Assert.Throws<ArgumentNullException>(() => new OcclusionQuery(null));
@@ -30,6 +32,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void MismatchedBeginEnd()
         {
             var occlusionQuery = new OcclusionQuery(gd);
@@ -43,6 +46,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void QueryOccludedSprites()
         {
             var spriteBatch = new SpriteBatch(gd);

--- a/Tests/Framework/Graphics/RasterizerStateTest.cs
+++ b/Tests/Framework/Graphics/RasterizerStateTest.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     internal class RasterizerStateTest : GraphicsDeviceTestFixtureBase
     {
         [TestCase(-1f)]
@@ -20,6 +21,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase(1f)]
 #endif
         [TestCase(-0.0004f)]
+        [RunOnUI]
         public void DepthBiasVisualTest(float depthBias)
         {
             var effect = new BasicEffect(gd)
@@ -65,12 +67,14 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToSetNullRasterizerState()
         {
             Assert.Throws<ArgumentNullException>(() => gd.RasterizerState = null);
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToMutateStateObjectAfterBindingToGraphicsDevice()
         {
             var rasterizerState = new RasterizerState();
@@ -90,6 +94,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToMutateDefaultStateObjects()
         {
             DoAsserts(RasterizerState.CullClockwise, d => Assert.Throws<InvalidOperationException>(d));
@@ -110,9 +115,11 @@ namespace MonoGame.Tests.Graphics
 #endif
         }
 
+        [Test]
         [TestCase(CullMode.CullClockwiseFace)]
         [TestCase(CullMode.CullCounterClockwiseFace)]
         [TestCase(CullMode.None)]
+        [RunOnUI]
         public void VisualTestCullMode(CullMode cullMode)
         {
             PrepareFrameCapture();
@@ -134,8 +141,10 @@ namespace MonoGame.Tests.Graphics
             rasterizerState.Dispose();
         }
 
+        [Test]
         [TestCase(FillMode.Solid)]
         [TestCase(FillMode.WireFrame)]
+        [RunOnUI]
         public void VisualTestFillMode(FillMode fillMode)
         {
             PrepareFrameCapture();
@@ -157,8 +166,10 @@ namespace MonoGame.Tests.Graphics
             rasterizerState.Dispose();
         }
 
+        [Test]
         [TestCase(false)]
         [TestCase(true)]
+        [RunOnUI]
         public void VisualTestScissorTestEnable(bool scissorTestEnable)
         {
             PrepareFrameCapture();
@@ -185,8 +196,10 @@ namespace MonoGame.Tests.Graphics
         }
 
 #if !XNA
+        [Test]
         [TestCase(false)]
         [TestCase(true)]
+        [RunOnUI]
         public void VisualTestDepthClipEnable(bool depthClipEnable)
         {
             PrepareFrameCapture();

--- a/Tests/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Tests/Framework/Graphics/RenderTarget2DTest.cs
@@ -10,9 +10,11 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     class RenderTarget2DTest : GraphicsDeviceTestFixtureBase
     {
         [Test]
+        [RunOnUI]
         public void ZeroSizeShouldFailTest()
         {
             RenderTarget2D renderTarget;
@@ -22,6 +24,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void NullDeviceShouldThrowArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => 
@@ -36,6 +39,7 @@ namespace MonoGame.Tests.Graphics
 #if XNA
         [Ignore("XNA mipmaps fail our pixel comparison tests")]
 #endif
+        [RunOnUI]
         public void GenerateMips()
         {
             // Please note:
@@ -113,6 +117,7 @@ namespace MonoGame.Tests.Graphics
             renderTarget.Dispose();
         }
         
+        [Test]
         [TestCase(SurfaceFormat.Color, SurfaceFormat.Color)]
         // unsupported renderTarget formats
         [TestCase(SurfaceFormat.Alpha8, SurfaceFormat.Color)]
@@ -127,6 +132,7 @@ namespace MonoGame.Tests.Graphics
 #endif
         [TestCase(SurfaceFormat.NormalizedByte2, SurfaceFormat.Color)]
         [TestCase(SurfaceFormat.NormalizedByte4, SurfaceFormat.Color)]
+        [RunOnUI]
         public void PreferredSurfaceFormatTest(SurfaceFormat preferredSurfaceFormat, SurfaceFormat expectedSurfaceFormat)
         {                    
             var renderTarget = new RenderTarget2D(gd, 16, 16, false, preferredSurfaceFormat, DepthFormat.None);
@@ -135,6 +141,10 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+#if DESKTOPGL
+        [Ignore ("Causes GL.GetError() returned 1282. Need to fix.")]
+#endif
+        [RunOnUI]
         public void GetDataMSAA()
         {
             const int size = 100;
@@ -157,8 +167,10 @@ namespace MonoGame.Tests.Graphics
         }
 
 #if DIRECTX
+        [Test]
         [TestCase(1)]
         [TestCase(2)]
+        [RunOnUI]
         public void GetSharedHandle(int preferredMultiSampleCount)
         {
             var rt = new RenderTarget2D(gd, 16, 16, false, SurfaceFormat.Color, DepthFormat.None, preferredMultiSampleCount, RenderTargetUsage.PlatformContents, true);            

--- a/Tests/Framework/Graphics/RenderTargetCubeTest.cs
+++ b/Tests/Framework/Graphics/RenderTargetCubeTest.cs
@@ -10,9 +10,11 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     class RenderTargetCubeTest : GraphicsDeviceTestFixtureBase
     {
         [Test]
+        [RunOnUI]
         public void ZeroSizeShouldFailTest()
         {
             RenderTargetCube renderTarget;
@@ -20,6 +22,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void NullDeviceShouldThrowArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => 
@@ -30,9 +33,11 @@ namespace MonoGame.Tests.Graphics
             GC.GetTotalMemory(true); // collect uninitialized renderTarget
         }
 
+        [Test]
         [TestCase(1)]
         [TestCase(8)]
         [TestCase(31)]
+        [RunOnUI]
         public void ShouldClearRenderTargetAndGetData(int size)
         {
             var dataSize = size * size;
@@ -66,7 +71,8 @@ namespace MonoGame.Tests.Graphics
 
             renderTargetCube.Dispose();
         }
-                
+
+        [Test]
         [TestCase(SurfaceFormat.Color, SurfaceFormat.Color)]
         // unsupported renderTarget formats
         [TestCase(SurfaceFormat.Alpha8, SurfaceFormat.Color)]
@@ -81,6 +87,7 @@ namespace MonoGame.Tests.Graphics
 #endif
         [TestCase(SurfaceFormat.NormalizedByte2, SurfaceFormat.Color)]
         [TestCase(SurfaceFormat.NormalizedByte4, SurfaceFormat.Color)]
+        [RunOnUI]
         public void PreferredSurfaceFormatTest(SurfaceFormat preferredSurfaceFormat, SurfaceFormat expectedSurfaceFormat)
         {                    
             var renderTarget = new RenderTargetCube(gd, 16, false, preferredSurfaceFormat, DepthFormat.None);

--- a/Tests/Framework/Graphics/SamplerStateTest.cs
+++ b/Tests/Framework/Graphics/SamplerStateTest.cs
@@ -10,15 +10,18 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     internal class SamplerStateTest : GraphicsDeviceTestFixtureBase
     {
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToSetNullSamplerState()
         {
             Assert.Throws<ArgumentNullException>(() => gd.SamplerStates[0] = null);
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToMutateStateObjectAfterBindingToGraphicsDevice()
         {
             var samplerState = new SamplerState();
@@ -38,6 +41,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldNotBeAbleToMutateDefaultStateObjects()
         {
             DoAsserts(SamplerState.AnisotropicClamp, d => Assert.Throws<InvalidOperationException>(d));
@@ -67,6 +71,7 @@ namespace MonoGame.Tests.Graphics
 
 #if !XNA
         [Test]
+        [RunOnUI]
         public void VisualTestAddressModes()
         {
             PrepareFrameCapture();
@@ -125,6 +130,7 @@ namespace MonoGame.Tests.Graphics
 #if DESKTOPGL
         [Ignore("Comparison samplers are ps_4_0 and up, cannot use them on DesktopGL due to MojoShader")]
 #endif
+        [RunOnUI]
         public void VisualTestComparisonFunction()
         {
             PrepareFrameCapture();

--- a/Tests/Framework/Graphics/ScissorRectangleTest.cs
+++ b/Tests/Framework/Graphics/ScissorRectangleTest.cs
@@ -1,10 +1,14 @@
+using System.Threading;
+using Microsoft.VisualStudio.TestPlatform.CrossPlatEngine;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    
     internal class ScissorRectangleTest : GraphicsDeviceTestFixtureBase
     {
         private SpriteBatch _spriteBatch;
@@ -41,6 +45,8 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [Ignore ("Fails Investigate?")]
+        [RunOnUI]
         public void Draw_with_scissor_rect()
         {
             PrepareFrameCapture();
@@ -69,6 +75,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void Draw_with_render_target_change()
         {
             PrepareFrameCapture();
@@ -85,6 +92,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void Draw_without_render_target_change()
         {
             PrepareFrameCapture();

--- a/Tests/Framework/Graphics/ShaderTest.cs
+++ b/Tests/Framework/Graphics/ShaderTest.cs
@@ -10,8 +10,10 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
 	[TestFixture]
+    [NonParallelizable]
 	class ShaderTest : GraphicsDeviceTestFixtureBase
     {
+        [Test]
 		[TestCase("NoEffect")]
 		[TestCase("HighContrast")]
 		[TestCase("Bevels")]
@@ -23,6 +25,7 @@ namespace MonoGame.Tests.Graphics
         // TODO this does not render for some reason, we need to fix this
         [TestCase("RainbowH")]
 #endif
+        [RunOnUI]
         public void Shader(string effectName)
 		{
             PrepareFrameCapture();

--- a/Tests/Framework/Graphics/SpriteBatchTest.cs
+++ b/Tests/Framework/Graphics/SpriteBatchTest.cs
@@ -3,12 +3,14 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Threading;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using NUnit.Framework;
 
 namespace MonoGame.Tests.Graphics {
-	[TestFixture]
+    [TestFixture]
+    [NonParallelizable]
 	class SpriteBatchTest : GraphicsDeviceTestFixtureBase {
 		private SpriteBatch _spriteBatch;
 		private Texture2D _texture;
@@ -50,6 +52,7 @@ namespace MonoGame.Tests.Graphics {
 	    }
 
         [Test]
+        [RunOnUI]
         public void BeginCalledTwiceThrows()
         {
             _spriteBatch.Begin();
@@ -57,12 +60,14 @@ namespace MonoGame.Tests.Graphics {
         }
 
         [Test]
+        [RunOnUI]
         public void BeginNotCalledThrows()
         {
             Assert.Throws<InvalidOperationException>(() => _spriteBatch.End());
         }
         
         [Test]
+        [RunOnUI]
         public void NullDeviceShouldThrowArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => 
@@ -74,6 +79,7 @@ namespace MonoGame.Tests.Graphics {
         }
         
 		[Test]
+        [RunOnUI]
 		public void Draw_without_blend ()
 		{
             PrepareFrameCapture();
@@ -86,6 +92,7 @@ namespace MonoGame.Tests.Graphics {
 		}
 
 		[Test]
+        [RunOnUI]
 		public void Draw_with_additive_blend ()
 		{
             PrepareFrameCapture();
@@ -99,6 +106,7 @@ namespace MonoGame.Tests.Graphics {
 		}
 
 		[Test]
+        [RunOnUI]
 		public void Draw_normal ()
 		{
             PrepareFrameCapture();
@@ -114,6 +122,7 @@ namespace MonoGame.Tests.Graphics {
 		[TestCase(1.5f, 1.5f)]
 		[TestCase(0.75f, 2.0f)]
 		[TestCase(1.25f, 0.8f)]
+        [RunOnUI]
 		public void Draw_stretched (float xScale, float yScale)
 		{
             PrepareFrameCapture();
@@ -131,6 +140,7 @@ namespace MonoGame.Tests.Graphics {
 		[TestCase("Red")]
 		[TestCase("GreenYellow")]
 		[TestCase("Teal")]
+        [RunOnUI]
 		public void Draw_with_filter_color (string colorName)
 		{
 			var color = colorName.ToColor ();
@@ -147,6 +157,7 @@ namespace MonoGame.Tests.Graphics {
 		[TestCase (1.41f)]
 		[TestCase (2.17f)]
 		[TestCase (2.81f)]
+        [RunOnUI]
 		public void Draw_rotated (float rotation)
 		{
             PrepareFrameCapture();
@@ -164,6 +175,7 @@ namespace MonoGame.Tests.Graphics {
 		}
 
 		[Test]
+        [RunOnUI]
 		public void Draw_with_source_rect ()
 		{
             PrepareFrameCapture();
@@ -180,6 +192,7 @@ namespace MonoGame.Tests.Graphics {
 		[TestCase(10, 10, 40, 40)]
 		[TestCase(30, 30, 30, 50)]
 		[TestCase(20, 30, 80, 60)]
+        [RunOnUI]
 		public void Draw_with_source_and_dest_rect (int x, int y, int width, int height)
 		{
             PrepareFrameCapture();
@@ -196,6 +209,7 @@ namespace MonoGame.Tests.Graphics {
 		[TestCase("Red", 120)]
 		[TestCase("White", 80)]
 		[TestCase("GreenYellow", 200)]
+        [RunOnUI]
 		public void Draw_with_alpha_blending (string colorName, byte alpha)
 		{
             PrepareFrameCapture();
@@ -214,6 +228,7 @@ namespace MonoGame.Tests.Graphics {
 		[TestCase (SpriteEffects.FlipHorizontally)]
 		[TestCase (SpriteEffects.FlipVertically)]
 		[TestCase (SpriteEffects.FlipHorizontally | SpriteEffects.FlipVertically)]
+        [RunOnUI]
 		public void Draw_with_SpriteEffects (SpriteEffects effects)
 		{
             PrepareFrameCapture();
@@ -240,6 +255,7 @@ namespace MonoGame.Tests.Graphics {
 		// in directly results in an enormous test name (and captured
 		// image filename).
 		[Test]
+        [RunOnUI]
 		public void Draw_with_matrix ([Range(0, 4)]int matrixIndex)
 		{
             PrepareFrameCapture();
@@ -263,6 +279,7 @@ namespace MonoGame.Tests.Graphics {
         // Disabled on XNA because the sorting algorithm is probably different
         [TestCase(SpriteSortMode.Texture)]
 #endif
+        [RunOnUI]
         public void Draw_with_SpriteSortMode(SpriteSortMode sortMode)
         {
             Similarity = 0.995f;
@@ -297,6 +314,7 @@ namespace MonoGame.Tests.Graphics {
 		//_spriteBatch.GraphicsDevice.RasterizerState.ScissorTestEnable = false;
 
         [Test]
+        [RunOnUI]
         public void DrawRequiresTexture()
         {
             _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.Opaque);
@@ -305,6 +323,7 @@ namespace MonoGame.Tests.Graphics {
         }
 
         [Test]
+        [RunOnUI]
         public void DrawWithTexture()
         {
             Assert.That(gd.Textures[0], Is.Null);
@@ -317,6 +336,7 @@ namespace MonoGame.Tests.Graphics {
         }
 
         [Test]
+        [RunOnUI]
         public void DrawWithCustomEffectAndTwoTextures()
         {
             var customSpriteEffect = AssetTestUtility.LoadEffect(content, "CustomSpriteBatchEffect");
@@ -337,6 +357,7 @@ namespace MonoGame.Tests.Graphics {
         }
 
         [Test]
+        [RunOnUI]
         public void DrawWithLayerDepth()
         {
             PrepareFrameCapture();
@@ -416,6 +437,7 @@ namespace MonoGame.Tests.Graphics {
         // There are possibly also some differences because of how rasterization is handled.
         [Ignore("OpenGL produces a slightly different result")]
 #endif
+        [RunOnUI]
         public void Draw_many()
         {
             PrepareFrameCapture();
@@ -431,6 +453,7 @@ namespace MonoGame.Tests.Graphics {
         
         [TestCase(SpriteSortMode.Deferred)]
         [TestCase(SpriteSortMode.Immediate)]
+        [RunOnUI]
         public void Draw_with_viewport_changing(SpriteSortMode sortMode)
         {
             Similarity = 0.975f;

--- a/Tests/Framework/Graphics/SpriteFontTest.cs
+++ b/Tests/Framework/Graphics/SpriteFontTest.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 
 namespace MonoGame.Tests.Graphics {
 	[TestFixture]
+    [NonParallelizable]
 	class SpriteFontTest : GraphicsDeviceTestFixtureBase {
 
 		private SpriteBatch _spriteBatch;
@@ -33,6 +34,7 @@ namespace MonoGame.Tests.Graphics {
 	        base.TearDown();
 	    }
 
+        [Test]
         [TestCase("Default", "The quick brown fox jumps over the lazy dog. 1234567890", 605, 21)]
         [TestCase("Default", "The quick brown fox jumps\nover the lazy dog.\n1234567890", 275, 59)]
         [TestCase("Default", "The quick brown fox jumps over the lazy dog.\r1234567890", 594, 21)]
@@ -57,6 +59,7 @@ namespace MonoGame.Tests.Graphics {
         [TestCase("SegoeKeycaps", "The quick brown fox jumps over the lazy dog. 1234567890", 988, 20)]
         [TestCase("SegoeKeycaps", "The quick brown fox jumps\nover the lazy dog.\n1234567890", 448, 58)]
         [TestCase("SegoeKeycaps", "!", 16, 20)] // LSB=1, W=15, RSB=0
+        [RunOnUI]
         public void MeasureString_returns_correct_values(string fontName, string text, float width, float height)
         {
             var font = game.Content.Load<SpriteFont>(Paths.Font(fontName));
@@ -66,6 +69,7 @@ namespace MonoGame.Tests.Graphics {
         }
 
 		[Test]
+        [RunOnUI]
 		public void Plain ()
 		{
             PrepareFrameCapture();
@@ -83,6 +87,7 @@ namespace MonoGame.Tests.Graphics {
 		}
 
 		[Test]
+        [RunOnUI]
 		public void Rotated ()
 		{
             PrepareFrameCapture();
@@ -108,6 +113,7 @@ namespace MonoGame.Tests.Graphics {
 		}
 
 		[Test]
+        [RunOnUI]
 		public void Scaled ()
 		{
             PrepareFrameCapture();
@@ -132,9 +138,11 @@ namespace MonoGame.Tests.Graphics {
             CheckFrames();
 		}
 
+        [Test]
 		[TestCase(SpriteEffects.FlipHorizontally)]
 		[TestCase(SpriteEffects.FlipVertically)]
 		[TestCase(SpriteEffects.FlipHorizontally | SpriteEffects.FlipVertically)]
+        [RunOnUI]
 		public void Draw_with_SpriteEffects (SpriteEffects effects)
 		{
             PrepareFrameCapture();
@@ -160,6 +168,7 @@ namespace MonoGame.Tests.Graphics {
 		}
 
 		[Test]
+        [RunOnUI]
 		public void Origins_rotated ()
 		{
             PrepareFrameCapture();
@@ -209,6 +218,7 @@ namespace MonoGame.Tests.Graphics {
 		}
 
 		[Test]
+        [RunOnUI]
 		public void Origins_scaled ()
 		{
             PrepareFrameCapture();
@@ -258,6 +268,7 @@ namespace MonoGame.Tests.Graphics {
 		}
         
 		[Test]
+        [RunOnUI]
 		public void Draw_with_LayerDepth()
 		{
             PrepareFrameCapture();
@@ -397,6 +408,7 @@ namespace MonoGame.Tests.Graphics {
 		}
         
 		[Test]
+        [RunOnUI]
 		public void Hullabaloo ()
 		{
             PrepareFrameCapture();
@@ -412,6 +424,7 @@ namespace MonoGame.Tests.Graphics {
 		}
 
 		[Test]
+        [RunOnUI]
 		public void Hullabaloo2 ()
 		{
             PrepareFrameCapture();
@@ -426,7 +439,7 @@ namespace MonoGame.Tests.Graphics {
             CheckFrames();
 		}
 
-		
+		[Test]
         [TestCase("The quick brown fox jumps over the lazy dog. 1234567890", TestName = "Multiline_noNewline")]
         [TestCase("The quick brown fox jumps\nover the lazy dog.\n1234567890", TestName = "Multiline_Newline")]
         [TestCase("The quick brown fox jumps over the lazy dog.\r1234567890", TestName = "Multiline_CarriageReturn")]
@@ -436,6 +449,7 @@ So he wrote a routine
 To ask 'What's it all mean?'
 But the answer was still '42'.
                 R Humphries, Sutton Coldfield", TestName = "Multiline_verbatimString")]
+        [RunOnUI]
 		public void Multiline (string text)
 		{
             PrepareFrameCapture();
@@ -478,6 +492,7 @@ But the answer was still '42'.
 		}
 
 		[Test]
+        [RunOnUI]
 		public void Font_spacing_is_respected ()
 		{
             PrepareFrameCapture();
@@ -504,9 +519,11 @@ But the answer was still '42'.
             CheckFrames();
 		}
 
+        [Test]
         [TestCase("The rain in España stays mainly in the plain - now in français")]
         [TestCase("\x1f")]
         [TestCase("\x7f")]
+        [RunOnUI]
         public void Throws_when_drawing_unavailable_characters(string text)
 		{
             _spriteBatch.Begin ();
@@ -515,18 +532,22 @@ But the answer was still '42'.
             _spriteBatch.End ();
 		}
 
+        [Test]
         [TestCase('ñ')]
         [TestCase((char)127)]
         [TestCase((char)31)]
+        [RunOnUI]
         public void Throws_when_setting_unavailable_DefaultCharacter(char character)
 		{
             Assert.Throws<ArgumentException> (() =>
                 _defaultFont.DefaultCharacter = character);
 		}
 
+        [Test]
         [TestCase((char)32)]
         [TestCase((char)63)]
         [TestCase((char)126)]
+        [RunOnUI]
         public void Does_not_throw_when_setting_available_DefaultCharacter(char character)
         {
             Assert.DoesNotThrow(() => _defaultFont.DefaultCharacter = character);

--- a/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
+++ b/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
@@ -13,10 +13,12 @@ using StbImageSharp;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     internal class Texture2DNonVisualTest : GraphicsDeviceTestFixtureBase
     {
         Texture2D _texture;
 
+        [Test]
 #if !XNA
         [TestCase("Assets/Textures/LogoOnly_64px.bmp")]
         [TestCase("Assets/Textures/LogoOnly_64px.tga")]
@@ -29,6 +31,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase("Assets/Textures/24bit.png")]
         [TestCase("Assets/Textures/32bit.png")]
         [TestCase("Assets/Textures/sample_1280x853.hdr")]
+        [RunOnUI]
         public void FromStreamShouldWorkTest(string filename)
         {
             using (System.IO.StreamReader reader = new System.IO.StreamReader(filename))
@@ -47,6 +50,7 @@ namespace MonoGame.Tests.Graphics
             _texture = null;
         }
 
+        [Test]
 #if XNA
         [TestCase("Assets/Textures/LogoOnly_64px.bmp")]
 #endif
@@ -54,6 +58,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase("Assets/Textures/LogoOnly_64px.tif")]
         [TestCase("Assets/Textures/LogoOnly_64px.dds")]
         [TestCase("Assets/Textures/SampleCube64DXT1Mips.dds")]
+        [RunOnUI]
         public void FromStreamShouldFailTest(string filename)
         {
             using (System.IO.StreamReader reader = new System.IO.StreamReader(filename))
@@ -63,6 +68,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void FromStreamArgumentNullTest()
         {
             Assert.Throws<ArgumentNullException>(() => Texture2D.FromStream(gd, (Stream) null));
@@ -73,6 +79,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void FromStreamCustomProcessor()
         {
             // This test sets the color of every other color to custom color
@@ -123,7 +130,8 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
-        [TestCase]
+        [Test]
+        [RunOnUI]
         public void FromStreamNotPremultiplied()
         {
             // XNA will not try to premultiply your image on
@@ -148,7 +156,8 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
-        [TestCase]
+        [Test]
+        [RunOnUI]
         public void FromStreamAtTheEnd()
         {
             // Check whether texture can be loaded if a stream being at its end
@@ -177,7 +186,8 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
-        [TestCase]
+        [Test]
+        [RunOnUI]
         public void FromStreamBlackAlpha()
         {
             // XNA will make any pixel with an alpha value
@@ -203,6 +213,7 @@ namespace MonoGame.Tests.Graphics
         }
         
         [Test]
+        [RunOnUI]
         public void ZeroSizeShouldFailTest()
         {
             Texture2D texture;
@@ -212,6 +223,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void SimpleGetSetDataTest()
         {
             using (var tex = new Texture2D(gd, 4, 4, false, SurfaceFormat.Color))
@@ -237,6 +249,7 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
+        [Test]
         [TestCase(25, 23, 1, 1, 0, 1)]
         [TestCase(25, 23, 1, 1, 1, 1)]
         [TestCase(25, 23, 2, 1, 0, 2)]
@@ -245,6 +258,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase(25, 23, 1, 2, 1, 2)]
         [TestCase(25, 23, 2, 2, 0, 4)]
         [TestCase(25, 23, 2, 2, 1, 4)]
+        [RunOnUI]
         public void PlatformGetDataWithOffsetTest(int rx, int ry, int rw, int rh, int startIndex, int elementsToRead)
         {
             using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
@@ -265,8 +279,10 @@ namespace MonoGame.Tests.Graphics
                 t.Dispose();
             }
         }
+        [Test]
         [TestCase(25, 23, 2, 2, 0, 2)]
         [TestCase(25, 23, 2, 2, 1, 2)]
+        [RunOnUI]
         public void GetDataException(int rx, int ry, int rw, int rh, int startIndex, int elementsToRead)
         {
             using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
@@ -284,7 +300,9 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
+        [Test]
         [TestCase(4096)]
+        [RunOnUI]
         public void SetData1ParameterGoodTest(int arraySize)
         {
             using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
@@ -322,10 +340,12 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
+        [Test]
         [TestCase(2000)]
         [TestCase(4095)]
         [TestCase(2000000)]
         [TestCase(4097)]
+        [RunOnUI]
         public void SetData1ParameterExceptionTest(int arraySize)
         {
             using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
@@ -352,6 +372,7 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
+        [Test]
         [TestCase(SurfaceFormat.HalfSingle, (short)(160 << 8 + 120))]
 #if !DESKTOPGL
         // format not supported
@@ -364,6 +385,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase(SurfaceFormat.Single, (byte)150)]
         [TestCase(SurfaceFormat.Single, (short)(160 << 8 + 120))]
         [TestCase(SurfaceFormat.Single, (float)(200 << 24 + 180 << 16 + 160 << 8 + 120))]
+        [RunOnUI]
         public void SetDataFormatTest<TBuffer>(SurfaceFormat format, TBuffer value) where TBuffer : struct
         {
             const int textureSize = 16;
@@ -390,8 +412,10 @@ namespace MonoGame.Tests.Graphics
             t.Dispose();
         }
 
+        [Test]
         [TestCase(SurfaceFormat.Color, (long)0)]
         [TestCase(SurfaceFormat.HalfSingle, (float)0)]
+        [RunOnUI]
         public void SetDataFormatFailingTestTBufferTooLarge<TBuffer>(SurfaceFormat format, TBuffer value) where TBuffer : struct
         {
             const int textureSize = 16;
@@ -413,6 +437,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void SetDataFormatFailingTestModTBufferNotZero()
         {
             const int textureSize = 12;
@@ -455,10 +480,12 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
+        [Test]
         [TestCase(4200, 0, 4096)]
         [TestCase(4097, 1, 4096)]
         [TestCase(4097, 0, 4096)]
         [TestCase(4096, 0, 4096)]
+        [RunOnUI]
         public void SetData3ParameterGoodTest(int arraySize, int startIndex, int elements)
         {
             using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
@@ -496,6 +523,7 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
+        [Test]
         [TestCase(2000, 0, 4096)]
         [TestCase(4095, 0, 4095)]
         [TestCase(4095, 1, 4095)]
@@ -509,6 +537,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase(4098, 1, 4097)]
         [TestCase(4097, 0, 4097)]
         [TestCase(4096, 0, 4095)]
+        [RunOnUI]
         public void SetData3ParameterExceptionTest(int arraySize, int startIndex, int elements)
         {
             using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
@@ -536,6 +565,7 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
+        [Test]
         [TestCase(4096, 0, 4096, 0, 0, 64, 64)]
         [TestCase(4096, 0, 3969, 1, 1, 63, 63)]
         [TestCase(3969, 0, 3969, 1, 1, 63, 63)]
@@ -543,6 +573,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase(4097, 1, 3969, 1, 1, 63, 63)]
         [TestCase(3970, 1, 3969, 1, 1, 63, 63)]
         [TestCase(4097, 1, 4096, 0, 0, 64, 64)]
+        [RunOnUI]
         public void SetData5ParameterGoodTest(int arraySize, int startIndex, int elements, int x, int y, int w, int h)
         {
             using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
@@ -582,6 +613,7 @@ namespace MonoGame.Tests.Graphics
                 t.Dispose();
             }
         }
+        [Test]
         [TestCase(3844, 0, 3844, 1, 1, 63, 63)]
         [TestCase(3845, 1, 3844, 1, 1, 63, 63)]
         [TestCase(3969, 0, 4096, 1, 1, 63, 63)]
@@ -594,6 +626,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase(4097, 1, 4095, 0, 0, 64, 64)]
         [TestCase(4097, 1, 3844, 1, 1, 63, 63)]
         [TestCase(3970, 1, 4096, 1, 1, 63, 63)]
+        [RunOnUI]
         public void SetData5ParameterExceptionTest(int arraySize, int startIndex, int elements, int x, int y, int w, int h)
         {
             using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
@@ -624,6 +657,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void GetDataNegativeOrZeroRectWidthAndHeightThrows()
         {
             using (var t = new Texture2D(gd, 10, 10))
@@ -641,6 +675,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void GetAndSetDataDxtCompressed()
         {
             var t = content.Load<Texture2D>(Paths.Texture ("random_16px_dxt"));
@@ -694,6 +729,7 @@ namespace MonoGame.Tests.Graphics
 #if DESKTOPGL
         [Ignore("PlatformGetData fails under OpenGL!")]
 #endif
+        [RunOnUI]
         public void LoadOddSizedDxtCompressed()
         {
             // This is testing that DXT compressed mip levels that 
@@ -732,12 +768,14 @@ namespace MonoGame.Tests.Graphics
             t.Dispose();
         }
 
+        [Test]
         // DXT1
         [TestCase(8, "random_16px_dxt", 0)]
         [TestCase(8, "random_16px_dxt", 1)]
         // DXT5
         [TestCase(16, "random_16px_dxt_alpha", 0)]
         [TestCase(16, "random_16px_dxt_alpha", 1)]
+        [RunOnUI]
         public void GetAndSetDataDxtNotMultipleOf4Rounding(int bs, string texName, int mip)
         {
             var t = content.Load<Texture2D>(Paths.Texture (texName));
@@ -786,8 +824,10 @@ namespace MonoGame.Tests.Graphics
             t.Dispose();
         }
 
+        [Test]
         [TestCase("random_16px_dxt", 8)]
         [TestCase("random_16px_dxt_alpha", 16)]
+        [RunOnUI]
         public void GetAndSetDataDxtDontRoundWhenOutsideBounds(string texName, int bs)
         {
             var t = content.Load<Texture2D>(Paths.Texture(texName));
@@ -802,8 +842,10 @@ namespace MonoGame.Tests.Graphics
             t.Dispose();
         }
 
+        [Test]
         [TestCase("random_16px_dxt", 8)]
         [TestCase("random_16px_dxt_alpha", 16)]
+        [RunOnUI]
         public void GetAndSetDataDxtLowerMips(string texName, int bs)
         {
             var t = content.Load<Texture2D>(Paths.Texture(texName));
@@ -826,6 +868,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void GetDataRowPitch()
         {
             const int w = 5;
@@ -845,6 +888,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void NullDeviceShouldThrowArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => 

--- a/Tests/Framework/Graphics/Texture2DTest.cs
+++ b/Tests/Framework/Graphics/Texture2DTest.cs
@@ -9,11 +9,14 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     class Texture2DTest : GraphicsDeviceTestFixtureBase
     {
+        [Test]
         [TestCase(1, 1)]
         [TestCase(8, 8)]
         [TestCase(31, 7)]
+        [RunOnUI]
         public void ShouldSetAndGetData(int width, int height)
         {
             var dataSize = width * height;
@@ -30,9 +33,11 @@ namespace MonoGame.Tests.Graphics
             texture2D.Dispose();
         }
 
+        [Test]
         [TestCase(1, 1)]
         [TestCase(8, 8)]
         [TestCase(31, 7)]
+        [RunOnUI]
         public void ShouldSetAndGetDataForLevel(int width, int height)
         {
             var texture2D = new Texture2D(gd, width, height, true, SurfaceFormat.Color);
@@ -56,6 +61,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldGetDataFromRectangle()
         {
             const int dataSize = 128 * 128;
@@ -80,10 +86,12 @@ namespace MonoGame.Tests.Graphics
         }
 		
 #if DIRECTX
+        [Test]
         [TestCase(SurfaceFormat.Color, false)]
         [TestCase(SurfaceFormat.Color, true)]
         [TestCase(SurfaceFormat.ColorSRgb, false)]
         [TestCase(SurfaceFormat.ColorSRgb, true)]
+        [RunOnUI]
         public void DrawWithSRgbFormats(SurfaceFormat textureFormat, bool sRgbSourceTexture)
         {
             PrepareFrameCapture();
@@ -134,12 +142,14 @@ namespace MonoGame.Tests.Graphics
 #endif
 
 #if !XNA
+        [Test]
         [TestCase(1, 1)]
         [TestCase(8, 8)]
         [TestCase(31, 7)]
 #if DESKTOPGL
         [Ignore("Not yet implemented in OpenGL")]
 #endif
+        [RunOnUI]
         public void ShouldSetAndGetDataForTextureArray(int width, int height)
         {
             const int arraySize = 4;
@@ -167,6 +177,7 @@ namespace MonoGame.Tests.Graphics
 
 #if DIRECTX
         [Test]
+        [RunOnUI]
         public void TextureArrayAsRenderTargetAndShaderResource()
         {
             PrepareFrameCapture();
@@ -223,6 +234,7 @@ namespace MonoGame.Tests.Graphics
 #endif
 
         [Test]
+        [RunOnUI]
         public void SetDataRowPitch()
         {
             PrepareFrameCapture();

--- a/Tests/Framework/Graphics/Texture3DNonVisualTest.cs
+++ b/Tests/Framework/Graphics/Texture3DNonVisualTest.cs
@@ -9,10 +9,11 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Tests.Graphics
 {
-#if !WINDOWS
+#if DESKTOPGL
     [Ignore("Texture3D is not implemented for the OpenGL backend.")]
 #endif
     [TestFixture]
+    [NonParallelizable]
     public class Texture3DNonVisualTest
     {
         Texture3D t;
@@ -53,6 +54,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ZeroSizeShouldFailTest()
         {
             Texture3D texture;
@@ -67,6 +69,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void SetData1ParameterTest()
         {
             Color[] written = new Color[a];
@@ -74,9 +77,11 @@ namespace MonoGame.Tests.Graphics
             Assert.AreEqual(reference, written);
         }
 
+        [Test]
         [TestCase(a, 0, a)]
         [TestCase(a + 1, 0, a)]
         [TestCase(a + 1, 1, a)]
+        [RunOnUI]
         public void SetData3ParametersSuccessTest(int arrayLength, int startIndex, int elementCount)
         {
             Color[] write = new Color[arrayLength];
@@ -99,11 +104,13 @@ namespace MonoGame.Tests.Graphics
 
         }
 
+        [Test]
         [TestCase(a, 0, a - 1)]
         [TestCase(a - 1, 0, a)]
         [TestCase(a, 1, a)]
         [TestCase(a, 0, a + 1)]
         [TestCase(a + 1, 1, a + 1)]
+        [RunOnUI]
         public void SetData3ParametersExceptionTest(int arrayLength, int startIndex, int elementCount)
         {
             Color[] write = new Color[arrayLength];
@@ -115,9 +122,11 @@ namespace MonoGame.Tests.Graphics
             Assert.Throws(Is.InstanceOf<Exception>(), () =>t.SetData(write, startIndex, elementCount));
         }
 
+        [Test]
         [TestCase((w - 2) * (h - 2) * (d - 2), 0, (w - 2) * (h - 2) * (d - 2), 1, 1, 1, w - 2, h - 2, d - 2)]
         [TestCase(a, 0, a, 0, 0, 0, w, h, d)]
         [TestCase(a + 1, 1, a, 0, 0, 0, w, h, d)]
+        [RunOnUI]
         public void SetData9ParametersSuccessTest(int arrayLength, int startIndex, int elementCount, int x, int y, int z, int w, int h, int d)
         {
             Color[] write = new Color[arrayLength];
@@ -141,8 +150,10 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
+        [Test]
         [TestCase(a, 0, a, -1, -1, -1, w + 1, h + 1, d + 1)]
         [TestCase(a, 1, a, 0, 0, 0, w, h, d)]
+        [RunOnUI]
         public void SetData9ParametersExceptionTest(int arrayLength, int startIndex, int elementCount, int x, int y, int z, int w, int h, int d)
         {
             Color[] write = new Color[arrayLength];
@@ -154,6 +165,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void NullDeviceShouldThrowArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => 

--- a/Tests/Framework/Graphics/Texture3DTest.cs
+++ b/Tests/Framework/Graphics/Texture3DTest.cs
@@ -7,15 +7,18 @@ using NUnit.Framework;
 
 namespace MonoGame.Tests.Graphics
 {
-#if !WINDOWS
+#if DESKTOPGL
     [Ignore("Texture3D is not implemented for the OpenGL backend.")]
 #endif
     [TestFixture]
+    [NonParallelizable]
     class Texture3DTest : GraphicsDeviceTestFixtureBase
     {
+        [Test]
         [TestCase(1, 1, 1)]
         [TestCase(8, 8, 8)]
         [TestCase(31, 7, 13)]
+        [RunOnUI]
         public void ShouldSetAndGetData(int width, int height, int depth)
         {
             var dataSize = width * height * depth;

--- a/Tests/Framework/Graphics/TextureCubeTest.cs
+++ b/Tests/Framework/Graphics/TextureCubeTest.cs
@@ -10,18 +10,22 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     class TextureCubeTest : GraphicsDeviceTestFixtureBase
     {
         [Test]
+        [RunOnUI]
         public void ZeroSizeShouldFailTest()
         {
             TextureCube texture;
             Assert.Throws<ArgumentOutOfRangeException>(() => texture = new TextureCube(gd, 0, false, SurfaceFormat.Color));
         }
 
+        [Test]
         [TestCase(1)]
         [TestCase(8)]
         [TestCase(31)]
+        [RunOnUI]
         public void ShouldSetAndGetData(int size)
         {
             var dataSize = size * size;
@@ -44,6 +48,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void GetAndSetDataDxtCompressed()
         {
             var t = content.Load<TextureCube>(Paths.Texture ("SampleCube64DXT1Mips"));
@@ -97,9 +102,11 @@ namespace MonoGame.Tests.Graphics
             t.Dispose();
         }
 
+        [Test]
         // DXT1
         [TestCase(8, "SampleCube64DXT1Mips", 0)]
         [TestCase(8, "SampleCube64DXT1Mips", 1)]
+        [RunOnUI]
         // TODO DXT5
         //[TestCase(16, "SampleCube64DXT5Mips", 0)]
         //[TestCase(16, "SampleCube64DXT5Mips", 1)]
@@ -155,8 +162,10 @@ namespace MonoGame.Tests.Graphics
             t.Dispose();
         }
 
+        [Test]
         [TestCase("SampleCube64DXT1Mips", 8)]
         //[TestCase("SampleCube64DXT5Mips", 16)]
+        [RunOnUI]
         public void GetAndSetDataDxtDontRoundWhenOutsideBounds(string texName, int bs)
         {
             var t = content.Load<TextureCube>(Paths.Texture(texName));
@@ -175,8 +184,10 @@ namespace MonoGame.Tests.Graphics
             t.Dispose();
         }
 
+        [Test]
         [TestCase("SampleCube64DXT1Mips", 8)]
         //[TestCase("SampleCube64DXT5Mips", 16)]
+        [RunOnUI]
         public void GetAndSetDataDxtLowerMips(string texName, int bs)
         {
             var t = content.Load<TextureCube>(Paths.Texture(texName));
@@ -203,6 +214,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void NullDeviceShouldThrowArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => 

--- a/Tests/Framework/Graphics/VertexBufferTest.cs
+++ b/Tests/Framework/Graphics/VertexBufferTest.cs
@@ -12,6 +12,7 @@ using Microsoft.Xna.Framework.Graphics;
 namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
+    [NonParallelizable]
     class VertexBufferTest : GraphicsDeviceTestFixtureBase
     {
         VertexPositionTexture[] savedData = new VertexPositionTexture[] 
@@ -23,8 +24,10 @@ namespace MonoGame.Tests.Graphics
         };
         VertexPositionTexture vertexZero = new VertexPositionTexture(Vector3.Zero, Vector2.Zero);
         
+        [Test]
         //[TestCase(true)]
         [TestCase(false)]
+        [RunOnUI]
         public void ShouldSetAndGetData(bool dynamic)
         {   
             var vertexBuffer = (dynamic)
@@ -39,8 +42,10 @@ namespace MonoGame.Tests.Graphics
             vertexBuffer.Dispose();
         }
 
+        [Test]
         //[TestCase(true)]
         [TestCase(false)]
+        [RunOnUI]
         public void ShouldSetAndGetData_elementCount(bool dynamic)
         {
             var vertexBuffer = (dynamic)
@@ -58,8 +63,10 @@ namespace MonoGame.Tests.Graphics
             vertexBuffer.Dispose();
         }
 
+        [Test]
         //[TestCase(true)]
         [TestCase(false)]
+        [RunOnUI]
         public void ShouldSetAndGetData_startIndex(bool dynamic)
         {
             var vertexBuffer = (dynamic)
@@ -77,8 +84,10 @@ namespace MonoGame.Tests.Graphics
             vertexBuffer.Dispose();
         }
         
+        [Test]
         //[TestCase(true)]
         [TestCase(false)]
+        [RunOnUI]
         public void ShouldSetAndGetData_offsetInBytes(bool dynamic)
         {
             var vertexBuffer = (dynamic)
@@ -96,8 +105,10 @@ namespace MonoGame.Tests.Graphics
             vertexBuffer.Dispose();
         }
 
+        [Test]
         //[TestCase(true)]
         [TestCase(false)]
+        [RunOnUI]
         public void ShouldSetAndGetDataBytes(bool dynamic)
         {
             var vertexBuffer = (dynamic)
@@ -119,6 +130,7 @@ namespace MonoGame.Tests.Graphics
             vertexBuffer.Dispose();
         }
 
+        [Test]
         //[TestCase(true)]
         [TestCase(false, -1, 0, false, typeof(ArgumentOutOfRangeException))]
         [TestCase(false, 0, 0, false, typeof(ArgumentOutOfRangeException))]
@@ -134,6 +146,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase(false, 79, 2, false, typeof(ArgumentOutOfRangeException))]
         [TestCase(false, 80, 0, false, typeof(ArgumentOutOfRangeException))]
         [TestCase(false, 80, 1, false, typeof(ArgumentOutOfRangeException))]
+        [RunOnUI]
         public void SetDataWithElementCount(bool dynamic, int startIndex, int elementCount, bool shouldSucceed, Type expectedExceptionType)
         {
             var vertexBuffer = (dynamic)
@@ -159,6 +172,7 @@ namespace MonoGame.Tests.Graphics
             vertexBuffer.Dispose();
         }
 
+        [Test]
         [TestCase(false, 1, -1, typeof(ArgumentOutOfRangeException))]
         [TestCase(false, 0, 0, typeof(ArgumentOutOfRangeException))]
         [TestCase(false, 80, 0, null)]
@@ -177,6 +191,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase(false, 1, 81, typeof(ArgumentOutOfRangeException))]
         [TestCase(false, 2, 81, typeof(ArgumentOutOfRangeException))]
 #endif
+        [RunOnUI]
         public void SetDataWithElementCountAndVertexStride(bool dynamic, int elementCount, int vertexStride, Type expectedExceptionType)
         {
             var vertexBuffer = (dynamic)
@@ -203,6 +218,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void BetterGetSetDataVertexStrideTest()
         {
             const int size = 5;
@@ -243,6 +259,7 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
+        [Test]
         //[TestCase(true)]
         [TestCase(false, 1, 20, true, null)]
         [TestCase(false, 3, 20, true, null)]
@@ -250,6 +267,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase(false, 4, 16, false, typeof(ArgumentOutOfRangeException))]
         [TestCase(false, 4, 20, true, null)]
         [TestCase(false, 5, 20, false, typeof(ArgumentOutOfRangeException))]
+        [RunOnUI]
         public void SetDataStructWithElementCountAndVertexStride(bool dynamic, int elementCount, int vertexStride, bool shouldSucceed, Type expectedExceptionType)
         {
             var vertexBuffer = (dynamic)
@@ -274,8 +292,10 @@ namespace MonoGame.Tests.Graphics
             vertexBuffer.Dispose();
         }
 
+        [Test]
         //[TestCase(true)]
         [TestCase(false)]
+        [RunOnUI]
         public void GetPosition(bool dynamic)
         {
             var vertexBuffer = (dynamic)
@@ -294,8 +314,10 @@ namespace MonoGame.Tests.Graphics
             vertexBuffer.Dispose();
         }
 
+        [Test]
         //[TestCase(true)]
         [TestCase(false)]
+        [RunOnUI]
         public void SetPosition(bool dynamic)
         {
             var vertexBuffer = (dynamic)
@@ -321,8 +343,10 @@ namespace MonoGame.Tests.Graphics
             vertexBuffer.Dispose();
         }
 
+        [Test]
         //[TestCase(true)]
         [TestCase(false)]
+        [RunOnUI]
         public void GetTextureCoordinate(bool dynamic)
         {
             var vertexBuffer = (dynamic)
@@ -342,8 +366,10 @@ namespace MonoGame.Tests.Graphics
             vertexBuffer.Dispose();
         }
 
+        [Test]
         //[TestCase(true)]
         [TestCase(false)]
+        [RunOnUI]
         public void SetTextureCoordinate(bool dynamic)
         {
             var vertexBuffer = (dynamic)
@@ -387,6 +413,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void ShouldSucceedWhenVertexFormatDoesMatchShader()
         {
             var vertexBuffer = new VertexBuffer(
@@ -406,6 +433,7 @@ namespace MonoGame.Tests.Graphics
 #if DESKTOPGL
         [Ignore("we should figure out if there's a way to check this in OpenGL")]
 #endif
+        [RunOnUI]
         public void ShouldThrowHelpfulExceptionWhenVertexFormatDoesNotMatchShader()
         {
             var vertexBuffer = new VertexBuffer(
@@ -430,6 +458,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        [RunOnUI]
         public void NullDeviceShouldThrowArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => 

--- a/Tests/Framework/Graphics/ViewportTest.cs
+++ b/Tests/Framework/Graphics/ViewportTest.cs
@@ -4,8 +4,11 @@ using Microsoft.Xna.Framework.Graphics;
 using NUnit.Framework;
 
 namespace MonoGame.Tests.Graphics {
+      [TestFixture]
+      [NonParallelizable]
 	class ViewportTest : GraphicsDeviceTestFixtureBase {
 		[Test]
+            [RunOnUI]
 		public void Affects_draw_origin ()
 		{
             PrepareFrameCapture();
@@ -27,6 +30,7 @@ namespace MonoGame.Tests.Graphics {
 		}
 
 		[Test]
+            [RunOnUI]
 		public void Does_not_clip_device_clear ()
 		{
             PrepareFrameCapture();
@@ -45,6 +49,7 @@ namespace MonoGame.Tests.Graphics {
 		}
 
 		[Test]
+            [RunOnUI]
 		public void Clips_SpriteBatch_draws ()
 		{
             PrepareFrameCapture();

--- a/Tests/Framework/Visual/MiscellaneousTests.cs
+++ b/Tests/Framework/Visual/MiscellaneousTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 namespace MonoGame.Tests.Visual {
 	[TestFixture]
+	[NonParallelizable]
 	class MiscellaneousTests : VisualTestFixtureBase
     {
 		[Test]
@@ -21,6 +22,7 @@ namespace MonoGame.Tests.Visual {
 #else
         [Ignore ("Microsoft.Xna.Framework.Graphics.MonoGameGLException : GL.GetError() returned 1286. Invesigate")]
 #endif
+		[RunOnUI]
 		public void DrawOrder_falls_back_to_order_of_addition_to_Game ()
 		{
 			Game.PreDrawWith += (sender, e) => {
@@ -34,6 +36,7 @@ namespace MonoGame.Tests.Visual {
 		[TestCase(true)]
 		[TestCase(false)]
         [Ignore("Fix me!")]
+		[RunOnUI]
 		public void TexturedQuad_lighting (bool enableLighting)
 		{
 			Game.Components.Add (new TexturedQuadComponent (Game, enableLighting));
@@ -41,6 +44,7 @@ namespace MonoGame.Tests.Visual {
 		}
 
 		[Test, Ignore("Fix me!")]
+		[RunOnUI]
 		public void SpaceshipModel ()
 		{
 			Game.Components.Add (new SpaceshipModelDrawComponent(Game));

--- a/Tests/MonoGame.Tests.DesktopGL.csproj
+++ b/Tests/MonoGame.Tests.DesktopGL.csproj
@@ -8,6 +8,9 @@
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
     <DefineConstants>DESKTOPGL</DefineConstants>
+    <DefineConstants Condition=" $([MSBuild]::IsOsPlatform('osx')) " >$(DefineConstants);MACOS</DefineConstants>
+    <DefineConstants Condition=" $([MSBuild]::IsOsPlatform('windows')) " >$(DefineConstants);WINDOWS</DefineConstants>
+    <DefineConstants Condition=" $([MSBuild]::IsOsPlatform('linux')) " >$(DefineConstants);LINUX</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Runner/Desktop/MainThreadSynchronizationContext.cs
+++ b/Tests/Runner/Desktop/MainThreadSynchronizationContext.cs
@@ -1,0 +1,60 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+using NUnit.Framework;
+namespace MonoGame.Tests
+{
+    /// <summary>
+    /// This class will run any test on the main UI thread. 
+    /// This is required for SDL Graphics Tests.
+    /// Add the [RunOnUI] attribute to the test to get it to run on the UI thread.
+    /// </summary>
+    public class MainThreadSynchronizationContext : SynchronizationContext
+    {
+        private readonly BlockingCollection<(SendOrPostCallback, object, ManualResetEvent, TestContext)> _callbackQueue = new BlockingCollection<(SendOrPostCallback, object, ManualResetEvent, TestContext)>();
+        private readonly Thread _mainThread;
+
+        public MainThreadSynchronizationContext(Thread mainThread)
+        {
+            _mainThread = mainThread;
+        }
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            _callbackQueue.TryAdd((d, state, new ManualResetEvent(false), TestContext.CurrentContext));
+        }
+
+        public override void Send(SendOrPostCallback d, object state)
+        {
+            var ev = new ManualResetEvent(false);
+            _callbackQueue.TryAdd((d, state, ev, TestContext.CurrentContext));
+            ev.WaitOne();
+        }
+
+        public void End()
+        {
+            _callbackQueue.CompleteAdding();
+        }
+
+        public void ExecuteQueuedCallbacks()
+        {
+            foreach (var workItem in _callbackQueue.GetConsumingEnumerable())
+            {
+                var (callback, state, ev, context) = workItem;
+                Extensions.RegisterTestWtihContext(TestContext.CurrentContext, context.Test);
+                try
+                {
+                    callback(state);
+                }
+                finally
+                {
+                    Extensions.UnRegisterTestWtihContext(TestContext.CurrentContext);
+                }
+                if (ev != null)
+                {
+                    ev.Set();
+                }
+            }
+        }
+    }
+}

--- a/Tests/Runner/Desktop/RunOnUIAttribute.cs
+++ b/Tests/Runner/Desktop/RunOnUIAttribute.cs
@@ -1,0 +1,33 @@
+using System;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
+
+namespace MonoGame.Tests 
+{
+    /// <summary>
+    /// Marshall the test onto the main UI thread.
+    /// </summary>
+    [System.AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+    sealed class RunOnUIAttribute : Attribute, IWrapSetUpTearDown, IWrapTestMethod
+    {
+//#if !DESKTOPGL
+//        public TestCommand Wrap(TestCommand command) => command;
+//#else
+        public TestCommand Wrap(TestCommand command) => new RunOnUICommand(command);
+
+        class RunOnUICommand : DelegatingTestCommand
+        {
+            public RunOnUICommand(TestCommand innerCommand)
+                : base(innerCommand)
+            {
+            }
+
+            public override TestResult Execute(TestExecutionContext context)
+            {
+                return Program.Invoke(() => innerCommand.Execute(context), context.CurrentTest.MakeTestResult ());
+            }
+        }
+//#endif
+    }
+}

--- a/Tests/Runner/Program.cs
+++ b/Tests/Runner/Program.cs
@@ -6,14 +6,57 @@ using System;
 using System.IO;
 using NUnitLite;
 using NUnit.Framework;
+using NUnit.Common;
+using NUnit.Framework.Api;
+using NUnit.Framework.Interfaces;
+using System.Reflection;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Filters;
+using System.Collections.Generic;
+using NUnit;
+using System.Diagnostics;
+using NUnit.Framework.Internal.Execution;
+using NUnit.Framework.Internal.Commands;
+using System.Threading;
+using Microsoft.VisualBasic;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Serialization;
 
 namespace MonoGame.Tests
 {
     static class Program
     {
-        static int Main(string [] args)
+        static Thread mainThread = Thread.CurrentThread;
+        static MainThreadSynchronizationContext mainThreadSynchronizationContext;
+        public static TestResult Invoke (Func<TestResult> func, TestResult result)
         {
-            return new AutoRun().Execute(args);
+            if (Thread.CurrentThread != mainThread) {
+                TestResult r = result;
+                mainThreadSynchronizationContext.Send (state => {
+                    try {
+                    r = func();
+                    } catch (Exception ex) {
+                        r.RecordException (ex);
+                    }
+                }, null);
+                return r;
+            } else {
+                return func();
+            }
+        }
+        static async Task<int> Main(string [] args)
+        {
+            mainThread = Thread.CurrentThread;
+            mainThreadSynchronizationContext = new MainThreadSynchronizationContext(mainThread);
+            SynchronizationContext.SetSynchronizationContext (mainThreadSynchronizationContext);
+            int result = 0;
+            var task = Task.Run (() => result = new AutoRun().Execute(args)).ContinueWith ((t) => {
+                mainThreadSynchronizationContext.End ();
+            }, continuationOptions: TaskContinuationOptions.ExecuteSynchronously);
+            mainThreadSynchronizationContext.ExecuteQueuedCallbacks ();
+            await task;
+            return result;
         }
     }
 }

--- a/Tools/MonoGame.Tools.Tests/AudioContentTests.cs
+++ b/Tools/MonoGame.Tools.Tests/AudioContentTests.cs
@@ -11,9 +11,7 @@ using NUnit.Framework;
 
 namespace MonoGame.Tests.ContentPipeline
 {
-#if MACOS && CI
-    [Ignore("Hanging on Mac in CI?")]
-#endif
+    [Category("Audio")]
     class AudioContentTests
     {
         [Test]

--- a/Tools/MonoGame.Tools.Tests/EffectProcessorTests.cs
+++ b/Tools/MonoGame.Tools.Tests/EffectProcessorTests.cs
@@ -10,9 +10,7 @@ using TwoMGFX;
 
 namespace MonoGame.Tests.ContentPipeline
 {
-#if MACOS || LINUX
-    [Ignore("Does not work on CI yet. need to get wine working.")]
-#endif
+    [Category("Effects")]
     class EffectProcessorTests
     {
         class ImporterContext : ContentImporterContext

--- a/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
+++ b/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
@@ -1087,4 +1087,14 @@
       <Link>Assets\Effects\Stock\Structures.fxh</Link>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\MonoGame.Content.Builder.Task\MonoGame.Content.Builder.Task.targets">
+      <Link>MonoGame.Content.Builder.Task.targets</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\\MonoGame.Content.Builder.Task\MonoGame.Content.Builder.Task.props">
+      <Link>MonoGame.Content.Builder.Task.props</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/Tools/MonoGame.Tools.Tests/Mp3ImporterTests.cs
+++ b/Tools/MonoGame.Tools.Tests/Mp3ImporterTests.cs
@@ -9,9 +9,7 @@ using NUnit.Framework;
 
 namespace MonoGame.Tests.ContentPipeline
 {
-#if MACOS && CI
-    [Ignore("Hanging on Mac in CI?")]
-#endif
+    [Category("Audio")]
     class Mp3ImporterTests
     {
         [Test]

--- a/Tools/MonoGame.Tools.Tests/OggImporterTests.cs
+++ b/Tools/MonoGame.Tools.Tests/OggImporterTests.cs
@@ -9,9 +9,7 @@ using NUnit.Framework;
 
 namespace MonoGame.Tests.ContentPipeline
 {
-#if MACOS && CI
-    [Ignore("Hanging on Mac in CI?")]
-#endif
+    [Category("Audio")]
     class OggImporterTests
     {
         [Test]

--- a/Tools/MonoGame.Tools.Tests/TextureImporterTests.cs
+++ b/Tools/MonoGame.Tools.Tests/TextureImporterTests.cs
@@ -106,7 +106,7 @@ namespace MonoGame.Tests.ContentPipeline
         /// </summary>
         [Test]
 #if MACOS || LINUX
-        [Ignore("Does not work on Unix based systems. We need to get wine working on CI.")]
+        [Ignore("Does not work on Unix based systems. Its odd the test passes?")]
 #endif
         public void ImportImageWithBadContent( )
         {

--- a/Tools/MonoGame.Tools.Tests/TextureProcessorTests.cs
+++ b/Tools/MonoGame.Tools.Tests/TextureProcessorTests.cs
@@ -296,6 +296,9 @@ namespace MonoGame.Tests.ContentPipeline
         }
 
         [Test]
+#if WINDOWS
+        [Ignore("This one crashes on windows?")]
+#endif
         public void CompressDefaultiOSOpaqueSquarePOT()
         {
             CompressDefault<PvrtcRgb4BitmapContent>(TargetPlatform.iOS, Color.Red, 16, 16);

--- a/Tools/MonoGame.Tools.Tests/TextureProcessorTests.cs
+++ b/Tools/MonoGame.Tools.Tests/TextureProcessorTests.cs
@@ -11,6 +11,7 @@ using MonoGame.Framework.Content;
 
 namespace MonoGame.Tests.ContentPipeline
 {
+    [TestFixture]
     class TextureProcessorTests
     {
         [Test]
@@ -297,7 +298,7 @@ namespace MonoGame.Tests.ContentPipeline
 
         [Test]
 #if WINDOWS
-        [Ignore("This one crashes on windows?")]
+        //[Ignore("This one crashes on windows?")]
 #endif
         public void CompressDefaultiOSOpaqueSquarePOT()
         {

--- a/Tools/MonoGame.Tools.Tests/TextureProcessorTests.cs
+++ b/Tools/MonoGame.Tools.Tests/TextureProcessorTests.cs
@@ -297,9 +297,6 @@ namespace MonoGame.Tests.ContentPipeline
         }
 
         [Test]
-#if WINDOWS
-        //[Ignore("This one crashes on windows?")]
-#endif
         public void CompressDefaultiOSOpaqueSquarePOT()
         {
             CompressDefault<PvrtcRgb4BitmapContent>(TargetPlatform.iOS, Color.Red, 16, 16);

--- a/Tools/MonoGame.Tools.Tests/WavImporterTests.cs
+++ b/Tools/MonoGame.Tools.Tests/WavImporterTests.cs
@@ -9,9 +9,7 @@ using NUnit.Framework;
 
 namespace MonoGame.Tests.ContentPipeline
 {
-#if MACOS && CI
-    [Ignore("Hanging on Mac in CI")]
-#endif
+    [Category("Audio")]
     class WavImporterTests
     {
         [Test]

--- a/Tools/MonoGame.Tools.Tests/WmaImporterTests.cs
+++ b/Tools/MonoGame.Tools.Tests/WmaImporterTests.cs
@@ -9,9 +9,7 @@ using NUnit.Framework;
 
 namespace MonoGame.Tests.ContentPipeline
 {
-#if MACOS && CI
-    [Ignore("Hanging on Mac in CI?")]
-#endif
+    [Category("Audio")]
     class WmaImporterTests
     {
         [Test]

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -9,6 +9,7 @@ public enum ProjectType
     Framework,
     Tools,
     Templates,
+    Tests,
     ContentPipeline,
     MGCBEditor,
     MGCBEditorLauncher
@@ -24,7 +25,7 @@ public class BuildContext : FrostingContext
     {
         var repositoryUrl = context.Argument("build-repository", DefaultRepositoryUrl);
         var buildConfiguration = context.Argument("build-configuration", "Release");
-        BuildOutput = context.Argument("build-output", "artifacts");
+        BuildOutput = context.Argument("build-output", "Artifacts");
         NuGetsDirectory = $"{BuildOutput}/NuGet/";
 
         var tags = GitAliases.GitTags(context, ".");
@@ -150,6 +151,7 @@ public class BuildContext : FrostingContext
         ProjectType.Framework => $"MonoGame.Framework/MonoGame.Framework.{id}.csproj",
         ProjectType.Tools => $"Tools/{id}/{id}.csproj",
         ProjectType.Templates => $"Templates/{id}/{id}.csproj",
+        ProjectType.Tests => $"Tests/{id}.csproj",
         ProjectType.ContentPipeline => "MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj",
         ProjectType.MGCBEditor => $"Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.{id}.csproj",
 		ProjectType.MGCBEditorLauncher => $"Tools/MonoGame.Content.Builder.Editor.Launcher/MonoGame.Content.Builder.Editor.Launcher.{id}.csproj",

--- a/build/BuildTestsTasks/BuildTestsTask.cs
+++ b/build/BuildTestsTasks/BuildTestsTask.cs
@@ -1,0 +1,15 @@
+
+namespace BuildScripts;
+
+[TaskName("Build Tests")]
+[IsDependentOn(typeof(BuildFrameworksTask))]
+[IsDependentOn(typeof(BuildContentPipelineTask))]
+public sealed class BuildTestsTask : FrostingTask<BuildContext>
+{
+    public override void Run(BuildContext context)
+    {
+        context.DotNetBuild(context.GetProjectPath(ProjectType.Tests, "MonoGame.Tests.DesktopGL"), context.DotNetBuildSettings);
+        if (context.IsRunningOnWindows())
+            context.DotNetBuild(context.GetProjectPath(ProjectType.Tests, "MonoGame.Tests.WindowsDX"), context.DotNetBuildSettings);
+    }
+}

--- a/build/BuildToolsTasks/BuildToolTestsTask.cs
+++ b/build/BuildToolsTasks/BuildToolTestsTask.cs
@@ -1,7 +1,7 @@
 
 namespace BuildScripts;
 
-[TaskName("Build ToolTests")]
+[TaskName("Build Tool Tests")]
 [IsDependentOn(typeof(BuildContentPipelineTask))]
 public sealed class BuildToolTestsTask : FrostingTask<BuildContext>
 {

--- a/build/DeployTasks/UploadArtifactsTask.cs
+++ b/build/DeployTasks/UploadArtifactsTask.cs
@@ -11,10 +11,14 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
         var os = context.Environment.Platform.Family switch
         {
             PlatformFamily.Windows => "windows",
-            PlatformFamily.OSX => "mac",
+            PlatformFamily.OSX => "macos",
             _ => "linux"
         };
 
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(context.NuGetsDirectory.FullPath), $"nuget-{os}");
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(System.IO.Path.Combine(context.BuildOutput, "Tests", "Tools", "Release")), $"tests-tools-{os}");
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(System.IO.Path.Combine(context.BuildOutput, "Tests", "DesktopGL", "Release")), $"tests-desktopgl-{os}");
+        if (context.IsRunningOnWindows())
+            await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(System.IO.Path.Combine(context.BuildOutput, "Tests", "WindowsDX", "Release")), $"tests-windowsdx-{os}");
     }
 }

--- a/build/Tasks.cs
+++ b/build/Tasks.cs
@@ -23,22 +23,27 @@ public sealed class BuildToolsTask : FrostingTask<BuildContext> { }
 [IsDependentOn(typeof(BuildVSTemplatesTask))]
 public sealed class BuildTemplatesTask : FrostingTask<BuildContext> { }
 
-[TaskName("Build Tests")]
+[TaskName("Build All Tests")]
+[IsDependentOn(typeof(BuildTestsTask))]
 [IsDependentOn(typeof(BuildToolTestsTask))]
-public sealed class BuildTestsTask : FrostingTask<BuildContext> { }
+public sealed class BuildAllTestsTask : FrostingTask<BuildContext> { }
 
 
 [TaskName("Build All")]
 [IsDependentOn(typeof(BuildFrameworksTask))]
 [IsDependentOn(typeof(BuildToolsTask))]
 [IsDependentOn(typeof(BuildTemplatesTask))]
-[IsDependentOn(typeof(BuildTestsTask))]
+[IsDependentOn(typeof(BuildAllTestsTask))]
 public sealed class BuildAllTask : FrostingTask<BuildContext> { }
 
 [TaskName("Deploy")]
 [IsDependentOn(typeof(DeployNuGetsToGitHubTask))]
 [IsDependentOn(typeof(DeployNuGetsToNuGetOrgTask))]
 public sealed class DeployTask : FrostingTask<BuildContext> { }
+
+[TaskName("Test")]
+[IsDependentOn(typeof(DownloadTestArtifactsTask))]
+public sealed class TestTask : FrostingTask<BuildContext> {}
 
 [TaskName("Default")]
 [IsDependentOn(typeof(BuildAllTask))]

--- a/build/TestTasks/DownloadTestArtifactsTask.cs
+++ b/build/TestTasks/DownloadTestArtifactsTask.cs
@@ -1,0 +1,23 @@
+
+namespace BuildScripts;
+
+[TaskName("DownloadTestArtifacts")]
+public sealed class DownloadTestArtifactsTask : AsyncFrostingTask<BuildContext>
+{
+    public override bool ShouldRun(BuildContext context) => context.BuildSystem().IsRunningOnGitHubActions;
+
+    public override async Task RunAsync(BuildContext context)
+    {
+        var os = context.Environment.Platform.Family switch
+        {
+            PlatformFamily.Windows => "windows",
+            PlatformFamily.OSX => "macos",
+            _ => "linux"
+        };
+        context.CreateDirectory("tests-tools");
+        await context.GitHubActions().Commands.DownloadArtifact($"tests-tools-{os}", "tests-tools");
+        await context.GitHubActions().Commands.DownloadArtifact($"tests-desktopgl-{os}", "tests-desktopgl");
+        if (context.IsRunningOnWindows())
+            await context.GitHubActions().Commands.DownloadArtifact($"tests-windowsdx-{os}", "tests-windowsdx");
+    }
+}


### PR DESCRIPTION
This enables the UI unit tests on some self hosted machines we have available. 
There were some issues regarding running UI based tests in NUnitLite via `dotnet test` on MacOS. This is because you MUST create NSWindow instances on the Main Thread. So we had to modify the Test runner to marshal the UI tests over to the main thread. 

This added a new `[RunOnUI]` attribute, which can be used to flag a test which MUST run on the UI thread. This works for all platforms. 

There were still some slight issues with the test on MacOS if running ALL the UI tests in on go they would fail. But running them in smaller batches works. I suspect that there is a bug in one of the tests which is causing this we need to track it down. 

A few tests have been disable, issues need to be opened for these so that they can be fixed. 

Also fixed Short2 and NormalizedByte4 types so they actually pass the tests.

Fixed the casing on the `Artifacts` folder so it is consistent across all platforms (Linux and Mac were using lower case in some areas). 

Fixed the Adpcm audio support so it unpacks the data correctly.