### PR TITLE
Fix Deploy Task Error

### DIFF
--- a/build/DeployTasks/DownloadArtifactsTask.cs
+++ b/build/DeployTasks/DownloadArtifactsTask.cs
@@ -9,7 +9,7 @@ public sealed class DownloadArtifactsTask : AsyncFrostingTask<BuildContext>
     public override async Task RunAsync(BuildContext context)
     {
         context.CreateDirectory("nugets");
-        foreach (var os in new[] { "windows", "mac", "linux" })
+        foreach (var os in new[] { "windows", "macos", "linux" })
             await context.GitHubActions().Commands.DownloadArtifact($"nuget-{os}", "nugets");
     }
 }


### PR DESCRIPTION
The commit 2dd7b76b changed the name of the Nuget
packages we archive. The DownloadArtifactsTask was not updated to match. It should have been using `macos` rather than `mac` for it nuget package name.