### PR TITLE
Bump Test timeout to 5 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
-        if: runner.environment == 'github-hosted'
+        #if: runner.environment == 'github-hosted'
 
       - name: install wine64 on linux
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+        if: runner.environment == 'github-hosted'
 
       - name: install wine64 on linux
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
         run: dotnet run --project build/Build.csproj -- --target=Default
 
       - name: Test
-        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 1m -c Release --filter="TestCategory!=Audio"
+        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 5m -c Release --filter="TestCategory!=Audio"
         env:
           DOTNET_ROOT: ${{github.workspace}}/dotnet64
           MGFXC_WINE_PATH: /home/runner/.winemonogame
@@ -83,7 +83,7 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Test
-        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 1m -c Release --filter="TestCategory!=Audio"
+        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 5m -c Release --filter="TestCategory!=Audio"
         env:
           DOTNET_ROOT: ${{github.workspace}}/dotnet64
           MGFXC_WINE_PATH: /Users/runner/.winemonogame
@@ -91,7 +91,7 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Test
-        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 1m -c Release
+        run: dotnet test Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj --blame-hang-timeout 5m -c Release
         env:
           CI: true
         if: runner.os == 'Windows'


### PR DESCRIPTION
The macOS tests were timing out after 60 seconds. So lets bump the timeout to 5 minutes to give `wine` a chance to startup.