### PR TITLE
Upgrade Mac Editor to net8.0-macos. Upgrade Eto.Forms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,11 @@ jobs:
         run: wget -qO- https://monogame.net/downloads/net9_mgfxc_wine_setup.sh | bash
         if: runner.os != 'Windows'
 
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+        if: runner.os == 'macOS'
+
       - name: Install required workloads
         run:   |
               if [ "$RUNNER_OS" == "Linux" ]; then
@@ -82,7 +87,7 @@ jobs:
               elif [ "$RUNNER_OS" == "Windows" ]; then
                     dotnet.exe workload install android ios macos
               else
-                    dotnet workload install android
+                    dotnet workload install android macos ios
               fi
         shell: bash
 

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -73,9 +73,11 @@
 
 
   <ItemGroup>
-    <PackageReference Include="AssimpNet" Version="4.1.0" />
+    <PackageReference Include="AssimpNet" Version="5.0.0-beta1" IncludeAssets="compile;runtime;build" ExcludeAssets="native" />
+    <PackageReference Include="MonoGame.Library.Assimp" Version="5.3.1.1" />
     <PackageReference Include="BCnEncoder.Net" Version="2.1.0" />
     <PackageReference Include="BCnEncoder.Net.ImageSharp" Version="1.1.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.1.30" />
     <PackageReference Include="RoyT.TrueType" Version="0.2.0" />
     <PackageReference Include="SharpDX" Version="4.0.1" />

--- a/Tools/MonoGame.Content.Builder.Editor.Launcher/MonoGame.Content.Builder.Editor.Launcher.Mac.csproj
+++ b/Tools/MonoGame.Content.Builder.Editor.Launcher/MonoGame.Content.Builder.Editor.Launcher.Mac.csproj
@@ -12,10 +12,11 @@
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <AssemblyName>mgcb-editor-mac</AssemblyName>
     <ImplicitUsings>true</ImplicitUsings>
+    <RuntimeIdentifiers>osx-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="..\..\Artifacts\MonoGame.Content.Builder.Editor\Mac\Release\MGCB Editor.app\**\*">
+    <Content Include="..\..\Artifacts\MonoGame.Content.Builder.Editor\Mac\Release\mgcb-editor-mac.app\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>MGCB Editor.app\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>

--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
@@ -38,8 +38,13 @@ namespace MonoGame.Tools.Pipeline
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "../../../MonoGame.Content.Builder/Debug/mgcb.dll"),
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "../../../../../../MonoGame.Content.Builder/Debug/mgcb.dll"),
 #else
+#if MAC
+            Path.Combine(Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "", "../../../MonoGame.Content.Builder/Release/mgcb.dll"),
+            Path.Combine(Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "", "../../../../../../MonoGame.Content.Builder/Release/mgcb.dll"),
+#else
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "../../../MonoGame.Content.Builder/Release/mgcb.dll"),
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "../../../../../../MonoGame.Content.Builder/Release/mgcb.dll"),
+#endif
 #endif
         };
 
@@ -108,7 +113,11 @@ namespace MonoGame.Tools.Pipeline
             ProjectOpen = false;
 
             _templateItems = new List<ContentItemTemplate>();
+#if MAC
+            var root = Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "";
+#else
             var root = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "";
+#endif
             var templatesPath = Path.Combine(root, "Templates");
 
 #if IDE

--- a/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Linux.csproj
+++ b/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Linux.csproj
@@ -35,9 +35,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.6.0" />
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.6.0" />
-    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
+    <PackageReference Include="Eto.Forms" Version="2.8.3" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.8.3" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.95" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj
+++ b/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-macos</TargetFramework>
     <RollForward>Major</RollForward>
     <BaseOutputPath>..\..\Artifacts\MonoGame.Content.Builder.Editor\Mac</BaseOutputPath>
     <DefineConstants>MONOMAC;MAC</DefineConstants>
@@ -11,9 +11,7 @@
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <AssemblyName>mgcb-editor-mac</AssemblyName>
     <AssemblyTitle>MGCB Editor</AssemblyTitle>
-    <MacBundleName>$(AssemblyTitle)</MacBundleName>
-    <PublishSingleFile>false</PublishSingleFile>
-    <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>osx-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,8 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.6.1" />
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.6.1" />
+    <PackageReference Include="Eto.Forms" Version="2.8.3" />
+    <PackageReference Include="Eto.Platform.macOS" Version="2.8.3" />
+    <PackageReference Include="AssimpNet" Version="5.0.0-beta1" ExcludeAssets="runtime;native" />
+    <PackageReference Include="MonoGame.Library.Assimp" Version="5.3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Windows.csproj
+++ b/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Windows.csproj
@@ -30,8 +30,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.6.0" />
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.6.0" />
+    <PackageReference Include="Eto.Forms" Version="2.8.3" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tools/MonoGame.Content.Builder.Editor/Platform/Mac/Styles.Mac.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Platform/Mac/Styles.Mac.cs
@@ -4,8 +4,8 @@
 
 using Eto;
 using Eto.Mac.Forms;
-using MonoMac.AppKit;
-using MonoMac.Foundation;
+using AppKit;
+using Foundation;
 
 namespace MonoGame.Tools.Pipeline
 {

--- a/Tools/MonoGame.Content.Builder.Editor/Program.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Program.cs
@@ -28,7 +28,7 @@ namespace MonoGame.Tools.Pipeline
 #elif WPF
             var app = new Application(Platforms.Wpf);
 #else
-            var app = new Application(Platforms.Mac64);
+            var app = new Application(Platforms.macOS);
 #endif
 
             app.Style = "PipelineTool";

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -114,6 +114,13 @@ public class BuildContext : FrostingContext
             Configuration = buildConfiguration,
             SelfContained = false
         };
+        // SelfContained needs to be default for MacOS
+        DotNetPublishSettingsForMac = new DotNetPublishSettings
+        {
+            MSBuildSettings = DotNetMSBuildSettings,
+            Verbosity = DotNetVerbosity.Minimal,
+            Configuration = buildConfiguration
+        };
 
         Console.WriteLine($"Version: {Version}");
         Console.WriteLine($"RepositoryUrl: {repositoryUrl}");
@@ -141,6 +148,8 @@ public class BuildContext : FrostingContext
     public DotNetPackSettings DotNetPackSettings { get; }
 
     public DotNetPublishSettings DotNetPublishSettings { get; }
+
+    public DotNetPublishSettings DotNetPublishSettingsForMac { get; }
 
     public MSBuildSettings MSBuildSettings { get; }
 

--- a/build/BuildToolsTasks/BuildMGCBEditorTask.cs
+++ b/build/BuildToolsTasks/BuildMGCBEditorTask.cs
@@ -22,7 +22,10 @@ public sealed class BuildMGCBEditorTask : FrostingTask<BuildContext>
             _ => "Linux"
         };
 
-        context.DotNetPublish(context.GetProjectPath(ProjectType.MGCBEditor, platform), context.DotNetPublishSettings);
+        if (context.Environment.Platform.Family != PlatformFamily.OSX)
+            context.DotNetPublish(context.GetProjectPath(ProjectType.MGCBEditor, platform), context.DotNetPublishSettings);
+        else
+            context.DotNetPublish(context.GetProjectPath(ProjectType.MGCBEditor, platform), context.DotNetPublishSettingsForMac);
         context.DotNetPack(context.GetProjectPath(ProjectType.Tools, "MonoGame.Content.Builder.Editor.Launcher.Bootstrap"), context.DotNetPackSettings);
 		context.DotNetPack(context.GetProjectPath(ProjectType.MGCBEditorLauncher, platform), context.DotNetPackSettings);
     }


### PR DESCRIPTION
Fixes https://github.com/MonoGame/MonoGame/discussions/8469

Upgrade Eto.Forms to the latest stable version.
Switch to using `net8.0-macos` for the mac editor so we can support both x64 and arm64 architectures.
Upgrade AssimpNet to 5.0.x
Switch over to using MonoGame.Library.Assimp to get macOS arm64 support.