### PR TITLE
Capture Asserts in MGCB logging

### DIFF
--- a/Tools/MonoGame.Content.Builder/Program.cs
+++ b/Tools/MonoGame.Content.Builder/Program.cs
@@ -13,11 +13,38 @@ namespace MonoGame.Content.Builder
 {
     class Program
     {
+        public class AssertListener : TraceListener
+        {
+            public override void Write(string message)
+            {
+                Console.Write(message);
+            }
+
+            public override void WriteLine(string message)
+            {
+                Console.WriteLine(message);
+            }
+
+            public override void Fail(string message, string detailMessage)
+            {
+                Console.WriteLine(message);
+
+                if (!string.IsNullOrEmpty(detailMessage))
+                    Console.WriteLine(detailMessage);
+            }
+        }
+
         static int Main(string[] args)
         {
             // We force all stderr to redirect to stdout
             // to avoid any out of order console output.
             Console.SetError(Console.Out);
+
+            // Hook in our own trace listener so that errors
+            // from asserts appear in the output logging instead
+            // of having silent failures.
+            Trace.Listeners.Clear();
+            Trace.Listeners.Add(new AssertListener());
 
             if (!Environment.Is64BitProcess && Environment.OSVersion.Platform != PlatformID.Unix)
             {

--- a/Tools/MonoGame.Content.Builder/Program.cs
+++ b/Tools/MonoGame.Content.Builder/Program.cs
@@ -13,7 +13,7 @@ namespace MonoGame.Content.Builder
 {
     class Program
     {
-        public class AssertListener : TraceListener
+        class AssertListener : TraceListener
         {
             public override void Write(string message)
             {


### PR DESCRIPTION
This adds a trace listener to the start of MGCB so that asserts and other diagnostic messages appear in the output logging.