### PR TITLE
Install dotnet tools locally in the Nuget Packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,7 @@ jobs:
         if: runner.os != 'Windows' && runner.environment == 'github-hosted'
 
       - name: Download Nuget
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nuget-${{ matrix.platform }}
           path: Artifacts/NuGet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
                     fc-match Arial
                     wget -qO- https://monogame.net/downloads/net9_mgfxc_wine_setup.sh | bash
               elif [ "$RUNNER_OS" == "Windows" ]; then
-                    dotnet.exe workload install android ios macos --version 8.0.402.0
+                    dotnet.exe workload install android
               else
                     dotnet workload install android macos ios --version 8.0.402.0
                     brew install wine-stable p7zip freeimage freetype

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: nuget-${{ matrix.platform }}
-          path: nuget
+          path: Artifacts/NuGet
 
       - name: Download tests-tools-${{ matrix.platform }}
         uses: actions/download-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,6 +185,12 @@ jobs:
         run: wget -qO- https://monogame.net/downloads/net9_mgfxc_wine_setup.sh | bash
         if: runner.os != 'Windows' && runner.environment == 'github-hosted'
 
+      - name: Download Nuget
+        uses: actions/download-artifact@v3
+        with:
+          name: nuget-${{ matrix.platform }}
+          path: nuget
+
       - name: Download tests-tools-${{ matrix.platform }}
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
                     fc-match Arial
                     wget -qO- https://monogame.net/downloads/net9_mgfxc_wine_setup.sh | bash
               elif [ "$RUNNER_OS" == "Windows" ]; then
-                    dotnet.exe workload install android ios macos
+                    dotnet.exe workload install android ios macos --version 8.0.402.0
               else
                     dotnet workload install android macos ios --version 8.0.402.0
                     brew install wine-stable p7zip freeimage freetype

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: tests-tools-${{ matrix.platform }}
-          path: tests-tools
+          path: tests tools
 
       - name: Download tests-desktopgl-${{ matrix.platform }}
         uses: actions/download-artifact@v4
@@ -204,13 +204,8 @@ jobs:
           path: tests-windowsdx
         if: runner.os == 'Windows'
 
-      - name: Install Tools
-        run: |
-          dotnet tool install --create-manifest-if-needed mgcb-basisu
-          dotnet tool install --create-manifest-if-needed mgcb-crunch
-
       - name: Run Tools Tests
-        run: dotnet test tests-tools/MonoGame.Tools.Tests.dll --blame-hang-timeout 1m --filter="TestCategory!=Effects"
+        run: dotnet test "tests tools/MonoGame.Tools.Tests.dll" --blame-hang-timeout 1m --filter="TestCategory!=Effects"
         env:
           CI: true
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "mgcb-editor-mac",
-            "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Mac/Debug/MGCB Editor.app/Contents/MacOS/mgcb-editor-mac",
+            "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Mac/Debug/mgcb-editor-mac.app/Contents/MacOS/mgcb-editor-mac",
             "args": [],
             "cwd": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder.Editor/Mac/Debug",
             "console": "internalConsole",

--- a/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
@@ -64,8 +64,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
         public static void ProbeFormat(string sourceFile, out AudioFileType audioFileType, out AudioFormat audioFormat, out TimeSpan duration, out int loopStart, out int loopLength)
         {
             string ffprobeStdout, ffprobeStderr;
-            var ffprobeExitCode = ExternalTool.Run(
-                "ffprobe",
+            var ffprobeExitCode = ExternalTool.RunDotnetTool(
+                ExternalTool.FFprobe,
                 string.Format("-i \"{0}\" -show_format -show_entries streams -v quiet -of flat", sourceFile),
                 out ffprobeStdout,
                 out ffprobeStderr);
@@ -277,8 +277,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
         public static void WritePcmFile(AudioContent content, string saveToFile, int bitRate = 192000, int? sampeRate = null)
         {
             string ffmpegStdout, ffmpegStderr;
-            var ffmpegExitCode = ExternalTool.Run(
-                "ffmpeg",
+            var ffmpegExitCode = ExternalTool.RunDotnetTool(
+                ExternalTool.FFmpeg,
                 string.Format(
                     "-y -i \"{0}\" -vn -c:a pcm_s16le -b:a {2} {3} -f:a wav -strict experimental \"{1}\"",
                     content.FileName,
@@ -362,8 +362,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                 int ffmpegExitCode;
                 do
                 {
-                    ffmpegExitCode = ExternalTool.Run(
-                        "ffmpeg",
+                    ffmpegExitCode = ExternalTool.RunDotnetTool(
+                        ExternalTool.FFmpeg,
                         string.Format(
                             "-y -i \"{0}\" -vn -c:a {1} -b:a {2} -ar {3} -f:a {4} -strict experimental \"{5}\"",
                             content.FileName,

--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         private static string CrunchVersion = "1.0.4.2";
         public static string BasisU = "mgcb-basisu";
         private static string BasisUVersion = "1.16.4.2";
+        public static string FFmpeg = "mgcb-ffmpeg";
+        private static string FFmpegVersion = "7.0.0.6";
+        public static string FFprobe = "mgcb-ffprobe";
+        private static string FFprobeVersion = "7.0.0.6";
 
         static ExternalTool()
         {
@@ -69,6 +73,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                 return;
             RestoreDotnetTool("install", Crunch, CrunchVersion, path);
             RestoreDotnetTool("install", BasisU, BasisUVersion, path);
+            RestoreDotnetTool("install", FFmpeg, FFmpegVersion, path);
+            RestoreDotnetTool("install", FFprobe, FFprobeVersion, path);
             File.WriteAllText(versionFile, version);
         }
 

--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         public static string BasisU = "mgcb-basisu";
         private static string BasisUVersion = "1.16.4.2";
 
+        static ExternalTool()
+        {
+            RestoreDotnetTools ();
+        }
+
         public static int Run(string command, string arguments)
         {
             string stdout, stderr;
@@ -34,7 +39,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             return result;
         }
 
-        public static void RestoreDotnetTool(string command, string toolName, string toolVersion, string path)
+        static void RestoreDotnetTool(string command, string toolName, string toolVersion, string path)
         {
             Directory.CreateDirectory(path);
             var exe = CurrentPlatform.OS == OS.Windows ? "dotnet.exe" : "dotnet";
@@ -50,7 +55,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             }
         }
 
-        public static void RestoreDotnetTools()
+        static void RestoreDotnetTools()
         {
             var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
             string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory);
@@ -71,7 +76,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// </summary>
         public static int RunDotnetTool(string toolName, string args, out string stdOut, out string stdErr, string stdIn=null, string workingDirectory=null)
         {
-            RestoreDotnetTools();
             var exe = FindCommand(toolName);
             var finalizedArgs =  args;
             return ExternalTool.Run(exe, finalizedArgs, out stdOut, out stdErr, stdIn, workingDirectory);

--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
+using System.Reflection;
 using System.Threading;
 using MonoGame.Framework.Utilities;
 
@@ -17,6 +19,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
     /// </summary>
     internal class ExternalTool
     {
+        public static string Crunch = "mgcb-crunch";
+        private static string CrunchVersion = "1.0.4.2";
+        public static string BasisU = "mgcb-basisu";
+        private static string BasisUVersion = "1.16.4.2";
+
         public static int Run(string command, string arguments)
         {
             string stdout, stderr;
@@ -27,13 +34,47 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             return result;
         }
 
+        public static void RestoreDotnetTool(string command, string toolName, string toolVersion, string path)
+        {
+            Directory.CreateDirectory(path);
+            var exe = CurrentPlatform.OS == OS.Windows ? "dotnet.exe" : "dotnet";
+            var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+            if (!string.IsNullOrEmpty(dotnetRoot))
+            {
+                exe = Path.Combine(dotnetRoot, exe);
+            }
+            if (Run(exe, $"tool {command} {toolName} --version {toolVersion} --tool-path .", out string _, out string _,  workingDirectory: path) != 0)
+            {
+                // install the latest
+                Run(exe, $"tool {command} {toolName} --tool-path .", out _, out _,  workingDirectory: path);
+            }
+        }
+
+        public static void RestoreDotnetTools()
+        {
+            var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory);
+            if (CurrentPlatform.OS == OS.Linux)
+                path= Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "linux");
+            if (CurrentPlatform.OS == OS.MacOSX)
+                path= Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "osx");
+            var versionFile = Path.Combine(path, $"tools_version.txt");
+            if (File.Exists(versionFile) && File.ReadAllText(versionFile) == version)
+                return;
+            RestoreDotnetTool("install", Crunch, CrunchVersion, path);
+            RestoreDotnetTool("install", BasisU, BasisUVersion, path);
+            File.WriteAllText(versionFile, version);
+        }
+
         /// <summary>
         /// Run a dotnet tool. The tool should be installed in a .config/dotnet-tools.json file somewhere in the project lineage.
         /// </summary>
         public static int RunDotnetTool(string toolName, string args, out string stdOut, out string stdErr, string stdIn=null, string workingDirectory=null)
         {
-            var finalizedArgs = toolName + " " + args;
-            return ExternalTool.Run("dotnet", finalizedArgs, out stdOut, out stdErr, stdIn, workingDirectory);
+            RestoreDotnetTools();
+            var exe = FindCommand(toolName);
+            var finalizedArgs =  args;
+            return ExternalTool.Run(exe, finalizedArgs, out stdOut, out stdErr, stdIn, workingDirectory);
         }
 
         public static int Run(string command, string arguments, out string stdout, out string stderr, string stdin = null, string workingDirectory=null)
@@ -67,6 +108,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 
             if (!string.IsNullOrEmpty(workingDirectory))
                 processInfo.WorkingDirectory = workingDirectory;
+
+            var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+            if (!string.IsNullOrEmpty(dotnetRoot))
+            {
+                processInfo.EnvironmentVariables["DOTNET_ROOT"] = dotnetRoot;
+            }
 
             EnsureExecutable(fullPath);
 

--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -48,10 +48,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             {
                 exe = Path.Combine(dotnetRoot, exe);
             }
-            if (Run(exe, $"tool {command} {toolName} --version {toolVersion} --tool-path .", out string _, out string _,  workingDirectory: path) != 0)
+            if (Run(exe, $"tool {command} {toolName} --version {toolVersion} --tool-path .", out string stdout, out string stderr,  workingDirectory: path) != 0)
             {
                 // install the latest
-                Run(exe, $"tool {command} {toolName} --tool-path .", out _, out _,  workingDirectory: path);
+                Debug.WriteLine ($"{command} returned {stdout} {stderr}. Trying backup path.");
+                Run(exe, $"tool {command} {toolName} --tool-path .", out stdout, out stderr,  workingDirectory: path);
             }
         }
 

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -76,8 +76,6 @@
     <PackageReference Include="AssimpNet" Version="5.0.0-beta1" IncludeAssets="compile;runtime;build" ExcludeAssets="native" />
     <PackageReference Include="MonoGame.Library.Assimp" Version="5.3.1.1" />
     <PackageReference Include="BCnEncoder.Net" Version="2.1.0" />
-    <PackageReference Include="BCnEncoder.Net.ImageSharp" Version="1.1.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.1.30" />
     <PackageReference Include="RoyT.TrueType" Version="0.2.0" />
     <PackageReference Include="SharpDX" Version="4.0.1" />

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -101,16 +101,6 @@
       <PackagePath>runtimes\linux-x64\native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\ThirdParty\Dependencies\ffmpeg\Linux\x64\ffmpeg" Visible="false">
-      <Link>linux\ffmpeg</Link>
-      <PackagePath>runtimes\linux-x64\native\linux</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\ffmpeg\Linux\x64\ffprobe" Visible="false">
-      <Link>linux\ffprobe</Link>
-      <PackagePath>runtimes\linux-x64\native\linux</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="..\ThirdParty\Dependencies\FreeImage.NET\MacOS\libfreeimage.dylib" Visible="false">
       <Link>libFreeImage.dylib</Link>
       <PackagePath>runtimes\osx\native\libFreeImage.dylib</PackagePath>
@@ -123,25 +113,6 @@
     </Content>
     <Content Include="..\ThirdParty\Dependencies\SharpFont\x64\libpng16.16.dylib" Visible="false">
       <PackagePath>runtimes\osx\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\ffmpeg\MacOS\ffmpeg" Visible="false">
-      <Link>osx\ffmpeg</Link>
-      <PackagePath>runtimes\osx\native\osx</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\ffmpeg\MacOS\ffprobe" Visible="false">
-      <Link>osx\ffprobe</Link>
-      <PackagePath>runtimes\osx\native\osx</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-
-    <Content Include="..\ThirdParty\Dependencies\ffmpeg\Windows\x64\ffmpeg.exe" Visible="false">
-      <PackagePath>runtimes\win-x64\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\ffmpeg\Windows\x64\ffprobe.exe" Visible="false">
-      <PackagePath>runtimes\win-x64\native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\ThirdParty\Dependencies\FreeImage.NET\Windows\FreeImage.dll" Visible="false">

--- a/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
@@ -206,7 +206,7 @@ internal static class BasisU
     /// <returns>The exit code for the basisu process. </returns>
     public static int Run(string args, out string stdOut, out string stdErr, string stdIn=null, string workingDirectory=null)
     {
-        return ExternalTool.RunDotnetTool("mgcb-basisu", args, out stdOut, out stdErr, stdIn, workingDirectory);
+        return ExternalTool.RunDotnetTool(ExternalTool.BasisU, args, out stdOut, out stdErr, stdIn, workingDirectory);
     }
 
     /// <summary>
@@ -430,7 +430,7 @@ internal static class BasisU
         //  basisu -unpack foo.ktx2 -ktx_only -linear -format_only 2
         var linearFlag = basisUFormat.isLinearColorSpace ? "-linear" : "";
         // var linearFlag = "";
-        var argStr = $"-unpack -file {basisFileName} -ktx_only -format_only {basisUFormat.code} {linearFlag}";
+        var argStr = $"-unpack -file \"{basisFileName}\" -ktx_only -format_only {basisUFormat.code} {linearFlag}";
         var exitCode = Run(
             args: argStr,
             stdOut: out var stdOut,
@@ -489,7 +489,7 @@ internal static class BasisU
     {
         var absImageFileName = Path.GetFullPath(imageFileName);
         var uastcFlag = format.nonUastcCompatible ? "": "-uastc";
-        var argStr = $"-file {absImageFileName} {uastcFlag} -ktx2 -output_file {intermediateFileName}";
+        var argStr = $"-file \"{absImageFileName}\" {uastcFlag} -ktx2 -output_file \"{intermediateFileName}\"";
         var exitCode = Run(
             args: argStr,
             stdOut: out var stdOut,

--- a/MonoGame.Framework.Content.Pipeline/Utilities/CrunchHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/CrunchHelpers.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities
         /// <returns>The exit code for the basisu process. </returns>
         private static int Run(string args, out string stdOut, out string stdErr)
         {
-            return ExternalTool.RunDotnetTool("mgcb-crunch", args, out stdOut, out stdErr);
+            return ExternalTool.RunDotnetTool(ExternalTool.Crunch, args, out stdOut, out stdErr);
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities
         )
         {
             errorMessage = null;
-            var argStr = $"-file {pngFileName} -{format.formatString} -out {intermediateFileName} -fileformat ktx -forceprimaryencoding -noNormalDetection";
+            var argStr = $"-file \"{pngFileName}\" -{format.formatString} -out \"{intermediateFileName}\" -fileformat ktx -forceprimaryencoding -noNormalDetection";
             var exitCode = Run(
                 args: argStr,
                 stdOut: out var stdOut,

--- a/MonoGame.Framework.Content.Pipeline/VideoContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/VideoContent.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             Filename = filename;
 
             string stdout, stderr;
-            var result = ExternalTool.Run("ffprobe",
+            var result = ExternalTool.RunDotnetTool(ExternalTool.FFmpeg,
                 string.Format("-i \"{0}\" -show_format -select_streams v -show_streams -print_format ini", Filename), out stdout, out stderr);
 
             var lines = stdout.Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.Android.CSharp/.config/dotnet-tools.json
@@ -2,12 +2,6 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "dotnet-mgcb": {
-      "version": "3.8.2.1-develop",
-      "commands": [
-        "mgcb"
-      ]
-    },
     "dotnet-mgcb-editor": {
       "version": "3.8.2.1-develop",
       "commands": [

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.DesktopGL.CSharp/.config/dotnet-tools.json
@@ -2,12 +2,6 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "dotnet-mgcb": {
-      "version": "3.8.2.1-develop",
-      "commands": [
-        "mgcb"
-      ]
-    },
     "dotnet-mgcb-editor": {
       "version": "3.8.2.1-develop",
       "commands": [

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.WindowsDX.CSharp/.config/dotnet-tools.json
@@ -2,12 +2,6 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "dotnet-mgcb": {
-      "version": "3.8.2.1-develop",
-      "commands": [
-        "mgcb"
-      ]
-    },
     "dotnet-mgcb-editor": {
       "version": "3.8.2.1-develop",
       "commands": [

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.iOS.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Application.iOS.CSharp/.config/dotnet-tools.json
@@ -2,12 +2,6 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "dotnet-mgcb": {
-      "version": "3.8.2.1-develop",
-      "commands": [
-        "mgcb"
-      ]
-    },
     "dotnet-mgcb-editor": {
       "version": "3.8.2.1-develop",
       "commands": [

--- a/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.CSharp/.config/dotnet-tools.json
+++ b/Templates/MonoGame.Templates.CSharp/content/MonoGame.Library.CSharp/.config/dotnet-tools.json
@@ -2,12 +2,6 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "dotnet-mgcb": {
-      "version": "3.8.2.1-develop",
-      "commands": [
-        "mgcb"
-      ]
-    },
     "dotnet-mgcb-editor": {
       "version": "3.8.2.1-develop",
       "commands": [

--- a/Tests/Assets/Projects/NuGet.config
+++ b/Tests/Assets/Projects/NuGet.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+        <add key="globalPackagesFolder" value="../../../../packages" />
+    </config>
+    <packageSources>
+        <add key="LocalPackages" value="../../../../nuget" />
+    </packageSources>
+</configuration>

--- a/Tests/Assets/Projects/NuGet.config
+++ b/Tests/Assets/Projects/NuGet.config
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <config>
-        <add key="globalPackagesFolder" value="../../../../packages" />
+        <add key="globalPackagesFolder" value="./packages" />
     </config>
     <packageSources>
-        <add key="LocalPackages" value="../../../../nuget" />
+        <add key="LocalPackages" value="../../../../../../Artifacts/NuGet" />
     </packageSources>
 </configuration>

--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
@@ -35,14 +35,20 @@ namespace MonoGame.Tools.Pipeline
         private static readonly string [] _mgcbSearchPaths = new []       
         {
 #if DEBUG
+#if MAC
+            Path.Combine(Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "", "../../../MonoGame.Content.Builder/Debug/mgcb.dll"),
+            Path.Combine(Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "", "../../../../../MonoGame.Content.Builder/Debug/mgcb.dll"),
+#else
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "../../../MonoGame.Content.Builder/Debug/mgcb.dll"),
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "../../../../../../../../MonoGame.Content.Builder/Debug/mgcb.dll"),
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "../../../../../../MonoGame.Content.Builder/Debug/mgcb.dll"),
+#endif
 #else
 #if MAC
             Path.Combine(Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "", "../../../MonoGame.Content.Builder/Release/mgcb.dll"),
             Path.Combine(Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "", "../../../../../../../../MonoGame.Content.Builder/Release/mgcb.dll"),
             Path.Combine(Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "", "../../../../../../MonoGame.Content.Builder/Release/mgcb.dll"),
+            Path.Combine(Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "", "../../../../../MonoGame.Content.Builder/Release/mgcb.dll"),
 #else
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "../../../MonoGame.Content.Builder/Release/mgcb.dll"),
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "", "../../../../../../../../MonoGame.Content.Builder/Release/mgcb.dll"),
@@ -130,6 +136,7 @@ namespace MonoGame.Tools.Pipeline
                 LoadTemplates(templatesPath);
 #endif
 
+            RestoreMGCB();
             UpdateMenu();
 
             view.UpdateRecentList(PipelineSettings.Default.ProjectHistory);
@@ -577,6 +584,22 @@ namespace MonoGame.Tools.Pipeline
             UpdateMenu();       
         }
 
+        private void RestoreMGCB()
+        {
+            var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            var workingDirectory = Path.Combine(appDataPath, "mgcb-dotnet-tool", version);
+            if (Directory.Exists(workingDirectory))
+                return;
+            Directory.CreateDirectory(workingDirectory);
+            var dotnet = Global.Unix ? "dotnet" : "dotnet.exe";
+            if (Util.Run(dotnet, $"tool install dotnet-mgcb --version {version} --tool-path .", workingDirectory) != 0)
+            {
+                // install the latest
+                Util.Run(dotnet, $"tool install dotnet-mgcb --tool-path .", workingDirectory);
+            }
+        }
+
         private void DoBuild(string commands)
         {
             Encoding encoding;
@@ -588,9 +611,11 @@ namespace MonoGame.Tools.Pipeline
                 encoding = Encoding.UTF8;
             }
             
-            var mgcbCommand = "mgcb";
+            
+            var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var version = Assembly.GetExecutingAssembly().GetName().Version.ToString ();
+            var mgcbCommand = Path.Combine(appDataPath, "mgcb-dotnet-tool", version, "mgcb");
             var currentDir = Environment.CurrentDirectory;
-
             foreach (var path in _mgcbSearchPaths)
             {
                 var fullPath = Path.Combine(currentDir, path);
@@ -601,26 +626,17 @@ namespace MonoGame.Tools.Pipeline
                     break;
                 }
             }
+            // allow the users to override the path with an environment variable
+            // the same as the MSBuild property in the .targets
+            var mgcbUserPath = Environment.GetEnvironmentVariable("MGCBCommand");
+            if (!string.IsNullOrEmpty(mgcbUserPath) && File.Exists(mgcbUserPath))
+            {
+                mgcbCommand = mgcbUserPath;
+            }
 
             try
             {
-                // Prepare the process.
-                _buildProcess = new Process
-                {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = Global.Unix ? "dotnet" : "dotnet.exe",
-                        Arguments = $"{mgcbCommand} {commands}",
-                        WorkingDirectory = Path.GetDirectoryName(_project.OriginalPath),
-                        CreateNoWindow = true,
-                        WindowStyle = ProcessWindowStyle.Hidden,
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true,
-                        StandardOutputEncoding = encoding
-                    }
-                };
-                _buildProcess.OutputDataReceived += (sender, args) => View.OutputAppend(args.Data);
-
+                _buildProcess = Util.CreateProcess(mgcbCommand, commands, Path.GetDirectoryName (_project.OriginalPath), encoding, (s) => View.OutputAppend (s));
                 // Fire off the process.
                 Console.WriteLine(_buildProcess.StartInfo.FileName + " " + _buildProcess.StartInfo.Arguments);
                 Environment.CurrentDirectory = _buildProcess.StartInfo.WorkingDirectory;

--- a/Tools/MonoGame.Content.Builder.Editor/Common/Util.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/Util.cs
@@ -62,7 +62,8 @@ namespace MonoGame.Tools.Pipeline
         {
             var exe = command;
             var args = arguments;
-            if (command.EndsWith (".dll")) {
+            if (command.EndsWith (".dll"))
+            {
                 // we are referencing the dll directly. We need to call dotnet to host.
                 exe = Global.Unix ? "dotnet" : "dotnet.exe";
                 args = $"\"{command}\" {arguments}";

--- a/Tools/MonoGame.Content.Builder.Editor/Common/Util.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/Util.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace MonoGame.Tools.Pipeline
 {
@@ -45,6 +47,42 @@ namespace MonoGame.Tools.Pipeline
             result = Uri.UnescapeDataString(result);
 
             return result;
+        }
+
+        public static int Run(string command, string arguments, string workingDirectory)
+        {
+            var process = CreateProcess(command, arguments, workingDirectory, Encoding.UTF8, (s) => Console.WriteLine(s));
+            process.Start();
+            process.BeginOutputReadLine();
+            process.WaitForExit();
+            return process.ExitCode;
+        }
+
+        public static Process CreateProcess(string command, string arguments, string workingDirectory, Encoding encoding, Action<string> output)
+        {
+            var exe = command;
+            var args = arguments;
+            if (command.EndsWith (".dll")) {
+                // we are referencing the dll directly. We need to call dotnet to host.
+                exe = Global.Unix ? "dotnet" : "dotnet.exe";
+                args = $"\"{command}\" {arguments}";
+            }
+            var _buildProcess = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = $"\"{exe}\"",
+                    Arguments = args,
+                    WorkingDirectory = workingDirectory,
+                    CreateNoWindow = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    StandardOutputEncoding = encoding
+                }
+            };
+            _buildProcess.OutputDataReceived += (sender, args) => output(args.Data);
+            return _buildProcess;
         }
     }
 }

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.csproj
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\MonoGame.Content.Builder\MonoGame.Content.Builder.csproj" />
+    <ProjectReference Include="..\MonoGame.Content.Builder\MonoGame.Content.Builder.csproj" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
@@ -3,7 +3,11 @@
   <PropertyGroup>
     <DotnetCommand Condition="'$(DotnetCommand)' == ''">dotnet</DotnetCommand>
     <EnableMGCBItems Condition="'$(EnableMGCBItems)' == ''">true</EnableMGCBItems>
+    <!-- Allow users the ability to disble tool restoration if needed -->
+    <AutoRestoreMGCBTool Condition="'$(AutoRestoreMGCBTool)' == ''">true</AutoRestoreMGCBTool>
+    <MGCBToolDirectory>$(MSBuildThisFileDirectory)dotnet-tools/</MGCBToolDirectory>
     <MGCBCommand Condition="'$(MGCBCommand)' == ''">mgcb</MGCBCommand>
+    <MonoGameVersion Condition="'$(MonoGameVersion)' == ''">3.8.1.1-develop</MonoGameVersion>
   </PropertyGroup>
 
 </Project>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
@@ -7,7 +7,7 @@
     <AutoRestoreMGCBTool Condition="'$(AutoRestoreMGCBTool)' == ''">true</AutoRestoreMGCBTool>
     <MGCBToolDirectory>$(MSBuildThisFileDirectory)dotnet-tools/</MGCBToolDirectory>
     <MGCBCommand Condition="'$(MGCBCommand)' == ''">mgcb</MGCBCommand>
-    <MonoGameVersion Condition="'$(MonoGameVersion)' == ''">3.8.1.1-develop</MonoGameVersion>
+    <MonoGameVersion Condition="'$(MonoGameVersion)' == ''">3.8.2.0</MonoGameVersion>
   </PropertyGroup>
 
 </Project>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
@@ -4,6 +4,8 @@
     <DotnetCommand Condition="'$(DotnetCommand)' == ''">dotnet</DotnetCommand>
     <EnableMGCBItems Condition="'$(EnableMGCBItems)' == ''">true</EnableMGCBItems>
     <!-- Allow users the ability to disble tool restoration if needed -->
+    <!-- If the user is using a custom $(MGCBCommand) , disable auto restore. -->
+    <AutoRestoreMGCBTool Condition="'$(AutoRestoreMGCBTool)' == '' And '$(MGCBCommand)' != ''">false</AutoRestoreMGCBTool>
     <AutoRestoreMGCBTool Condition="'$(AutoRestoreMGCBTool)' == ''">true</AutoRestoreMGCBTool>
     <MGCBToolDirectory Condition="'$(MGCBToolDirectory)' == ''">$(MSBuildThisFileDirectory)dotnet-tools/</MGCBToolDirectory>
     <MGCBToolDirectory Condition="'$(MGCBToolDirectory)' != '' And !HasTrailingSlash('$(MGCBToolDirectory)')">$(MGCBToolDirectory)/</MGCBToolDirectory>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
@@ -5,7 +5,8 @@
     <EnableMGCBItems Condition="'$(EnableMGCBItems)' == ''">true</EnableMGCBItems>
     <!-- Allow users the ability to disble tool restoration if needed -->
     <AutoRestoreMGCBTool Condition="'$(AutoRestoreMGCBTool)' == ''">true</AutoRestoreMGCBTool>
-    <MGCBToolDirectory>$(MSBuildThisFileDirectory)dotnet-tools/</MGCBToolDirectory>
+    <MGCBToolDirectory Condition="'$(MGCBToolDirectory)' == ''">$(MSBuildThisFileDirectory)dotnet-tools/</MGCBToolDirectory>
+    <MGCBToolDirectory Condition="'$(MGCBToolDirectory)' != '' And !HasTrailingSlash('$(MGCBToolDirectory)')">$(MGCBToolDirectory)/</MGCBToolDirectory>
     <MGCBCommand Condition="'$(MGCBCommand)' == ''">mgcb</MGCBCommand>
     <MonoGameVersion Condition="'$(MonoGameVersion)' == ''">3.8.2.0</MonoGameVersion>
   </PropertyGroup>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -85,9 +85,12 @@
   </Target>
 
   <!-- Restore the dotnet-mgcb tool to a known location. -->
+  <!-- Use MGCBToolAdditionalArguments to provide additional arguments to the install
+   for example a path to your custom NuGet.config file.
+  -->
   <Target Name="RestoreContentCompiler" Condition=" '$(AutoRestoreMGCBTool)' == 'true' And !Exists ('$(MGCBToolDirectory)$(MGCBCommand)')">
     <MakeDir Directories="$(MGCBToolDirectory)"/>
-    <Exec Command="&quot;$(DotnetCommand)&quot; tool install dotnet-mgcb --version $(MonoGameVersion) --tool-path ." WorkingDirectory="$(MGCBToolDirectory)" ContinueOnError="true" />
+    <Exec Command="&quot;$(DotnetCommand)&quot; tool install $(MGCBToolAdditionalArguments) dotnet-mgcb --version $(MonoGameVersion) --tool-path ." WorkingDirectory="$(MGCBToolDirectory)" ContinueOnError="true" />
   </Target>
 
   <!--
@@ -143,7 +146,7 @@
   <Target Name="RunContentBuilder" DependsOnTargets="RestoreContentCompiler;PrepareContentBuilder">
 
     <PropertyGroup>
-      <_Command Condition="Exists ('$(MGCBToolDirectory)\$(MGCBCommand)')">&quot;$(MGCBToolDirectory)\$(MGCBCommand)&quot;</_Command>
+      <_Command Condition="Exists ('$(MGCBToolDirectory)$(MGCBCommand)')">&quot;$(MGCBToolDirectory)$(MGCBCommand)&quot;</_Command>
       <!-- Fallback to old behaviour this allows people to override $(MGCBCommand) with the mgcb.dll -->
       <_Command Condition=" '$(_Command)' == '' ">&quot;$(DotnetCommand)&quot; &quot;$(MGCBCommand)&quot;</_Command>
     </PropertyGroup>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -84,6 +84,12 @@
 
   </Target>
 
+  <!-- Restore the dotnet-mgcb tool to a known location. -->
+  <Target Name="RestoreContentCompiler" Condition=" '$(AutoRestoreMGCBTool)' == 'true' And !Exists ('$(MGCBToolDirectory)$(MGCBCommand)')">
+    <MakeDir Directories="$(MGCBToolDirectory)"/>
+    <Exec Command="&quot;$(DotnetCommand)&quot; tool install dotnet-mgcb --version $(MonoGameVersion) --tool-path ." WorkingDirectory="$(MGCBToolDirectory)" ContinueOnError="true" />
+  </Target>
+
   <!--
     =====================
     PrepareContentBuilder
@@ -134,16 +140,18 @@
       - ExtraContent: built content files
         - ContentDir: the relative path of the embedded folder to contain the content files
   -->
-  <Target Name="RunContentBuilder" DependsOnTargets="PrepareContentBuilder">
+  <Target Name="RunContentBuilder" DependsOnTargets="RestoreContentCompiler;PrepareContentBuilder">
 
-    <!-- Remove this line if they make dotnet tool restore part of dotnet restore build -->
-    <!-- https://github.com/dotnet/sdk/issues/4241 -->
-    <Exec Command="&quot;$(DotnetCommand)&quot; tool restore" />
+    <PropertyGroup>
+      <_Command Condition="Exists ('$(MGCBToolDirectory)\$(MGCBCommand)')">&quot;$(MGCBToolDirectory)\$(MGCBCommand)&quot;</_Command>
+      <!-- Fallback to old behaviour this allows people to override $(MGCBCommand) with the mgcb.dll -->
+      <_Command Condition=" '$(_Command)' == '' ">&quot;$(DotnetCommand)&quot; &quot;$(MGCBCommand)&quot;</_Command>
+    </PropertyGroup>
 
     <!-- Execute MGCB from the project directory so we use the correct manifest. -->
     <Exec
       Condition="'%(ContentReference.FullPath)' != ''"
-      Command="&quot;$(DotnetCommand)&quot; &quot;$(MGCBCommand)&quot; $(MonoGameMGCBAdditionalArguments) /@:&quot;%(ContentReference.FullPath)&quot; /platform:$(MonoGamePlatform) /outputDir:&quot;%(ContentReference.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReference.ContentIntermediateOutputDir)&quot; /workingDir:&quot;%(ContentReference.FullDir)&quot;"
+      Command="$(_Command) $(MonoGameMGCBAdditionalArguments) /@:&quot;%(ContentReference.FullPath)&quot; /platform:$(MonoGamePlatform) /outputDir:&quot;%(ContentReference.ContentOutputDir)&quot; /intermediateDir:&quot;%(ContentReference.ContentIntermediateOutputDir)&quot; /workingDir:&quot;%(ContentReference.FullDir)&quot;"
       WorkingDirectory="$(MSBuildProjectDirectory)" />
 
     <ItemGroup>

--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -16,7 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj" />
+    <ProjectReference Include="..\..\MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj">
+      <IncludeAssets>compile</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
     <ProjectReference Include="..\..\MonoGame.Framework.Content.Pipeline\MonoGame.Framework.Content.Pipeline.csproj" />
   </ItemGroup>
 

--- a/Tools/MonoGame.Tools.Tests/BuilderTargetsTest.cs
+++ b/Tools/MonoGame.Tools.Tests/BuilderTargetsTest.cs
@@ -57,7 +57,8 @@ namespace MonoGame.Tests.ContentPipeline
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
                 if (!process.WaitForExit(60000)) {// wait for 60 seconds
-                    process.Kill ();
+                    process.Kill();
+                    process.WaitForExit();
                 }
                 return process.ExitCode == 0;
             }

--- a/Tools/MonoGame.Tools.Tests/BuilderTargetsTest.cs
+++ b/Tools/MonoGame.Tools.Tests/BuilderTargetsTest.cs
@@ -31,7 +31,7 @@ namespace MonoGame.Tests.ContentPipeline
             var tool = FindTool(buildTool);
             var psi = new ProcessStartInfo(tool)
             {
-                Arguments = $"build {projectFile} -t:IncludeContent {string.Join(" ", parameters)} -tl:off -bl -p:DotnetCommand=\"{tool}\"",
+                Arguments = $"build \"{projectFile}\" -t:IncludeContent {string.Join(" ", parameters)} -tl:off -bl -p:DotnetCommand=\"{tool}\"",
                 WorkingDirectory = root,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
@@ -72,11 +72,11 @@ namespace MonoGame.Tests.ContentPipeline
                 Directory.Delete(outputPath, recursive: true);
 
             var result = RunBuild("dotnet", Path.Combine(root, "Assets", "Projects", "BuildSimpleProject.csproj"), new string[] {
-                "-p:MGCBCommand=" + Path.Combine(root, "mgcb.dll")
+                $"-p:MGCBCommand=\"{Path.Combine(root, "mgcb.dll")}\""
             });
             Assert.AreEqual(true, result, "Content Build should have succeeded.");
             var contentFont = Path.Combine(outputPath, "DesktopGL", "Content", "ContentFont.xnb");
-            Assert.IsTrue(File.Exists(contentFont), "'" + contentFont + "' should exist.");
+            Assert.IsTrue(File.Exists(contentFont), $"'{contentFont}' should exist.");
         }
     }
 }

--- a/build/BuildToolsTasks/BuildContentPipelineTask.cs
+++ b/build/BuildToolsTasks/BuildContentPipelineTask.cs
@@ -9,11 +9,5 @@ public sealed class BuildContentPipelineTask : FrostingTask<BuildContext>
     {
         var builderPath = context.GetProjectPath(ProjectType.ContentPipeline);
         context.DotNetPack(builderPath, context.DotNetPackSettings);
-
-        // ensure that the local development has the required dotnet tools.
-        //  this won't actually include the tool manifest in a final build,
-        //  but it will setup a local developer's project
-        context.DotNetTool(builderPath, "tool install --create-manifest-if-needed mgcb-basisu");
-        context.DotNetTool(builderPath, "tool install --create-manifest-if-needed mgcb-crunch");
     }
 }

--- a/build/BuildToolsTasks/BuildMGCBEditorTask.cs
+++ b/build/BuildToolsTasks/BuildMGCBEditorTask.cs
@@ -8,12 +8,15 @@ public sealed class BuildMGCBEditorTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
     {
-        context.ReplaceRegexInFiles(
-            @"<key>CFBundleShortVersionString<\/key>\s*<string>([^\s]*)<\/string>",
-            "Tools/MonoGame.Content.Builder.Editor/Info.plist",
-            $"<key>CFBundleShortVersionString</key>\n\t<string>{context.Version}</string>",
-            RegexOptions.Singleline
-        );
+        if (context.BuildSystem().IsRunningOnGitHubActions)
+        {
+            context.ReplaceRegexInFiles(
+                "Tools/MonoGame.Content.Builder.Editor/Info.plist",
+                @"<key>CFBundleShortVersionString<\/key>\s*<string>([^\s]*)<\/string>",
+                $"<key>CFBundleShortVersionString</key>\n\t<string>{context.Version}</string>",
+                RegexOptions.Singleline
+            );
+        }
 
         var platform = context.Environment.Platform.Family switch
         {

--- a/build/BuildToolsTasks/BuildMGCBTask.cs
+++ b/build/BuildToolsTasks/BuildMGCBTask.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 
 namespace BuildScripts;
 
@@ -7,6 +8,15 @@ public sealed class BuildMGCBTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
     {
+        if (context.BuildSystem().IsRunningOnGitHubActions)
+        {
+            context.ReplaceRegexInFiles(
+                "Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props",
+                @"<MonoGameVersion Condition=""'$(MonoGameVersion)' == ''"">([^\s]*)<\/MonoGameVersion>",
+                $"<MonoGameVersion Condition=\"'$(MonoGameVersion)' == ''\">{context.Version}</MonoGameVersion>",
+                RegexOptions.Singleline
+            );
+        }
         context.DotNetPack(context.GetProjectPath(ProjectType.Tools, "MonoGame.Content.Builder"), context.DotNetPackSettings);
         context.DotNetPack(context.GetProjectPath(ProjectType.Tools, "MonoGame.Content.Builder.Task"), context.DotNetPackSettings);
     }

--- a/build/BuildToolsTasks/BuildMGCBTask.cs
+++ b/build/BuildToolsTasks/BuildMGCBTask.cs
@@ -12,7 +12,7 @@ public sealed class BuildMGCBTask : FrostingTask<BuildContext>
         {
             context.ReplaceRegexInFiles(
                 "Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props",
-                @"<MonoGameVersion Condition=""'$(MonoGameVersion)' == ''"">([^\s]*)<\/MonoGameVersion>",
+                @"<MonoGameVersion Condition=""'\$\(MonoGameVersion\)' == ''"">([^\s]*)<\/MonoGameVersion>",
                 $"<MonoGameVersion Condition=\"'$(MonoGameVersion)' == ''\">{context.Version}</MonoGameVersion>",
                 RegexOptions.Singleline
             );

--- a/build/DeployTasks/UploadArtifactsTask.cs
+++ b/build/DeployTasks/UploadArtifactsTask.cs
@@ -15,6 +15,33 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
             _ => "linux"
         };
 
+        // Clean up build tools if installed
+        // otherwise we get permission issues after extraction
+        // because the zip removes all the permissions.
+        // Plus in windows hidden files (like the .store directory)
+        // are ignored. This causes `dotnet tool` to error.
+        var path = System.IO.Path.Combine(context.BuildOutput, "Tests", "Tools", "Release", "dotnet-tools");
+        if (System.IO.Directory.Exists(path)) {
+            context.Log.Information ($"Deleting: {path}");
+            System.IO.Directory.Delete (path, recursive: true);
+        }
+        if (context.IsRunningOnMacOs())
+        {
+            path = System.IO.Path.Combine(context.BuildOutput, "Tests", "Tools", "Release", "osx");
+            DeleteToolStore(context, path);
+        }
+        if (context.IsRunningOnLinux())
+        {
+            path = System.IO.Path.Combine(context.BuildOutput, "Tests", "Tools", "Release", "linux");
+            DeleteToolStore(context, path);
+        }
+        if (context.IsRunningOnWindows())
+        {
+            path = System.IO.Path.Combine(context.BuildOutput, "Tests", "Tools", "Release");
+            DeleteToolStore(context, path);
+        }
+       
+
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(context.NuGetsDirectory.FullPath), $"nuget-{os}");
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(System.IO.Path.Combine(context.BuildOutput, "Tests", "Tools", "Release")), $"tests-tools-{os}");
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(System.IO.Path.Combine(context.BuildOutput, "Tests", "DesktopGL", "Release")), $"tests-desktopgl-{os}");
@@ -25,6 +52,26 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
             // Assuming that the .vsix file has already been created and is located at this exact path.
             var vsixFilePath = System.IO.Path.Combine(context.BuildOutput, "MonoGame.Templates.VSExtension", "net472", "MonoGame.Templates.VSExtension.vsix");
             await context.GitHubActions().Commands.UploadArtifact(new FilePath(vsixFilePath), "MonoGame.Templates.VSExtension.vsix");
+        }
+    }
+
+    void DeleteToolStore(BuildContext context, string path)
+    {
+        if (System.IO.Directory.Exists(path)) {
+            var store = System.IO.Path.Combine (path, ".store");
+            if (System.IO.Directory.Exists(store)) {
+                context.Log.Information($"Deleting: {store}");
+                System.IO.Directory.Delete(store, recursive: true);
+                foreach (var file in System.IO.Directory.GetFiles(path, "mgcb-*", System.IO.SearchOption.TopDirectoryOnly)) {
+                    context.Log.Information($"Deleting: {file}");
+                    System.IO.File.Delete(file);
+                }
+                foreach (var file in System.IO.Directory.GetFiles(path, "tools_version.txt", System.IO.SearchOption.TopDirectoryOnly)) {
+                    context.Log.Information($"Deleting: {file}");
+                    System.IO.File.Delete(file);
+                }
+                
+            }
         }
     }
 }


### PR DESCRIPTION
In commit 7a398b01 we added two new tools for compressing textures, `crunch` and `basisu`. 
The problem there is that the management of the `.config/dotnet-tool.json` file by the users was becoming an issue. 
We needed a more automatic way to install the required tooling. 

The problem is using the standard `dotnet tool install` calls requires a `.config/dotnet-tool.json` file to be present in either the current directory or a directory that is in the path ABOVE the current one. You would use the `--create-manifest-if-needed` flag to create the manifest, but that will still leave the users having to manage and upgrade the .json file every time we do a release. 

So lets get the pipeline to install the tooling itself. 
The `dotnet tool install` command has an additional argument`--tool-path` this allows us to say where we want the tool installed. Once that has happened we get a native binary launcher in `--tool-path` which allows us to launch the app directly without using the `dotnet` executable. So what this allows us to do is install the tooling locally in the directory that the content pipeline is installed. This will usually be the global `.nuget/package` directory. 

We need to keep an eye on the `DOTNET_ROOT` environment variable when installing the tooling, just in case a user (or CI) wants to use a custom dotnet install. 

Fix the calls to `basisu` and `crunch` to handle spaces in paths. Same for other area's which shell out to `mgcb`. 

Also added support for overriding which MGCB to use in the editor by looking for a `MGCBCommand` environment variable. This should be the full path to either the `mgcb` exe or the `mgcb.dll` that the user wants to use. This will allow users to change to a custom content compiler without having to change the editor.

The one downside is users will no longer be able to run `dotnet mgcb` directly in their project directory unless they install the tooling manually. 

The Editor also needs to download the `mgcb` tool. We place this in the `ApplicationData` folder rather than in the local assembly folder because we cannot guarantee that folder is writable. So in this instance a location specific to the current user seemed like the best approach.

The long term plan is to bundle all these tools into a single native library which can be called directly by the content pipeline.
