### PR TITLE
Fixes SPIR-V globals key lookup & parsing int/uint/float input types

### DIFF
--- a/Tools/MonoGame.Effect.Compiler/Effect/ConstantBufferData.Vulkan.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ConstantBufferData.Vulkan.cs
@@ -15,6 +15,7 @@ namespace MonoGame.Effect
             {
                 case "float":
                     return EffectObject.D3DXPARAMETER_TYPE.FLOAT;
+                case "uint":
                 case "int":
                     return EffectObject.D3DXPARAMETER_TYPE.INT;
                 case "bool":

--- a/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.Vulkan.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.Vulkan.cs
@@ -380,7 +380,7 @@ namespace MonoGame.Effect
 
                 // First gather the uniforms.
                 VkStruct globals;
-                if (structs.TryGetValue("%type__MG_Globals", out globals))
+                if (structs.TryGetValue("%type__Globals", out globals))
                 {
                     foreach (var member in globals.members.Values)
                         cbuffer.AddParameter(member.name, member.type, 0, member.offset);
@@ -449,24 +449,29 @@ namespace MonoGame.Effect
                         }
 
                         int size;
-                        if (input.type.StartsWith("v"))
+                        int len;
+                        int inputTypeStringStartIndex;
+                        if (input.type.StartsWith("v") && char.IsDigit(input.type[1]))
                         {
-                            int len = (int)char.GetNumericValue(input.type[1]);
-                            switch (input.type.Substring(2))
-                            {
-                                case "int":
-                                case "float":
-                                    size = len * 4;
-                                    break;
-                                default:
-                                    errorsAndWarnings += string.Format("Unknown vertex shader input type '{0}'.", input.type);
-                                    throw new ShaderCompilerException();
-                            }
+                            len = (int)char.GetNumericValue(input.type[1]);
+                            inputTypeStringStartIndex = 2;
                         }
                         else
                         {
-                            errorsAndWarnings += string.Format("Unknown vertex shader input type '{0}'.", input.type);
-                            throw new ShaderCompilerException();
+                            len = 1;
+                            inputTypeStringStartIndex = 0;
+                        }
+
+                        switch (input.type.Substring(inputTypeStringStartIndex))
+                        {
+                            case "int":
+                            case "uint":
+                            case "float":
+                                size = len * 4;
+                                break;
+                            default:
+                                errorsAndWarnings += string.Format("Unknown vertex shader input type '{0}'.", input.type);
+                                throw new ShaderCompilerException();
                         }
 
                         offset += size;


### PR DESCRIPTION
### Issue

Various custom effects failed to build. This was happening at the shader creation stage where the SPIR-V code is used to generate the `ConstantBuffer` along with its parameters' data types / sizes set.

### Description of Changes
- Changed `"%type__MG_Globals"` to `"%type__Globals"` according to this line in the SPIR-V output: `"type__Globals" OpName %type__Globals "type.$Globals"`.
- Initial changes for supporting parsing scalar types where only vector types worked before. For example `v2float` worked but `float` didn't. (https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_types)  
- Initial changes for supporting `uint` data type. (https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_unsigned_versus_signed_integers)