### PR TITLE
Update README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We support a growing list of platforms across the desktop, mobile, and console s
 * Mobile/Tablet Devices
   * Android 6.0 and up (OpenGL)
   * iPhone/iPad 10.0 and up (OpenGL)
-* Consoles (for registered developers)
+* [Consoles (for registered developers)](https://docs.monogame.net/articles/console_access.html)
   * PlayStation 4
   * PlayStation 5
   * Xbox One (XDK only) (GDK coming soon)
@@ -40,9 +40,28 @@ We support a growing list of platforms across the desktop, mobile, and console s
 
 ## Getting started
 - [Getting started →](https://docs.monogame.net/articles/getting_started/index.html)
+- ["How To" Guides →](https://docs.monogame.net/articles/getting_to_know/howto/)
 - [Documentation Hub →](https://docs.monogame.net/)
-- [API Reference →](https://docs.monogame.net/articles/tutorials.html)
-- [Tutorials →](https://docs.monogame.net/articles/tutorials.html)
+- [API Reference →](https://docs.monogame.net/api/index.html)
+- [Community Tutorials →](https://docs.monogame.net/articles/tutorials.html)
+
+## [Samples](https://github.com/MonoGame/MonoGame.Samples)
+
+Check out the awesome []"full game" samples](https://github.com/MonoGame/MonoGame.Samples) maintained by the MonoGame team:
+
+[Platformer 2D Sample](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/Platformer2D/README.md) | [NeonShooter](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/NeonShooter/README.md)|
+|-|-|
+Supported on all platforms | Supported on all platforms |
+[![Platformer 2D Sample](https://raw.githubusercontent.com/MonoGame/MonoGame.Samples/refs/heads/3.8.2/Images/Platformer2D-Sample.png)](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/Platformer2D/README.md) | [![NeonShooter Sample](https://raw.githubusercontent.com/MonoGame/MonoGame.Samples/refs/heads/3.8.2/Images/NeonShooter-Sample.png)](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/NeonShooter/README.md) |
+The [Platformer 2D](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/Platformer2D/README.md) sample is a basic 2D platformer pulled from the original XNA samples and upgraded for MonoGame.| [Neon Shooter](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/NeonShooter/README.md) Is a graphically intensive twin-stick shooter with particle effects and save data from Michael Hoffman |
+|||
+
+| [Auto Pong Sample](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/AutoPong/README.md) | [Ship Game 3D](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/ShipGame/README.md) |
+|-|-|
+| Supported on all platforms | GL / DX/ iOS / Android |
+| [![Auto Pong Sample](https://raw.githubusercontent.com/MonoGame/MonoGame.Samples/refs/heads/3.8.2/Images/AutoPong_1.gif)](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/AutoPong/README.md) | [![ShipGame 3D Sample](https://raw.githubusercontent.com/MonoGame/MonoGame.Samples/refs/heads/3.8.2/Images/ShipGame.gif)](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/ShipGame/README.md) |
+| A short [sample project](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/AutoPong/README.md) showing you how to make the classic game of pong, with generated soundfx, in 300 lines of code. | 3D Ship Game (Descent clone) sample, pulled from the XNA archives and updated for MonoGame |
+|||
 
 ## Support and Contributions
 
@@ -78,8 +97,8 @@ A high level breakdown of the components of the framework:
 * Project templates are in [Templates](Templates).
 * See [Tests](Tests) for the framework unit tests.
 * See [Tools/Tests](Tools/MonoGame.Tools.Tests) for the content pipeline and other tool tests.
-* [mgcb](Tools/MonoGame.Content.Builder) is the command line tool for content processing.
-* [mgfxc](Tools/MonoGame.Effect.Compiler) is the command line effect compiler tool.
+* The [mgcb](Tools/MonoGame.Content.Builder) is a command line tool for content processing.
+* The [mgfxc](Tools/MonoGame.Effect.Compiler) is a command line effect compiler tool.
 * The [mgcb-editor](Tools/MonoGame.Content.Builder.Editor) tool is a GUI frontend for content processing.
 
 ## Helpful Links
@@ -90,6 +109,7 @@ A high level breakdown of the components of the framework:
 * The [official documentation](https://docs.monogame.net/articles/index.html) is on our website.
 * Download [release](https://github.com/MonoGame/MonoGame/releases) and [development](https://github.com/orgs/MonoGame/packages) packages.
 * Follow [@MonoGameTeam](https://twitter.com/monogameteam) on Twitter.
+* Get premium content on [Patreon](https://www.patreon.com/bePatron?u=3142012) (coming soon)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
- <img height="128" alt="MonoGame" src="https://raw.githubusercontent.com/MonoGame/MonoGame.Logo/refs/heads/master/FullColorOnLight/LogoOnly_128px.png">
+ <a href="https://monogame.net/">
+   <img height="128" alt="MonoGame" src="https://raw.githubusercontent.com/MonoGame/MonoGame.Logo/refs/heads/master/FullColorOnLight/LogoOnly_128px.png">
+ </a>
  <h1>MonoGame</h1>
 
  [![Join the chat at https://discord.gg/monogame](https://img.shields.io/discord/355231098122272778?style=flat-square&color=%237289DA&label=Discord%20server&logo=discord&logoColor=white)](https://discord.gg/monogame) 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-﻿# MonoGame
+<div align="center">
+ <img height="128" alt="MonoGame" src="https://raw.githubusercontent.com/MonoGame/MonoGame.Logo/refs/heads/master/FullColorOnLight/LogoOnly_128px.png">
+ <h1>MonoGame</h1>
 
-MonoGame is a simple and powerful .NET framework for creating games for desktop PCs, video game consoles, and mobile devices using the C# programming language. It has been successfully used to create games such as [Streets of Rage 4](https://store.steampowered.com/app/985890/Streets_of_Rage_4/), [Carrion](https://store.steampowered.com/app/953490/CARRION/), [Celeste](https://store.steampowered.com/app/504230/Celeste/), [Stardew Valley](https://store.steampowered.com/app/413150/Stardew_Valley/), and [many others](https://monogame.net/showcase/).
+ [![Join the chat at https://discord.gg/monogame](https://img.shields.io/discord/355231098122272778?style=flat-square&color=%237289DA&label=Discord%20server&logo=discord&logoColor=white)](https://discord.gg/monogame) 
+ ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/monogame/monogame/main.yml?style=flat-square)
+ [![Donate](https://img.shields.io/badge/donate-F1465A?style=flat-square&logo=monogame&logoColor=FFFFFF)](https://monogame.net/donate/) 
+
+ One framework for creating powerful cross-platfrom games
+
+[Supported Platforms](#supported-platforms) • 
+[Getting started](#getting-started) • 
+[Support and Contributions](#support-and-contributions) • 
+[Source Code](#source-code) • 
+[Helpful Links](#helpful-links) • 
+[License](#license)
+</div>
+
+## Overview
+**MonoGame** is a simple and powerful .NET framework for creating games for desktop PCs, video game consoles, and mobile devices using the C# programming language. It has been successfully used to create games such as [Streets of Rage 4](https://store.steampowered.com/app/985890/Streets_of_Rage_4/), [Carrion](https://store.steampowered.com/app/953490/CARRION/), [Celeste](https://store.steampowered.com/app/504230/Celeste/), [Stardew Valley](https://store.steampowered.com/app/413150/Stardew_Valley/), and [many others](https://monogame.net/showcase/). 
 
 It is an open-source re-implementation of the discontinued [Microsoft's XNA Framework](https://msdn.microsoft.com/en-us/library/bb200104.aspx).
-
-[![Join the chat at https://discord.gg/monogame](https://img.shields.io/discord/355231098122272778?color=%237289DA&label=MonoGame&logo=discord&logoColor=white)](https://discord.gg/monogame)
-
-* [Build Status](#build-status)
-* [Supported Platforms](#supported-platforms)
-* [Support and Contributions](#support-and-contributions)
-* [Source Code](#source-code)
-* [Helpful Links](#helpful-links)
-* [License](#license)
-
-## Build Status
-
-We use [GitHub Actions](https://github.com/MonoGame/MonoGame/actions) to automate builds and packages distribution of the latest MonoGame changes. We also rely on a [build server](http://teamcity.monogame.net/?guest=1) to run tests in order to avoid regressions. The table below shows the current build status for the ```develop``` branch.
-
-| Name | Status |
-|:---- | ------ |
-| Builds | [![Build](https://github.com/MonoGame/MonoGame/actions/workflows/main.yml/badge.svg?branch=develop)](https://github.com/MonoGame/MonoGame/actions/workflows/main.yml) |
 
 ## Supported Platforms
 
@@ -38,11 +38,17 @@ We support a growing list of platforms across the desktop, mobile, and console s
   * Xbox One (XDK only) (GDK coming soon)
   * Nintendo Switch
 
+## Getting started
+- [Getting started →](https://docs.monogame.net/articles/getting_started/index.html)
+- [Documentation Hub →](https://docs.monogame.net/)
+- [API Reference →](https://docs.monogame.net/articles/tutorials.html)
+- [Tutorials →](https://docs.monogame.net/articles/tutorials.html)
+
 ## Support and Contributions
 
 If you think you have found a bug or have a feature request, use our [issue tracker](https://github.com/MonoGame/MonoGame/issues). Before opening a new issue, please search to see if your problem has already been reported. Try to be as detailed as possible in your issue reports.
 
-If you need help using MonoGame or have other questions we suggest you post on our [community forums](http://community.monogame.net). Please do not use the GitHub issue tracker for personal support requests.
+If you need help using MonoGame or have other questions we suggest you post on [GitHub discussions](https://github.com/MonoGame/MonoGame/discussions) page or [Discord server](https://discord.gg/monogame). Please do not use the issue tracker for personal support requests.
 
 If you are interested in contributing fixes or features to MonoGame, please read our [contributors guide](CONTRIBUTING.md) first.
 
@@ -80,7 +86,6 @@ A high level breakdown of the components of the framework:
 
 * The official website is [monogame.net](http://www.monogame.net).
 * Our [issue tracker](https://github.com/MonoGame/MonoGame/issues) is on GitHub.
-* Use our [community forums](http://community.monogame.net/) for support questions.
 * You can [join the Discord server](https://discord.gg/monogame) and chat live with the core developers and other users.
 * The [official documentation](https://docs.monogame.net/articles/index.html) is on our website.
 * Download [release](https://github.com/MonoGame/MonoGame/releases) and [development](https://github.com/orgs/MonoGame/packages) packages.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We support a growing list of platforms across the desktop, mobile, and console s
 
 ## [Samples](https://github.com/MonoGame/MonoGame.Samples)
 
-Check out the awesome []"full game" samples](https://github.com/MonoGame/MonoGame.Samples) maintained by the MonoGame team:
+Check out the awesome ["full game"] samples](https://github.com/MonoGame/MonoGame.Samples) maintained by the MonoGame team:
 
 [Platformer 2D Sample](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/Platformer2D/README.md) | [NeonShooter](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/NeonShooter/README.md)|
 |-|-|

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
  One framework for creating powerful cross-platfrom games
 
 [Supported Platforms](#supported-platforms) • 
-[Getting started](#getting-started) • 
+[Resources](#resources) • 
+[Samples](#samples) • 
 [Support and Contributions](#support-and-contributions) • 
 [Source Code](#source-code) • 
 [Helpful Links](#helpful-links) • 
@@ -38,16 +39,16 @@ We support a growing list of platforms across the desktop, mobile, and console s
   * Xbox One (XDK only) (GDK coming soon)
   * Nintendo Switch
 
-## Getting started
+## Resources
 - [Getting started →](https://docs.monogame.net/articles/getting_started/index.html)
 - ["How To" Guides →](https://docs.monogame.net/articles/getting_to_know/howto/)
 - [Documentation Hub →](https://docs.monogame.net/)
 - [API Reference →](https://docs.monogame.net/api/index.html)
 - [Community Tutorials →](https://docs.monogame.net/articles/tutorials.html)
 
-## [Samples](https://github.com/MonoGame/MonoGame.Samples)
+## Samples
 
-Check out the awesome ["full game" samples](https://github.com/MonoGame/MonoGame.Samples) maintained by the MonoGame team:
+Check out the awesome [game samples](https://github.com/MonoGame/MonoGame.Samples) maintained by the MonoGame team:
 
 [Platformer 2D Sample](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/Platformer2D/README.md) | [NeonShooter](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/NeonShooter/README.md)|
 |-|-|
@@ -58,7 +59,7 @@ The [Platformer 2D](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/Plat
 
 | [Auto Pong Sample](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/AutoPong/README.md) | [Ship Game 3D](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/ShipGame/README.md) |
 |-|-|
-| Supported on all platforms | GL / DX/ iOS / Android |
+| Supported on all platforms | GL / DX / iOS / Android |
 | [![Auto Pong Sample](https://raw.githubusercontent.com/MonoGame/MonoGame.Samples/refs/heads/3.8.2/Images/AutoPong_1.gif)](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/AutoPong/README.md) | [![ShipGame 3D Sample](https://raw.githubusercontent.com/MonoGame/MonoGame.Samples/refs/heads/3.8.2/Images/ShipGame.gif)](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/ShipGame/README.md) |
 | A short [sample project](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/AutoPong/README.md) showing you how to make the classic game of pong, with generated soundfx, in 300 lines of code. | 3D Ship Game (Descent clone) sample, pulled from the XNA archives and updated for MonoGame |
 |||

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We support a growing list of platforms across the desktop, mobile, and console s
 
 ## [Samples](https://github.com/MonoGame/MonoGame.Samples)
 
-Check out the awesome ["full game"] samples](https://github.com/MonoGame/MonoGame.Samples) maintained by the MonoGame team:
+Check out the awesome ["full game" samples](https://github.com/MonoGame/MonoGame.Samples) maintained by the MonoGame team:
 
 [Platformer 2D Sample](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/Platformer2D/README.md) | [NeonShooter](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.2/NeonShooter/README.md)|
 |-|-|


### PR DESCRIPTION
Fixes #8550

This PR aims to clean up and update info in README.md file. You can always view how the WIP looks like right now [here](https://github.com/Maniekko/MonoGame/blob/develop/README.md) 
- Added a logo (from [MonoGame.Logo](https://github.com/MonoGame/MonoGame.Logo) repo) and moved the badges to the top
- Removed outdated links to community forums, replacing them with GitHub discussions page
- Removed the Build Status chapter, the Build badge is usually enough to show that Actions are used.

This PR is marked as a draft since there's some things to do:
\- Add a proper "Getting started" chapter, instead of dry links to docs
\- Make sure all information is up to date
\- Maybe prettify existing info?

:warning: My knowledge of English is pretty limited, if you see a typo (or just want to help) feel free to open a PR **in my fork**.