### PR TITLE
Update MonoGame.Library.OpenAL to 1.23.1.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,14 +171,20 @@ jobs:
         include:
           - os: windows
             platform: windows
+            shell: cmd
           - os: macos
             platform: macos
+            shell: bash
           - os: ubuntu-latest
             platform: linux
+            shell: bash
             filter: --where="Category != Audio"
           # - os: linux
           #   platform: linux
       fail-fast: false
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -243,7 +249,6 @@ jobs:
           CI: true
 
       - name: Run DirectX Tests
-        shell: cmd
         run: dotnet MonoGame.Tests.dll
         env:
           CI: true

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.7" />
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="MonoGame.Library.SDL" Version="2.26.5.5" />
-    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.7" />
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.10" />
     <PackageReference Include="NVorbis" Version="0.10.4" />
   </ItemGroup>
 

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.7" />
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
An issue was reported that our OpenAL binaries were not working on Linux. It turns out that we had not installed the developer packages for most of the supported backends. As a result we only supported ALSA.

The CI has been updated to include all the supported backends with the exception of SoundIO. This is because if you build with SoundIO support you get a hard link to the library. However it is not a common library. Having a hard link stops the .so being loaded if it is not installed.

So lets bump all the projects that use OpenAL to use the latest package.
