### PR TITLE
Bump Cake.Frosting to 5.0.0 for github actions update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,19 +214,19 @@ jobs:
         if: runner.os != 'Windows' && runner.environment == 'github-hosted'
 
       - name: Download tests-tools-${{ matrix.platform }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tests-tools-${{ matrix.platform }}
           path: tests-tools
 
       - name: Download tests-desktopgl-${{ matrix.platform }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tests-desktopgl-${{ matrix.platform }}
           path: tests-desktopgl
           
       - name: Download tests-windowsdx-${{ matrix.platform }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tests-windowsdx-${{ matrix.platform }}
           path: tests-windowsdx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,11 +83,11 @@ jobs:
       - name: Install required workloads
         run:   |
               if [ "$RUNNER_OS" == "Linux" ]; then
-                    dotnet workload install android
+                    dotnet workload install android --version 8.0.402.0
               elif [ "$RUNNER_OS" == "Windows" ]; then
                     dotnet.exe workload install android ios macos
               else
-                    dotnet workload install android macos ios
+                    dotnet workload install android macos ios --version 8.0.402.0
               fi
         shell: bash
 
@@ -189,7 +189,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
-        #if: runner.environment == 'github-hosted'
+        if: runner.environment == 'github-hosted'
 
       - name: install wine64 on linux
         run: |

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Cake.FileHelpers" Version="7.0.0" />
     <PackageReference Include="Cake.Frosting" Version="4.2.0" />
     <PackageReference Include="Cake.Git" Version="4.0.0" />
-    <PackageReference Include="NuGet.Packaging" Version="6.10.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.11.1" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
   </ItemGroup>
 

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cake.FileHelpers" Version="7.0.0" />
-    <PackageReference Include="Cake.Frosting" Version="4.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="4.2.0" />
     <PackageReference Include="Cake.Git" Version="4.0.0" />
     <PackageReference Include="NuGet.Packaging" Version="6.10.1" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cake.FileHelpers" Version="7.0.0" />
-    <PackageReference Include="Cake.Frosting" Version="4.2.0" />
+    <PackageReference Include="Cake.Frosting" Version="5.0.0" />
     <PackageReference Include="Cake.Git" Version="4.0.0" />
     <PackageReference Include="NuGet.Packaging" Version="6.11.1" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Cake.Frosting" Version="5.0.0" />
     <PackageReference Include="Cake.Git" Version="4.0.0" />
     <PackageReference Include="NuGet.Packaging" Version="6.11.1" />
-    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Context https://github.com/cake-build/cake/issues/4331
Support github actions upload/download v4

Pin the MacOS Workloads to 8.0.402.0 so that we can avoid build issues until the CI images have been upgraded.
 