### PR TITLE
Throw Exception In `Content.Load` When `assetName` Is A Rooted Path.

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -345,6 +345,10 @@ namespace Microsoft.Xna.Framework.Content
             {
                 throw new ObjectDisposedException("ContentManager");
             }
+            if(Path.IsPathRooted(assetName))
+            {
+                throw new ContentLoadException("assetName '" + assetName + "' cannot be a rooted (absolute) path. Remove any leading drive letters (e.g. 'C:'), forward slashes or backslashes");
+            }
 
             T result = default(T);
 

--- a/Tests/Framework/Content/ContentManagerTest.cs
+++ b/Tests/Framework/Content/ContentManagerTest.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+using NUnit.Framework;
+
+namespace MonoGame.Tests.Content
+{
+    public class ContentManagerTest
+    {
+        [TestCase("C:\\image.png")]
+        [TestCase("\\image.png")]
+        [TestCase("//image.png")]
+        public void ThrowExceptionIfAssetNameIsRootedPath(string assetName)
+        {
+            GameServiceContainer services = new GameServiceContainer();
+            ContentManager content = new ContentManager(services, "Content");
+            var exception = Assert.Throws<ContentLoadException>(() => content.Load<Texture2D>(assetName));
+            StringAssert.Contains("rooted (absolute)", exception.Message);
+        }
+    }
+}

--- a/Tests/Framework/Content/ContentManagerTest.cs
+++ b/Tests/Framework/Content/ContentManagerTest.cs
@@ -9,7 +9,7 @@ namespace MonoGame.Tests.Content
     {
         [TestCase("C:\\image.png")]
         [TestCase("\\image.png")]
-        [TestCase("//image.png")]
+        [TestCase("/image.png")]
         public void ThrowExceptionIfAssetNameIsRootedPath(string assetName)
         {
             GameServiceContainer services = new GameServiceContainer();


### PR DESCRIPTION
Fixes #8568 


### Description of Change
Adds a `Path.IsRootedPath` check on the `assetName` parameter, and if it is a rooted path, throws a `ContentLoadException` with a clear exception message on why the exception occurred.  

Previous behavior would have allowed a rooted path as the `assetName` parameter which would later throw a `FileNotFoundException` in the `ContentManager.OpenStream` method when attempting to open the stream.  This is due to how `Path.Combine` works, where if the second parameter is a rooted path, it ignores the first parameter.

While technically the `FileNotFoundException` is correct when the stream is attempted to open, the exception doesn't clearly describe to the developer why it occurred.  The `assetName` parameter is defined as being a relative path, so if it is a rooted path, the exception should be thrown earlier to tell the developer they used a rooted path and need to use a relative path instead.
<!-- 
Enter description of the fix in this section.
Please be as descriptive as possible, future contributors will need to know *why* these changes are being made.
For inspiration review the commit/PR history in the MonoGame repository.
-->




