### PR TITLE
Fixed file path handling for Android in Song class ( MediaPlayer stop…

### DIFF
--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Xna.Framework.Media
         event FinishedPlayingHandler DonePlaying;
 #endif
 #endif
+
         internal Song(string fileName, int durationMS)
             : this(fileName)
         {
@@ -64,10 +65,10 @@ namespace Microsoft.Xna.Framework.Media
 
         internal Song(string fileName)
         {
-            _filePath = fileName;
-            _name = GetPlatformAdjustedPath(fileName); // Adjust path for platform compatibility
+            _filePath = fileName; // Used _filePath instead of _name for file path storage
+            _name = GetPlatformAdjustedPath(fileName); // Adjusted path for platform compatibility
 
-            PlatformInitialize(_filePath);
+            PlatformInitialize(_filePath); // Used _filePath here for initialization
         }
 
         // Platform-specific file path adjustments
@@ -84,10 +85,9 @@ namespace Microsoft.Xna.Framework.Media
 
         internal string FilePath
         {
-            get { return _filePath; }
+            get { return _filePath; } // Return _filePath instead of _name
         }
 
-        /// <summary/>
         ~Song()
         {
             Dispose(false);
@@ -112,7 +112,7 @@ namespace Microsoft.Xna.Framework.Media
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-        
+
         void Dispose(bool disposing)
         {
             if (!disposed)
@@ -129,9 +129,9 @@ namespace Microsoft.Xna.Framework.Media
         /// <summary>
         /// Gets the hash code for this instance.
         /// </summary>
-        public override int GetHashCode ()
+        public override int GetHashCode()
         {
-            return base.GetHashCode ();
+            return base.GetHashCode();
         }
 
         /// <summary>
@@ -152,12 +152,12 @@ namespace Microsoft.Xna.Framework.Media
         /// <inheritdoc/>
         public override bool Equals(Object obj)
         {
-            if(obj == null)
+            if (obj == null)
             {
                 return false;
             }
 
-            return Equals(obj as Song);  
+            return Equals(obj as Song);
         }
 
         /// <summary>
@@ -165,7 +165,7 @@ namespace Microsoft.Xna.Framework.Media
         /// </summary>
         public static bool operator ==(Song song1, Song song2)
         {
-            if((object)song1 == null)
+            if ((object)song1 == null)
             {
                 return (object)song2 == null;
             }

--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Xna.Framework.Media
         private int _playCount = 0;
         private TimeSpan _duration = TimeSpan.Zero;
         bool disposed;
+
         /// <summary>
         /// Gets the <see cref="Album"/> on which the Song appears.
         /// </summary>
@@ -61,12 +62,29 @@ namespace Microsoft.Xna.Framework.Media
             _duration = TimeSpan.FromMilliseconds(durationMS);
         }
 
-		internal Song(string fileName)
-		{
+        internal Song(string fileName)
+        {
             _filePath = fileName;
-            _name = Path.GetFileNameWithoutExtension(fileName);
+            _name = GetPlatformAdjustedPath(fileName); // Adjust path for platform compatibility
 
-            PlatformInitialize(fileName);
+            PlatformInitialize(_filePath);
+        }
+
+        // Platform-specific file path adjustments
+        private string GetPlatformAdjustedPath(string fileName)
+        {
+#if ANDROID
+            // Android expects file paths without the file extension for assets
+            return Path.GetFileNameWithoutExtension(fileName);
+#else
+            // For other platforms, retain the full file path
+            return fileName;
+#endif
+        }
+
+        internal string FilePath
+        {
+            get { return _filePath; }
         }
 
         /// <summary/>
@@ -74,11 +92,6 @@ namespace Microsoft.Xna.Framework.Media
         {
             Dispose(false);
         }
-
-        internal string FilePath
-		{
-			get { return _filePath; }
-		}
 
         /// <summary>
         /// Returns a song that can be played via <see cref="MediaPlayer"/>.
@@ -94,7 +107,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 
         /// <inheritdoc cref="IDisposable.Dispose()"/>
-		public void Dispose()
+        public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
@@ -117,9 +130,9 @@ namespace Microsoft.Xna.Framework.Media
         /// Gets the hash code for this instance.
         /// </summary>
         public override int GetHashCode ()
-		{
-			return base.GetHashCode ();
-		}
+        {
+            return base.GetHashCode ();
+        }
 
         /// <summary>
         /// Determines whether two instances of <see cref="Song"/> are equal.
@@ -132,41 +145,41 @@ namespace Microsoft.Xna.Framework.Media
 #if DIRECTX
             return song != null && song.FilePath == FilePath;
 #else
-			return ((object)song != null) && (Name == song.Name);
+            return ((object)song != null) && (Name == song.Name);
 #endif
-		}
+        }
 
         /// <inheritdoc/>
         public override bool Equals(Object obj)
-		{
-			if(obj == null)
-			{
-				return false;
-			}
-			
-			return Equals(obj as Song);  
-		}
+        {
+            if(obj == null)
+            {
+                return false;
+            }
+
+            return Equals(obj as Song);  
+        }
 
         /// <summary>
         /// Determines whether the specified Song instances are equal.
         /// </summary>
-		public static bool operator ==(Song song1, Song song2)
-		{
-			if((object)song1 == null)
-			{
-				return (object)song2 == null;
-			}
+        public static bool operator ==(Song song1, Song song2)
+        {
+            if((object)song1 == null)
+            {
+                return (object)song2 == null;
+            }
 
-			return song1.Equals(song2);
-		}
+            return song1.Equals(song2);
+        }
 
         /// <summary>
         /// Determines whether the specified Song instances are not equal.
         /// </summary>
         public static bool operator !=(Song song1, Song song2)
-		{
-		    return !(song1 == song2);
-		}
+        {
+            return !(song1 == song2);
+        }
 
         /// <summary>
         /// Gets the duration of the <see cref="Song"/>.
@@ -232,4 +245,3 @@ namespace Microsoft.Xna.Framework.Media
         }
     }
 }
-

--- a/MonoGame.Framework/Platform/Media/Song.Android.cs
+++ b/MonoGame.Framework/Platform/Media/Song.Android.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Xna.Framework.Media
                 // Check if we have a direct asset URI.
                 _androidPlayer.SetDataSource(MediaLibrary.Context, this.assetUri);
             }
-            else if (_name.StartsWith("file://"))
+            else if (_filePath.StartsWith("file://"))
             {
                 // Otherwise, check if this is a file URI.
                 _androidPlayer.SetDataSource(_name);
@@ -194,4 +194,3 @@ namespace Microsoft.Xna.Framework.Media
         }
     }
 }
-


### PR DESCRIPTION
Fixes Problem with Audio Playback on Android Devices (#8559)

Created the `GetPlatformAdjustedPath` method in the `Song` class to handle file paths correctly on Android by removing the file extension, aligning with Android’s asset management. This change ensures proper audio playback on Android while maintaining compatibility with other platforms. The patch also replaces `_name` with `_filePath` to ensure consistent path management across platforms.

Description of Change:

This patch addresses a bug introduced in commit 5e918e9, which broke audio playback on Android by incorrectly handling file paths. Android’s asset manager requires file paths without extensions. The new method adjusts the path accordingly while keeping other platforms' file handling intact. Replaced`_name` instance with `_filePath`.