### PR TITLE
Add support for multiplying two colors

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1749,6 +1749,17 @@ namespace Microsoft.Xna.Framework
 	    {
 	        return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
 	    }
+
+        /// <summary>
+        /// Multiplies the Alpha component value of a color by the specified value.
+        /// </summary>
+        /// <param name="value">The source color value to multiply.</param>
+        /// <param name="scale">The value to multiply the Alpha component value by.</param>
+        /// <returns>The new color value created as a result of the multiplication.</returns>
+        public static Color MultiplyAlpha(Color value, float scale)
+	    {
+	        return new Color(value.R, value.G, value.B, (int)(value.A * scale));
+	    }
 	
 	    /// <summary>
         /// Multiplies the RGBA component values of a color by the specified value.
@@ -1772,6 +1783,22 @@ namespace Microsoft.Xna.Framework
             return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
         }
 
+        /// <summary>
+        /// Multiplies two colors compenent-wise.
+        /// </summary>
+        /// <param name="color1">The first color to be multiplied.</param>
+        /// <param name="color2">The second color to be multiplied.</param>
+        /// <returns>The new color value created as a result of the multiplication.</returns>
+        public static Color operator *(Color color1, Color color2)
+        {
+            return new Color(
+                (color1.R / 255f) * (color2.R / 255f),
+                (color1.G / 255f) * (color2.G / 255f),
+                (color1.B / 255f) * (color2.B / 255f),
+                (color1.A / 255f) * (color2.A / 255f)
+            );
+        }
+        
         /// <summary>
         /// Gets a <see cref="Vector3"/> representation for this object.
         /// </summary>


### PR DESCRIPTION
Lets you multiply two colors component-wise via "Color * Color".
Also adds a method that lets you only multiply the alpha channel of a color.

Currently, working with non-premultiplied colors is pretty painful in Monogame and this seeks to help improve that.




