### PR TITLE
Modify .gitmodules to use https for Templates to resolve permission i…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,4 @@
 	url = https://github.com/LunarG/VulkanMemoryAllocator.git
 [submodule "external/MonoGame.Templates"]
 	path = external/MonoGame.Templates
-	url = git@github.com:MonoGame/MonoGame.Templates.git
+	url = https://github.com/MonoGame/MonoGame.Templates.git


### PR DESCRIPTION
Fixes #8593


### Description of Change


Set the url protocol to `https` for consistency with all other entries and to correct permission errors on non-configured git clients:

> fatal: clone of 'git@github.com:MonoGame/MonoGame.Templates.git'
git@github.com: Permission denied (publickey).

```
[submodule "external/MonoGame.Templates"]
	path = external/MonoGame.Templates
	url = https://github.com/MonoGame/MonoGame.Templates.git

```