### PR TITLE
Making MonoGame AOT/trimming compliant

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/AlphaTestEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/AlphaTestEffectReader.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     class AlphaTestEffectReader : ContentTypeReader<AlphaTestEffect>
     {
         protected internal override AlphaTestEffect Read(ContentReader input, AlphaTestEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/AlphaTestEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/AlphaTestEffectReader.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     class AlphaTestEffectReader : ContentTypeReader<AlphaTestEffect>
     {
         protected internal override AlphaTestEffect Read(ContentReader input, AlphaTestEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/AlphaTestEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/AlphaTestEffectReader.cs
@@ -6,9 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     class AlphaTestEffectReader : ContentTypeReader<AlphaTestEffect>
     {
         protected internal override AlphaTestEffect Read(ContentReader input, AlphaTestEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
@@ -7,7 +7,9 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class ArrayReader<T> : ContentTypeReader<T[]>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
@@ -7,8 +7,13 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    /// <summary>
+    /// This type is not meant to be used directly by MonoGame users.
+    /// Its purpose is to allow to work-around AOT issues when loading assets with the ContentManager fail due to the absence of runtime-reflection support in that context (i.e. missing types due to trimming and inability to statically discover them at compile-time).
+    /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
+    /// </summary>
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    internal class ArrayReader<T> : ContentTypeReader<T[]>
+    public class ArrayReader<T> : ContentTypeReader<T[]>
     {
         ContentTypeReader elementReader;
 

--- a/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
@@ -7,9 +7,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class ArrayReader<T> : ContentTypeReader<T[]>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ArrayReader.cs
@@ -7,6 +7,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class ArrayReader<T> : ContentTypeReader<T[]>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/BasicEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BasicEffectReader.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class BasicEffectReader : ContentTypeReader<BasicEffect>
     {
         protected internal override BasicEffect Read(ContentReader input, BasicEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/BasicEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BasicEffectReader.cs
@@ -6,9 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class BasicEffectReader : ContentTypeReader<BasicEffect>
     {
         protected internal override BasicEffect Read(ContentReader input, BasicEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/BasicEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BasicEffectReader.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class BasicEffectReader : ContentTypeReader<BasicEffect>
     {
         protected internal override BasicEffect Read(ContentReader input, BasicEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/BooleanReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BooleanReader.cs
@@ -2,15 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-using Microsoft.Xna.Framework.Content;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class BooleanReader : ContentTypeReader<bool>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class BooleanReader : ContentTypeReader<bool>
     {
         public BooleanReader()
         {

--- a/MonoGame.Framework/Content/ContentReaders/BooleanReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BooleanReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class BooleanReader : ContentTypeReader<bool>
     {
         public BooleanReader()

--- a/MonoGame.Framework/Content/ContentReaders/BooleanReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BooleanReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class BooleanReader : ContentTypeReader<bool>
     {
         public BooleanReader()

--- a/MonoGame.Framework/Content/ContentReaders/BoundingBoxReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BoundingBoxReader.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     class BoundingBoxReader : ContentTypeReader<BoundingBox>
     {
         protected internal override BoundingBox Read(ContentReader input, BoundingBox existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/BoundingBoxReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BoundingBoxReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     class BoundingBoxReader : ContentTypeReader<BoundingBox>
     {
         protected internal override BoundingBox Read(ContentReader input, BoundingBox existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/BoundingBoxReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BoundingBoxReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     class BoundingBoxReader : ContentTypeReader<BoundingBox>
     {
         protected internal override BoundingBox Read(ContentReader input, BoundingBox existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/BoundingFrustumReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BoundingFrustumReader.cs
@@ -2,11 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using Microsoft.Xna.Framework;
-
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class BoundingFrustumReader : ContentTypeReader<BoundingFrustum>
     {
         public BoundingFrustumReader()

--- a/MonoGame.Framework/Content/ContentReaders/BoundingFrustumReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BoundingFrustumReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class BoundingFrustumReader : ContentTypeReader<BoundingFrustum>
     {
         public BoundingFrustumReader()

--- a/MonoGame.Framework/Content/ContentReaders/BoundingFrustumReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BoundingFrustumReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class BoundingFrustumReader : ContentTypeReader<BoundingFrustum>
     {
         public BoundingFrustumReader()

--- a/MonoGame.Framework/Content/ContentReaders/BoundingSphereReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BoundingSphereReader.cs
@@ -2,11 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using Microsoft.Xna.Framework;
-
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class BoundingSphereReader : ContentTypeReader<BoundingSphere>
     {
         public BoundingSphereReader()

--- a/MonoGame.Framework/Content/ContentReaders/BoundingSphereReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BoundingSphereReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class BoundingSphereReader : ContentTypeReader<BoundingSphere>
     {
         public BoundingSphereReader()

--- a/MonoGame.Framework/Content/ContentReaders/BoundingSphereReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/BoundingSphereReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class BoundingSphereReader : ContentTypeReader<BoundingSphere>
     {
         public BoundingSphereReader()

--- a/MonoGame.Framework/Content/ContentReaders/ByteReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ByteReader.cs
@@ -2,10 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class ByteReader : ContentTypeReader<byte>
     {
         public ByteReader()

--- a/MonoGame.Framework/Content/ContentReaders/ByteReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ByteReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class ByteReader : ContentTypeReader<byte>
     {
         public ByteReader()

--- a/MonoGame.Framework/Content/ContentReaders/ByteReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ByteReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class ByteReader : ContentTypeReader<byte>
     {
         public ByteReader()

--- a/MonoGame.Framework/Content/ContentReaders/CharReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/CharReader.cs
@@ -2,15 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-using Microsoft.Xna.Framework.Content;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class CharReader : ContentTypeReader<char>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class CharReader : ContentTypeReader<char>
     {
         public CharReader()
         {

--- a/MonoGame.Framework/Content/ContentReaders/CharReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/CharReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class CharReader : ContentTypeReader<char>
     {
         public CharReader()

--- a/MonoGame.Framework/Content/ContentReaders/CharReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/CharReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class CharReader : ContentTypeReader<char>
     {
         public CharReader()

--- a/MonoGame.Framework/Content/ContentReaders/ColorReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ColorReader.cs
@@ -2,14 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
-using Microsoft.Xna.Framework.Content;
-using Microsoft.Xna.Framework;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class ColorReader : ContentTypeReader<Color>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class ColorReader : ContentTypeReader<Color>
 	{
 		public ColorReader ()
 		{

--- a/MonoGame.Framework/Content/ContentReaders/ColorReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ColorReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class ColorReader : ContentTypeReader<Color>
 	{
 		public ColorReader ()

--- a/MonoGame.Framework/Content/ContentReaders/ColorReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ColorReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class ColorReader : ContentTypeReader<Color>
 	{
 		public ColorReader ()

--- a/MonoGame.Framework/Content/ContentReaders/CurveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/CurveReader.cs
@@ -2,11 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class CurveReader : ContentTypeReader<Curve>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class CurveReader : ContentTypeReader<Curve>
 	{
 		protected internal override Curve Read(ContentReader input, Curve existingInstance)
 		{

--- a/MonoGame.Framework/Content/ContentReaders/CurveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/CurveReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class CurveReader : ContentTypeReader<Curve>
 	{
 		protected internal override Curve Read(ContentReader input, Curve existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/CurveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/CurveReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class CurveReader : ContentTypeReader<Curve>
 	{
 		protected internal override Curve Read(ContentReader input, Curve existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/DateTimeReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DateTimeReader.cs
@@ -6,6 +6,7 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class DateTimeReader : ContentTypeReader<DateTime>
     {
         public DateTimeReader()

--- a/MonoGame.Framework/Content/ContentReaders/DateTimeReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DateTimeReader.cs
@@ -6,9 +6,7 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class DateTimeReader : ContentTypeReader<DateTime>
     {
         public DateTimeReader()

--- a/MonoGame.Framework/Content/ContentReaders/DateTimeReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DateTimeReader.cs
@@ -6,7 +6,9 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class DateTimeReader : ContentTypeReader<DateTime>
     {
         public DateTimeReader()

--- a/MonoGame.Framework/Content/ContentReaders/DecimalReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DecimalReader.cs
@@ -2,10 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class DecimalReader : ContentTypeReader<decimal>
     {
         public DecimalReader()

--- a/MonoGame.Framework/Content/ContentReaders/DecimalReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DecimalReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class DecimalReader : ContentTypeReader<decimal>
     {
         public DecimalReader()

--- a/MonoGame.Framework/Content/ContentReaders/DecimalReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DecimalReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class DecimalReader : ContentTypeReader<decimal>
     {
         public DecimalReader()

--- a/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
@@ -8,8 +8,13 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    /// <summary>
+    /// This type is not meant to be used directly by MonoGame users.
+    /// Its purpose is to allow to work-around AOT issues when loading assets with the ContentManager fail due to the absence of runtime-reflection support in that context (i.e. missing types due to trimming and inability to statically discover them at compile-time).
+    /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
+    /// </summary>
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    internal class DictionaryReader<TKey, TValue> : ContentTypeReader<Dictionary<TKey, TValue>>
+    public class DictionaryReader<TKey, TValue> : ContentTypeReader<Dictionary<TKey, TValue>>
     {
         ContentTypeReader keyReader;
 		ContentTypeReader valueReader;

--- a/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
@@ -8,7 +8,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
-
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class DictionaryReader<TKey, TValue> : ContentTypeReader<Dictionary<TKey, TValue>>
     {
         ContentTypeReader keyReader;

--- a/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
@@ -8,9 +8,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class DictionaryReader<TKey, TValue> : ContentTypeReader<Dictionary<TKey, TValue>>
     {
         ContentTypeReader keyReader;

--- a/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
@@ -8,7 +8,9 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class DictionaryReader<TKey, TValue> : ContentTypeReader<Dictionary<TKey, TValue>>
     {
         ContentTypeReader keyReader;

--- a/MonoGame.Framework/Content/ContentReaders/DoubleReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DoubleReader.cs
@@ -2,11 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class DoubleReader : ContentTypeReader<double>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class DoubleReader : ContentTypeReader<double>
     {
         public DoubleReader()
         {

--- a/MonoGame.Framework/Content/ContentReaders/DoubleReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DoubleReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class DoubleReader : ContentTypeReader<double>
     {
         public DoubleReader()

--- a/MonoGame.Framework/Content/ContentReaders/DoubleReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DoubleReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class DoubleReader : ContentTypeReader<double>
     {
         public DoubleReader()

--- a/MonoGame.Framework/Content/ContentReaders/DualTextureEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DualTextureEffectReader.cs
@@ -2,12 +2,11 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     class DualTextureEffectReader : ContentTypeReader<DualTextureEffect>
     {
         protected internal override DualTextureEffect Read(ContentReader input, DualTextureEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/DualTextureEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DualTextureEffectReader.cs
@@ -6,9 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     class DualTextureEffectReader : ContentTypeReader<DualTextureEffect>
     {
         protected internal override DualTextureEffect Read(ContentReader input, DualTextureEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/DualTextureEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DualTextureEffectReader.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     class DualTextureEffectReader : ContentTypeReader<DualTextureEffect>
     {
         protected internal override DualTextureEffect Read(ContentReader input, DualTextureEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/EffectMaterialReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectMaterialReader.cs
@@ -10,7 +10,8 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class EffectMaterialReader : ContentTypeReader<EffectMaterial>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class EffectMaterialReader : ContentTypeReader<EffectMaterial>
 	{
 		protected internal override EffectMaterial Read (ContentReader input, EffectMaterial existingInstance)
 		{

--- a/MonoGame.Framework/Content/ContentReaders/EffectMaterialReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectMaterialReader.cs
@@ -10,7 +10,9 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class EffectMaterialReader : ContentTypeReader<EffectMaterial>
 	{
 		protected internal override EffectMaterial Read (ContentReader input, EffectMaterial existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/EffectMaterialReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectMaterialReader.cs
@@ -10,9 +10,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class EffectMaterialReader : ContentTypeReader<EffectMaterial>
 	{
 		protected internal override EffectMaterial Read (ContentReader input, EffectMaterial existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class EffectReader : ContentTypeReader<Effect>
     {
         public EffectReader()

--- a/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class EffectReader : ContentTypeReader<Effect>
     {
         public EffectReader()

--- a/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EffectReader.cs
@@ -6,9 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class EffectReader : ContentTypeReader<Effect>
     {
         public EffectReader()

--- a/MonoGame.Framework/Content/ContentReaders/EnumReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EnumReader.cs
@@ -6,7 +6,9 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class EnumReader<T> : ContentTypeReader<T>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/EnumReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EnumReader.cs
@@ -6,6 +6,7 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class EnumReader<T> : ContentTypeReader<T>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/EnumReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EnumReader.cs
@@ -6,9 +6,7 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class EnumReader<T> : ContentTypeReader<T>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/EnumReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EnumReader.cs
@@ -6,8 +6,13 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    /// <summary>
+    /// This type is not meant to be used directly by MonoGame users.
+    /// Its purpose is to allow to work-around AOT issues when loading assets with the ContentManager fail due to the absence of runtime-reflection support in that context (i.e. missing types due to trimming and inability to statically discover them at compile-time).
+    /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
+    /// </summary>
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    internal class EnumReader<T> : ContentTypeReader<T>
+    public class EnumReader<T> : ContentTypeReader<T>
     {
         ContentTypeReader elementReader;
 

--- a/MonoGame.Framework/Content/ContentReaders/EnvironmentMapEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EnvironmentMapEffectReader.cs
@@ -2,11 +2,11 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     class EnvironmentMapEffectReader : ContentTypeReader<EnvironmentMapEffect>
     {
         protected internal override EnvironmentMapEffect Read(ContentReader input, EnvironmentMapEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/EnvironmentMapEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EnvironmentMapEffectReader.cs
@@ -6,9 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     class EnvironmentMapEffectReader : ContentTypeReader<EnvironmentMapEffect>
     {
         protected internal override EnvironmentMapEffect Read(ContentReader input, EnvironmentMapEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/EnvironmentMapEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/EnvironmentMapEffectReader.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     class EnvironmentMapEffectReader : ContentTypeReader<EnvironmentMapEffect>
     {
         protected internal override EnvironmentMapEffect Read(ContentReader input, EnvironmentMapEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/ExternalReferenceReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ExternalReferenceReader.cs
@@ -7,9 +7,7 @@ namespace Microsoft.Xna.Framework.Content
     /// <summary>
     /// External reference reader, provided for compatibility with XNA Framework built content
     /// </summary>
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class ExternalReferenceReader : ContentTypeReader
     {
         public ExternalReferenceReader()

--- a/MonoGame.Framework/Content/ContentReaders/ExternalReferenceReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ExternalReferenceReader.cs
@@ -7,7 +7,9 @@ namespace Microsoft.Xna.Framework.Content
     /// <summary>
     /// External reference reader, provided for compatibility with XNA Framework built content
     /// </summary>
-	[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #if !NET45
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class ExternalReferenceReader : ContentTypeReader
     {
         public ExternalReferenceReader()

--- a/MonoGame.Framework/Content/ContentReaders/ExternalReferenceReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ExternalReferenceReader.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Xna.Framework.Content
     /// <summary>
     /// External reference reader, provided for compatibility with XNA Framework built content
     /// </summary>
+	[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class ExternalReferenceReader : ContentTypeReader
     {
         public ExternalReferenceReader()

--- a/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     class IndexBufferReader : ContentTypeReader<IndexBuffer>
     {
         protected internal override IndexBuffer Read(ContentReader input, IndexBuffer existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     class IndexBufferReader : ContentTypeReader<IndexBuffer>
     {
         protected internal override IndexBuffer Read(ContentReader input, IndexBuffer existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/IndexBufferReader.cs
@@ -6,9 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     class IndexBufferReader : ContentTypeReader<IndexBuffer>
     {
         protected internal override IndexBuffer Read(ContentReader input, IndexBuffer existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/Int16Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Int16Reader.cs
@@ -2,13 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
-using Microsoft.Xna.Framework.Content;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class Int16Reader : ContentTypeReader<short>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class Int16Reader : ContentTypeReader<short>
 	{
 		public Int16Reader ()
 		{

--- a/MonoGame.Framework/Content/ContentReaders/Int16Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Int16Reader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class Int16Reader : ContentTypeReader<short>
 	{
 		public Int16Reader ()

--- a/MonoGame.Framework/Content/ContentReaders/Int16Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Int16Reader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class Int16Reader : ContentTypeReader<short>
 	{
 		public Int16Reader ()

--- a/MonoGame.Framework/Content/ContentReaders/Int32Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Int32Reader.cs
@@ -2,11 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class Int32Reader : ContentTypeReader<int>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class Int32Reader : ContentTypeReader<int>
     {
         public Int32Reader()
         {

--- a/MonoGame.Framework/Content/ContentReaders/Int32Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Int32Reader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class Int32Reader : ContentTypeReader<int>
     {
         public Int32Reader()

--- a/MonoGame.Framework/Content/ContentReaders/Int32Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Int32Reader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class Int32Reader : ContentTypeReader<int>
     {
         public Int32Reader()

--- a/MonoGame.Framework/Content/ContentReaders/Int64Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Int64Reader.cs
@@ -2,13 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
-using Microsoft.Xna.Framework.Content;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class Int64Reader : ContentTypeReader<long>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class Int64Reader : ContentTypeReader<long>
 	{
 		public Int64Reader ()
 		{

--- a/MonoGame.Framework/Content/ContentReaders/Int64Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Int64Reader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class Int64Reader : ContentTypeReader<long>
 	{
 		public Int64Reader ()

--- a/MonoGame.Framework/Content/ContentReaders/Int64Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Int64Reader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class Int64Reader : ContentTypeReader<long>
 	{
 		public Int64Reader ()

--- a/MonoGame.Framework/Content/ContentReaders/ListReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ListReader.cs
@@ -8,7 +8,9 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class ListReader<T> : ContentTypeReader<List<T>>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/ListReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ListReader.cs
@@ -8,8 +8,13 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    /// <summary>
+    /// This type is not meant to be used directly by MonoGame users.
+    /// Its purpose is to allow to work-around AOT issues when loading assets with the ContentManager fail due to the absence of runtime-reflection support in that context (i.e. missing types due to trimming and inability to statically discover them at compile-time).
+    /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
+    /// </summary>
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    internal class ListReader<T> : ContentTypeReader<List<T>>
+    public class ListReader<T> : ContentTypeReader<List<T>>
     {
         ContentTypeReader elementReader;
 

--- a/MonoGame.Framework/Content/ContentReaders/ListReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ListReader.cs
@@ -8,9 +8,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class ListReader<T> : ContentTypeReader<List<T>>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/ListReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ListReader.cs
@@ -4,11 +4,11 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Xna.Framework.Content;
 using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class ListReader<T> : ContentTypeReader<List<T>>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/MatrixReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/MatrixReader.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     class MatrixReader : ContentTypeReader<Matrix>
     {
         protected internal override Matrix Read(ContentReader input, Matrix existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/MatrixReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/MatrixReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     class MatrixReader : ContentTypeReader<Matrix>
     {
         protected internal override Matrix Read(ContentReader input, Matrix existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/MatrixReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/MatrixReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     class MatrixReader : ContentTypeReader<Matrix>
     {
         protected internal override Matrix Read(ContentReader input, Matrix existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/ModelReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ModelReader.cs
@@ -2,14 +2,12 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.Diagnostics;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Content;
 using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class ModelReader : ContentTypeReader<Model>
 	{
 //      List<VertexBuffer> vertexBuffers = new List<VertexBuffer>();

--- a/MonoGame.Framework/Content/ContentReaders/ModelReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ModelReader.cs
@@ -7,9 +7,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class ModelReader : ContentTypeReader<Model>
 	{
 //      List<VertexBuffer> vertexBuffers = new List<VertexBuffer>();

--- a/MonoGame.Framework/Content/ContentReaders/ModelReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ModelReader.cs
@@ -7,7 +7,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class ModelReader : ContentTypeReader<Model>
 	{
 //      List<VertexBuffer> vertexBuffers = new List<VertexBuffer>();

--- a/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
@@ -7,6 +7,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class MultiArrayReader<T> : ContentTypeReader<Array>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
@@ -7,8 +7,13 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    /// <summary>
+    /// This type is not meant to be used directly by MonoGame users.
+    /// Its purpose is to allow to work-around AOT issues when loading assets with the ContentManager fail due to the absence of runtime-reflection support in that context (i.e. missing types due to trimming and inability to statically discover them at compile-time).
+    /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
+    /// </summary>
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    internal class MultiArrayReader<T> : ContentTypeReader<Array>
+    public class MultiArrayReader<T> : ContentTypeReader<Array>
     {
         ContentTypeReader elementReader;
 

--- a/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
@@ -7,9 +7,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class MultiArrayReader<T> : ContentTypeReader<Array>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
@@ -7,7 +7,9 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class MultiArrayReader<T> : ContentTypeReader<Array>
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/NullableReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/NullableReader.cs
@@ -6,7 +6,8 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class NullableReader<T> : ContentTypeReader<T?> where T : struct
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class NullableReader<T> : ContentTypeReader<T?> where T : struct
     {
         ContentTypeReader elementReader;
 

--- a/MonoGame.Framework/Content/ContentReaders/NullableReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/NullableReader.cs
@@ -6,9 +6,7 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class NullableReader<T> : ContentTypeReader<T?> where T : struct
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/NullableReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/NullableReader.cs
@@ -6,7 +6,9 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class NullableReader<T> : ContentTypeReader<T?> where T : struct
     {
         ContentTypeReader elementReader;

--- a/MonoGame.Framework/Content/ContentReaders/NullableReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/NullableReader.cs
@@ -6,8 +6,13 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    /// <summary>
+    /// This type is not meant to be used directly by MonoGame users.
+    /// Its purpose is to allow to work-around AOT issues when loading assets with the ContentManager fail due to the absence of runtime-reflection support in that context (i.e. missing types due to trimming and inability to statically discover them at compile-time).
+    /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
+    /// </summary>
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    internal class NullableReader<T> : ContentTypeReader<T?> where T : struct
+    public class NullableReader<T> : ContentTypeReader<T?> where T : struct
     {
         ContentTypeReader elementReader;
 

--- a/MonoGame.Framework/Content/ContentReaders/PlaneReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/PlaneReader.cs
@@ -2,10 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class PlaneReader : ContentTypeReader<Plane>
     {
         public PlaneReader()

--- a/MonoGame.Framework/Content/ContentReaders/PlaneReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/PlaneReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class PlaneReader : ContentTypeReader<Plane>
     {
         public PlaneReader()

--- a/MonoGame.Framework/Content/ContentReaders/PlaneReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/PlaneReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class PlaneReader : ContentTypeReader<Plane>
     {
         public PlaneReader()

--- a/MonoGame.Framework/Content/ContentReaders/PointReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/PointReader.cs
@@ -2,15 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-using Microsoft.Xna.Framework.Content;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class PointReader : ContentTypeReader<Point>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class PointReader : ContentTypeReader<Point>
 	{
 		public PointReader ()
 			{

--- a/MonoGame.Framework/Content/ContentReaders/PointReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/PointReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class PointReader : ContentTypeReader<Point>
 	{
 		public PointReader ()

--- a/MonoGame.Framework/Content/ContentReaders/PointReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/PointReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class PointReader : ContentTypeReader<Point>
 	{
 		public PointReader ()

--- a/MonoGame.Framework/Content/ContentReaders/QuaternionReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/QuaternionReader.cs
@@ -2,10 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class QuaternionReader : ContentTypeReader<Quaternion>
     {
         public QuaternionReader()

--- a/MonoGame.Framework/Content/ContentReaders/QuaternionReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/QuaternionReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class QuaternionReader : ContentTypeReader<Quaternion>
     {
         public QuaternionReader()

--- a/MonoGame.Framework/Content/ContentReaders/QuaternionReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/QuaternionReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class QuaternionReader : ContentTypeReader<Quaternion>
     {
         public QuaternionReader()

--- a/MonoGame.Framework/Content/ContentReaders/RayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/RayReader.cs
@@ -2,11 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using Microsoft.Xna.Framework;
-
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class RayReader : ContentTypeReader<Ray>
     {
         public RayReader()

--- a/MonoGame.Framework/Content/ContentReaders/RayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/RayReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class RayReader : ContentTypeReader<Ray>
     {
         public RayReader()

--- a/MonoGame.Framework/Content/ContentReaders/RayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/RayReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class RayReader : ContentTypeReader<Ray>
     {
         public RayReader()

--- a/MonoGame.Framework/Content/ContentReaders/RectangleReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/RectangleReader.cs
@@ -2,16 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-using Microsoft.Xna.Framework.Content;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	
-	internal class RectangleReader : ContentTypeReader<Rectangle>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class RectangleReader : ContentTypeReader<Rectangle>
     {
         public RectangleReader()
         {

--- a/MonoGame.Framework/Content/ContentReaders/RectangleReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/RectangleReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class RectangleReader : ContentTypeReader<Rectangle>
     {
         public RectangleReader()

--- a/MonoGame.Framework/Content/ContentReaders/RectangleReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/RectangleReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class RectangleReader : ContentTypeReader<Rectangle>
     {
         public RectangleReader()

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -11,8 +11,13 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    /// <summary>
+    /// This type is not meant to be used directly by MonoGame users.
+    /// Its purpose is to allow to work-around AOT issues when loading assets with the ContentManager fail due to the absence of runtime-reflection support in that context (i.e. missing types due to trimming and inability to statically discover them at compile-time).
+    /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
+    /// </summary>
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    internal class ReflectiveReader<T> : ContentTypeReader
+    public class ReflectiveReader<T> : ContentTypeReader
     {
         delegate void ReadElement(ContentReader input, object parent);
 

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -11,6 +11,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class ReflectiveReader<T> : ContentTypeReader
     {
         delegate void ReadElement(ContentReader input, object parent);

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -11,7 +11,9 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class ReflectiveReader<T> : ContentTypeReader
     {
         delegate void ReadElement(ContentReader input, object parent);

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -11,9 +11,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class ReflectiveReader<T> : ContentTypeReader
     {
         delegate void ReadElement(ContentReader input, object parent);

--- a/MonoGame.Framework/Content/ContentReaders/SByteReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SByteReader.cs
@@ -2,10 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class SByteReader : ContentTypeReader<sbyte>
     {
         public SByteReader()

--- a/MonoGame.Framework/Content/ContentReaders/SByteReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SByteReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class SByteReader : ContentTypeReader<sbyte>
     {
         public SByteReader()

--- a/MonoGame.Framework/Content/ContentReaders/SByteReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SByteReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class SByteReader : ContentTypeReader<sbyte>
     {
         public SByteReader()

--- a/MonoGame.Framework/Content/ContentReaders/SingleReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SingleReader.cs
@@ -2,11 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class SingleReader : ContentTypeReader<float>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class SingleReader : ContentTypeReader<float>
     {
         public SingleReader()
         {

--- a/MonoGame.Framework/Content/ContentReaders/SingleReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SingleReader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class SingleReader : ContentTypeReader<float>
     {
         public SingleReader()

--- a/MonoGame.Framework/Content/ContentReaders/SingleReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SingleReader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class SingleReader : ContentTypeReader<float>
     {
         public SingleReader()

--- a/MonoGame.Framework/Content/ContentReaders/SkinnedEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SkinnedEffectReader.cs
@@ -2,12 +2,11 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     class SkinnedEffectReader : ContentTypeReader<SkinnedEffect>
     {
         protected internal override SkinnedEffect Read(ContentReader input, SkinnedEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/SkinnedEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SkinnedEffectReader.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     class SkinnedEffectReader : ContentTypeReader<SkinnedEffect>
     {
         protected internal override SkinnedEffect Read(ContentReader input, SkinnedEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/SkinnedEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SkinnedEffectReader.cs
@@ -6,9 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     class SkinnedEffectReader : ContentTypeReader<SkinnedEffect>
     {
         protected internal override SkinnedEffect Read(ContentReader input, SkinnedEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/SongReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SongReader.cs
@@ -9,7 +9,8 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class SongReader : ContentTypeReader<Song>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class SongReader : ContentTypeReader<Song>
 	{
 		protected internal override Song Read(ContentReader input, Song existingInstance)
 		{

--- a/MonoGame.Framework/Content/ContentReaders/SongReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SongReader.cs
@@ -9,7 +9,9 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class SongReader : ContentTypeReader<Song>
 	{
 		protected internal override Song Read(ContentReader input, Song existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/SongReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SongReader.cs
@@ -9,9 +9,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class SongReader : ContentTypeReader<Song>
 	{
 		protected internal override Song Read(ContentReader input, Song existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
@@ -2,13 +2,13 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
 using Microsoft.Xna.Framework.Audio;
 
 
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class SoundEffectReader : ContentTypeReader<SoundEffect>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class SoundEffectReader : ContentTypeReader<SoundEffect>
 	{
 		protected internal override SoundEffect Read(ContentReader input, SoundEffect existingInstance)
 		{         

--- a/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
@@ -7,7 +7,9 @@ using Microsoft.Xna.Framework.Audio;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class SoundEffectReader : ContentTypeReader<SoundEffect>
 	{
 		protected internal override SoundEffect Read(ContentReader input, SoundEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
@@ -7,9 +7,7 @@ using Microsoft.Xna.Framework.Audio;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class SoundEffectReader : ContentTypeReader<SoundEffect>
 	{
 		protected internal override SoundEffect Read(ContentReader input, SoundEffect existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/SpriteFontReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SpriteFontReader.cs
@@ -2,14 +2,12 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
 using System.Collections.Generic;
-
-using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class SpriteFontReader : ContentTypeReader<SpriteFont>
     {
         public SpriteFontReader()

--- a/MonoGame.Framework/Content/ContentReaders/SpriteFontReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SpriteFontReader.cs
@@ -7,9 +7,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class SpriteFontReader : ContentTypeReader<SpriteFont>
     {
         public SpriteFontReader()

--- a/MonoGame.Framework/Content/ContentReaders/SpriteFontReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SpriteFontReader.cs
@@ -7,7 +7,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class SpriteFontReader : ContentTypeReader<SpriteFont>
     {
         public SpriteFontReader()

--- a/MonoGame.Framework/Content/ContentReaders/StringReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/StringReader.cs
@@ -3,11 +3,10 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class StringReader : ContentTypeReader<String>
     {
         public StringReader()

--- a/MonoGame.Framework/Content/ContentReaders/StringReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/StringReader.cs
@@ -6,9 +6,7 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class StringReader : ContentTypeReader<String>
     {
         public StringReader()

--- a/MonoGame.Framework/Content/ContentReaders/StringReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/StringReader.cs
@@ -6,7 +6,9 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class StringReader : ContentTypeReader<String>
     {
         public StringReader()

--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -3,13 +3,11 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using Microsoft.Xna;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class Texture2DReader : ContentTypeReader<Texture2D>
     {
 		public Texture2DReader()

--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -7,9 +7,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class Texture2DReader : ContentTypeReader<Texture2D>
     {
 		public Texture2DReader()

--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -7,7 +7,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class Texture2DReader : ContentTypeReader<Texture2D>
     {
 		public Texture2DReader()

--- a/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
@@ -7,6 +7,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class Texture3DReader : ContentTypeReader<Texture3D>
     {
         protected internal override Texture3D Read(ContentReader reader, Texture3D existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
@@ -7,7 +7,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class Texture3DReader : ContentTypeReader<Texture3D>
     {
         protected internal override Texture3D Read(ContentReader reader, Texture3D existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
@@ -7,9 +7,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class Texture3DReader : ContentTypeReader<Texture3D>
     {
         protected internal override Texture3D Read(ContentReader reader, Texture3D existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
@@ -2,11 +2,11 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class TextureCubeReader : ContentTypeReader<TextureCube>
     {
 

--- a/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
@@ -6,9 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class TextureCubeReader : ContentTypeReader<TextureCube>
     {
 

--- a/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class TextureCubeReader : ContentTypeReader<TextureCube>
     {
 

--- a/MonoGame.Framework/Content/ContentReaders/TextureReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TextureReader.cs
@@ -2,11 +2,11 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class TextureReader : ContentTypeReader<Texture>
 	{
 		protected internal override Texture Read(ContentReader reader, Texture existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/TextureReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TextureReader.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class TextureReader : ContentTypeReader<Texture>
 	{
 		protected internal override Texture Read(ContentReader reader, Texture existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/TextureReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TextureReader.cs
@@ -6,9 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class TextureReader : ContentTypeReader<Texture>
 	{
 		protected internal override Texture Read(ContentReader reader, Texture existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/TimeSpanReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TimeSpanReader.cs
@@ -4,11 +4,10 @@
 
 using System;
 
-using Microsoft.Xna.Framework.Content;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class TimeSpanReader : ContentTypeReader<TimeSpan>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class TimeSpanReader : ContentTypeReader<TimeSpan>
 	{
 		public TimeSpanReader ()
 		{

--- a/MonoGame.Framework/Content/ContentReaders/TimeSpanReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TimeSpanReader.cs
@@ -6,9 +6,7 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class TimeSpanReader : ContentTypeReader<TimeSpan>
 	{
 		public TimeSpanReader ()

--- a/MonoGame.Framework/Content/ContentReaders/TimeSpanReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TimeSpanReader.cs
@@ -6,7 +6,9 @@ using System;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class TimeSpanReader : ContentTypeReader<TimeSpan>
 	{
 		public TimeSpanReader ()

--- a/MonoGame.Framework/Content/ContentReaders/UInt16Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/UInt16Reader.cs
@@ -2,11 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class UInt16Reader : ContentTypeReader<ushort>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class UInt16Reader : ContentTypeReader<ushort>
     {
         public UInt16Reader()
         {

--- a/MonoGame.Framework/Content/ContentReaders/UInt16Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/UInt16Reader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class UInt16Reader : ContentTypeReader<ushort>
     {
         public UInt16Reader()

--- a/MonoGame.Framework/Content/ContentReaders/UInt16Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/UInt16Reader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class UInt16Reader : ContentTypeReader<ushort>
     {
         public UInt16Reader()

--- a/MonoGame.Framework/Content/ContentReaders/UInt32Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/UInt32Reader.cs
@@ -2,11 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class UInt32Reader : ContentTypeReader<uint>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class UInt32Reader : ContentTypeReader<uint>
     {
         public UInt32Reader()
         {

--- a/MonoGame.Framework/Content/ContentReaders/UInt32Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/UInt32Reader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class UInt32Reader : ContentTypeReader<uint>
     {
         public UInt32Reader()

--- a/MonoGame.Framework/Content/ContentReaders/UInt32Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/UInt32Reader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class UInt32Reader : ContentTypeReader<uint>
     {
         public UInt32Reader()

--- a/MonoGame.Framework/Content/ContentReaders/UInt64Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/UInt64Reader.cs
@@ -2,11 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class UInt64Reader : ContentTypeReader<ulong>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class UInt64Reader : ContentTypeReader<ulong>
     {
         public UInt64Reader()
         {

--- a/MonoGame.Framework/Content/ContentReaders/UInt64Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/UInt64Reader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class UInt64Reader : ContentTypeReader<ulong>
     {
         public UInt64Reader()

--- a/MonoGame.Framework/Content/ContentReaders/UInt64Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/UInt64Reader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class UInt64Reader : ContentTypeReader<ulong>
     {
         public UInt64Reader()

--- a/MonoGame.Framework/Content/ContentReaders/Vector2Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Vector2Reader.cs
@@ -2,13 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
-using Microsoft.Xna.Framework.Content;
-
 namespace Microsoft.Xna.Framework.Content
 {
-	internal class Vector2Reader : ContentTypeReader<Vector2>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    internal class Vector2Reader : ContentTypeReader<Vector2>
 	{
 		public Vector2Reader ()
 		{

--- a/MonoGame.Framework/Content/ContentReaders/Vector2Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Vector2Reader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class Vector2Reader : ContentTypeReader<Vector2>
 	{
 		public Vector2Reader ()

--- a/MonoGame.Framework/Content/ContentReaders/Vector2Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Vector2Reader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class Vector2Reader : ContentTypeReader<Vector2>
 	{
 		public Vector2Reader ()

--- a/MonoGame.Framework/Content/ContentReaders/Vector3Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Vector3Reader.cs
@@ -2,12 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class Vector3Reader : ContentTypeReader<Vector3>
     {
         public Vector3Reader()

--- a/MonoGame.Framework/Content/ContentReaders/Vector3Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Vector3Reader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class Vector3Reader : ContentTypeReader<Vector3>
     {
         public Vector3Reader()

--- a/MonoGame.Framework/Content/ContentReaders/Vector3Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Vector3Reader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class Vector3Reader : ContentTypeReader<Vector3>
     {
         public Vector3Reader()

--- a/MonoGame.Framework/Content/ContentReaders/Vector4Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Vector4Reader.cs
@@ -2,10 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class Vector4Reader : ContentTypeReader<Vector4>
     {
         public Vector4Reader()

--- a/MonoGame.Framework/Content/ContentReaders/Vector4Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Vector4Reader.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class Vector4Reader : ContentTypeReader<Vector4>
     {
         public Vector4Reader()

--- a/MonoGame.Framework/Content/ContentReaders/Vector4Reader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Vector4Reader.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class Vector4Reader : ContentTypeReader<Vector4>
     {
         public Vector4Reader()

--- a/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
@@ -2,11 +2,11 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     class VertexBufferReader : ContentTypeReader<VertexBuffer>
     {
         protected internal override VertexBuffer Read(ContentReader input, VertexBuffer existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
@@ -6,9 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     class VertexBufferReader : ContentTypeReader<VertexBuffer>
     {
         protected internal override VertexBuffer Read(ContentReader input, VertexBuffer existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VertexBufferReader.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     class VertexBufferReader : ContentTypeReader<VertexBuffer>
     {
         protected internal override VertexBuffer Read(ContentReader input, VertexBuffer existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/VertexDeclarationReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VertexDeclarationReader.cs
@@ -5,6 +5,7 @@
 using Microsoft.Xna.Framework.Graphics;
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class VertexDeclarationReader : ContentTypeReader<VertexDeclaration>
 	{
 		protected internal override VertexDeclaration Read(ContentReader reader, VertexDeclaration existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/VertexDeclarationReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VertexDeclarationReader.cs
@@ -5,9 +5,7 @@
 using Microsoft.Xna.Framework.Graphics;
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class VertexDeclarationReader : ContentTypeReader<VertexDeclaration>
 	{
 		protected internal override VertexDeclaration Read(ContentReader reader, VertexDeclaration existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/VertexDeclarationReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VertexDeclarationReader.cs
@@ -5,7 +5,9 @@
 using Microsoft.Xna.Framework.Graphics;
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class VertexDeclarationReader : ContentTypeReader<VertexDeclaration>
 	{
 		protected internal override VertexDeclaration Read(ContentReader reader, VertexDeclaration existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
@@ -2,13 +2,13 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
 using System.IO;
 using Microsoft.Xna.Framework.Media;
 using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
     internal class VideoReader : ContentTypeReader<Video>
     {
         protected internal override Video Read(ContentReader input, Video existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
@@ -8,7 +8,9 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    #endif
     internal class VideoReader : ContentTypeReader<Video>
     {
         protected internal override Video Read(ContentReader input, Video existingInstance)

--- a/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/VideoReader.cs
@@ -8,9 +8,7 @@ using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
-    #if !NET45
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    #endif
     internal class VideoReader : ContentTypeReader<Video>
     {
         protected internal override Video Read(ContentReader input, Video existingInstance)

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -54,8 +54,73 @@ namespace Microsoft.Xna.Framework.Content
             return null;
         }
 
+#if NET45
+        // Trick to prevent the linker removing the code, but not actually execute the code
+        static bool falseflag = false;
+#endif
+
         internal ContentTypeReader[] LoadAssetReaders(ContentReader reader)
         {
+#if NET45
+#pragma warning disable 0219, 0649
+            // Trick to prevent the linker removing the code, but not actually execute the code
+            if (falseflag)
+            {
+                // Dummy variables required for it to work on iDevices ** DO NOT DELETE **
+                // This forces the classes not to be optimized out when deploying to iDevices
+                var hByteReader = new ByteReader();
+                var hSByteReader = new SByteReader();
+                var hDateTimeReader = new DateTimeReader();
+                var hDecimalReader = new DecimalReader();
+                var hBoundingSphereReader = new BoundingSphereReader();
+                var hBoundingFrustumReader = new BoundingFrustumReader();
+                var hRayReader = new RayReader();
+                var hCharListReader = new ListReader<char>();
+                var hRectangleListReader = new ListReader<Rectangle>();
+                var hRectangleArrayReader = new ArrayReader<Rectangle>();
+                var hVector3ListReader = new ListReader<Vector3>();
+                var hStringListReader = new ListReader<StringReader>();
+                var hIntListReader = new ListReader<Int32>();
+                var hSpriteFontReader = new SpriteFontReader();
+                var hTexture2DReader = new Texture2DReader();
+                var hCharReader = new CharReader();
+                var hRectangleReader = new RectangleReader();
+                var hStringReader = new StringReader();
+                var hVector2Reader = new Vector2Reader();
+                var hVector3Reader = new Vector3Reader();
+                var hVector4Reader = new Vector4Reader();
+                var hCurveReader = new CurveReader();
+                var hIndexBufferReader = new IndexBufferReader();
+                var hBoundingBoxReader = new BoundingBoxReader();
+                var hMatrixReader = new MatrixReader();
+                var hBasicEffectReader = new BasicEffectReader();
+                var hVertexBufferReader = new VertexBufferReader();
+                var hAlphaTestEffectReader = new AlphaTestEffectReader();
+                var hEnumSpriteEffectsReader = new EnumReader<Graphics.SpriteEffects>();
+                var hArrayFloatReader = new ArrayReader<float>();
+                var hArrayVector2Reader = new ArrayReader<Vector2>();
+                var hListVector2Reader = new ListReader<Vector2>();
+                var hArrayMatrixReader = new ArrayReader<Matrix>();
+                var hEnumBlendReader = new EnumReader<Graphics.Blend>();
+                var hNullableRectReader = new NullableReader<Rectangle>();
+                var hEffectMaterialReader = new EffectMaterialReader();
+                var hExternalReferenceReader = new ExternalReferenceReader();
+                var hSoundEffectReader = new SoundEffectReader();
+                var hSongReader = new SongReader();
+                var hModelReader = new ModelReader();
+                var hInt32Reader = new Int32Reader();
+                var hEffectReader = new EffectReader();
+                var hSingleReader = new SingleReader();
+
+                // At the moment the Video class doesn't exist
+                // on all platforms... Allow it to compile anyway.
+#if ANDROID || (IOS && !TVOS) || MONOMAC || (WINDOWS && !OPENGL)
+                var hVideoReader = new VideoReader();
+#endif
+            }
+#pragma warning restore 0219, 0649
+#endif
+
             // The first content byte i read tells me the number of content readers in this XNB file
             var numberOfReaders = reader.Read7BitEncodedInt();
             var contentReaders = new ContentTypeReader[numberOfReaders];

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -155,7 +155,19 @@ namespace Microsoft.Xna.Framework.Content
 
                         readerTypeString = PrepareType(readerTypeString);
 
-                        var l_readerType = Type.GetType(readerTypeString);
+                        Type l_readerType = null;
+                        try
+                        {
+                            // this might fail in AOT context and we need to properly warn the user on what to do if it happens
+#pragma warning disable IL2057
+                            l_readerType = Type.GetType(readerTypeString);
+#pragma warning restore IL2057
+                        }
+                        catch (NotSupportedException e)
+                        {
+                            throw new NotSupportedException("It seems that you are using PublishAot and trying to load assets with a reflection-based serializer (which is not natively supported). To work around this error, call ContentTypeReaderManager.AddTypeCreator() in your Game constructor with the type mentionned in the following message: " + e.Message);
+                        }
+
                         if (l_readerType != null)
                         {
                             ContentTypeReader typeReader;

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -54,69 +54,8 @@ namespace Microsoft.Xna.Framework.Content
             return null;
         }
 
-        // Trick to prevent the linker removing the code, but not actually execute the code
-        static bool falseflag = false;
-
         internal ContentTypeReader[] LoadAssetReaders(ContentReader reader)
         {
-#pragma warning disable 0219, 0649
-            // Trick to prevent the linker removing the code, but not actually execute the code
-            if (falseflag)
-            {
-                // Dummy variables required for it to work on iDevices ** DO NOT DELETE **
-                // This forces the classes not to be optimized out when deploying to iDevices
-                var hByteReader = new ByteReader();
-                var hSByteReader = new SByteReader();
-                var hDateTimeReader = new DateTimeReader();
-                var hDecimalReader = new DecimalReader();
-                var hBoundingSphereReader = new BoundingSphereReader();
-                var hBoundingFrustumReader = new BoundingFrustumReader();
-                var hRayReader = new RayReader();
-                var hCharListReader = new ListReader<char>();
-                var hRectangleListReader = new ListReader<Rectangle>();
-                var hRectangleArrayReader = new ArrayReader<Rectangle>();
-                var hVector3ListReader = new ListReader<Vector3>();
-                var hStringListReader = new ListReader<StringReader>();
-                var hIntListReader = new ListReader<Int32>();
-                var hSpriteFontReader = new SpriteFontReader();
-                var hTexture2DReader = new Texture2DReader();
-                var hCharReader = new CharReader();
-                var hRectangleReader = new RectangleReader();
-                var hStringReader = new StringReader();
-                var hVector2Reader = new Vector2Reader();
-                var hVector3Reader = new Vector3Reader();
-                var hVector4Reader = new Vector4Reader();
-                var hCurveReader = new CurveReader();
-                var hIndexBufferReader = new IndexBufferReader();
-                var hBoundingBoxReader = new BoundingBoxReader();
-                var hMatrixReader = new MatrixReader();
-                var hBasicEffectReader = new BasicEffectReader();
-                var hVertexBufferReader = new VertexBufferReader();
-                var hAlphaTestEffectReader = new AlphaTestEffectReader();
-                var hEnumSpriteEffectsReader = new EnumReader<Graphics.SpriteEffects>();
-                var hArrayFloatReader = new ArrayReader<float>();
-                var hArrayVector2Reader = new ArrayReader<Vector2>();
-                var hListVector2Reader = new ListReader<Vector2>();
-                var hArrayMatrixReader = new ArrayReader<Matrix>();
-                var hEnumBlendReader = new EnumReader<Graphics.Blend>();
-                var hNullableRectReader = new NullableReader<Rectangle>();
-                var hEffectMaterialReader = new EffectMaterialReader();
-                var hExternalReferenceReader = new ExternalReferenceReader();
-                var hSoundEffectReader = new SoundEffectReader();
-                var hSongReader = new SongReader();
-                var hModelReader = new ModelReader();
-                var hInt32Reader = new Int32Reader();
-                var hEffectReader = new EffectReader();
-                var hSingleReader = new SingleReader();
-
-                // At the moment the Video class doesn't exist
-                // on all platforms... Allow it to compile anyway.
-#if ANDROID || (IOS && !TVOS) || MONOMAC || (WINDOWS && !OPENGL)
-                var hVideoReader = new VideoReader();
-#endif
-            }
-#pragma warning restore 0219, 0649
-
             // The first content byte i read tells me the number of content readers in this XNB file
             var numberOfReaders = reader.Read7BitEncodedInt();
             var contentReaders = new ContentTypeReader[numberOfReaders];

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -10,6 +10,7 @@
     <PackageTags>monogame;.net core;core;.net standard;standard;android</PackageTags>
     <PackageId>MonoGame.Framework.Android</PackageId>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
-    <DefineConstants>WINDOWS;XNADESIGNPROVIDED;STBSHARP_INTERNAL</DefineConstants>
+    <DefineConstants>WINDOWS;XNADESIGNPROVIDED;STBSHARP_INTERNAL;NET45</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWindowsForms>true</UseWindowsForms>
     <Description>Fake console assembly that checks if MonoGame's code is still compatible with the private console implementations and building against .NET 4.5.2 and C# 5.</Description>

--- a/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
@@ -7,6 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <Description>Fake console assembly that checks if MonoGame's code is still compatible with the private console implementations and building against .NET 4.5.2 and C# 5.</Description>
     <LangVersion>5</LangVersion>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -9,6 +9,7 @@
     <PackageId>MonoGame.Framework.DesktopGL</PackageId>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <CopyContentFiles>True</CopyContentFiles>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <!-- NETFX reference assemblies let us target .NET Framework on Mac/Linux without Mono -->

--- a/MonoGame.Framework/MonoGame.Framework.Native.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Native.csproj
@@ -11,6 +11,7 @@
     <CopyContentFiles>True</CopyContentFiles>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -9,7 +9,8 @@
     <PackageTags>monogame;.net core;core;.net standard;standard;windowsdx</PackageTags>
     <PackageId>MonoGame.Framework.WindowsDX</PackageId>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
-    <IsAotCompatible>true</IsAotCompatible>
+    <IsAotCompatible>false</IsAotCompatible>
+	<IsTrimmable>false</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -9,6 +9,7 @@
     <PackageTags>monogame;.net core;core;.net standard;standard;windowsdx</PackageTags>
     <PackageId>MonoGame.Framework.WindowsDX</PackageId>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -10,6 +10,7 @@
     <PackageId>MonoGame.Framework.iOS</PackageId>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <SupportedOSPlatformVersion>11.2</SupportedOSPlatformVersion>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -670,7 +670,7 @@ namespace MonoGame.OpenAL
             }
             try
             {
-                setBufferMode = (XRamExtension.SetBufferModeDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("EAXSetBufferMode"), typeof(XRamExtension.SetBufferModeDelegate));
+                setBufferMode = Marshal.GetDelegateForFunctionPointer<XRamExtension.SetBufferModeDelegate>(AL.alGetProcAddress("EAXSetBufferMode"));
             }
             catch (Exception)
             {
@@ -763,19 +763,19 @@ namespace MonoGame.OpenAL
                 return;
             }
 
-            alGenEffects = (alGenEffectsDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alGenEffects"), typeof(alGenEffectsDelegate));
-            alDeleteEffects = (alDeleteEffectsDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alDeleteEffects"), typeof(alDeleteEffectsDelegate));
-            alEffectf = (alEffectfDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alEffectf"), typeof(alEffectfDelegate));
-            alEffecti = (alEffectiDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alEffecti"), typeof(alEffectiDelegate));
-            alGenAuxiliaryEffectSlots = (alGenAuxiliaryEffectSlotsDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alGenAuxiliaryEffectSlots"), typeof(alGenAuxiliaryEffectSlotsDelegate));
-            alDeleteAuxiliaryEffectSlots = (alDeleteAuxiliaryEffectSlotsDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alDeleteAuxiliaryEffectSlots"), typeof(alDeleteAuxiliaryEffectSlotsDelegate));
-            alAuxiliaryEffectSloti = (alAuxiliaryEffectSlotiDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alAuxiliaryEffectSloti"), typeof(alAuxiliaryEffectSlotiDelegate));
-            alAuxiliaryEffectSlotf = (alAuxiliaryEffectSlotfDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alAuxiliaryEffectSlotf"), typeof(alAuxiliaryEffectSlotfDelegate));
+            alGenEffects = Marshal.GetDelegateForFunctionPointer<alGenEffectsDelegate>(AL.alGetProcAddress("alGenEffects"));
+            alDeleteEffects = Marshal.GetDelegateForFunctionPointer<alDeleteEffectsDelegate>(AL.alGetProcAddress("alDeleteEffects"));
+            alEffectf = Marshal.GetDelegateForFunctionPointer<alEffectfDelegate>(AL.alGetProcAddress("alEffectf"));
+            alEffecti = Marshal.GetDelegateForFunctionPointer<alEffectiDelegate>(AL.alGetProcAddress("alEffecti"));
+            alGenAuxiliaryEffectSlots = Marshal.GetDelegateForFunctionPointer<alGenAuxiliaryEffectSlotsDelegate>(AL.alGetProcAddress("alGenAuxiliaryEffectSlots"));
+            alDeleteAuxiliaryEffectSlots = Marshal.GetDelegateForFunctionPointer<alDeleteAuxiliaryEffectSlotsDelegate>(AL.alGetProcAddress("alDeleteAuxiliaryEffectSlots"));
+            alAuxiliaryEffectSloti = Marshal.GetDelegateForFunctionPointer<alAuxiliaryEffectSlotiDelegate>(AL.alGetProcAddress("alAuxiliaryEffectSloti"));
+            alAuxiliaryEffectSlotf = Marshal.GetDelegateForFunctionPointer<alAuxiliaryEffectSlotfDelegate>(AL.alGetProcAddress("alAuxiliaryEffectSlotf"));
 
-            alGenFilters = (alGenFiltersDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alGenFilters"), typeof(alGenFiltersDelegate));
-            alFilteri = (alFilteriDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alFilteri"), typeof(alFilteriDelegate));
-            alFilterf = (alFilterfDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alFilterf"), typeof(alFilterfDelegate));
-            alDeleteFilters = (alDeleteFiltersDelegate)Marshal.GetDelegateForFunctionPointer(AL.alGetProcAddress("alDeleteFilters"), typeof(alDeleteFiltersDelegate));
+            alGenFilters = Marshal.GetDelegateForFunctionPointer<alGenFiltersDelegate>(AL.alGetProcAddress("alGenFilters"));
+            alFilteri = Marshal.GetDelegateForFunctionPointer<alFilteriDelegate>(AL.alGetProcAddress("alFilteri"));
+            alFilterf = Marshal.GetDelegateForFunctionPointer<alFilterfDelegate>(AL.alGetProcAddress("alFilterf"));
+            alDeleteFilters = Marshal.GetDelegateForFunctionPointer<alDeleteFiltersDelegate>(AL.alGetProcAddress("alDeleteFilters"));
 
             IsInitialized = true;
         }

--- a/MonoGame.Framework/Platform/Input/KeysHelper.cs
+++ b/MonoGame.Framework/Platform/Input/KeysHelper.cs
@@ -14,7 +14,11 @@ namespace Microsoft.Xna.Framework.Input
         static KeysHelper()
         {
             _map = new HashSet<int>();
+#if NET45
             var allKeys = (Keys[])Enum.GetValues(typeof(Keys));
+#else
+            var allKeys = Enum.GetValues<Keys>();
+#endif
             foreach (var key in allKeys)
             {
                 _map.Add((int)key);

--- a/MonoGame.Framework/Platform/Utilities/ReflectionHelpers.Legacy.cs
+++ b/MonoGame.Framework/Platform/Utilities/ReflectionHelpers.Legacy.cs
@@ -16,8 +16,7 @@ namespace MonoGame.Framework.Utilities
 
             static SizeOf()
             {
-                var type = typeof(T);
-                _sizeOf = Marshal.SizeOf(type);
+                _sizeOf = Marshal.SizeOf<T>();
             }
 
             static public int Get()

--- a/MonoGame.Framework/Utilities/DynamicallyAccessedMembers.cs
+++ b/MonoGame.Framework/Utilities/DynamicallyAccessedMembers.cs
@@ -1,0 +1,38 @@
+// fake attribute for backward compatibility with .NET 4.5
+
+#if NET45
+namespace System.Diagnostics.CodeAnalysis
+{
+    [Flags]
+    public enum DynamicallyAccessedMemberTypes
+    {
+        All = -1,
+        None = 0,
+        PublicParameterlessConstructor = 1,
+        PublicConstructors = 3,
+        NonPublicConstructors = 4,
+        PublicMethods = 8,
+        NonPublicMethods = 16,
+        PublicFields = 32,
+        NonPublicFields = 64,
+        PublicNestedTypes = 128,
+        NonPublicNestedTypes = 256,
+        PublicProperties = 512,
+        NonPublicProperties = 1024,
+        PublicEvents = 2048,
+        NonPublicEvents = 4096,
+        Interfaces = 8192
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Parameter | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter, Inherited = false)]
+    public sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+}
+#endif

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -187,7 +187,7 @@ namespace MonoGame.Framework.Utilities
         /// </summary>
         internal static int ManagedSizeOf(Type type)
         {
-            return Marshal.SizeOf(type);
+            return Marshal.SizeOf<Type>(type);
         }
 
     }


### PR DESCRIPTION
I started addressing #8104 and those changes should make MonoGame mostly safe in AOT contexts (it fixes all the errors of loading assets and removes the need to force MonoGame to not be trimmed).

Working on this actually made visible more AOT issues. I fixed the most trivial IL warnings but some of them persists. 
Also, since BRUTE hasn't fully retired yet, I'm trying to write this in a ```net452``` backward compatible way (some of the newer and better reflection stuff isn't available on older .NET Frameworks).

Any help is welcome!

Here are my notes on the remaining issues (none really are blockers, just enhancing the AOT experience and avoid misleading warnings for users):

- [x] ```ReflectiveReader```, ```DictionaryReader```, ```ArrayReader```, and ```MultiArrayReader``` need to be flagged as not compatible with AOT with the ```RequiresDynamicCode``` attribute. Those types are generic and can't be made safe for AOT. The warning inside the attribute must encourage users to rewrite their content serialization in a way that doesn't rely on reflection is they wish to use AOT.

- [ ] WindowsDX will [fail loading an embedded icon](https://github.com/MonoGame/MonoGame/blob/develop/MonoGame.Framework/Platform/Windows/WinFormsGameWindow.cs#L261) because ```assembly.Location``` is always null in AOT contexts.

Those ones aren't really issues and will likely not trigger runtime errors. We could just disable warnings on those, but it would be nice to try to fix them in a clean way to avoid unforeseen consequences:

- [ ] [VectorConversion](https://github.com/MonoGame/MonoGame/blob/develop/MonoGame.Framework/Design/VectorConversion.cs) uses reflection to convert to/from ```IPackedVector```. This needs to be rewritten reflection-free. We can also assume that ```IPackedVector``` is never trimmed and just disable the warnings, but that's an easy fix and likely less error-prone to not rely on disabling warnings.

- [ ] There are a couple of instances of type instance creation that we should try to get rid of if possible:
https://github.com/MonoGame/MonoGame/blob/2e72fcfa4144ea5bc413963af8f97a2d5e902338/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs#L36
https://github.com/MonoGame/MonoGame/blob/2e72fcfa4144ea5bc413963af8f97a2d5e902338/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.cs#L214

- [ ] ```ContentTypeReaderManager``` has a warning here (might be fixable):
https://github.com/MonoGame/MonoGame/blob/2e72fcfa4144ea5bc413963af8f97a2d5e902338/MonoGame.Framework/Content/ContentTypeReaderManager.cs#L154

- [ ] ```ContentManager``` has 2 warnings here (can be disabled, this will likely never fail, and this is only useful for Android):
https://github.com/MonoGame/MonoGame/blob/2e72fcfa4144ea5bc413963af8f97a2d5e902338/MonoGame.Framework/Content/ContentManager.cs#L592

- [ ] DesktopGL has ```VertexBuffer.GetBufferData()``` which might fail in AOT depending on the vertex declaration (we can't fix this, but it would be best to flag this method as incompatible, but like other warnings, this should actually be fine):
https://github.com/MonoGame/MonoGame/blob/2e72fcfa4144ea5bc413963af8f97a2d5e902338/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.OpenGL.cs#L92