### PR TITLE
fix uses of ellipses in options in the menu strip of the MGCB Editor

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
@@ -165,7 +165,7 @@ namespace MonoGame.Tools.Pipeline
 
             cmdSaveAs = new Command();
             cmdSaveAs.MenuText = "Save As...";
-            cmdSave.ToolTip = "Save As";
+            cmdSaveAs.ToolTip = "Save As";
             cmdSaveAs.Image = Global.GetEtoIcon("Commands.SaveAs.png");
 
             cmdExit = new Command();

--- a/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/MainWindow.eto.cs
@@ -158,13 +158,14 @@ namespace MonoGame.Tools.Pipeline
             cmdImport.MenuText = "Import";
 
             cmdSave = new Command();
-            cmdSave.MenuText = "Save...";
+            cmdSave.MenuText = "Save";
             cmdSave.ToolTip = "Save";
             cmdSave.Image = Global.GetEtoIcon("Commands.Save.png");
             cmdSave.Shortcut = Application.Instance.CommonModifier | Keys.S;
 
             cmdSaveAs = new Command();
-            cmdSaveAs.MenuText = "Save As";
+            cmdSaveAs.MenuText = "Save As...";
+            cmdSave.ToolTip = "Save As";
             cmdSaveAs.Image = Global.GetEtoIcon("Commands.SaveAs.png");
 
             cmdExit = new Command();


### PR DESCRIPTION
Changed the name of the **save** option from 'Save...' to 'Save' and changed 'Save As' to 'Save As...' under the **file** menu of the menu strip of the MGCB Editor for convention. As **save as** opens a dialog while **save** does not.