### PR TITLE
Fix: Last char missing from filename on filedrop event - WindowsDX platform

### DIFF
--- a/MonoGame.Framework/Platform/Windows/WinFormsGameForm.cs
+++ b/MonoGame.Framework/Platform/Windows/WinFormsGameForm.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Xna.Framework.Windows
             {
                 uint buffSize = DragQueryFile(hdrop, i, null, int.MaxValue);
                 StringBuilder builder = new StringBuilder((int)buffSize);
-                DragQueryFile(hdrop, i, builder, buffSize);
+                DragQueryFile(hdrop, i, builder, buffSize + 1); // Extra byte for null terminator
                 files[i] = builder.ToString();
             }
 


### PR DESCRIPTION
Fixes #8657 

FileDrop in a WindowsDX project cuts off the last character in the path

### Description of Change

Adding a byte to the final call of DragQueryFile as it expects the final byte to be the destination of the null string terminator. Ie, '.png' is 4 chars, with buffSize = 4, result would be '.pn`null`'

> [out] lpszFile
> 
> Type: LPTSTR
> 
> The address of a buffer that receives the file name of a dropped file when the function returns. This file name is a null-terminated string. If this parameter is NULL, DragQueryFile returns the required size, in characters, of this buffer.




