### PR TITLE
Add a new native API to handle loading assets

### DIFF
--- a/MonoGame.Framework/Platform/Native/TitleContainer.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/TitleContainer.Interop.cs
@@ -1,0 +1,115 @@
+using System;
+using System.IO;
+using MonoGame.Interop;
+using System.Runtime.InteropServices;
+
+internal unsafe class MGReadOnlyStream : Stream
+{
+    private MG_Asset* _asset;
+    private long _length;
+    private long _position;
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => true;
+
+    public override bool CanWrite => false;
+
+    public override long Length => _length;
+
+    public override long Position
+    {
+        get => _position;
+        set
+        {
+            if (value < 0 || value > _length)
+                throw new ArgumentOutOfRangeException();
+
+            _position = value;
+        }
+    }
+
+    public MGReadOnlyStream(string assetname)
+    {
+        if (!MG.AssetOpen(assetname, out _asset, out _length))
+            throw new FileNotFoundException("Asset not found", assetname);
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        if (_position + count > _length)
+            count = (int)(_length - _position);
+
+        if (count == 0)
+            return 0;
+
+        var bytesRead = MG.AssetRead(_asset, buffer, count);
+        _position += bytesRead;
+
+        return bytesRead;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        var newPosition = MG.AssetSeek(_asset, offset, (int)origin);
+        if (newPosition < 0 || newPosition > _length)
+            throw new ArgumentOutOfRangeException();
+
+        _position = newPosition;
+
+        return _position;
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+
+    protected unsafe override void Dispose(bool disposing)
+    {
+        if (_asset != null)
+        {
+            MG.AssetClose(_asset);
+            _asset = null;
+        }
+
+        base.Dispose(disposing);
+    }
+}
+
+[MGHandle]
+internal readonly struct MG_Asset
+{
+}
+
+internal static unsafe partial class MG
+{
+    public const string MonoGameNativeDLL = "monogame.native";
+
+    [LibraryImport(MonoGameNativeDLL, EntryPoint = "MG_Asset_Open", StringMarshalling = StringMarshalling.Utf8)]
+    [return: MarshalAs(UnmanagedType.U1)]
+    public static partial bool AssetOpen(string assetname, out MG_Asset* file, out long length);
+
+    [LibraryImport(MonoGameNativeDLL, EntryPoint = "MG_Asset_Read", StringMarshalling = StringMarshalling.Utf8)]
+    public static partial int AssetRead(MG_Asset* file, byte[] buffer, int count);
+
+    [LibraryImport(MonoGameNativeDLL, EntryPoint = "MG_Asset_Seek", StringMarshalling = StringMarshalling.Utf8)]
+    public static partial long AssetSeek(MG_Asset* file, long offset, int origin);
+
+    [LibraryImport(MonoGameNativeDLL, EntryPoint = "MG_Asset_Close", StringMarshalling = StringMarshalling.Utf8)]
+    public static partial void AssetClose(MG_Asset* file);
+
+    public static Stream OpenRead(string path)
+    {
+        return new MGReadOnlyStream(path);
+    }
+}

--- a/MonoGame.Framework/Platform/Native/TitleContainer.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/TitleContainer.Interop.cs
@@ -3,7 +3,7 @@ using System.IO;
 using MonoGame.Interop;
 using System.Runtime.InteropServices;
 
-internal unsafe class MGReadOnlyStream : Stream
+internal unsafe class ReadOnlyAssetStream : Stream
 {
     private MG_Asset* _asset;
     private long _length;
@@ -29,7 +29,7 @@ internal unsafe class MGReadOnlyStream : Stream
         }
     }
 
-    public MGReadOnlyStream(string assetname)
+    public ReadOnlyAssetStream(string assetname)
     {
         if (!MG.AssetOpen(assetname, out _asset, out _length))
             throw new FileNotFoundException("Asset not found", assetname);
@@ -110,6 +110,6 @@ internal static unsafe partial class MG
 
     public static Stream OpenRead(string path)
     {
-        return new MGReadOnlyStream(path);
+        return new ReadOnlyAssetStream(path);
     }
 }

--- a/MonoGame.Framework/Platform/Native/TitleContainer.Native.cs
+++ b/MonoGame.Framework/Platform/Native/TitleContainer.Native.cs
@@ -1,7 +1,7 @@
 // MonoGame - Copyright (C) The MonoGame Team
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
-
+using System;
 using System.IO;
 using MonoGame.Interop;
 
@@ -10,6 +10,7 @@ namespace Microsoft.Xna.Framework;
 
 partial class TitleContainer
 {
+
     static partial void PlatformInit()
     {
     }
@@ -17,7 +18,6 @@ partial class TitleContainer
     private static Stream PlatformOpenStream(string safeName)
     {
         var absolutePath = MGP.Platform_MakePath(Location, safeName);
-
-        return File.OpenRead(absolutePath);
+        return MG.OpenRead(absolutePath);
     }
 }

--- a/native/monogame/common/MG_Asset.cpp
+++ b/native/monogame/common/MG_Asset.cpp
@@ -1,0 +1,37 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#include "mg_common.h"
+#include "api_MG_Asset.h"
+#include <stdio.h>
+
+struct MG_Asset
+{
+    FILE* file;
+};
+
+mgbool MG_Asset_Open(const char* path, MG_Asset*& handle, mglong& length)
+{
+    handle = new MG_Asset();
+    handle->file = fopen(path, "rb");
+    if (handle->file == nullptr)
+    {
+        delete handle;
+        return false;
+    }
+    return true;
+}
+mgint MG_Asset_Read(MG_Asset* handle,  mgbyte* buffer, mglong count)
+{
+    return fread(buffer, 1, count, handle->file);
+}
+mglong MG_Asset_Seek(MG_Asset* handle, mglong offset, mgint whence)
+{
+    return fseek(handle->file, offset, whence);
+}
+void MG_Asset_Close(MG_Asset* handle)
+{
+    fclose(handle->file);
+    delete handle;
+}

--- a/native/monogame/common/MG_Asset.cpp
+++ b/native/monogame/common/MG_Asset.cpp
@@ -22,14 +22,17 @@ mgbool MG_Asset_Open(const char* path, MG_Asset*& handle, mglong& length)
     }
     return true;
 }
+
 mgint MG_Asset_Read(MG_Asset* handle,  mgbyte* buffer, mglong count)
 {
     return fread(buffer, 1, count, handle->file);
 }
+
 mglong MG_Asset_Seek(MG_Asset* handle, mglong offset, mgint whence)
 {
     return fseek(handle->file, offset, whence);
 }
+
 void MG_Asset_Close(MG_Asset* handle)
 {
     fclose(handle->file);

--- a/native/monogame/include/api_MG_Asset.h
+++ b/native/monogame/include/api_MG_Asset.h
@@ -1,0 +1,18 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+                
+// This code is auto generated, don't modify it by hand.
+// To regenerate it run: Tools/MonoGame.Generator.CTypes
+
+#pragma once
+
+#include "api_common.h"
+#include "api_enums.h"
+
+struct MG_Asset;
+
+MG_EXPORT mgbool MG_Asset_Open (const char* path, MG_Asset*& handle, mglong& length);
+MG_EXPORT mgint MG_Asset_Read (MG_Asset* handle,  mgbyte* buffer, mglong count);
+MG_EXPORT mglong MG_Asset_Seek (MG_Asset* handle, mglong offset, mgint whence);
+MG_EXPORT void MG_Asset_Close (MG_Asset* handle);


### PR DESCRIPTION
So lets expose an API for loading ReadOnly assets. 
This will allow us to make use of specific native I/O API's on various platforms such as Consoles and Mobile, while keeping the native C# interop code consistent and free of #if blocks or partial classes.

