### PR TITLE
Fixes OpenAssetImporter.GetRelativeTransform to return a row-major matrix

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -70,7 +70,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="AssimpNetter" Version="5.4.3" />
+    <PackageReference Include="AssimpNetter" Version="5.4.3.3" />
     <PackageReference Include="BCnEncoder.Net" Version="2.1.0" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.1.30" />
     <PackageReference Include="MonoGame.Library.FreeImage" Version="3.18.0.3" />

--- a/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
@@ -548,7 +548,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                     _pivots.Add(originalName, pivot);
                 }
 
-                Matrix transform = aiNode.Transform;
+                Matrix transform = Matrix.Transpose(aiNode.Transform);
                 if (aiNode.Name.EndsWith("_Translation"))
                     pivot.Translation = transform;
                 else if (aiNode.Name.EndsWith("_RotationOffset"))
@@ -730,7 +730,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                     if (mesh.HasBones)
                         foreach (var bone in mesh.Bones)
                             if (!offsetMatrices.ContainsKey(bone.Name))
-                                offsetMatrices[bone.Name] = bone.OffsetMatrix;
+                                offsetMatrices[bone.Name] = Matrix.Transpose(bone.OffsetMatrix);
 
             return offsetMatrices;
         }

--- a/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
@@ -1147,7 +1147,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             if (parent == null && ancestor != null)
                 throw new ArgumentException(string.Format("Node \"{0}\" is not an ancestor of \"{1}\".", ancestor.Name, node.Name));
 
-            return transform;
+            return Matrix4x4.Transpose(transform);
         }
 
         /// <summary>

--- a/Tools/MonoGame.Tools.Tests/FbxImporterTests.cs
+++ b/Tools/MonoGame.Tools.Tests/FbxImporterTests.cs
@@ -48,7 +48,6 @@ namespace MonoGame.Tests.ContentPipeline
         }
 
         [Test]
-        [Ignore("Disabled until latest assimp is merged on Mac and Linux or windows!")]
         public void Dude()
         {
             var context = new TestImporterContext("TestObj", "TestBin");
@@ -227,7 +226,7 @@ namespace MonoGame.Tests.ContentPipeline
             // returned a bigger animation duration that is correct.  Looking
             // at the content of the FBX ascii i can see the math is:
             // 
-            //  (57732697500 - 1924423250) / 46186158000 = 1.208 seconds
+            //  (57732697500 - 1924423250) / 46186158000 = 1.2083333 seconds
             //
             // Which is the correct result and what our FBX importer returns.
             // I highly suspect that XNA was wrong.
@@ -237,7 +236,7 @@ namespace MonoGame.Tests.ContentPipeline
 #if XNA
             Assert.AreEqual(12670000, animationContent.Duration.Ticks);
 #else
-            Assert.AreEqual(12080000, animationContent.Duration.Ticks);            
+            Assert.AreEqual(12083333, animationContent.Duration.Ticks);            
 #endif
 
             // TODO: XNA assigns the identity to null on all NodeContent


### PR DESCRIPTION
Fixes #8661

### Description of Change

Fixes `OpenAssetImporter.GetRelativeTransform` to now correctly return a row-major matrix. Appears to have been broken when #8607 removed the `ToXna(Matrix4x4 matrix)` method, resulting in the return of an incorrect column-major matrix.

While this fixes the rendering of ShipGame models, I just realised other changes from that PR might have broken other things. I'll try some other 3d models and import options next I guess.


