### PR TITLE
Fix Effect WineHelper to work with wine 10.0.

### DIFF
--- a/Tools/MonoGame.Effect.Compiler/WineHelper.cs
+++ b/Tools/MonoGame.Effect.Compiler/WineHelper.cs
@@ -10,6 +10,43 @@ namespace MonoGame.Effect.Compiler
 {
     public static class WineHelper
     {
+        static string wineExecutable = "wine";
+        static WineHelper()
+        {
+            if (Environment.OSVersion.Platform != PlatformID.Unix)
+                throw new PlatformNotSupportedException("WineHelper is only supported on Unix platforms.");
+
+            var proc = new Process();
+            proc.StartInfo.FileName = "wine64";
+            proc.StartInfo.Arguments = "--version";
+            proc.StartInfo.UseShellExecute = false;
+            proc.StartInfo.CreateNoWindow = true;
+            try {
+                proc.Start();
+                proc.WaitForExit();
+                if (proc.ExitCode == 0) {
+                    wineExecutable = "wine64";
+                    return;
+                }
+            }
+            catch (Exception)
+            {
+                proc.StartInfo.FileName = "wine";
+                return;
+            }
+            try {
+                proc.Start();
+                proc.WaitForExit();
+                if (proc.ExitCode == 0) {
+                    wineExecutable = "wine";
+                    return;
+                }
+            }
+            catch (Exception)
+            {
+                throw new PlatformNotSupportedException("Wine is not installed on this system.");
+            }
+        }
         public static int Run(Options options)
         {
             var mgfxcwine = Environment.GetEnvironmentVariable("MGFXC_WINE_PATH");
@@ -37,8 +74,11 @@ namespace MonoGame.Effect.Compiler
             var output = ToPrefixPath(options.OutputFile);
 
             var proc = new Process();
-            proc.StartInfo.FileName = "wine64";
+            proc.StartInfo.FileName = wineExecutable;
             proc.StartInfo.Arguments = "dotnet ";
+            proc.StartInfo.WorkingDirectory = Path.GetDirectoryName(assemblyLocation);
+            proc.StartInfo.UseShellExecute = false;
+            proc.StartInfo.CreateNoWindow = true;
             proc.StartInfo.AddPathArgument(assemblyLocation);
             proc.StartInfo.AddPathArgument(input);
             proc.StartInfo.AddPathArgument(output);
@@ -76,10 +116,12 @@ namespace MonoGame.Effect.Compiler
 
         public static string ToPrefixPath(string localPath)
         {
+            var assemblyLocation = typeof(Program).Assembly.Location;
             var proc = new Process();
-            proc.StartInfo.FileName = "wine64";
+            proc.StartInfo.FileName = wineExecutable;
             proc.StartInfo.Arguments = "winepath.exe -w \"" + localPath + "\"";
             proc.StartInfo.UseShellExecute = false;
+            proc.StartInfo.WorkingDirectory = Path.GetDirectoryName(assemblyLocation);
             proc.StartInfo.RedirectStandardOutput = true;
             proc.Start();
 


### PR DESCRIPTION
Wine 10.0 removed the wine64 executable and now only has wine. This change detects which one is available and uses it.

It also fixes an issue where the working directory could not be set.

```
An error occurred trying to start process 'wine64' with working directory '/Users/runner/work/MonoGame/MonoGame/Artifacts/Tests/Tools/Release'.
```

We do this by providing an actual working directory which we know exists. This is the location of the WineHelper executable.
