### PR TITLE
Backout change made in 5595e502

### DIFF
--- a/Tools/MonoGame.Effect.Compiler/WineHelper.cs
+++ b/Tools/MonoGame.Effect.Compiler/WineHelper.cs
@@ -76,7 +76,6 @@ namespace MonoGame.Effect.Compiler
             var proc = new Process();
             proc.StartInfo.FileName = wineExecutable;
             proc.StartInfo.Arguments = "dotnet ";
-            proc.StartInfo.WorkingDirectory = Path.GetDirectoryName(assemblyLocation);
             proc.StartInfo.UseShellExecute = false;
             proc.StartInfo.CreateNoWindow = true;
             proc.StartInfo.AddPathArgument(assemblyLocation);
@@ -121,7 +120,6 @@ namespace MonoGame.Effect.Compiler
             proc.StartInfo.FileName = wineExecutable;
             proc.StartInfo.Arguments = "winepath.exe -w \"" + localPath + "\"";
             proc.StartInfo.UseShellExecute = false;
-            proc.StartInfo.WorkingDirectory = Path.GetDirectoryName(assemblyLocation);
             proc.StartInfo.RedirectStandardOutput = true;
             proc.Start();
 


### PR DESCRIPTION
Comit 5595e502 added changes to the working directory that caused a problem when compiling effects.
So lets back out that change.

```
The input file '/Users/xxx/.nuget/packages/dotnet-mgcb/3.8.2.1922-develop/tools/net8.0/any/shaders/NormalMapping.fx' was not found!
```