### PR TITLE
Fix .NET 4.5 compatibility and restore ConsoleCheck

### DIFF
--- a/MonoGame.Framework/BoundingBox.cs
+++ b/MonoGame.Framework/BoundingBox.cs
@@ -159,21 +159,21 @@ namespace Microsoft.Xna.Framework
         /// </returns>
         public ContainmentType ContainsPrecise(BoundingFrustum frustum)
         {
-            Vector3[] boxNormals =
-            [
+            Vector3[] boxNormals = new Vector3[]
+            {
                 Vector3.Up,
                 Vector3.Right,
                 Vector3.Forward
-            ];
+            };
 
-            Vector3[] frustumNormals =
-            [
+            Vector3[] frustumNormals = new Vector3[]
+            {
                 frustum.Left.Normal,
                 frustum.Right.Normal,
                 frustum.Top.Normal,
                 frustum.Bottom.Normal,
                 frustum.Far.Normal
-            ];
+            };
 
             // allAxes = box normals + frustum normals + cross products of box normals and frustum normals
             Vector3[] allAxes = new Vector3[23]; // 3 + 5 + 3 * 5

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -459,18 +459,9 @@ namespace Microsoft.Xna.Framework.Content
                 {
                     // If the file is not found, we try searching a file with differents extensions
                     // based on the type of asset searched (e.g. '.bmp' and '.png' for a Texture2D)
-                    switch (typeof(T).Name)
+                    if (typeof(Texture2D).IsAssignableFrom(typeof(T)))
                     {
-                        case nameof(Texture2D):
-                            result = LoadTexture2DFromImageFile(assetName);
-                            break;
-                        // Futures cases here (see relevant GitHub Issues):
-                        // Video
-                        // Song
-                        // SoundEffect
-                        // Texture3D (?)
-                        default:
-                            break;
+                        result = LoadTexture2DFromImageFile(assetName);
                     }
                 }
                 catch
@@ -550,12 +541,14 @@ namespace Microsoft.Xna.Framework.Content
                 string assetPath = Path.Combine(RootDirectory, assetName);
                 assetPath = Path.ChangeExtension(assetPath, extension);
 
-                using Stream file = TitleContainer.OpenStreamNoException(assetPath);
-                if (file != null)
+                using (Stream file = TitleContainer.OpenStreamNoException(assetPath))
                 {
-                    Texture2D result = Texture2D.FromStream(graphicsDeviceService.GraphicsDevice, file, DefaultColorProcessors.PremultiplyAlpha);
+                    if (file != null)
+                    {
+                        Texture2D result = Texture2D.FromStream(graphicsDeviceService.GraphicsDevice, file, DefaultColorProcessors.PremultiplyAlpha);
 
-                    return result;
+                        return result;
+                    }
                 }
             }
 

--- a/MonoGame.Framework/Graphics/Shader/Shader.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.cs
@@ -46,31 +46,31 @@ namespace Microsoft.Xna.Framework.Graphics
             switch (usage)
             {
                 case VertexElementUsage.Position:
-                    return $"POSITION{index}";
+                    return "POSITION" + index;
                 case VertexElementUsage.Color:
-                    return $"COLOR{index}";
+                    return "COLOR" + index;
                 case VertexElementUsage.Normal:
-                    return $"NORMAL{index}";
+                    return "NORMAL" + index;
                 case VertexElementUsage.TextureCoordinate:
-                    return $"TEXCOORD{index}";
+                    return "TEXCOORD" + index;
                 case VertexElementUsage.BlendIndices:
-                    return $"BLENDINDICES{index}";
+                    return "BLENDINDICES" + index;
                 case VertexElementUsage.BlendWeight:
-                    return $"BLENDWEIGHT{index}";
+                    return "BLENDWEIGHT" + index;
                 case VertexElementUsage.Binormal:
-                    return $"BINORMAL{index}";
+                    return "BINORMAL" + index;
                 case VertexElementUsage.Tangent:
-                    return $"TANGENT{index}";
+                    return "TANGENT" + index;
                 case VertexElementUsage.PointSize:
-                    return $"PSIZE{index}";
+                    return "PSIZE" + index;
                 case VertexElementUsage.Depth:
-                    return $"DEPTH{index}";
+                    return "DEPTH" + index;
                 case VertexElementUsage.Fog:
-                    return $"FOG{index}";
+                    return "FOG" + index;
                 case VertexElementUsage.Sample: // Huh?  What is this?
-                    return $"SAMPLE{index}";
+                    return "SAMPLE" + index;
                 case VertexElementUsage.TessellateFactor:
-                    return $"TESSELLATEFACTOR{index}";
+                    return "TESSELLATEFACTOR" + index;
                 default:
                     throw new NotSupportedException("Unknown vertex element usage!");
             }

--- a/MonoGame.Framework/Utilities/DynamicallyAccessedMembers.cs
+++ b/MonoGame.Framework/Utilities/DynamicallyAccessedMembers.cs
@@ -27,12 +27,14 @@ namespace System.Diagnostics.CodeAnalysis
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Parameter | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter, Inherited = false)]
     public sealed class DynamicallyAccessedMembersAttribute : Attribute
     {
+        private DynamicallyAccessedMemberTypes _memberTypes;
+
         public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
         {
-            MemberTypes = memberTypes;
+            _memberTypes = memberTypes;
         }
 
-        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+        public DynamicallyAccessedMemberTypes MemberTypes { get { return _memberTypes; } }
     }
 }
 #endif

--- a/build/BuildFrameworksTasks/BuildConsoleCheckTask.cs
+++ b/build/BuildFrameworksTasks/BuildConsoleCheckTask.cs
@@ -1,0 +1,11 @@
+﻿
+namespace BuildScripts;
+
+[TaskName("Build ConsoleCheck")]
+public sealed class BuildConsoleCheckTask : FrostingTask<BuildContext>
+{
+    public override bool ShouldRun(BuildContext context) => context.IsRunningOnWindows();
+
+    public override void Run(BuildContext context)
+        => context.DotNetPack(context.GetProjectPath(ProjectType.Framework, "ConsoleCheck"), context.DotNetPackSettings);
+}

--- a/build/Tasks.cs
+++ b/build/Tasks.cs
@@ -9,6 +9,7 @@ namespace BuildScripts;
 [IsDependentOn(typeof(BuildAndroidTask))]
 [IsDependentOn(typeof(BuildiOSTask))]
 [IsDependentOn(typeof(BuildContentPipelineTask))]
+[IsDependentOn(typeof(BuildConsoleCheckTask))]
 public sealed class BuildFrameworksTask : FrostingTask<BuildContext> { }
 
 [TaskName("Build Tools")]


### PR DESCRIPTION
For some reason, ```ConsoleCheck``` has been unplugged from the CI and as a result some PRs introduced incompatibilities with .NET 4.5 / C# 5.

This PR fixes the incompatibilities and restores ```ConsoleCheck```.

For now, the ```ConsoleCheck``` only tests against the current code architecture. It doesn't test the newer ```Native``` structure but some consoles have already been ported to that structure, so we need something like ```ConsoleCheck.Native```.

Additionnaly, it would be necessary to have the ```DesktopGL``` tests to run using ```PublishAot``` to make sure that no PR uses runtime reflection (which we can't test with building ```ConsoleCheck```) to avoid regressions on the ```PublishAot``` compatibility.

-----

If anyone wonders "why is this limitation still in place? didn't you change the console runtime?", the answer is: yes and no.

Yes, the consoles have been moved toward using ```PublishAot``` instead of BRUTE. All but one, because ```PublishAot``` can't be used there. Which means that there is one single platform currently limiting the entirety of MonoGame. We're trying to figuring it out, but it's a process we don't have a power over and involves bureaucracy (or possibly to rewrite entirely BRUTE). So no ETA on fixing this, but it's expected to take a very long time.