### PR TITLE
Bump extension versions to 3.8.3.0 for next release.

### DIFF
--- a/Templates/MonoGame.Templates.VSExtension/Templates.pkgdef
+++ b/Templates/MonoGame.Templates.VSExtension/Templates.pkgdef
@@ -1,2 +1,2 @@
-[$RootKey$\TemplateEngine\Templates\MonoGame.Templates.VSExtension\3.8.1.1]
+[$RootKey$\TemplateEngine\Templates\MonoGame.Templates.VSExtension\3.8.3.0]
 "InstalledPath"="$PackageFolder$\ProjectTemplates"

--- a/Templates/MonoGame.Templates.VSExtension/source.extension.vsixmanifest
+++ b/Templates/MonoGame.Templates.VSExtension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Version="3.8.2.0" Id="MonoGame.Templates.VSExtension.03a6f6d5-6ec0-45ff-a4f6-ec098d51464d" Language="en-US" Publisher="MonoGame" />
+    <Identity Version="3.8.3.0" Id="MonoGame.Templates.VSExtension.03a6f6d5-6ec0-45ff-a4f6-ec098d51464d" Language="en-US" Publisher="MonoGame" />
     <DisplayName>MonoGame Framework C# project templates</DisplayName>
     <Description xml:space="preserve">This extension contains the C# project templates for using the MonoGame Framework</Description>
     <Tags>.NET,C#,Game development,Templates,Games,Gamedev,Project,Mono,MonoGame</Tags>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
@@ -10,7 +10,7 @@
     <MGCBToolDirectory Condition="'$(MGCBToolDirectory)' == ''">$(MSBuildThisFileDirectory)dotnet-tools/</MGCBToolDirectory>
     <MGCBToolDirectory Condition="'$(MGCBToolDirectory)' != '' And !HasTrailingSlash('$(MGCBToolDirectory)')">$(MGCBToolDirectory)/</MGCBToolDirectory>
     <MGCBCommand Condition="'$(MGCBCommand)' == ''">mgcb</MGCBCommand>
-    <MonoGameVersion Condition="'$(MonoGameVersion)' == ''">3.8.2.0</MonoGameVersion>
+    <MonoGameVersion Condition="'$(MonoGameVersion)' == ''">3.8.3.0</MonoGameVersion>
   </PropertyGroup>
 
 </Project>

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -18,7 +18,7 @@ public enum ProjectType
 
 public class BuildContext : FrostingContext
 {
-    public static string VersionBase = "3.8.2";
+    public static string VersionBase = "3.8.3";
     public static readonly Regex VersionRegex = new(@"^v\d+.\d+.\d+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     public static readonly string DefaultRepositoryUrl = "https://github.com/MonoGame/MonoGame";
 


### PR DESCRIPTION
Bump versions before next release.
Still Draft because we're waiting for MonoGame.Template submodule bump, once https://github.com/MonoGame/MonoGame.Templates/pull/3 is merged.





