### PR TITLE
Respect <link> elements when importing XNA content projects.

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineProjectParser.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineProjectParser.cs
@@ -448,22 +448,23 @@ namespace MonoGame.Tools.Pipeline
                         }
                         else if (buildAction.Equals("Content") || buildAction.Equals("None"))
                         {
-                            string include, copyToOutputDirectory;
-                            ReadIncludeContent(io, out include, out copyToOutputDirectory);
+                            string include, link, copyToOutputDirectory;
+                            ReadIncludeContent(io, out include, out link, out copyToOutputDirectory);
 
                             if (!string.IsNullOrEmpty(copyToOutputDirectory) && !copyToOutputDirectory.Equals("Never"))
                             {
                                 var sourceFilePath = Path.GetDirectoryName(projectFilePath);
                                 sourceFilePath += "\\" + include;
 
-                                OnCopy(sourceFilePath);
+                                var sourceFileArg = (link == null) ? sourceFilePath : sourceFilePath + ";" + link;
+                                OnCopy(sourceFileArg);
                             }
                         }
                         else if (buildAction.Equals("Compile"))
                         {
-                            string include, name, importer, processor;
+                            string include, link, name, importer, processor;
                             string[] processorParams;
-                            ReadIncludeCompile(io, out include, out name, out importer, out processor, out processorParams);
+                            ReadIncludeCompile(io, out include, out link, out name, out importer, out processor, out processorParams);
 
                             Importer = importer;
                             Processor = processor;
@@ -476,7 +477,8 @@ namespace MonoGame.Tools.Pipeline
                             var sourceFilePath = Path.GetDirectoryName(projectFilePath);
                             sourceFilePath += "\\" + include;
 
-                            OnBuild(sourceFilePath);
+                            var sourceFileArg = (link == null) ? sourceFilePath : sourceFilePath + ";" + link;
+                            OnBuild(sourceFileArg);
                         }
                     }
                 }
@@ -511,8 +513,9 @@ namespace MonoGame.Tools.Pipeline
             }
         }
 
-        private void ReadIncludeContent(XmlReader io, out string include, out string copyToOutputDirectory)
+        private void ReadIncludeContent(XmlReader io, out string include, out string link, out string copyToOutputDirectory)
         {
+            link = null;
             copyToOutputDirectory = null;
             include = io.GetAttribute("Include").Unescape();
 
@@ -527,6 +530,10 @@ namespace MonoGame.Tools.Pipeline
                     {
                         switch (io.LocalName)
                         {
+                            case "Link":
+                                io.Read();
+                                link = io.Value.Unescape();
+                                break;
                             case "CopyToOutputDirectory":
                                 io.Read();
                                 copyToOutputDirectory = io.Value.Unescape();
@@ -539,11 +546,13 @@ namespace MonoGame.Tools.Pipeline
 
         private void ReadIncludeCompile(XmlReader io,
                                         out string include,
+                                        out string link,
                                         out string name,
                                         out string importer,
                                         out string processor,
                                         out string[] processorParams)
         {
+            link = null;
             name = null;
             importer = null;
             processor = null;
@@ -562,6 +571,10 @@ namespace MonoGame.Tools.Pipeline
                     {
                         switch (io.LocalName)
                         {
+                            case "Link":
+                                io.Read();
+                                link = io.Value.Unescape();
+                                break;
                             case "Name":
                                 io.Read();
                                 name = io.Value.Unescape();


### PR DESCRIPTION
Fixes #8683

### Description of Change

Fixes importing contentproj files that reference files outside the project directory. Visual Studio puts a `<Link>` in a `<Content>`, `<Compile>` or `<None>` element to show the desired position in the structure, which MGCB was not respecting.