### PR TITLE
Fix GamePad button mappings for Android and iOS devices.

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -76,8 +76,8 @@
     <Compile Include="Platform\Utilities\InteropHelpers.cs" />
     <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
 
-    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp"/>
-    <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp"/>
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -151,6 +151,8 @@ namespace Microsoft.Xna.Framework.Input
             {
                 if (index == 0 && Back)
                 {
+                    Back = false;
+
                     return new GamePadState(
                         new GamePadThumbSticks(),
                         new GamePadTriggers(),

--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -283,7 +283,26 @@ namespace Microsoft.Xna.Framework.Input
             gamePad._leftTrigger = e.GetAxisValue(Axis.Brake);
             gamePad._rightTrigger = e.GetAxisValue(Axis.Gas);
 
-            if(!gamePad.DPadButtons)
+            // We set the Trigger buttons here, because it never fires in OnKeyDown
+            if (gamePad._leftTrigger > 0f)
+            {
+                gamePad._buttons |= Buttons.LeftTrigger;
+            }
+            else
+            {
+                gamePad._buttons &= Buttons.LeftTrigger;
+            }
+
+            if (gamePad._rightTrigger > 0f)
+            {
+                gamePad._buttons |= Buttons.RightTrigger;
+            }
+            else
+            {
+                gamePad._buttons &= Buttons.RightTrigger;
+            }
+
+            if (!gamePad.DPadButtons)
             {
                 if(e.GetAxisValue(Axis.HatX) < 0)
                 {

--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Xna.Framework.Input
             keyMap[13] = (int)Keycode.DpadUp;
 
             keyMap[14] = (int)Keycode.ButtonStart;
-            keyMap[15] = (int)Keycode.Back;
+            keyMap[15] = (int)Keycode.ButtonSelect;
 
             // get a bool[] with indices matching the keyMap
             bool[] hasMap = new bool[16];
@@ -359,7 +359,7 @@ namespace Microsoft.Xna.Framework.Input
 
                 case Keycode.ButtonStart:
                     return Buttons.Start;
-                case Keycode.Back:
+                case Keycode.ButtonSelect:
                     return Buttons.Back;
             }
 

--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -382,8 +382,6 @@ namespace Microsoft.Xna.Framework.Input
                     return Buttons.Start;
                 case Keycode.ButtonSelect:
                     return Buttons.Back;
-                case Keycode.ButtonMode:
-                    return Buttons.BigButton;
             }
 
             return 0;

--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -142,41 +142,41 @@ namespace Microsoft.Xna.Framework.Input
 
         private static GamePadState PlatformGetState(int index, GamePadDeadZone leftDeadZoneMode, GamePadDeadZone rightDeadZoneMode)
         {
+            if (index < 0 || index >= GamePads.Length)
+                return GamePadState.Default;
+
             var gamePad = GamePads[index];
-            GamePadState state = GamePadState.Default;
-            if (gamePad != null && gamePad._isConnected)
+
+            if (gamePad == null || !gamePad._isConnected)
             {
-                // Check if the device was disconnected
-                var dvc = InputDevice.GetDevice(gamePad._deviceId);
-                if (dvc == null)
-                {
-                    Android.Util.Log.Debug("MonoGame", "Detected controller disconnect [" + index + "] ");
-                    gamePad._isConnected = false;
-                    return state;
-                }
-
-                GamePadThumbSticks thumbSticks = new GamePadThumbSticks(gamePad._leftStick, gamePad._rightStick, leftDeadZoneMode, rightDeadZoneMode);
-
-                state = new GamePadState(
-                    thumbSticks,
-                    new GamePadTriggers(gamePad._leftTrigger, gamePad._rightTrigger),
-                    new GamePadButtons(gamePad._buttons),
-                    new GamePadDPad(gamePad._buttons));
-            }
-            // we need to add the default "no gamepad connected but the user hit back"
-            // behaviour here
-            else {
                 if (index == 0 && Back)
                 {
-                    // Consume state
-                    state = new GamePadState(new GamePadThumbSticks(), new GamePadTriggers(), new GamePadButtons(Buttons.Back), new GamePadDPad());
-                    state.IsConnected = false;
+                    return new GamePadState(
+                        new GamePadThumbSticks(),
+                        new GamePadTriggers(),
+                        new GamePadButtons(Buttons.Back),
+                        new GamePadDPad())
+                    {
+                        IsConnected = false
+                    };
                 }
-                else
-                    state = new GamePadState();
+
+                return GamePadState.Default;
             }
 
-            return state;
+            var dvc = InputDevice.GetDevice(gamePad._deviceId);
+            if (dvc == null)
+            {
+                Android.Util.Log.Debug("MonoGame", $"Detected controller disconnect [{index}]");
+                gamePad._isConnected = false;
+                return GamePadState.Default;
+            }
+
+            return new GamePadState(
+                new GamePadThumbSticks(gamePad._leftStick, gamePad._rightStick, leftDeadZoneMode, rightDeadZoneMode),
+                new GamePadTriggers(gamePad._leftTrigger, gamePad._rightTrigger),
+                new GamePadButtons(gamePad._buttons),
+                new GamePadDPad(gamePad._buttons));
         }
 
         private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor, float leftTrigger, float rightTrigger)

--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Xna.Framework.Input
                     device.VibratorManager.DefaultVibrator.HasVibrator;
 
             // build out supported inputs from what the gamepad exposes
-            int[] keyMap = new int[16];
+            int[] keyMap = new int[17];
             keyMap[0] = (int)Keycode.ButtonA;
             keyMap[1] = (int)Keycode.ButtonB;
             keyMap[2] = (int)Keycode.ButtonX;
@@ -64,6 +64,8 @@ namespace Microsoft.Xna.Framework.Input
 
             keyMap[14] = (int)Keycode.ButtonStart;
             keyMap[15] = (int)Keycode.ButtonSelect;
+
+            keyMap[16] = (int)Keycode.ButtonMode;
 
             // get a bool[] with indices matching the keyMap
             bool[] hasMap = new bool[16];
@@ -380,6 +382,8 @@ namespace Microsoft.Xna.Framework.Input
                     return Buttons.Start;
                 case Keycode.ButtonSelect:
                     return Buttons.Back;
+                case Keycode.ButtonMode:
+                    return Buttons.BigButton;
             }
 
             return 0;

--- a/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Xna.Framework.Input
             return false;
         }
 
-        static void AssingIndex(GCControllerPlayerIndex index)
+        static void AssignIndex(GCControllerPlayerIndex index)
         {
             if (IndexIsUsed(index))
                 return;
@@ -42,7 +42,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             var ind = (GCControllerPlayerIndex)index;
 
-            AssingIndex(ind);
+            AssignIndex(ind);
 
             foreach (var controller in GCController.Controllers)
             {
@@ -117,7 +117,7 @@ namespace Microsoft.Xna.Framework.Input
             float leftTriggerValue = 0;
             float rightTriggerValue = 0;
 
-            AssingIndex(ind);
+            AssignIndex(ind);
 
             foreach (var controller in GCController.Controllers)
             {
@@ -179,13 +179,11 @@ namespace Microsoft.Xna.Framework.Input
 
                     if (controller.ExtendedGamepad.LeftThumbstickButton.IsPressed)
                     {
-                        Down = ButtonState.Pressed;
                         buttons |= Buttons.LeftStick;
                     }
 
                     if (controller.ExtendedGamepad.RightThumbstickButton.IsPressed)
                     {
-                        Down = ButtonState.Pressed;
                         buttons |= Buttons.RightStick;
                     }
 

--- a/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
@@ -177,6 +177,18 @@ namespace Microsoft.Xna.Framework.Input
                         buttons |= Buttons.DPadRight;
                     }
 
+                    if (controller.ExtendedGamepad.LeftThumbstickButton.IsPressed)
+                    {
+                        Down = ButtonState.Pressed;
+                        buttons |= Buttons.LeftStick;
+                    }
+
+                    if (controller.ExtendedGamepad.RightThumbstickButton.IsPressed)
+                    {
+                        Down = ButtonState.Pressed;
+                        buttons |= Buttons.RightStick;
+                    }
+
                     leftThumbStickPosition.X = controller.ExtendedGamepad.LeftThumbstick.XAxis.Value;
                     leftThumbStickPosition.Y = controller.ExtendedGamepad.LeftThumbstick.YAxis.Value;
                     rightThumbStickPosition.X = controller.ExtendedGamepad.RightThumbstick.XAxis.Value;

--- a/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Xna.Framework.Input
                     }
 
                     if (controller.ExtendedGamepad.RightThumbstickButton != null
-                    && controller.ExtendedGamepad.LeftThumbstickButton.IsPressed)
+                    && controller.ExtendedGamepad.RightThumbstickButton.IsPressed)
                     {
                         buttons |= Buttons.RightStick;
                     }

--- a/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
@@ -151,10 +151,16 @@ namespace Microsoft.Xna.Framework.Input
                     if (controller.ExtendedGamepad.RightTrigger.IsPressed)
                         buttons |= Buttons.RightTrigger;
 
-                    if (controller.ExtendedGamepad.ButtonMenu.IsPressed)
+                    if (controller.ExtendedGamepad.ButtonMenu != null
+                    && controller.ExtendedGamepad.ButtonMenu.IsPressed)
+                    {
                         buttons |= Buttons.Start;
+                    }
+                        
                     if (controller.ExtendedGamepad.ButtonOptions?.IsPressed == true)
+                    {
                         buttons |= Buttons.Back;
+                    }
 
                     if (controller.ExtendedGamepad.DPad.Up.IsPressed)
                     {
@@ -177,17 +183,20 @@ namespace Microsoft.Xna.Framework.Input
                         buttons |= Buttons.DPadRight;
                     }
 
-                    if (controller.ExtendedGamepad.LeftThumbstickButton.IsPressed)
+                    if (controller.ExtendedGamepad.LeftThumbstickButton != null
+                    && controller.ExtendedGamepad.LeftThumbstickButton.IsPressed)
                     {
                         buttons |= Buttons.LeftStick;
                     }
 
-                    if (controller.ExtendedGamepad.RightThumbstickButton.IsPressed)
+                    if (controller.ExtendedGamepad.RightThumbstickButton != null
+                    && controller.ExtendedGamepad.LeftThumbstickButton.IsPressed)
                     {
                         buttons |= Buttons.RightStick;
                     }
 
-                    if (controller.ExtendedGamepad.ButtonHome.IsPressed)
+                    if (controller.ExtendedGamepad.ButtonHome != null
+                    && controller.ExtendedGamepad.ButtonHome.IsPressed)
                     {
                         buttons |= Buttons.BigButton;
                     }

--- a/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
@@ -187,6 +187,11 @@ namespace Microsoft.Xna.Framework.Input
                         buttons |= Buttons.RightStick;
                     }
 
+                    if (controller.ExtendedGamepad.ButtonHome.IsPressed)
+                    {
+                        buttons |= Buttons.BigButton;
+                    }
+
                     leftThumbStickPosition.X = controller.ExtendedGamepad.LeftThumbstick.XAxis.Value;
                     leftThumbStickPosition.Y = controller.ExtendedGamepad.LeftThumbstick.YAxis.Value;
                     rightThumbStickPosition.X = controller.ExtendedGamepad.RightThumbstick.XAxis.Value;

--- a/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
@@ -195,12 +195,6 @@ namespace Microsoft.Xna.Framework.Input
                         buttons |= Buttons.RightStick;
                     }
 
-                    if (controller.ExtendedGamepad.ButtonHome != null
-                    && controller.ExtendedGamepad.ButtonHome.IsPressed)
-                    {
-                        buttons |= Buttons.BigButton;
-                    }
-
                     leftThumbStickPosition.X = controller.ExtendedGamepad.LeftThumbstick.XAxis.Value;
                     leftThumbStickPosition.Y = controller.ExtendedGamepad.LeftThumbstick.YAxis.Value;
                     rightThumbStickPosition.X = controller.ExtendedGamepad.RightThumbstick.XAxis.Value;


### PR DESCRIPTION
Fixes #8522

**Known Issue** 
iOS *ThumbStickButton is always null. Issue raised here - https://github.com/dotnet/macios/issues/22524



