### PR TITLE
Respect the /quiet command line option when converting content.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -116,6 +116,11 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         public bool RethrowExceptions { get; set; }
 
         /// <summary>
+        /// If true, messages which are non-essential to the build process will be suppressed.
+        /// </summary>
+        public bool Quiet { get; set; }
+
+        /// <summary>
         /// Creates a new instance of PipelineManager.
         /// </summary>
         /// <param name="projectDir">The directory that contains the content project./param>
@@ -686,7 +691,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             var rebuild = pipelineEvent.NeedsRebuild(this, cachedEvent);
             if (rebuild)
                 Logger.LogMessage("{0}", pipelineEvent.SourceFile);
-            else
+            else if (!Quiet)
                 Logger.LogMessage("Skipping {0}", pipelineEvent.SourceFile);
 
             Logger.Indent();

--- a/Tools/MonoGame.Content.Builder/BuildContent.cs
+++ b/Tools/MonoGame.Content.Builder/BuildContent.cs
@@ -305,6 +305,7 @@ namespace MonoGame.Content.Builder
             _manager = new PipelineManager(projectDirectory, outputPath, intermediatePath);
             _manager.Logger = new ConsoleLogger();
             _manager.CompressContent = CompressContent;
+            _manager.Quiet = Quiet;
 
             // If the intent is to debug build, break at the original location
             // of any exception, eg, within the actual importer/processor.


### PR DESCRIPTION
Prevents a "Skipping XYZ..." message for each asset which is _not_ converted during the content build process.

On projects with a lot of content, this creates a lot of noise. I left the normal output message enabled since the conversion can be slow, and it gives the user indication of what is happening. The "Skipping XYZ..." messages just tend to drown out everything else.