### PR TITLE
Fix some build warnings in Debug due to malformed xmldoc comments.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -118,7 +118,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         /// <summary>
         /// Creates a new instance of PipelineManager.
         /// </summary>
-        /// <param name="projectDir">The directory that contains the content project./param>
+        /// <param name="projectDir">The directory that contains the content project.</param>
         /// <param name="outputDir">The directory that contains the results of the project.</param>
         /// <param name="intermediateDir">The directory that is used for temporary files created by the content build process</param>
         public PipelineManager(string projectDir, string outputDir, string intermediateDir)

--- a/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         /// <summary>
         /// Gets or sets the color key flag.
         /// <remarks>
-        /// Must be set to <see langword="true"> to use the color key.
+        /// Must be set to <see langword="true"/> to use the color key.
         /// </remarks>
         /// </summary>
         [DefaultValueAttribute(true)]

--- a/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
+++ b/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
@@ -91,7 +91,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// All desktop versions using Vulkan.
         /// </summary>
         DesktopVK,
-        
+
+        /// <summary>
         /// Windows GDK
         /// </summary>
         WindowsGDK,


### PR DESCRIPTION
Just a quick one - saw a few trivial warnings when building in debug that were due to invalid XMLDOC comments. Thought I'd fix them up.