### PR TITLE
Remove call to RestoreMGCB()

### DIFF
--- a/MonoGame.Tools.Linux.sln
+++ b/MonoGame.Tools.Linux.sln
@@ -23,8 +23,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoGame.Content.Builder.Ed
 		{B3201192-46D5-40C5-A24E-493EC66D8C9B} = {B3201192-46D5-40C5-A24E-493EC66D8C9B}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Packaging.Flatpak", "Tools\MonoGame.Packaging.Flatpak\MonoGame.Packaging.Flatpak.csproj", "{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Content.Builder.Editor.Launcher.Linux", "Tools\MonoGame.Content.Builder.Editor.Launcher\MonoGame.Content.Builder.Editor.Launcher.Linux.csproj", "{E0804E98-4464-4E27-BEA8-3F223F7F0F00}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Content.Builder.Editor.Launcher.Bootstrap", "Tools\MonoGame.Content.Builder.Editor.Launcher.Bootstrap\MonoGame.Content.Builder.Editor.Launcher.Bootstrap.csproj", "{D78864E4-DFBD-45EE-86BA-71213EC5976C}"
@@ -135,18 +133,6 @@ Global
 		{F673A915-308F-4111-8950-A5755BE5CEEA}.Release|x64.Build.0 = Release|Any CPU
 		{F673A915-308F-4111-8950-A5755BE5CEEA}.Release|x86.ActiveCfg = Release|Any CPU
 		{F673A915-308F-4111-8950-A5755BE5CEEA}.Release|x86.Build.0 = Release|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|x64.Build.0 = Debug|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|x86.Build.0 = Debug|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|x64.ActiveCfg = Release|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|x64.Build.0 = Release|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|x86.ActiveCfg = Release|Any CPU
-		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|x86.Build.0 = Release|Any CPU
 		{E0804E98-4464-4E27-BEA8-3F223F7F0F00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E0804E98-4464-4E27-BEA8-3F223F7F0F00}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E0804E98-4464-4E27-BEA8-3F223F7F0F00}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/MonoGame.Tools.Linux.sln
+++ b/MonoGame.Tools.Linux.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoGame.Content.Builder.Ed
 		{B3201192-46D5-40C5-A24E-493EC66D8C9B} = {B3201192-46D5-40C5-A24E-493EC66D8C9B}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Packaging.Flatpak", "Tools\MonoGame.Packaging.Flatpak\MonoGame.Packaging.Flatpak.csproj", "{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Content.Builder.Editor.Launcher.Linux", "Tools\MonoGame.Content.Builder.Editor.Launcher\MonoGame.Content.Builder.Editor.Launcher.Linux.csproj", "{E0804E98-4464-4E27-BEA8-3F223F7F0F00}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Content.Builder.Editor.Launcher.Bootstrap", "Tools\MonoGame.Content.Builder.Editor.Launcher.Bootstrap\MonoGame.Content.Builder.Editor.Launcher.Bootstrap.csproj", "{D78864E4-DFBD-45EE-86BA-71213EC5976C}"
@@ -133,6 +135,18 @@ Global
 		{F673A915-308F-4111-8950-A5755BE5CEEA}.Release|x64.Build.0 = Release|Any CPU
 		{F673A915-308F-4111-8950-A5755BE5CEEA}.Release|x86.ActiveCfg = Release|Any CPU
 		{F673A915-308F-4111-8950-A5755BE5CEEA}.Release|x86.Build.0 = Release|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|x64.Build.0 = Debug|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Debug|x86.Build.0 = Debug|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|x64.ActiveCfg = Release|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|x64.Build.0 = Release|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|x86.ActiveCfg = Release|Any CPU
+		{2AAE746F-0EBE-48B4-8657-2B469B3E1C8F}.Release|x86.Build.0 = Release|Any CPU
 		{E0804E98-4464-4E27-BEA8-3F223F7F0F00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E0804E98-4464-4E27-BEA8-3F223F7F0F00}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E0804E98-4464-4E27-BEA8-3F223F7F0F00}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
@@ -136,7 +136,6 @@ namespace MonoGame.Tools.Pipeline
                 LoadTemplates(templatesPath);
 #endif
 
-            RestoreMGCB();
             UpdateMenu();
 
             view.UpdateRecentList(PipelineSettings.Default.ProjectHistory);
@@ -582,22 +581,6 @@ namespace MonoGame.Tools.Pipeline
             _buildTask.ContinueWith((e) => View.Invoke(UpdateMenu));
 
             UpdateMenu();       
-        }
-
-        private void RestoreMGCB()
-        {
-            var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-            var workingDirectory = Path.Combine(appDataPath, "mgcb-dotnet-tool", version);
-            if (Directory.Exists(workingDirectory))
-                return;
-            Directory.CreateDirectory(workingDirectory);
-            var dotnet = Global.Unix ? "dotnet" : "dotnet.exe";
-            if (Util.Run(dotnet, $"tool install dotnet-mgcb --version {version} --tool-path .", workingDirectory) != 0)
-            {
-                // install the latest
-                Util.Run(dotnet, $"tool install dotnet-mgcb --tool-path .", workingDirectory);
-            }
         }
 
         private void DoBuild(string commands)


### PR DESCRIPTION
As per subject line. 

Devs should be relying on `dotnet tool restore` and we shouldn't be doing it for them.




