### PR TITLE
Fix GamePad issue with Android and iOS

### DIFF
--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -92,18 +92,21 @@ namespace Microsoft.Xna.Framework.Input
             // this will need fixing
             capabilities.HasLeftXThumbStick = hasMap[4];
             capabilities.HasLeftYThumbStick = hasMap[4];
+            capabilities.HasLeftStickButton = hasMap[4];
+
             capabilities.HasRightXThumbStick = hasMap[5];
             capabilities.HasRightYThumbStick = hasMap[5];
+            capabilities.HasRightStickButton = hasMap[5];
 
             capabilities.HasLeftShoulderButton = hasMap[6];
             capabilities.HasRightShoulderButton = hasMap[7];
             capabilities.HasLeftTrigger = hasMap[8];
             capabilities.HasRightTrigger = hasMap[9];
 
-            capabilities.HasDPadDownButton = hasMap[10];
-            capabilities.HasDPadLeftButton = hasMap[11];
-            capabilities.HasDPadRightButton = hasMap[12];
-            capabilities.HasDPadUpButton = hasMap[13];
+            capabilities.HasDPadDownButton = true;
+            capabilities.HasDPadLeftButton = true;
+            capabilities.HasDPadRightButton = true;
+            capabilities.HasDPadUpButton = true;
 
             capabilities.HasStartButton = hasMap[14];
             capabilities.HasBackButton = hasMap[15];
@@ -294,7 +297,7 @@ namespace Microsoft.Xna.Framework.Input
             }
             else
             {
-                gamePad._buttons &= Buttons.LeftTrigger;
+                gamePad._buttons &= ~Buttons.LeftTrigger;
             }
 
             if (gamePad._rightTrigger > 0f)
@@ -303,7 +306,7 @@ namespace Microsoft.Xna.Framework.Input
             }
             else
             {
-                gamePad._buttons &= Buttons.RightTrigger;
+                gamePad._buttons &= ~Buttons.RightTrigger;
             }
 
             if (!gamePad.DPadButtons)

--- a/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Xna.Framework.Input
             //All iOS controllers have these basics
             var capabilities = new GamePadCapabilities()
             {
-                IsConnected = false,
+                IsConnected = true,
                 GamePadType = GamePadType.GamePad,
             };
             if (controller.ExtendedGamepad != null)
@@ -80,8 +80,10 @@ namespace Microsoft.Xna.Framework.Input
                 capabilities.HasRightTrigger = true;
                 capabilities.HasLeftXThumbStick = true;
                 capabilities.HasLeftYThumbStick = true;
+                capabilities.HasLeftStickButton = true;
                 capabilities.HasRightXThumbStick = true;
                 capabilities.HasRightYThumbStick = true;
+                capabilities.HasRightStickButton = true;
             }
             else if (controller.Gamepad != null)
             {
@@ -212,6 +214,11 @@ namespace Microsoft.Xna.Framework.Input
                         buttons |= Buttons.X;
                     if (controller.Gamepad.ButtonY.IsPressed)
                         buttons |= Buttons.Y;
+
+                    if (controller.Gamepad.LeftShoulder.IsPressed)
+                        buttons |= Buttons.LeftShoulder;
+                    if (controller.Gamepad.RightShoulder.IsPressed)
+                        buttons |= Buttons.RightShoulder;
 
                     if (controller.Gamepad.DPad.Up.IsPressed)
                     {


### PR DESCRIPTION
*  Regression on Android resetting button state.
*  Update `HasLeftStickButton` and  `HasRightStickButton` (Android)
*  Mark `HasDPadDownButton` as true since `hasKeys` always return false for directional keys
*  Update `LeftShoulder` and `RightShoulder` on iOS when falling back to `GamePad`
*  Mark `capability.IsConnected` as `true`

cc @CartBlanche 




