### PR TITLE
Fix unhandled exception when invalid target platform is provided in mgcb

### DIFF
--- a/Tools/MonoGame.Content.Builder/CommandLineParser.cs
+++ b/Tools/MonoGame.Content.Builder/CommandLineParser.cs
@@ -15,7 +15,7 @@ namespace MonoGame.Content.Builder
 {
     /// <summary>
     /// Adapted from this generic command line argument parser:
-    /// http://blogs.msdn.com/b/shawnhar/archive/2012/04/20/a-reusable-reflection-based-command-line-parser.aspx     
+    /// https://shawnhargreaves.com/blog/a-reusable-reflection-based-command-line-parser.html     
     /// </summary>
     public class MGBuildParser
     {

--- a/Tools/MonoGame.Content.Builder/CommandLineParser.cs
+++ b/Tools/MonoGame.Content.Builder/CommandLineParser.cs
@@ -398,9 +398,9 @@ namespace MonoGame.Content.Builder
 
                 return true;
             }
-            catch
+            catch(Exception ex)
             {
-                ShowError("Invalid value '{0}' for option '{1}'", value, GetAttribute<CommandLineParameterAttribute>(member).Name);
+                ShowError("Invalid value '{0}' for option '{1}': {2}", value, GetAttribute<CommandLineParameterAttribute>(member).Name, ex.Message);
                 return false;
             }
         }
@@ -425,9 +425,27 @@ namespace MonoGame.Content.Builder
 
         static object ChangeType(string value, Type type)
         {
-            var converter = TypeDescriptor.GetConverter(type);
-
-            return converter.ConvertFromInvariantString(value);
+            if (type.IsEnum)
+            {
+                object result;
+                // Try to parse the provided value using case-insensitive matching.
+                if (Enum.TryParse(type, value, true, out result) && Enum.IsDefined(type, result))
+                {
+                    return result;
+                }
+                else
+                {
+                    // Build a list of valid values.
+                    string validValues = string.Join(", ", Enum.GetNames(type));
+                    throw new Exception(string.Format("Valid values are: '{0}'.", validValues));
+                }
+            }
+            else
+            {
+                // For non-enum types, use the standard type converter.
+                var converter = TypeDescriptor.GetConverter(type);
+                return converter.ConvertFromInvariantString(value);
+            }
         }
 
 
@@ -567,7 +585,19 @@ namespace MonoGame.Content.Builder
                     s = s.PadRight(35, ' ');
 
                     // Wrap text description
-                    var bw = Math.Max(60, Console.BufferWidth);
+                    int bw = 60;
+                    try
+                    {
+                        // Only try to access Console.BufferWidth if we have a valid console
+                        if (Console.IsOutputRedirected == false)
+                            bw = Math.Max(60, Console.BufferWidth);
+                    }
+                    catch (IOException)
+                    {
+                        // Use default width if console is not available
+                        bw = 80;
+                    }
+                    
                     var desc = attr.Description.Split(' ');
 
                     foreach(var dw in desc)

--- a/Tools/MonoGame.Effect.Compiler/Effect/CommandLineParser.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/CommandLineParser.cs
@@ -17,7 +17,7 @@ namespace MonoGame.Effect
     // Reusable, reflection based helper for parsing commandline options.
     //
     // From Shawn Hargreaves Blog:
-    // http://blogs.msdn.com/b/shawnhar/archive/2012/04/20/a-reusable-reflection-based-command-line-parser.aspx
+    // https://shawnhargreaves.com/blog/a-reusable-reflection-based-command-line-parser.html
     //
     public class CommandLineParser
     {


### PR DESCRIPTION
Fixes #8519 

### Description of Change

The _System.IO.IOException: The handle is invalid._ error when using an Invalid Platform was coming from the ShowError method when it tries to get the Consoles BufferWidth. Setting a fallback value and handling the error so that the default bw is set, even if the console has been output redirected, makes the build at least fail gracefully. If there are other suggested lengths or preferences feel free to let me know and I can update it!

Additionally, I did add some code to the output message that gets printed for enums and grabs the list of valid values if an incorrect value is provided. 

Since I was working on the CommandLineParser.cs files I did notice that they had the old reference link for Shawn's blog. So I did update those to point to the new locations instead of the 404s.

Updated output (not all of the Options are shown for brevity):

![image](https://github.com/user-attachments/assets/3ba0f681-e857-4a35-9642-dae9a64a7780)

