### PR TITLE
Add device name for Android Gamepads

### DIFF
--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -111,6 +111,8 @@ namespace Microsoft.Xna.Framework.Input
             capabilities.HasStartButton = hasMap[14];
             capabilities.HasBackButton = hasMap[15];
 
+            capabilities.DisplayName = device.Name;
+
             return capabilities;
         }
     }


### PR DESCRIPTION
Fixes #8731 


### Description of Change

Adds DeviceName to GamePadCapabilities for the Android platform



