### PR TITLE
Map BigButton on Android to Keycode.BigButton

### DIFF
--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Xna.Framework.Input
 
             capabilities.HasStartButton = hasMap[14];
             capabilities.HasBackButton = hasMap[15];
+            capabilities.HasBigButton = hasMap[16];
 
             return capabilities;
         }
@@ -387,6 +388,8 @@ namespace Microsoft.Xna.Framework.Input
                     return Buttons.Start;
                 case Keycode.ButtonSelect:
                     return Buttons.Back;
+                case Keycode.ButtonMode:
+                    return Buttons.BigButton;
             }
 
             return 0;


### PR DESCRIPTION
Fixes #8733

### Description of Change

Adds a mapping on the Android platform for gamepads to BigButton. This is internally mapped to Keycode.ButtonMode.

Tested with controllers:
Xbox One  - Registers the Xbox button
Playstation 4 - Registers PS button
Playstation 5 - Registers PS button
Switch Pro - Registers Capture button (Home button is picked up by Android system)
Gamesir x2 - Registers Xbox button



