### PR TITLE
Fix imported link paths not being nested correctly in the MGCB browser.

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineProjectParser.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineProjectParser.cs
@@ -175,7 +175,7 @@ namespace MonoGame.Tools.Pipeline
                 sourceFile = split[0];
 
                 if (split.Length > 0)
-                    link = split[1];
+                    link = split[1].Replace('\\', '/');
             }
 
             // Make sure the source file is relative to the project.
@@ -230,7 +230,7 @@ namespace MonoGame.Tools.Pipeline
                 sourceFile = split[0];
 
                 if (split.Length > 0)
-                    link = split[1];
+                    link = split[1].Replace('\\', '/');
             }
 
             // Make sure the source file is relative to the project.

--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineProjectParser.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineProjectParser.cs
@@ -175,7 +175,7 @@ namespace MonoGame.Tools.Pipeline
                 sourceFile = split[0];
 
                 if (split.Length > 0)
-                    link = split[1].Replace('\\', '/');
+                    link = PathHelper.Normalize(split[1]);
             }
 
             // Make sure the source file is relative to the project.

--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineProjectParser.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineProjectParser.cs
@@ -230,7 +230,7 @@ namespace MonoGame.Tools.Pipeline
                 sourceFile = split[0];
 
                 if (split.Length > 0)
-                    link = split[1].Replace('\\', '/');
+                    link = PathHelper.Normalize(split[1]);
             }
 
             // Make sure the source file is relative to the project.


### PR DESCRIPTION
XNA contentproj files use Windows paths separated by backslashes. MGCB expects forward slashes to be able to nest content items correctly.

The call to PathHelper.GetRelativePath() below the lines changed use System.Uri methods, which has the effect of performing backslash -> slash conversions on the supplied source file path, so this seemed the correct location to convert the link path too.

Without this change, any contentproj that references items with a `<Link>` path will be shown at the root of the MGCB project. With this change, the items will be nested at the correct location in the browser.