### PR TITLE
Add NO_AUDIO switch to build without audio

### DIFF
--- a/MonoGame.Framework/Media/Album.cs
+++ b/MonoGame.Framework/Media/Album.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Xna.Framework.Media
 
 			return this.thumbnail.ImageWithSize(new CGSize(width, height));
         }
-#elif ANDROID
+#elif ANDROID && !NO_AUDIO
         public Bitmap GetAlbumArt(int width = 0, int height = 0)
         {
             Bitmap albumArt;
@@ -197,7 +197,7 @@ namespace Microsoft.Xna.Framework.Media
         {
             return this.GetAlbumArt(220, 220);
         }
-#elif ANDROID
+#elif ANDROID && !NO_AUDIO
         public Bitmap GetThumbnail()
         {
             return this.GetAlbumArt(220, 220);

--- a/MonoGame.Framework/Media/MediaQueue.cs
+++ b/MonoGame.Framework/Media/MediaQueue.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Xna.Framework.Media
 			}
 		}
 
-#if !DIRECTX
+#if !DIRECTX || NO_AUDIO
         internal void SetVolume(float volume)
         {
             int count = songs.Count;
@@ -132,7 +132,7 @@ namespace Microsoft.Xna.Framework.Media
             songs.Add(song);
         }
 
-#if !DIRECTX
+#if !DIRECTX || NO_AUDIO
         internal void Stop()
         {
             int count = songs.Count;

--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Xna.Framework.Media
             get { return disposed; }
         }
 
-#if ANDROID || OPENAL || WEB || IOS || NATIVE
+#if ANDROID || OPENAL || WEB || IOS || NATIVE || NO_AUDIO
         internal delegate void FinishedPlayingHandler(object sender, EventArgs args);
 #if !DESKTOPGL
         event FinishedPlayingHandler DonePlaying;

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -19,10 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.10" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Remove="bin\**\*" />
     <Compile Remove="obj\**\*" />
     <Compile Remove="Platform\**\*" />
@@ -70,11 +66,7 @@
     <Compile Include="Platform\Input\MessageBox.Android.cs" />
     <Compile Include="Platform\Input\Mouse.Default.cs" />
     <Compile Include="Platform\Input\MouseCursor.Default.cs" />
-    <Compile Include="Platform\Media\MediaLibrary.Android.cs" />
     <Compile Include="Platform\Media\MediaPlayer.Default.cs" />
-    <Compile Include="Platform\Media\Song.Android.cs" />
-    <Compile Include="Platform\Media\Video.Android.cs" />
-    <Compile Include="Platform\Media\VideoPlayer.Android.cs" />
     <Compile Include="Platform\PrimaryThreadLoader.cs" />
     <Compile Include="Platform\TitleContainer.Android.cs" />
     <Compile Include="Platform\Utilities\FuncLoader.Android.cs" />

--- a/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
@@ -38,14 +38,7 @@
     <Compile Include="Platform\Input\MessageBox.Windows.cs" />
     <Compile Include="Platform\Input\Mouse.Windows.cs" />
     <Compile Include="Platform\Input\MouseCursor.Windows.cs" />
-
     <Compile Include="Platform\Media\MediaLibrary.Default.cs" />
-    <Compile Include="Platform\Media\MediaManagerState.cs" />
-    <Compile Include="Platform\Media\MediaPlayer.WMS.cs" />
-    <Compile Include="Platform\Media\Song.WMS.cs" />
-    <Compile Include="Platform\Media\Video.WMS.cs" />
-    <Compile Include="Platform\Media\VideoPlayer.WMS.cs" />
-    <Compile Include="Platform\Media\VideoSampleGrabber.cs" />
     <Compile Include="Platform\TitleContainer.Desktop.cs" />
     <Compile Include="Platform\Utilities\AssemblyHelper.cs" />
     <Compile Include="Platform\Utilities\CurrentPlatform.cs" />
@@ -69,16 +62,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Version="4.0.1" Include="SharpDX" />
     <PackageReference Version="4.0.1" Include="SharpDX.Direct2D1" />
     <PackageReference Version="4.0.1" Include="SharpDX.Direct3D11" />
     <PackageReference Version="4.0.1" Include="SharpDX.DXGI" />
-    <PackageReference Version="4.0.1" Include="SharpDX.MediaFoundation" />
-    <PackageReference Version="4.0.1" Include="SharpDX.XAudio2" />
     <PackageReference Version="4.0.1" Include="SharpDX.XInput" />
   </ItemGroup>
 

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <DefineConstants>OPENGL;OPENAL;XNADESIGNPROVIDED;LINUX;DESKTOPGL;SUPPORTS_EFX;NETSTANDARD;STBSHARP_INTERNAL</DefineConstants>
+    <DefineConstants>OPENGL;XNADESIGNPROVIDED;DESKTOPGL;NETSTANDARD;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>The MonoGame runtime supporting Windows, Linux and macOS using SDL2 and OpenGL.</Description>
     <PackageTags>monogame;.net core;core;.net standard;standard;desktopgl</PackageTags>
@@ -17,14 +17,8 @@
     <None Include="..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
-  <!-- NETFX reference assemblies let us target .NET Framework on Mac/Linux without Mono -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="MonoGame.Library.SDL" Version="2.32.2.1" />
-    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.10" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,13 +37,6 @@
 
   <ItemGroup>
     <Compile Remove="Graphics\GraphicsAdapter.cs" />
-  </ItemGroup>
-  
-  <!-- Song support with Vorbis, depends on OpenAL -->
-  <ItemGroup>
-    <PackageReference Include="NVorbis" Version="0.10.4" />
-    <Compile Include="Platform\Media\OggStream.NVorbis.cs" />
-    <Compile Include="Platform\Media\Song.NVorbis.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.Native.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Native.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <DefineConstants>XNADESIGNPROVIDED;NATIVE;SUPPORTS_EFX;NETSTANDARD;STBSHARP_INTERNAL</DefineConstants>
+    <DefineConstants>XNADESIGNPROVIDED;NATIVE;NETSTANDARD;STBSHARP_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>The MonoGame Native platform.</Description>
     <PackageTags>monogame;.net core;core;.net standard;standard;native</PackageTags>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -46,14 +46,7 @@
     <Compile Include="Platform\Input\MessageBox.Windows.cs" />
     <Compile Include="Platform\Input\Mouse.Windows.cs" />
     <Compile Include="Platform\Input\MouseCursor.Windows.cs" />
-
     <Compile Include="Platform\Media\MediaLibrary.Default.cs" />
-    <Compile Include="Platform\Media\MediaManagerState.cs" />
-    <Compile Include="Platform\Media\MediaPlayer.WMS.cs" />
-    <Compile Include="Platform\Media\Song.WMS.cs" />
-    <Compile Include="Platform\Media\Video.WMS.cs" />
-    <Compile Include="Platform\Media\VideoPlayer.WMS.cs" />
-    <Compile Include="Platform\Media\VideoSampleGrabber.cs" />
     <Compile Include="Platform\TitleContainer.Desktop.cs" />
     <Compile Include="Platform\Utilities\AssemblyHelper.cs" />
     <Compile Include="Platform\Utilities\CurrentPlatform.cs" />
@@ -79,16 +72,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="2.1.30" />
     <PackageReference Include="Microsoft.NETCore.Jit" Version="2.0.8" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Version="4.0.1" Include="SharpDX" />
     <PackageReference Version="4.0.1" Include="SharpDX.Direct2D1" />
     <PackageReference Version="4.0.1" Include="SharpDX.Direct3D11" />
     <PackageReference Version="4.0.1" Include="SharpDX.DXGI" />
-    <PackageReference Version="4.0.1" Include="SharpDX.MediaFoundation" />
-    <PackageReference Version="4.0.1" Include="SharpDX.XAudio2" />
     <PackageReference Version="4.0.1" Include="SharpDX.XInput" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0-ios</TargetFramework>
@@ -69,11 +69,7 @@
     <Compile Include="Platform\Input\MessageBox.iOS.cs" />
     <Compile Include="Platform\Input\Mouse.Default.cs" />
     <Compile Include="Platform\Input\MouseCursor.Default.cs" />
-    <Compile Include="Platform\Media\MediaLibrary.iOS.cs" />
     <Compile Include="Platform\Media\MediaPlayer.Default.cs" />
-    <Compile Include="Platform\Media\Song.iOS.cs" />
-    <Compile Include="Platform\Media\Video.iOS.cs" />
-    <Compile Include="Platform\Media\VideoPlayer.iOS.cs" />
     <Compile Include="Platform\TitleContainer.MacOS.cs" />
     <Compile Include="Platform\Utilities\FuncLoader.iOS.cs" />
     <Compile Include="Platform\Utilities\InteropHelpers.cs" />

--- a/MonoGame.Framework/Platform/Android/AndroidGamePlatform.cs
+++ b/MonoGame.Framework/Platform/Android/AndroidGamePlatform.cs
@@ -22,7 +22,9 @@ namespace Microsoft.Xna.Framework
             _gameWindow = new AndroidGameWindow(Game.Activity, game);
             Window = _gameWindow;
 
+#if !NO_AUDIO
             MediaLibrary.Context = Game.Activity;
+#endif
         }
 
         protected override void Dispose(bool disposing)

--- a/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.Default.cs
+++ b/MonoGame.Framework/Platform/Audio/DynamicSoundEffectInstance.Default.cs
@@ -1,0 +1,57 @@
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Audio
+{
+    public sealed partial class DynamicSoundEffectInstance : SoundEffectInstance
+    {
+        private void PlatformCreate()
+        {
+            throw new NotImplementedException();
+        }
+
+        private int PlatformGetPendingBufferCount()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformPlay()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformPause()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformResume()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformStop()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformSubmitBuffer(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformDispose(bool disposing)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformUpdateQueue()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MonoGame.Framework/Platform/Audio/Microphone.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/Microphone.OpenAL.cs
@@ -7,13 +7,11 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using MonoGame.Framework.Utilities;
 
-#if OPENAL
 using MonoGame.OpenAL;
 #if IOS || MONOMAC
 using AudioToolbox;
 using AudioUnit;
 using AVFoundation;
-#endif
 #endif
 
 namespace Microsoft.Xna.Framework.Audio

--- a/MonoGame.Framework/Platform/Audio/SoundEffect.Default.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffect.Default.cs
@@ -1,0 +1,75 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+﻿
+using System;
+using System.IO;
+
+namespace Microsoft.Xna.Framework.Audio
+{
+    public sealed partial class SoundEffect : IDisposable
+    {
+        internal const int MAX_PLAYING_INSTANCES = 0;
+
+        private void PlatformLoadAudioStream(Stream stream, out TimeSpan duration)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformInitializePcm(byte[] buffer, int offset, int count, int sampleBits, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformInitializeIeeeFloat(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformInitializeAdpcm(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int blockAlignment, int loopStart, int loopLength)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformInitializeIma4(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int blockAlignment, int loopStart, int loopLength)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformInitializeFormat(byte[] header, byte[] buffer, int bufferSize, int loopStart, int loopLength)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformInitializeXact(MiniFormatTag codec, byte[] buffer, int channels, int sampleRate, int blockAlignment, int loopStart, int loopLength, out TimeSpan duration)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformSetupInstance(SoundEffectInstance inst)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal static void PlatformSetReverbSettings(ReverbSettings reverbSettings)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformDispose(bool disposing)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal static void PlatformInitialize()
+        {
+            throw new NotImplementedException();
+        }
+
+        internal static void PlatformShutdown()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+

--- a/MonoGame.Framework/Platform/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffect.OpenAL.cs
@@ -5,9 +5,7 @@
 using System;
 using System.IO;
 
-#if OPENAL
 using MonoGame.OpenAL;
-#endif
 #if IOS
 using AudioToolbox;
 using AudioUnit;

--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.Default.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.Default.cs
@@ -1,0 +1,111 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+namespace Microsoft.Xna.Framework.Audio
+{
+    public partial class SoundEffectInstance : IDisposable
+    {
+        internal void PlatformInitialize(byte[] buffer, int sampleRate, int channels)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void InitializeSound()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformApply3D(AudioListener listener, AudioEmitter emitter)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformPause()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformPlay()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformResume()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformStop(bool immediate)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void FreeSource()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformSetIsLooped(bool value)
+        {
+            throw new NotImplementedException();
+        }
+
+        private bool PlatformGetIsLooped()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformSetPan(float value)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformSetPitch(float value)
+        {
+            throw new NotImplementedException();
+        }
+
+        private SoundState PlatformGetState()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformSetVolume(float value)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void PlatformSetReverbMix(float mix)
+        {
+            throw new NotImplementedException();
+        }
+
+        void ApplyReverb()
+        {
+            throw new NotImplementedException();
+        }
+
+        void ApplyFilter()
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void PlatformSetFilter(FilterMode mode, float filterQ, float frequency)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void PlatformClearFilter()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void PlatformDispose(bool disposing)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MonoGame.Framework/Platform/Media/Song.Default.cs
+++ b/MonoGame.Framework/Platform/Media/Song.Default.cs
@@ -79,6 +79,11 @@ namespace Microsoft.Xna.Framework.Media
             {
                 throw new NotImplementedException();				
             }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
         }
 
         private Album PlatformGetAlbum()

--- a/MonoGame.Framework/Platform/Media/Song.Default.cs
+++ b/MonoGame.Framework/Platform/Media/Song.Default.cs
@@ -10,110 +10,66 @@ namespace Microsoft.Xna.Framework.Media
 {
     public sealed partial class Song : IEquatable<Song>, IDisposable
     {
-        private SoundEffectInstance _sound;
-
         private void PlatformInitialize(string fileName)
         {
-
-#if MONOMAC || (WINDOWS && OPENGL) || WEB
-
-            using (var s = File.OpenRead(_name))
-            {
-                var soundEffect = SoundEffect.FromStream(s);
-                _sound = soundEffect.CreateInstance();
-            }
-#endif
+            throw new NotImplementedException();
         }
 
         private void PlatformDispose(bool disposing)
         {
-            if (_sound == null)
-                return;
-
-            _sound.Dispose();
-            _sound = null;
+            throw new NotImplementedException();
         }
 
 		internal void OnFinishedPlaying (object sender, EventArgs args)
 		{
-			if (DonePlaying == null)
-				return;
-			
-			DonePlaying(sender, args);
+			throw new NotImplementedException();
 		}
 
-		/// <summary>
-		/// Set the event handler for "Finished Playing". Done this way to prevent multiple bindings.
-		/// </summary>
 		internal void SetEventHandler(FinishedPlayingHandler handler)
 		{
-			if (DonePlaying != null)
-				return;
-			
-			DonePlaying += handler;
+			throw new NotImplementedException();
 		}
 
 		internal void Play(TimeSpan? startPosition)
 		{	
-			if (startPosition.HasValue)
-				throw new Exception("startPosition not implemented on this Platform"); //Should be possible to implement in OpenAL
-			if ( _sound == null )
-				return;
-
-            PlatformPlay();
-
-            _playCount++;
+			throw new NotImplementedException();
         }
 
         private void PlatformPlay()
         {
-            _sound.Play();
+            throw new NotImplementedException();
         }
 
 		internal void Resume()
 		{
-			if (_sound == null)
-				return;
-
-            PlatformResume();
+			throw new NotImplementedException();
 		}
 
         private void PlatformResume()
         {
-            _sound.Resume();
+            throw new NotImplementedException();
         }
 		
 		internal void Pause()
 		{			            
-			if ( _sound == null )
-				return;
-			
-			_sound.Pause();
+			throw new NotImplementedException();
         }
 		
 		internal void Stop()
 		{
-			if ( _sound == null )
-				return;
-			
-			_sound.Stop();
-			_playCount = 0;
+			throw new NotImplementedException();
 		}
 
 		internal float Volume
 		{
 			get
 			{
-				if (_sound != null)
-					return _sound.Volume;
-				else
-					return 0.0f;
+				throw new NotImplementedException();
 			}
 			
 			set
 			{
-				if ( _sound != null && _sound.Volume != value )
-					_sound.Volume = value;
+				throw new NotImplementedException();
 			}			
 		}
 
@@ -121,54 +77,53 @@ namespace Microsoft.Xna.Framework.Media
         {
             get
             {
-                // TODO: Implement
-                return new TimeSpan(0);				
+                throw new NotImplementedException();				
             }
         }
 
         private Album PlatformGetAlbum()
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         private Artist PlatformGetArtist()
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         private Genre PlatformGetGenre()
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         private bool PlatformIsProtected()
         {
-            return false;
+            throw new NotImplementedException();
         }
 
         private bool PlatformIsRated()
         {
-            return false;
+            throw new NotImplementedException();
         }
 
         private string PlatformGetName()
         {
-            return Path.GetFileNameWithoutExtension(_name);
+            throw new NotImplementedException();
         }
 
         private int PlatformGetPlayCount()
         {
-            return _playCount;
+            throw new NotImplementedException();
         }
 
         private int PlatformGetRating()
         {
-            return 0;
+            throw new NotImplementedException();
         }
 
         private int PlatformGetTrackNumber()
         {
-            return 0;
+            throw new NotImplementedException();
         }
     }
 }

--- a/MonoGame.Framework/Platform/OpenAL.targets
+++ b/MonoGame.Framework/Platform/OpenAL.targets
@@ -1,9 +1,11 @@
 <Project>
-  <PropertyGroup>
+  <PropertyGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true'">
     <DefineConstants>$(DefineConstants);OPENAL</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true'">
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.10" />
+	
     <Compile Include="Platform\Audio\AudioLoader.cs" />
     <Compile Include="Platform\Audio\DynamicSoundEffectInstance.OpenAL.cs" />
     <Compile Include="Platform\Audio\Microphone.OpenAL.cs" />
@@ -12,5 +14,19 @@
     <Compile Include="Platform\Audio\OpenALSoundController.cs" />
     <Compile Include="Platform\Audio\SoundEffect.OpenAL.cs" />
     <Compile Include="Platform\Audio\SoundEffectInstance.OpenAL.cs" />
+	
+	<PackageReference Include="NVorbis" Version="0.10.4" />
+
+    <Compile Include="Platform\Media\OggStream.NVorbis.cs" />
+    <Compile Include="Platform\Media\Song.NVorbis.cs" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO'))">
+    <Compile Include="Platform\Audio\DynamicSoundEffectInstance.Default.cs" />
+    <Compile Include="Platform\Audio\Microphone.Default.cs" />
+    <Compile Include="Platform\Audio\SoundEffect.Default.cs" />
+    <Compile Include="Platform\Audio\SoundEffectInstance.Default.cs" />
+	
+    <Compile Include="Platform\Media\Song.Default.cs" />
   </ItemGroup>
 </Project>

--- a/MonoGame.Framework/Platform/OpenAL.targets
+++ b/MonoGame.Framework/Platform/OpenAL.targets
@@ -3,9 +3,48 @@
     <DefineConstants>$(DefineConstants);OPENAL</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true'">
-    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.10" />
+  <!-- iOS has its own Song and Video implementation -->
+  <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('IOS'))">
+    <Compile Include="Platform\Media\Song.iOS.cs" />
 	
+	<Compile Include="Platform\Media\MediaLibrary.iOS.cs" />
+    <Compile Include="Platform\Media\Video.iOS.cs" />
+    <Compile Include="Platform\Media\VideoPlayer.iOS.cs" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) And $(DefineConstants.Contains('IOS'))">
+    <Compile Include="Platform\Media\MediaLibrary.Default.cs" />
+    <Compile Include="Platform\Media\Video.Default.cs" />
+    <Compile Include="Platform\Media\VideoPlayer.Default.cs" />
+  </ItemGroup>
+  
+  <!-- Android has its own Song and Video implementation, and need OpenAL binaries -->
+  <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('ANDROID'))">
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.10" />
+    <Compile Include="Platform\Media\Song.Android.cs" />
+	
+	<Compile Include="Platform\Media\MediaLibrary.Android.cs" />
+    <Compile Include="Platform\Media\Video.Android.cs" />
+    <Compile Include="Platform\Media\VideoPlayer.Android.cs" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) And $(DefineConstants.Contains('ANDROID'))">
+    <Compile Include="Platform\Media\MediaLibrary.Default.cs" />
+    <Compile Include="Platform\Media\Video.Default.cs" />
+    <Compile Include="Platform\Media\VideoPlayer.Default.cs" />
+  </ItemGroup>
+  
+  <!-- DesktopGL has its own Song implementation, and need OpenAL binaries -->
+  <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('DESKTOPGL'))">
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.10" />
+	<PackageReference Include="NVorbis" Version="0.10.4" />
+
+    <Compile Include="Platform\Media\OggStream.NVorbis.cs" />
+    <Compile Include="Platform\Media\Song.NVorbis.cs" />
+  </ItemGroup>
+  
+  <!-- Standard OpenAL implementation -->
+  <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true'">
     <Compile Include="Platform\Audio\AudioLoader.cs" />
     <Compile Include="Platform\Audio\DynamicSoundEffectInstance.OpenAL.cs" />
     <Compile Include="Platform\Audio\Microphone.OpenAL.cs" />
@@ -14,13 +53,9 @@
     <Compile Include="Platform\Audio\OpenALSoundController.cs" />
     <Compile Include="Platform\Audio\SoundEffect.OpenAL.cs" />
     <Compile Include="Platform\Audio\SoundEffectInstance.OpenAL.cs" />
-	
-	<PackageReference Include="NVorbis" Version="0.10.4" />
-
-    <Compile Include="Platform\Media\OggStream.NVorbis.cs" />
-    <Compile Include="Platform\Media\Song.NVorbis.cs" />
   </ItemGroup>
   
+  <!-- No sound -->
   <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO'))">
     <Compile Include="Platform\Audio\DynamicSoundEffectInstance.Default.cs" />
     <Compile Include="Platform\Audio\Microphone.Default.cs" />

--- a/MonoGame.Framework/Platform/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Platform/Windows/WinFormsGamePlatform.cs
@@ -131,7 +131,7 @@ namespace MonoGame.Framework
                     _window = null;
                     Window = null;
                 }
-#if !GDKX
+#if !GDKX && !NO_AUDIO
                 Microsoft.Xna.Framework.Media.MediaManagerState.CheckShutdown();
 #endif
             }

--- a/MonoGame.Framework/Platform/XAudio.targets
+++ b/MonoGame.Framework/Platform/XAudio.targets
@@ -1,8 +1,31 @@
 <Project>
-  <ItemGroup>
+  <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true'">
+    <PackageReference Version="4.0.1" Include="SharpDX.MediaFoundation" />
+    <PackageReference Version="4.0.1" Include="SharpDX.XAudio2" />
+	
     <Compile Include="Platform\Audio\DynamicSoundEffectInstance.XAudio.cs" />
     <Compile Include="Platform\Audio\Microphone.Default.cs" />
     <Compile Include="Platform\Audio\SoundEffect.XAudio.cs" />
     <Compile Include="Platform\Audio\SoundEffectInstance.XAudio.cs" />
+	
+    <Compile Include="Platform\Media\MediaManagerState.cs" />
+    <Compile Include="Platform\Media\VideoSampleGrabber.cs" />
+	
+    <Compile Include="Platform\Media\MediaPlayer.WMS.cs" />
+    <Compile Include="Platform\Media\Song.WMS.cs" />
+    <Compile Include="Platform\Media\Video.WMS.cs" />
+    <Compile Include="Platform\Media\VideoPlayer.WMS.cs" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO'))">
+    <Compile Include="Platform\Audio\DynamicSoundEffectInstance.Default.cs" />
+    <Compile Include="Platform\Audio\Microphone.Default.cs" />
+    <Compile Include="Platform\Audio\SoundEffect.Default.cs" />
+    <Compile Include="Platform\Audio\SoundEffectInstance.Default.cs" />
+	
+	<Compile Include="Platform\Media\MediaPlayer.Default.cs" />
+    <Compile Include="Platform\Media\Song.Default.cs" />
+	<Compile Include="Platform\Media\Video.Default.cs" />
+	<Compile Include="Platform\Media\VideoPlayer.Default.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds a ```NO_AUDIO``` constant switch to the DesktopGL, WindowsDX, Android, and iOS .csproj of MonoGame.

The reasoning for this switch is to better accommodate third-party sound engines like FMOD or Wwise by entirely disabling audio and any audio dependency that could interfere with or corrupt FMOD/Wwise (while not changing the API).

While MonoGame already has a mechanism that doesn't initialize audio unless you use it, there are still possible annoyances:
- OpenAL/NVorbis/XAudio are enforced as a dependency, even if ```PrivateAssets``` is used. Therefore users using FMOD or Wwise are still required to ship with those binaries even if they don't use the MonoGame Audio namespace at all (otherwise the app won't start);
- the non-initialization mechanism doesn't guarantee that OpenAL or XAudio aren't loaded (it entrusts static initializers for not doing so, which can't be assumed to be reliable throughout all .NET runtimes)

The ```NO_AUDIO``` switch fixes those concerns by replacing the Audio implementation with a ```NotImplemented``` version and also removes OpenAL/NVorbis/XAudio binaries/nugets dependencies.