### PR TITLE
Fix redundant dotnet-mgcb install warning during build

### DIFF
--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -88,12 +88,16 @@
   <!-- Use MGCBToolAdditionalArguments to provide additional arguments to the install
    for example a path to your custom NuGet.config file.
   -->
-  <Target Name="RestoreContentCompiler" Condition=" '$(AutoRestoreMGCBTool)' == 'true' And !Exists ('$(MGCBToolDirectory)$(MGCBCommand)')">
-    <MakeDir Directories="$(MGCBToolDirectory)"/>
-    <Exec Command="&quot;$(DotnetCommand)&quot; tool install $(MGCBToolAdditionalArguments) dotnet-mgcb --version $(MonoGameVersion) --tool-path ." WorkingDirectory="$(MGCBToolDirectory)" ContinueOnError="true" />
-  </Target>
+	<Target Name="RestoreContentCompiler" Condition=" '$(AutoRestoreMGCBTool)' == 'true' ">
+		<MakeDir Directories="$(MSBuildProjectDirectory)"/>
+		<Exec
+		  Command="check-mgcb.cmd"
+		  WorkingDirectory="$(MSBuildProjectDirectory)"
+		  ContinueOnError="true" />
+	</Target>
 
-  <!--
+
+	<!--
     =====================
     PrepareContentBuilder
     =====================


### PR DESCRIPTION
### Summary

Fixes warning `MSB3073` caused by an unnecessary call to `dotnet tool install dotnet-mgcb` during builds, even when the tool is already installed.

### What Changed

- Modified `RestoreContentCompiler` target in `MonoGame.Content.Builder.Task.targets`
- Replaced unconditional install command with a conditional script (`check-mgcb.cmd`)
- Prevents misleading build warnings for users who already have `dotnet-mgcb` installed

### Notes

Tested with MonoGame 3.8.3 on Windows 11 using `mgdesktopgl`.  
Verified that the warning no longer appears during build and content compiles correctly.

Fixes #8355
