### PR TITLE
use a more modern implementation for CurrentPlatform

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <DefineConstants>WINDOWS;XNADESIGNPROVIDED;STBSHARP_INTERNAL;NET45</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWindowsForms>true</UseWindowsForms>

--- a/MonoGame.Framework/Platform/Utilities/CurrentPlatform.cs
+++ b/MonoGame.Framework/Platform/Utilities/CurrentPlatform.cs
@@ -25,6 +25,7 @@ namespace MonoGame.Framework.Utilities
             if (_init)
                 return;
 
+            _os = OS.Unknown;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 _os = OS.Windows;

--- a/MonoGame.Framework/Platform/Utilities/CurrentPlatform.cs
+++ b/MonoGame.Framework/Platform/Utilities/CurrentPlatform.cs
@@ -20,54 +20,23 @@ namespace MonoGame.Framework.Utilities
         private static bool _init = false;
         private static OS _os;
 
-        [DllImport("libc")]
-        static extern int uname(IntPtr buf);
-
         private static void Init()
         {
             if (_init)
                 return;
 
-            var pid = Environment.OSVersion.Platform;
-
-            switch (pid)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                case PlatformID.Win32NT:
-                case PlatformID.Win32S:
-                case PlatformID.Win32Windows:
-                case PlatformID.WinCE:
-                    _os = OS.Windows;
-                    break;
-                case PlatformID.MacOSX:
-                    _os = OS.MacOSX;
-                    break;
-                case PlatformID.Unix:
-                    _os = OS.MacOSX;
-
-                    var buf = IntPtr.Zero;
-                    
-                    try
-                    {
-                        buf = Marshal.AllocHGlobal(8192);
-
-                        if (uname(buf) == 0 && Marshal.PtrToStringAnsi(buf) == "Linux")
-                            _os = OS.Linux;
-                    }
-                    catch
-                    {
-                    }
-                    finally
-                    {
-                        if (buf != IntPtr.Zero)
-                            Marshal.FreeHGlobal(buf);
-                    }
-
-                    break;
-                default:
-                    _os = OS.Unknown;
-                    break;
+                _os = OS.Windows;
             }
-
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                _os = OS.MacOSX;
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                _os = OS.Linux;
+            }
             _init = true;
         }
 


### PR DESCRIPTION
Fixes #

The code to check for the current platform was some ancient esoteric magic.
Surely this implementation is more understandable, succint, and perhaps more robust.

### Description of Change

Instead of voodoo we simply check RuntimeInformation.IsOSPlatform.




