### PR TITLE
Update Cake build to include specific runtime platforms when building tools

### DIFF
--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -1,5 +1,4 @@
 using Cake.Git;
-using Microsoft.VisualBasic;
 using System.Text.RegularExpressions;
 
 namespace BuildScripts;

--- a/build/BuildToolsTasks/BuildMGCBEditorTask.cs
+++ b/build/BuildToolsTasks/BuildMGCBEditorTask.cs
@@ -25,6 +25,13 @@ public sealed class BuildMGCBEditorTask : FrostingTask<BuildContext>
             _ => "Linux"
         };
 
+        var runtime = context.Environment.Platform.Family switch
+        {
+            PlatformFamily.Windows => context.DotNetPublishSettings.Runtime = "win-x64",
+            PlatformFamily.OSX => context.DotNetPublishSettings.Runtime = "osx",
+            _ => context.DotNetPublishSettings.Runtime = "linux-x64"
+        };
+
         if (context.Environment.Platform.Family != PlatformFamily.OSX)
             context.DotNetPublish(context.GetProjectPath(ProjectType.MGCBEditor, platform), context.DotNetPublishSettings);
         else


### PR DESCRIPTION
### Description of Change

Enhancements to address nuget packaging size issues where additional runtime platforms are included by default



