### PR TITLE
Fixed bug where asset file length wasn't being written in MG_Asset_Open

### DIFF
--- a/native/monogame/common/MG_Asset.cpp
+++ b/native/monogame/common/MG_Asset.cpp
@@ -21,7 +21,6 @@ mgbool MG_Asset_Open(const char* path, MG_Asset*& handle, mglong& length)
         return false;
     }
 
-    mglong prevPos = ftell(handle->file);
     if (fseek(handle->file, 0, SEEK_END) != 0)
     {
         //unable to seek file for some reason
@@ -31,7 +30,7 @@ mgbool MG_Asset_Open(const char* path, MG_Asset*& handle, mglong& length)
 
     length = ftell(handle->file);
 
-    if (fseek(handle->file, prevPos, SEEK_SET) != 0)
+    if (fseek(handle->file, 0, SEEK_SET) != 0)
     {
         //unable to seek back to file start for some reason
         delete handle;


### PR DESCRIPTION
Issue: Parameter mglong& length was not being written to. Causing returned stream to have a length of zero. Causing assets to fail to load with exception: System.IO.EndOfStreamException : Unable to read beyond the end of the stream.

