### PR TITLE
Resolves issue with handling compressed DDS textures

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
@@ -161,7 +161,29 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 return true;
             }
 
-            // No other support for copying from a DXT texture yet
+            if ((destinationFormat == SurfaceFormat.Vector4)
+                && (format == SurfaceFormat.Dxt1 || format == SurfaceFormat.Dxt3 || format == SurfaceFormat.Dxt5))
+            {
+                CompressionFormat bcnFormat = default;
+                switch (format)
+                {
+                    case SurfaceFormat.Dxt1:
+                        bcnFormat = CompressionFormat.Bc1;
+                        break;
+                    case SurfaceFormat.Dxt3:
+                        bcnFormat = CompressionFormat.Bc2;
+                        break;
+                    case SurfaceFormat.Dxt5:
+                        bcnFormat = CompressionFormat.Bc3;
+                        break;
+                }
+
+                PixelBitmapContent<Vector4> pixelBitmapContent = BcnUtil.Decode(_bitmapData, bcnFormat, Width, Height);
+                destinationBitmap.SetPixelData(pixelBitmapContent.GetPixelData());
+                return true;
+            }
+
+            // Unsupported SurfaceFormat(s) for bitmap copying
             return false;
         }
     }

--- a/MonoGame.Framework.Content.Pipeline/Utilities/BcnHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/BcnHelpers.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using BCnEncoder.Encoder;
+using BCnEncoder.Decoder;
 using BCnEncoder.Shared;
 using KtxSharp;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
@@ -57,5 +58,28 @@ internal static class BcnUtil
         ktxStream.Seek(0, SeekOrigin.Begin);
         var ktx = KtxLoader.LoadInput(ktxStream);
         compressedBytes = ktx.textureData.textureDataOfMipmapLevel[0];
+    }
+
+    public static PixelBitmapContent<Vector4> Decode(
+        byte[] compressedBytes,
+        CompressionFormat format,
+        int width,
+        int height)
+    {
+        var decoder = new BcDecoder();
+        using MemoryStream stream = new MemoryStream(compressedBytes);
+        Toolkit.HighPerformance.Memory2D<ColorRgba32> pixels = decoder.DecodeRaw2D(stream, width, height, format);
+
+        PixelBitmapContent<Vector4> resultBitmap = new PixelBitmapContent<Vector4>(width, height);
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                ColorRgba32 pixel = pixels.Span[y, x];
+                resultBitmap.SetPixel(x, y, new Vector4(pixel.r / 255f, pixel.g / 255f, pixel.b / 255f, pixel.a / 255f));
+            }
+        }
+
+        return resultBitmap;
     }
 }


### PR DESCRIPTION
# Description of Change

An XNA regression issue where DDS textures could not be read through BitmapContent.Copy, this would fail as it could not handle compressed DDS textures as source.

The fix adds compression handling using the existing `BCnEncoder` implementation (it just adds a Decode function)

Fixes:
- Issue where using Bitmap.Copy with DDS textures would fail as the compressed file could not be read
- resolves #8575





