### PR TITLE
Fixed: incorrectly calculated rgbaBytes value which lead to vulkan validation error

### DIFF
--- a/MonoGame.Framework/Platform/Native/Texture2D.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Texture2D.Native.cs
@@ -154,7 +154,7 @@ public partial class Texture2D : Texture
         }
 
         var texture = new Texture2D(graphicsDevice, width, height);
-        var rgbaBytes = width * height;
+        var rgbaBytes = (width * height) * 4;
 
         if (colorProcessor == null)
         {


### PR DESCRIPTION
ISSUE:

rgbaBytes was previously being calculated as width * height, when it should be (width * height) * 4

This lead to vulkan validation error (and failure): 

`
Validation Error: [ VUID-vkCmdCopyBufferToImage-pRegions-00171 ] | MessageID = 0x6f4d3c00
vkCmdCopyBufferToImage(): pRegions[0] is trying to copy 256 bytes + 0 offset to/from the (VkBuffer 0x230000000023) which exceeds the VkBuffer total size of 64 bytes.
The Vulkan spec states: srcBuffer must be large enough to contain all buffer locations that are accessed according to Buffer and Image Addressing, for each element of pRegions (https://vulkan.lunarg.com/doc/view/1.4.313.0/windows/antora/spec/latestchapters/copies.html#VUID-vkCmdCopyBufferToImage-pRegions-00171)
Objects: 2
    [0] VkCommandBuffer 0x20f410124f0
    [1] VkBuffer 0x230000000023
`

From line 3646 in MGG_Vulkan.cpp when MGVK_CopyBufferToImage is called