### PR TITLE
Restore behavior of LoadTexture2DFromImageFile

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -591,7 +591,7 @@ namespace Microsoft.Xna.Framework.Content
                 {
                     using (stream)
                     {
-                        Texture2D result = Texture2D.FromStream(graphicsDeviceService.GraphicsDevice, stream);
+                        Texture2D result = Texture2D.FromStream(graphicsDeviceService.GraphicsDevice, stream, DefaultColorProcessors.PremultiplyAlpha);
                         return result;
                     }
                 }


### PR DESCRIPTION
Fix regression introduced by #8787

The optional parameter default to ```ZeroTransparentPixels``` while ```LoadTexture2DFromImageFile``` expects ```PremultiplyAlpha```.