### PR TITLE
Better Runtime Shader Compiler Errors

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
@@ -51,6 +51,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         public override CompiledEffectContent Process(EffectContent input, ContentProcessorContext context)
         {
             var mgfxc = Path.Combine(Path.GetDirectoryName(typeof(EffectProcessor).Assembly.Location), "mgfxc.dll");
+            if (!File.Exists(mgfxc))
+                throw new FileNotFoundException("The shader compiler mgfxc.dll was not found!", mgfxc);
+
             var sourceFile = input.Identity.SourceFilename;
             var destFile = Path.GetTempFileName();
             var arguments = "\"" + mgfxc + "\" \"" + sourceFile + "\" \"" + destFile + "\" /Profile:" + GetProfileForPlatform(context.TargetPlatform);

--- a/MonoGame.Framework/Graphics/Effect/Effect.cs
+++ b/MonoGame.Framework/Graphics/Effect/Effect.cs
@@ -29,7 +29,13 @@ namespace Microsoft.Xna.Framework.Graphics
             /// We should avoid supporting old versions for very long if at all 
             /// as users should be rebuilding content when packaging their game.
             /// </remarks>
-            public const int MGFXVersion = 10;
+            public const int MGFXVersion = 11;
+
+            /// <summary>
+            /// This is the minimum version of MGFX file we can support
+            /// for cases when the changes are backwards compatible.
+            /// </summary>
+            public const int MGFXMinVersion = 10;
 
             public int Signature;
             public int Version;
@@ -133,7 +139,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 // Create one.
                 cloneSource = new Effect(graphicsDevice);
-                    cloneSource.ReadEffect(reader);
+                cloneSource.ReadEffect(header, reader);
 
                 // Check file tail to ensure we parsed the content correctly.
                     var tail = reader.ReadInt32();
@@ -160,7 +166,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (header.Signature != MGFXHeader.MGFXSignature)
                 throw new Exception("This does not appear to be a MonoGame MGFX file!");
-            if (header.Version < MGFXHeader.MGFXVersion)
+            if (header.Version < MGFXHeader.MGFXMinVersion)
                 throw new Exception("This MGFX effect is for an older release of MonoGame and needs to be rebuilt.");
             if (header.Version > MGFXHeader.MGFXVersion)
                 throw new Exception("This MGFX effect seems to be for a newer release of MonoGame.");
@@ -267,7 +273,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         #region Effect File Reader
 
-		private void ReadEffect (BinaryReader reader)
+		private void ReadEffect (MGFXHeader header, BinaryReader reader)
 		{
 			// TODO: Maybe we should be reading in a string 
 			// table here to save some bytes in the file.
@@ -300,7 +306,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _shaders = new Shader[reader.ReadInt32()];
 
             for (var s = 0; s < _shaders.Length; s++)
-                _shaders[s] = new Shader(GraphicsDevice, reader);
+                _shaders[s] = new Shader(GraphicsDevice, header.Version, reader);
 
             Parameters = ReadParameters(reader);
 

--- a/MonoGame.Framework/Graphics/Shader/Shader.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.cs
@@ -97,12 +97,29 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public VertexAttribute[] Attributes { get; private set; }
 
-        internal Shader(GraphicsDevice device, BinaryReader reader)
+        public string Entrypoint { get; private set; }
+
+        public string SourceFile { get; private set; }
+
+        internal Shader(GraphicsDevice device, int version, BinaryReader reader)
         {
             GraphicsDevice = device;
 
             var isVertexShader = reader.ReadBoolean();
             Stage = isVertexShader ? ShaderStage.Vertex : ShaderStage.Pixel;
+
+            if (version > 10)
+            {
+                // We don't really need these at runtime unless there is an
+                // error with the shader and this information is very useful.
+                SourceFile = reader.ReadString();
+                Entrypoint = reader.ReadString();
+            }
+            else
+            {
+                SourceFile = "<unknown>";
+                Entrypoint = "<unknown>";
+            }
 
             var shaderLength = reader.ReadInt32();
             var shaderBytecode = reader.ReadBytes(shaderLength);

--- a/MonoGame.Framework/Graphics/Shader/ShaderStage.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderStage.cs
@@ -1,6 +1,10 @@
-﻿namespace Microsoft.Xna.Framework.Graphics
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Graphics
 {
-    internal enum ShaderStage
+    public enum ShaderStage
     {
         Vertex,
         Pixel,

--- a/MonoGame.Framework/Graphics/ShaderCompilerException.cs
+++ b/MonoGame.Framework/Graphics/ShaderCompilerException.cs
@@ -6,75 +6,75 @@ using System;
 using System.Runtime.Serialization;
 
 
-namespace Microsoft.Xna.Framework.Graphics
+namespace Microsoft.Xna.Framework.Graphics;
+
+/// <summary>
+/// This exception occurs when a shader compiled at runtime has errors.
+/// It should provide enough information to help diagnose the bug.
+/// </summary>
+[DataContract]
+public sealed class ShaderCompilerException : Exception
 {
     /// <summary>
-    /// This exception occurs when a shader compiled at runtime has errors.
-    /// It should provide enough information to help diagnose the bug.
+    /// The relative shader source file.
     /// </summary>
-    [DataContract]
-    public sealed class ShaderCompilerException : Exception
+    public string SourceFile { get; private set; }
+
+    /// <summary>
+    /// The shader entrypoint function.
+    /// </summary>
+    public string Entrypoint { get; private set; }
+
+    /// <summary>
+    /// The shader stage.
+    /// </summary>
+    public ShaderStage Stage { get; private set; }
+
+    /// <summary>
+    /// The error logging from the shader compiler.
+    /// </summary>
+    public string Errors { get; private set; }
+
+    /// <summary>
+    /// The source code being compiled.
+    /// </summary>
+    public string SourceCode { get; private set; }
+
+    private static string GetMessage(string sourceFile, string entrypoint, ShaderStage stage)
     {
-        /// <summary>
-        /// The relative shader source file.
-        /// </summary>
-        public string SourceFile { get; private set; }
-
-        /// <summary>
-        /// The shader entrypoint function.
-        /// </summary>
-        public string Entrypoint { get; private set; }
-
-        /// <summary>
-        /// The shader stage.
-        /// </summary>
-        public ShaderStage Stage { get; private set; }
-
-        /// <summary>
-        /// The error logging from the shader compiler.
-        /// </summary>
-        public string Errors { get; private set; }
-
-        /// <summary>
-        /// The source code being compiled.
-        /// </summary>
-        public string SourceCode { get; private set; }
-
-        private static string GetMessage(string sourceFile, string entrypoint, ShaderStage stage)
+        switch (stage)
         {
-            switch (stage)
-            {
-                case ShaderStage.Pixel:
-                    return $"Failed to compile pixel shader {entrypoint}. See {sourceFile}.";
+            case ShaderStage.Pixel:
+                return $"Failed to compile pixel shader {entrypoint}. See {sourceFile}.";
 
-                default:
-                case ShaderStage.Vertex:
-                    return $"Failed to compile vertex shader {entrypoint}. See {sourceFile}.";
-            }
+            default:
+            case ShaderStage.Vertex:
+                return $"Failed to compile vertex shader {entrypoint}. See {sourceFile}.";
         }
+    }
 
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        /// <param name="sourceFile">The relative shader source file.</param>
-        /// <param name="entrypoint">The shader entrypoint function.</param>
-        /// <param name="stage">The shader stage.</param>
-        /// <param name="errors">The error logging from the shader compiler.</param>
-        /// <param name="sourceCode">The source code that was being compiled.</param>
-        public ShaderCompilerException(string sourceFile, string entrypoint, ShaderStage stage, string errors, string sourceCode)
-            : base(GetMessage(sourceFile, entrypoint, stage))
-        {
-            SourceFile = sourceFile;
-            Entrypoint = entrypoint;
-            Stage = stage;
-            Errors = errors;
-            SourceCode = sourceCode;
-        }
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="sourceFile">The relative shader source file.</param>
+    /// <param name="entrypoint">The shader entrypoint function.</param>
+    /// <param name="stage">The shader stage.</param>
+    /// <param name="errors">The error logging from the shader compiler.</param>
+    /// <param name="sourceCode">The source code that was being compiled.</param>
+    public ShaderCompilerException(string sourceFile, string entrypoint, ShaderStage stage, string errors, string sourceCode)
+        : base(GetMessage(sourceFile, entrypoint, stage))
+    {
+        SourceFile = sourceFile;
+        Entrypoint = entrypoint;
+        Stage = stage;
+        Errors = errors;
+        SourceCode = sourceCode;
+    }
 
-        public override string ToString()
-        {
-            // Return all the data we got by default.
-            return $"""
+    public override string ToString()
+    {
+        // Return all the data we got by default.
+        return $"""
 {base.ToString()}
 
 ---------------------------------------------------------------------------------------------------
@@ -91,6 +91,5 @@ Source Code:
 
 ---------------------------------------------------------------------------------------------------
 """;                    
-        }
     }
 }

--- a/MonoGame.Framework/Graphics/ShaderCompilerException.cs
+++ b/MonoGame.Framework/Graphics/ShaderCompilerException.cs
@@ -1,0 +1,68 @@
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Runtime.Serialization;
+
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    /// <summary>
+    /// This exception occurs when a shader compiled at runtime has errors.
+    /// It should provide enough information to help diagnose the bug.
+    /// </summary>
+    [DataContract]
+    public sealed class ShaderCompilerException : Exception
+    {
+        /// <summary>
+        /// The error logging from the shader compiler.
+        /// </summary>
+        public string Errors { get; }
+
+        /// <summary>
+        /// The source code being compiled.
+        /// </summary>
+        public string SourceCode { get; }
+
+        private static string GetMessage(ShaderStage stage)
+        {
+            switch (stage)
+            {
+                case ShaderStage.Pixel:
+                    return "Failed to compile pixel shader.";
+
+                default:
+                case ShaderStage.Vertex:
+                    return "Failed to compile vertex shader.";
+            }
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="stage">The stage that failed to compile.</param>
+        /// <param name="errors">The error logging from the shader compiler.</param>
+        /// <param name="sourceCode">The source code that was being compiled.</param>
+        public ShaderCompilerException(ShaderStage stage, string errors, string sourceCode)
+            : base(GetMessage(stage))
+        {
+            Errors = errors;
+            SourceCode = sourceCode;
+        }
+
+        public override string ToString()
+        {
+            // Return all the data we got by default.
+            return $"""
+{base.ToString()}
+
+Shader Compiler Errors:
+{Errors}
+
+Shader Source Code:
+{SourceCode}
+""";                    
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/ShaderCompilerException.cs
+++ b/MonoGame.Framework/Graphics/ShaderCompilerException.cs
@@ -16,6 +16,21 @@ namespace Microsoft.Xna.Framework.Graphics
     public sealed class ShaderCompilerException : Exception
     {
         /// <summary>
+        /// The relative shader source file.
+        /// </summary>
+        public string SourceFile { get; }
+
+        /// <summary>
+        /// The shader entrypoint function.
+        /// </summary>
+        public string Entrypoint { get; }
+
+        /// <summary>
+        /// The shader stage.
+        /// </summary>
+        ShaderStage Stage { get; }
+
+        /// <summary>
         /// The error logging from the shader compiler.
         /// </summary>
         public string Errors { get; }
@@ -25,28 +40,33 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         public string SourceCode { get; }
 
-        private static string GetMessage(ShaderStage stage)
+        private static string GetMessage(string sourceFile, string entrypoint, ShaderStage stage)
         {
             switch (stage)
             {
                 case ShaderStage.Pixel:
-                    return "Failed to compile pixel shader.";
+                    return $"Failed to compile pixel shader {entrypoint}. See {sourceFile}.";
 
                 default:
                 case ShaderStage.Vertex:
-                    return "Failed to compile vertex shader.";
+                    return $"Failed to compile vertex shader {entrypoint}. See {sourceFile}.";
             }
         }
 
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="stage">The stage that failed to compile.</param>
+        /// <param name="sourceFile">The relative shader source file.</param>
+        /// <param name="entrypoint">The shader entrypoint function.</param>
+        /// <param name="stage">The shader stage.</param>
         /// <param name="errors">The error logging from the shader compiler.</param>
         /// <param name="sourceCode">The source code that was being compiled.</param>
-        public ShaderCompilerException(ShaderStage stage, string errors, string sourceCode)
-            : base(GetMessage(stage))
+        public ShaderCompilerException(string sourceFile, string entrypoint, ShaderStage stage, string errors, string sourceCode)
+            : base(GetMessage(sourceFile, entrypoint, stage))
         {
+            SourceFile = sourceFile;
+            Entrypoint = entrypoint;
+            Stage = stage;
             Errors = errors;
             SourceCode = sourceCode;
         }
@@ -57,11 +77,19 @@ namespace Microsoft.Xna.Framework.Graphics
             return $"""
 {base.ToString()}
 
-Shader Compiler Errors:
+---------------------------------------------------------------------------------------------------
+Source File: {SourceFile}
+Stage: {Stage}
+Entrypoint: {Entrypoint}
+
 {Errors}
 
-Shader Source Code:
+
+Source Code:
+
 {SourceCode}
+
+---------------------------------------------------------------------------------------------------
 """;                    
         }
     }

--- a/MonoGame.Framework/Graphics/ShaderCompilerException.cs
+++ b/MonoGame.Framework/Graphics/ShaderCompilerException.cs
@@ -18,27 +18,27 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// The relative shader source file.
         /// </summary>
-        public string SourceFile { get; }
+        public string SourceFile { get; private set; }
 
         /// <summary>
         /// The shader entrypoint function.
         /// </summary>
-        public string Entrypoint { get; }
+        public string Entrypoint { get; private set; }
 
         /// <summary>
         /// The shader stage.
         /// </summary>
-        ShaderStage Stage { get; }
+        public ShaderStage Stage { get; private set; }
 
         /// <summary>
         /// The error logging from the shader compiler.
         /// </summary>
-        public string Errors { get; }
+        public string Errors { get; private set; }
 
         /// <summary>
         /// The source code being compiled.
         /// </summary>
-        public string SourceCode { get; }
+        public string SourceCode { get; private set; }
 
         private static string GetMessage(string sourceFile, string entrypoint, ShaderStage stage)
         {

--- a/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.ConsoleCheck.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWindowsForms>true</UseWindowsForms>
     <Description>Fake console assembly that checks if MonoGame's code is still compatible with the private console implementations and building against .NET 4.5.2 and C# 5.</Description>
-    <LangVersion>5</LangVersion>
+    <LangVersion>11</LangVersion>
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 

--- a/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsDevice.DisposeShader(_shaderHandle);
                 _shaderHandle = -1;
 
-                throw new ShaderCompilerException(Stage, errorLog, _glslCode);
+                throw new ShaderCompilerException(SourceFile, Entrypoint, Stage, errorLog, _glslCode);
             }
 
             return _shaderHandle;

--- a/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
@@ -47,13 +47,12 @@ namespace Microsoft.Xna.Framework.Graphics
             GraphicsExtensions.CheckGLError();
             if (compiled != (int)Bool.True)
             {
-                var log = GL.GetShaderInfoLog(_shaderHandle);
-                Debug.WriteLine(log);
+                var errorLog = GL.GetShaderInfoLog(_shaderHandle);
 
                 GraphicsDevice.DisposeShader(_shaderHandle);
                 _shaderHandle = -1;
 
-                throw new InvalidOperationException("Shader Compilation Failed");
+                throw new ShaderCompilerException(Stage, errorLog, _glslCode);
             }
 
             return _shaderHandle;

--- a/Tools/MonoGame.Effect.Compiler/Effect/EffectObject.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/EffectObject.cs
@@ -796,12 +796,13 @@ namespace MonoGame.Effect
         private d3dx_state CreateShader(ShaderResult shaderResult, string shaderFunction, string shaderProfile, bool isVertexShader, ref string errorsAndWarnings)
         {
             // Check if this shader has already been created.
-            var shaderData = Shaders.Find(shader => shader.ShaderFunctionName == shaderFunction && shader.ShaderProfile == shaderProfile);
+            var shaderData = Shaders.Find(shader => shader.Entrypoint == shaderFunction && shader.ShaderProfile == shaderProfile);
             if (shaderData == null)
             {
                 // Compile and create the shader.
                 shaderData = shaderResult.Profile.CreateShader(shaderResult, shaderFunction, shaderProfile, isVertexShader, this, ref errorsAndWarnings);
-                shaderData.ShaderFunctionName = shaderFunction;
+                shaderData.SourceFile = shaderResult.RelativeFilePath;
+                shaderData.Entrypoint = shaderFunction;
                 shaderData.ShaderProfile = shaderProfile;
             }
 

--- a/Tools/MonoGame.Effect.Compiler/Effect/EffectObject.writer.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/EffectObject.writer.cs
@@ -13,7 +13,7 @@ namespace MonoGame.Effect
 	{
 
         private const string Header = "MGFX";
-        internal const int Version = 10;
+        internal const int Version = 11;
         
         static int ComputeHash(Stream stream)
         {

--- a/Tools/MonoGame.Effect.Compiler/Effect/ShaderData.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ShaderData.cs
@@ -13,6 +13,10 @@ namespace MonoGame.Effect
 
 		public bool IsVertexShader { get; private set; }
 
+        public string SourceFile { get; set; }
+
+        public string Entrypoint { get; set; }
+
 		public struct Sampler
 		{
 			public MojoShader.MOJOSHADER_samplerType type;
@@ -53,8 +57,6 @@ namespace MonoGame.Effect
 
 		// The index of the shader in the shared list.
 		public int SharedIndex { get; private set; }
-
-        public string ShaderFunctionName { get; set; }
 
         public string ShaderProfile { get; set; }
 

--- a/Tools/MonoGame.Effect.Compiler/Effect/ShaderData.writer.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ShaderData.writer.cs
@@ -8,6 +8,9 @@ namespace MonoGame.Effect
         {
             writer.Write(IsVertexShader);
 
+            writer.Write(SourceFile ?? "<unknown>");
+            writer.Write(Entrypoint ?? "<unknown>");
+
             writer.Write(ShaderCode.Length);
             writer.Write(ShaderCode);
 

--- a/Tools/MonoGame.Effect.Compiler/Effect/ShaderResult.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ShaderResult.cs
@@ -14,6 +14,7 @@ namespace MonoGame.Effect
         public ShaderInfo ShaderInfo { get; private set; }
 
         public string FilePath { get; private set; }
+        public string RelativeFilePath { get; set; }
 
         public string FileContent { get; private set; }
 

--- a/Tools/MonoGame.Effect.Compiler/Program.cs
+++ b/Tools/MonoGame.Effect.Compiler/Program.cs
@@ -70,6 +70,7 @@ namespace MonoGame.Effect.Compiler
             try
             {
                 shaderResult = ShaderResult.FromFile(sourceFilepath, options, new ConsoleEffectCompilerOutput());
+                shaderResult.RelativeFilePath = options.SourceFile;
 
                 foreach (var dependency in shaderResult.Dependencies)
                 {


### PR DESCRIPTION
On all our OpenGL platforms we depend on runtime shader compiling of GLSL.

If that GLSL source (currently generated from HLSL -> MojoShader) has an error you get just "Shader Compilation Failed" exception with no further details.  This was not helpful in cases where you had complex effects with lots of different passes and techniques.

This PR adds a new public type `ShaderCompilerException` which is thrown when a OpenGL shader fails to compile at runtime. (This also can be used for runtime shader compiling of HLSL on desktop at a later date).

To have enough information to diagnose issues we now pass the original shader source file path and the entrypoint method to the serialized shader data from MGFXC.

The exception now looks like this:

![image](https://github.com/user-attachments/assets/2ff9f941-5d2f-43e3-a3ff-40f5dbd3b2f2)

![image](https://github.com/user-attachments/assets/f9e12155-3ce9-4fc0-adc9-0516777b4177)

The exception itself contains all the useful details... the errors, the source code, the source file, the stage and entrypoint:

![image](https://github.com/user-attachments/assets/2830040b-9768-4e64-8837-5e9ae77d2691)

Further the `ToString()` on the exception will output all the details:

![image](https://github.com/user-attachments/assets/b4800e74-1017-4e43-971f-2bb24db96d85)

This should make shader development under OpenGL much easier than before.
