### PR TITLE
Some small improvements to WineHelper.cs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,20 @@
             "stopAtEntry": false
         },
         {
+            "name": "MGFX",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build: mgcb",
+            "program": "${workspaceFolder}/Artifacts/MonoGame.Content.Builder/Debug/mgfxc",
+            "args": [
+                "${workspaceFolder}/Artifacts/Tests/DesktopGL/Debug/Assets/Effects/Grayscale.fx",
+                "{workspaceFolder}/Artifacts/Tests/DesktopGL/Debug/Assets/Effects/Grayscale.mgfxo",
+                "/Profile:DirectX_11"
+            ],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
             "name": "Attach to Process",
             "type": "coreclr",
             "request": "attach",

--- a/Tools/MonoGame.Effect.Compiler/WineHelper.cs
+++ b/Tools/MonoGame.Effect.Compiler/WineHelper.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.IO;
 
 namespace MonoGame.Effect.Compiler
@@ -53,21 +54,16 @@ namespace MonoGame.Effect.Compiler
 
             if (string.IsNullOrEmpty(mgfxcwine))
             {
-                Console.Error.WriteLine("MGFXC effect compiler requires a valid Wine installation to be able to compile shaders.");
-                Console.Error.WriteLine("");
-                Console.Error.WriteLine("Setup instructions:");
-                Console.Error.WriteLine("- Create 64 bit wine prefix");
-                Console.Error.WriteLine("- Install d3dcompiler_47 using winetricks");
-                Console.Error.WriteLine("- Install .NET 8");
-                Console.Error.WriteLine("- Setup MGFXC_WINE_PATH environmental variable to point to a valid wine prefix");
-                Console.Error.WriteLine("");
+                string os = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "macos" : "linux";
+                Console.Error.WriteLine($"Error: MGFXC0001: MGFXC effect compiler requires a valid Wine installation to be able to compile shaders. Please visit https://monogame.net/MGFX1000?tab={os} for instructions on how to set up Wine.");
                 return -1;
             }
 
             Environment.SetEnvironmentVariable("WINEARCH", "win64");
-            Environment.SetEnvironmentVariable("WINEDLLOVERRIDES", "d3dcompiler_47=n");
+            Environment.SetEnvironmentVariable("WINEDLLOVERRIDES", "d3dcompiler_47=n,explorer.exe=e,services.exe=f");
             Environment.SetEnvironmentVariable("WINEPREFIX", mgfxcwine);
             Environment.SetEnvironmentVariable("WINEDEBUG", "-all");
+            Environment.SetEnvironmentVariable("MVK_CONFIG_LOG_LEVEL", "0"); // hide MoltenVK logs
 
             var assemblyLocation = typeof(Program).Assembly.Location;
             var input = ToPrefixPath(options.SourceFile);

--- a/Tools/MonoGame.Effect.Compiler/WineHelper.cs
+++ b/Tools/MonoGame.Effect.Compiler/WineHelper.cs
@@ -55,7 +55,7 @@ namespace MonoGame.Effect.Compiler
             if (string.IsNullOrEmpty(mgfxcwine))
             {
                 string os = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "macos" : "linux";
-                Console.Error.WriteLine($"Error: MGFXC0001: MGFXC effect compiler requires a valid Wine installation to be able to compile shaders. Please visit https://monogame.net/MGFX1000?tab={os} for instructions on how to set up Wine.");
+                Console.Error.WriteLine($"Error: MGFXC0001: MGFXC effect compiler requires a valid Wine installation to be able to compile shaders. Please visit https://docs.monogame.net/errors/mgfx0001?tab={os} for more details.");
                 return -1;
             }
 


### PR DESCRIPTION
There are a few additional environment variables that can be set to help with MonoGame development on Wine.

We can expand the items in `WINEDLLOVERRIDES` so that it does not try to start `explorer.exe` when running the content pipeline. Also that it does not start `services.exe` either.

The `MVK_CONFIG_LOG_LEVEL` environment variable can be set to `0` to disable the MoltenVK logging, which can be quite verbose and distracting when running the content pipeline.

Also added an entry in the launch.json file to allow the debugging of `MGFX` in VSCode.

Added a new error message to the `WineHelper` class if wine is not found. 

- [ ]  update the docs site so the error url works.
