### PR TITLE
Remove the `RestoreContentCompiler` as it was redundant.

### DIFF
--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
@@ -8,7 +8,6 @@
     <AutoRestoreMGCBTool Condition="'$(AutoRestoreMGCBTool)' == '' And '$(MGCBCommand)' != ''">false</AutoRestoreMGCBTool>
     <AutoRestoreMGCBTool Condition="'$(AutoRestoreMGCBTool)' == ''">true</AutoRestoreMGCBTool>
     <MGCBCommand Condition="'$(MGCBCommand)' == ''">mgcb</MGCBCommand>
-    <MonoGameVersion Condition="'$(MonoGameVersion)' == ''">3.8.4.0</MonoGameVersion>
   </PropertyGroup>
 
 </Project>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.props
@@ -7,8 +7,6 @@
     <!-- If the user is using a custom $(MGCBCommand) , disable auto restore. -->
     <AutoRestoreMGCBTool Condition="'$(AutoRestoreMGCBTool)' == '' And '$(MGCBCommand)' != ''">false</AutoRestoreMGCBTool>
     <AutoRestoreMGCBTool Condition="'$(AutoRestoreMGCBTool)' == ''">true</AutoRestoreMGCBTool>
-    <MGCBToolDirectory Condition="'$(MGCBToolDirectory)' == ''">$(MSBuildThisFileDirectory)dotnet-tools/</MGCBToolDirectory>
-    <MGCBToolDirectory Condition="'$(MGCBToolDirectory)' != '' And !HasTrailingSlash('$(MGCBToolDirectory)')">$(MGCBToolDirectory)/</MGCBToolDirectory>
     <MGCBCommand Condition="'$(MGCBCommand)' == ''">mgcb</MGCBCommand>
     <MonoGameVersion Condition="'$(MonoGameVersion)' == ''">3.8.4.0</MonoGameVersion>
   </PropertyGroup>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -84,15 +84,6 @@
 
   </Target>
 
-  <!-- Restore the dotnet-mgcb tool to a known location. -->
-  <!-- Use MGCBToolAdditionalArguments to provide additional arguments to the install
-   for example a path to your custom NuGet.config file.
-  -->
-  <Target Name="RestoreContentCompiler" Condition=" '$(AutoRestoreMGCBTool)' == 'true' And !Exists ('$(MGCBToolDirectory)$(MGCBCommand)')">
-    <MakeDir Directories="$(MGCBToolDirectory)"/>
-    <Exec Command="&quot;$(DotnetCommand)&quot; tool install $(MGCBToolAdditionalArguments) dotnet-mgcb --version $(MonoGameVersion) --tool-path ." WorkingDirectory="$(MGCBToolDirectory)" ContinueOnError="true" />
-  </Target>
-
   <!--
     =====================
     PrepareContentBuilder
@@ -132,6 +123,21 @@
 
   </Target>
 
+  <Target Name="_RestoreMGCBTool" Condition="'$(AutoRestoreMGCBTool)' == 'true'"
+        Inputs="$(MSBuildProjectFullPath)"
+        Outputs="$(IntermediateOutputPath)mgcb.tool.restore">
+    <Exec
+      Condition="'$(DotnetCommand)' == ''"
+      Command="&quot;$(DotnetCommand)&quot; tool restore"
+      WorkingDirectory="$(MSBuildProjectDirectory)"
+      ContinueOnError="true"
+    />
+    <Touch Files="$(IntermediateOutputPath)mgcb.tool.restore" AlwaysCreate="true" />
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)mgcb.tool.restore" />
+    </ItemGroup>
+  </Target>
+
   <!--
     =================
     RunContentBuilder
@@ -143,11 +149,9 @@
       - ExtraContent: built content files
         - ContentDir: the relative path of the embedded folder to contain the content files
   -->
-  <Target Name="RunContentBuilder" DependsOnTargets="RestoreContentCompiler;PrepareContentBuilder">
+  <Target Name="RunContentBuilder" DependsOnTargets="_RestoreMGCBTool;PrepareContentBuilder">
 
     <PropertyGroup>
-      <_Command Condition="Exists ('$(MGCBToolDirectory)$(MGCBCommand)')">&quot;$(MGCBToolDirectory)$(MGCBCommand)&quot;</_Command>
-      <!-- Fallback to old behaviour this allows people to override $(MGCBCommand) with the mgcb.dll -->
       <_Command Condition=" '$(_Command)' == '' ">&quot;$(DotnetCommand)&quot; &quot;$(MGCBCommand)&quot;</_Command>
     </PropertyGroup>
 
@@ -173,6 +177,8 @@
     ==============
 
     Include ExtraContent as platform-specific content in the project output.
+    Runs just before the complile step. But after the project references have been resolved.
+    This allows for content pipeline extensions to be built first.
 
     Outputs:
       - AndroidAsset: built content files if Android
@@ -184,7 +190,8 @@
     DependsOnTargets="RunContentBuilder"
     Condition="'$(EnableMGCBItems)' == 'true' OR '@(MonoGameContentReference)' != ''"
     Outputs="%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension)"
-    BeforeTargets="BeforeBuild">
+    BeforeTargets="BeforeCompile"
+    AfterTargets="ResolveProjectReferences">
 
     <!-- Call CreateItem on each piece of ExtraContent so it's easy to switch the item type by platform. -->
     <CreateItem

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -142,6 +142,7 @@
       WorkingDirectory="$(MSBuildProjectDirectory)"
       ContinueOnError="true"
     />
+    <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
     <Touch Files="$(IntermediateOutputPath)mgcb.tool.restore" AlwaysCreate="true" />
     <ItemGroup>
       <FileWrites Include="$(IntermediateOutputPath)mgcb.tool.restore" />

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -123,11 +123,13 @@
 
   </Target>
 
-  <Target Name="_RestoreMGCBTool" Condition="'$(AutoRestoreMGCBTool)' == 'true'"
+  <Target Name="_RestoreMGCBTool"
+        Condition="'$(AutoRestoreMGCBTool)' == 'true'"
+        AfterTargets="Restore"
         Inputs="$(MSBuildProjectFullPath)"
         Outputs="$(IntermediateOutputPath)mgcb.tool.restore">
     <Exec
-      Condition="'$(DotnetCommand)' == ''"
+      Condition="'$(DotnetCommand)' != ''"
       Command="&quot;$(DotnetCommand)&quot; tool restore"
       WorkingDirectory="$(MSBuildProjectDirectory)"
       ContinueOnError="true"

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -123,10 +123,18 @@
 
   </Target>
 
+  <Target Name="_CollectDotnetToolConfigFiles">
+    <ItemGroup>
+      <_DotnetToolConfigFiles Include="$(SolutionDir)/.config/dotnet-tools.json" Condition="Exists('$(SolutionDir)/.config/dotnet-tools.json')" />
+      <_DotnetToolConfigFiles Include="$(MSBuildProjectDirectory)/.config/dotnet-tools.json" Condition="Exists('$(MSBuildProjectDirectory)/.config/dotnet-tools.json')" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="_RestoreMGCBTool"
         Condition="'$(AutoRestoreMGCBTool)' == 'true'"
         BeforeTargets="CollectPackageReferences"
-        Inputs="$(MSBuildProjectFullPath)"
+        DependsOnTargets="_CollectDotnetToolConfigFiles"
+        Inputs="$(MSBuildProjectFullPath);@(_DotnetToolConfigFiles);$(ProjectAssetsFile)"
         Outputs="$(IntermediateOutputPath)mgcb.tool.restore">
     <Exec
       Condition="'$(DotnetCommand)' != ''"

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -125,13 +125,13 @@
 
   <Target Name="_CollectDotnetToolConfigFiles">
     <ItemGroup>
-      <_DotnetToolConfigFiles Include="$(SolutionDir)/.config/dotnet-tools.json" Condition="Exists('$(SolutionDir)/.config/dotnet-tools.json')" />
+      <_DotnetToolConfigFiles Include="$(SolutionDir).config/dotnet-tools.json" Condition=" '$(SolutionDir)' != '' And Exists('$(SolutionDir).config/dotnet-tools.json')" />
       <_DotnetToolConfigFiles Include="$(MSBuildProjectDirectory)/.config/dotnet-tools.json" Condition="Exists('$(MSBuildProjectDirectory)/.config/dotnet-tools.json')" />
     </ItemGroup>
   </Target>
 
   <Target Name="_RestoreMGCBTool"
-        Condition="'$(AutoRestoreMGCBTool)' == 'true'"
+        Condition="'$(AutoRestoreMGCBTool)' == 'true' And '$(DesignTimeBuild)' != 'true'"
         BeforeTargets="CollectPackageReferences"
         DependsOnTargets="_CollectDotnetToolConfigFiles"
         Inputs="$(MSBuildProjectFullPath);@(_DotnetToolConfigFiles);$(ProjectAssetsFile)"
@@ -201,7 +201,7 @@
   <Target
     Name="IncludeContent"
     DependsOnTargets="RunContentBuilder"
-    Condition="'$(EnableMGCBItems)' == 'true' OR '@(MonoGameContentReference)' != ''"
+    Condition="'$(EnableMGCBItems)' == 'true' OR '@(MonoGameContentReference)' != '' And '$(DesignTimeBuild)' != 'true'"
     Outputs="%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension)"
     BeforeTargets="BeforeCompile"
     AfterTargets="ResolveProjectReferences">

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -201,7 +201,7 @@
   <Target
     Name="IncludeContent"
     DependsOnTargets="RunContentBuilder"
-    Condition="'$(EnableMGCBItems)' == 'true' OR '@(MonoGameContentReference)' != '' And '$(DesignTimeBuild)' != 'true'"
+    Condition="('$(EnableMGCBItems)' == 'true' OR '@(MonoGameContentReference)' != '') And '$(DesignTimeBuild)' != 'true'"
     Outputs="%(ExtraContent.RecursiveDir)%(ExtraContent.Filename)%(ExtraContent.Extension)"
     BeforeTargets="BeforeCompile"
     AfterTargets="ResolveProjectReferences">

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -125,7 +125,7 @@
 
   <Target Name="_RestoreMGCBTool"
         Condition="'$(AutoRestoreMGCBTool)' == 'true'"
-        AfterTargets="Restore"
+        BeforeTargets="CollectPackageReferences"
         Inputs="$(MSBuildProjectFullPath)"
         Outputs="$(IntermediateOutputPath)mgcb.tool.restore">
     <Exec

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -151,7 +151,7 @@
       - ExtraContent: built content files
         - ContentDir: the relative path of the embedded folder to contain the content files
   -->
-  <Target Name="RunContentBuilder" DependsOnTargets="_RestoreMGCBTool;PrepareContentBuilder">
+  <Target Name="RunContentBuilder" DependsOnTargets="PrepareContentBuilder">
 
     <PropertyGroup>
       <_Command Condition=" '$(_Command)' == '' ">&quot;$(DotnetCommand)&quot; &quot;$(MGCBCommand)&quot;</_Command>

--- a/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
+++ b/Tools/MonoGame.Content.Builder.Task/MonoGame.Content.Builder.Task.targets
@@ -141,9 +141,11 @@
       Command="&quot;$(DotnetCommand)&quot; tool restore"
       WorkingDirectory="$(MSBuildProjectDirectory)"
       ContinueOnError="true"
-    />
+    >
+      <Output TaskParameter="ExitCode" PropertyName="_MGCBToolRestoreExitCode" />
+    </Exec>
     <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
-    <Touch Files="$(IntermediateOutputPath)mgcb.tool.restore" AlwaysCreate="true" />
+    <Touch Files="$(IntermediateOutputPath)mgcb.tool.restore" AlwaysCreate="true" Condition="'$(_MGCBToolRestoreExitCode)' == '0'" />
     <ItemGroup>
       <FileWrites Include="$(IntermediateOutputPath)mgcb.tool.restore" />
     </ItemGroup>


### PR DESCRIPTION
* Remove the code which installed tools in a custom folder.
* Added a new `_RestoreMGCBTool` target. This target will restore the tools, but importantly it will put a flag in the `obj` directory to track that is has done so. This means that the target will not run on every build. 
* Moved the content build from before `Build` to before `Compile` but after `ResolveProjectReferences` , this allows any dependencies to be built first. So if you reference a content pipeline extension it will be built before the content is built.