### PR TITLE
Fix build error where the Effect Compiler was referening the Pipeline

### DIFF
--- a/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.DirectX12.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.DirectX12.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Win32;
-using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Effect
@@ -80,7 +79,7 @@ namespace MonoGame.Effect
 
                 // Compile the shader once just to get reflection info.
                 string stdout, stderr;
-                var result = ExternalTool.Run("dxc", toolArgs + "\"" + inputFile + "\"", out reflectionData, out stderr);
+                var result = RunTool("dxc", toolArgs + "\"" + inputFile + "\"", out reflectionData, out stderr);
                 errorsAndWarnings += stderr;
                 if (result > 0)
                     throw new ShaderCompilerException();
@@ -103,7 +102,7 @@ namespace MonoGame.Effect
                 }
 
                 toolArgs += "/Fo " + "\"" + outputFile + "\"" + " ";
-                result = ExternalTool.Run("dxc", toolArgs + "\"" + inputFile + "\"", out stdout, out stderr);
+                result = RunTool("dxc", toolArgs + "\"" + inputFile + "\"", out stdout, out stderr);
                 errorsAndWarnings += stderr;
                 if (result > 0)
                     throw new ShaderCompilerException();
@@ -114,8 +113,8 @@ namespace MonoGame.Effect
             finally
             {
                 // Cleanup.
-                ExternalTool.DeleteFile(inputFile);
-                ExternalTool.DeleteFile(outputFile);
+                DeleteFile(inputFile);
+                DeleteFile(outputFile);
             }
 
             // First look to see if we already created this same shader.

--- a/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.Vulkan.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.Vulkan.cs
@@ -223,52 +223,7 @@ namespace MonoGame.Effect
                 }
                 toolArgs += "\"" + hlslFile + "\"";
 
-                var processInfo = new ProcessStartInfo
-                {
-                    Arguments = toolArgs,
-                    CreateNoWindow = true,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    ErrorDialog = false,
-                    FileName = "dxc",
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    RedirectStandardInput = true,
-                };
-
-                using (var process = new Process { StartInfo = processInfo })
-                {
-                    process.Start();
-
-                    var stdoutThread = new Thread(new ThreadStart(() =>
-                    {
-                        var memory = new MemoryStream();
-                        process.StandardOutput.BaseStream.CopyTo(memory);
-                        var bytes = new byte[memory.Position];
-                        memory.Seek(0, SeekOrigin.Begin);
-                        memory.Read(bytes, 0, bytes.Length);
-                        stdout = System.Text.Encoding.ASCII.GetString(bytes);
-                    }));
-                    stdoutThread.Start();
-
-                    var stderrThread = new Thread(new ThreadStart(() =>
-                    {
-                        var memory = new MemoryStream();
-                        process.StandardError.BaseStream.CopyTo(memory);
-                        var bytes = new byte[memory.Position];
-                        memory.Seek(0, SeekOrigin.Begin);
-                        memory.Read(bytes, 0, bytes.Length);
-                        stderr = System.Text.Encoding.ASCII.GetString(bytes);
-                    }));
-                    stderrThread.Start();
-
-                    process.WaitForExit();
-
-                    stdoutThread.Join();
-                    stderrThread.Join();
-
-                    toolResult = process.ExitCode;
-                }
+                toolResult = RunTool("dxc", toolArgs, out stdout, out stderr);
 
                 errorsAndWarnings += stderr;
 

--- a/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.cs
@@ -5,9 +5,12 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using MonoGame.Effect.TPGParser;
 
 namespace MonoGame.Effect
@@ -91,6 +94,77 @@ namespace MonoGame.Effect
                 }
 
                 return base.ConvertFrom(context, culture, value);
+            }
+        }
+
+        protected static int RunTool(string exe, string args, out string stdout, out string stderr)
+        {
+            stdout = string.Empty;
+            stderr = string.Empty;
+            var processInfo = new ProcessStartInfo
+            {
+                Arguments = args,
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
+                ErrorDialog = false,
+                FileName = exe,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = true,
+            };
+
+            using (var process = new Process { StartInfo = processInfo })
+            {
+                process.Start();
+                string stderrOutput = string.Empty;
+                string stdoutOutput = string.Empty;
+                var stdoutThread = new Thread(new ThreadStart(() =>
+                {
+                    var memory = new MemoryStream();
+                    process.StandardOutput.BaseStream.CopyTo(memory);
+                    var bytes = new byte[memory.Position];
+                    memory.Seek(0, SeekOrigin.Begin);
+                    memory.Read(bytes, 0, bytes.Length);
+                    stdoutOutput = System.Text.Encoding.ASCII.GetString(bytes);
+                }));
+                stdoutThread.Start();
+
+                var stderrThread = new Thread(new ThreadStart(() =>
+                {
+                    var memory = new MemoryStream();
+                    process.StandardError.BaseStream.CopyTo(memory);
+                    var bytes = new byte[memory.Position];
+                    memory.Seek(0, SeekOrigin.Begin);
+                    memory.Read(bytes, 0, bytes.Length);
+                    stderrOutput = System.Text.Encoding.ASCII.GetString(bytes);
+                }));
+                stderrThread.Start();
+
+                process.WaitForExit();
+
+                stdoutThread.Join();
+                stderrThread.Join();
+
+                stderr = stderrOutput;
+                stdout = stdoutOutput;
+
+                return process.ExitCode;
+            }
+        }
+
+        /// <summary>
+        /// Safely deletes the file if it exists.
+        /// </summary>
+        /// <param name="filePath">The path to the file to delete.</param>
+        protected static void DeleteFile(string filePath)
+        {
+            try
+            {
+                File.Delete(filePath);
+            }
+            catch (Exception)
+            {
             }
         }
     }


### PR DESCRIPTION
Fix an build error where we were using `ExternalToo.Run` from the Effect Compiler. 
Recent changes means we cannot access that method. So lets refactor the Vulkan code to use a shared `RunTool` method which can be used from DX12. 