### PR TITLE
Fix issue where the NewItem templates do not appear on MacOS

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
+++ b/Tools/MonoGame.Content.Builder.Editor/Common/PipelineController.cs
@@ -118,7 +118,7 @@ namespace MonoGame.Tools.Pipeline
 
             _templateItems = new List<ContentItemTemplate>();
 #if MAC
-            var root = Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "";
+            var root = Path.Combine(Path.GetDirectoryName(System.AppContext.BaseDirectory) ?? "", "Resources");
 #else
             var root = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "";
 #endif


### PR DESCRIPTION
Fixes #

https://github.com/MonoGame/MonoGame/issues/8810

### Description of Change

We were looking in the wrong directory for the Templates since the move to MacCatalyst.




