### PR TITLE
Added ProjectDirectory to ContentProcessorContext

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -969,7 +969,11 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         /// <returns>The asset name.</returns>
         public string GetAssetName(string sourceFileName, string importerName, string processorName, OpaqueDataDictionary processorParameters)
         {
-            Debug.Assert(Path.IsPathRooted(sourceFileName), "Absolute path expected.");
+            // If the source file is non-rooted we can assume it is relative
+            // to the project directory... if it is not then we should get a
+            // file not found error later in content processing.
+            if (!Path.IsPathRooted(sourceFileName))
+                sourceFileName = Path.Combine(ProjectDirectory, sourceFileName);
 
             // Get source file name, which is used for lookup in _pipelineBuildEvents.
             sourceFileName = PathHelper.Normalize(sourceFileName);

--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineProcessorContext.cs
@@ -55,6 +55,9 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         public override ContentIdentity SourceIdentity { get { return new ContentIdentity(_pipelineEvent.SourceFile); } }
 
         /// <inheritdoc/>
+        public override string ProjectDirectory { get { return _manager.ProjectDirectory; } }
+
+        /// <inheritdoc/>
         public override void AddDependency(string filename)
         {
             _pipelineEvent.Dependencies.AddUnique(filename);

--- a/MonoGame.Framework.Content.Pipeline/ContentProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentProcessorContext.cs
@@ -57,6 +57,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         public abstract GraphicsProfile TargetProfile { get; }
 
         /// <summary>
+        /// Gets the directory that contains the content project.
+        /// </summary>
+        public abstract string ProjectDirectory { get; }
+
+        /// <summary>
         /// Initializes a new instance of ContentProcessorContext.
         /// </summary>
         public ContentProcessorContext()

--- a/Tools/MonoGame.Tools.Tests/TestProcessorContext.cs
+++ b/Tools/MonoGame.Tools.Tests/TestProcessorContext.cs
@@ -54,6 +54,11 @@ namespace MonoGame.Tests.ContentPipeline
         {
             get { throw new NotImplementedException(); }
         }
+
+        public override string ProjectDirectory
+        {
+            get { throw new NotImplementedException(); }
+        }
 #endif
 
         public override TargetPlatform TargetPlatform


### PR DESCRIPTION
This adds `ContentProcessorContext.ProjectDirectory` which can be helpful when you have complex content processors that reference other source content files.

This also tries to do some fixup to non-rooted paths when generating asset names.