### PR TITLE
Only extract the needed d3dcompiler_47.dll

### DIFF
--- a/Tools/MonoGame.Effect.Compiler/mgfxc_wine_setup.sh
+++ b/Tools/MonoGame.Effect.Compiler/mgfxc_wine_setup.sh
@@ -51,8 +51,7 @@ curl $DOTNET_URL --output "$SCRIPT_DIR/dotnet-sdk.zip"
 # get d3dcompiler_47
 FIREFOX_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/62.0.3/win64/ach/Firefox%20Setup%2062.0.3.exe"
 curl $FIREFOX_URL --output "$SCRIPT_DIR/firefox.exe"
-7z x "$SCRIPT_DIR/firefox.exe" -o"$SCRIPT_DIR/firefox_data/"
-cp -f "$SCRIPT_DIR/firefox_data/core/d3dcompiler_47.dll" "$WINEPREFIX/drive_c/windows/system32/d3dcompiler_47.dll"
+7z e "$SCRIPT_DIR/firefox.exe" "core/d3dcompiler_47.dll" -o"$WINEPREFIX/drive_c/windows/system32/" -aoa
 
 # append MGFXC_WINE_PATH env variable
 echo -e "\nexport MGFXC_WINE_PATH=$HOME/.winemonogame" >> ~/.profile


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes #

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

We only need to extract the one file we need for the Wine prefix.




