### PR TITLE
Fix BoundingSphere.CreateMerged

### DIFF
--- a/MonoGame.Framework/BoundingSphere.cs
+++ b/MonoGame.Framework/BoundingSphere.cs
@@ -406,7 +406,6 @@ namespace Microsoft.Xna.Framework
             float Rightradius = Math.Max(original.Radius + distance, additional.Radius);
             ocenterToaCenter = ocenterToaCenter + (((leftRadius - Rightradius) / (2 * ocenterToaCenter.Length())) * ocenterToaCenter);//oCenterToResultCenter
 
-            result = new BoundingSphere();
             result.Center = original.Center + ocenterToaCenter;
             result.Radius = (leftRadius + Rightradius) / 2;
         }


### PR DESCRIPTION
### Description of Change

Fix issue in `BoundingSphere.CreateMerged` when `original` and `result` are references to the same variable.
The behavior now matches `BoundingBox.CreateMerged`




