### PR TITLE
Partial fix for issue 8104 (ContentLoaders in AOT/Trimmed published executables fail to load at startup)

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ReflectiveWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ReflectiveWriter.cs
@@ -27,11 +27,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
         {
         }
 
+        /// <inheritdoc />
         public override bool CanDeserializeIntoExistingObject
         {
             get { return TargetType.IsClass; }
         }
 
+        /// <inheritdoc />
         protected override void Initialize(ContentCompiler compiler)
         {
             _compiler = compiler;
@@ -47,8 +49,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
             if (typeVersion != null)
                 _typeVersion = typeVersion.TypeVersion;
 
-            _properties = TargetType.GetAllProperties().Where(IsValidProperty).ToArray();
-            _fields = TargetType.GetAllFields().Where(IsValidField).ToArray();
+            _properties = ContentExtensions.GetAllProperties<T>().Where(IsValidProperty).ToArray();
+            _fields = ContentExtensions.GetAllFields<T>().Where(IsValidField).ToArray();
         }
 
         /// <inheritdoc/>

--- a/MonoGame.Framework/Content/ContentExtensions.cs
+++ b/MonoGame.Framework/Content/ContentExtensions.cs
@@ -1,12 +1,24 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Linq;
 
 namespace Microsoft.Xna.Framework.Content
 {
+    /// <summary>
+    /// Methods to retrieve information about types, such as constructors, properties, and fields.
+    /// </summary>
     internal static class ContentExtensions
     {
-        public static ConstructorInfo GetDefaultConstructor(this Type type)
+        /// <summary>
+        /// Retrieves all non-static constructors belonging to <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">Type to retrieve the constructors from.</param>
+        /// <returns>List of found non-static constructors</returns>
+        public static ConstructorInfo GetDefaultConstructor(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+            this Type type
+            )
         {
 #if NET45
             var typeInfo = type.GetTypeInfo();
@@ -18,7 +30,14 @@ namespace Microsoft.Xna.Framework.Content
 #endif
         }
 
-        public static PropertyInfo[] GetAllProperties(this Type type)
+        /// <summary>
+        /// Retrieves all non-static properties belonging to <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">Type to retrieve the properties from.</param>
+        /// <returns>List of found non-static properties</returns>
+        public static PropertyInfo[] GetAllProperties(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+            this Type type)
         {
 
             // Sometimes, overridden properties of abstract classes can show up even with 
@@ -41,8 +60,15 @@ namespace Microsoft.Xna.Framework.Content
 #endif
         }
 
-
-        public static FieldInfo[] GetAllFields(this Type type)
+        /// <summary>
+        /// Retrieves all non-static fields belonging to <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">Type to retrieve the fields from.</param>
+        /// <returns>List of found non-static fields</returns>
+        public static FieldInfo[] GetAllFields(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
+            this Type type
+            )
         {
 #if NET45
             FieldInfo[] fields= type.GetTypeInfo().DeclaredFields.ToArray();
@@ -56,6 +82,11 @@ namespace Microsoft.Xna.Framework.Content
 #endif
         }
 
+        /// <summary>
+        /// Whether <paramref name="type"/> is a <see langword="class" />.
+        /// </summary>
+        /// <param name="type">Type to determine.</param>
+        /// <returns>Whether <paramref name="type"/> is a <see langword="class" />.</returns>
         public static bool IsClass(this Type type)
         {
 #if NET45

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -626,7 +626,7 @@ namespace Microsoft.Xna.Framework.Content
                 if (asset.Key == null)
                     ReloadAsset(asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()));
 
-                var methodInfo = ReflectionHelpers.GetMethodInfo(typeof(ContentManager), "ReloadAsset");
+                var methodInfo = ReflectionHelpers.GetMethodInfo<ContentManager>("ReloadAsset");
                 var genericMethod = methodInfo.MakeGenericMethod(asset.Value.GetType());
                 genericMethod.Invoke(this, new object[] { asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()) });
             }

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using MonoGame.Framework.Utilities;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Content
 {
@@ -17,7 +18,13 @@ namespace Microsoft.Xna.Framework.Content
     /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    public class ReflectiveReader<T> : ContentTypeReader
+    public class ReflectiveReader<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors
+                                    | DynamicallyAccessedMemberTypes.NonPublicConstructors
+                                    | DynamicallyAccessedMemberTypes.PublicProperties
+                                    | DynamicallyAccessedMemberTypes.NonPublicProperties
+                                    | DynamicallyAccessedMemberTypes.PublicFields
+                                    | DynamicallyAccessedMemberTypes.NonPublicFields)] T> : ContentTypeReader
     {
         delegate void ReadElement(ContentReader input, object parent);
 
@@ -48,10 +55,13 @@ namespace Microsoft.Xna.Framework.Content
             if (baseType != null && baseType != typeof(object))
 				_baseTypeReader = manager.GetTypeReader(baseType);
 
+            // TargetType is based on T, which has been annotated.
+            #pragma warning disable IL2702
             _constructor = TargetType.GetDefaultConstructor();
 
             var properties = TargetType.GetAllProperties();
             var fields = TargetType.GetAllFields();
+            #pragma warning restore IL2702
             _readers = new List<ReadElement>(fields.Length + properties.Length);
 
             // Gather the properties.

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Xna.Framework.Content
     /// Its purpose is to allow to work-around AOT issues when loading assets with the ContentManager fail due to the absence of runtime-reflection support in that context (i.e. missing types due to trimming and inability to statically discover them at compile-time).
     /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     public class ReflectiveReader<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors
                                     | DynamicallyAccessedMemberTypes.NonPublicConstructors
@@ -55,13 +55,10 @@ namespace Microsoft.Xna.Framework.Content
             if (baseType != null && baseType != typeof(object))
 				_baseTypeReader = manager.GetTypeReader(baseType);
 
-            // TargetType is based on T, which has been annotated.
-            #pragma warning disable IL2702
-            _constructor = TargetType.GetDefaultConstructor();
+            _constructor = ContentExtensions.GetDefaultConstructor<T>();
+            var properties = ContentExtensions.GetAllProperties<T>();
+            var fields = ContentExtensions.GetAllFields<T>();
 
-            var properties = TargetType.GetAllProperties();
-            var fields = TargetType.GetAllFields();
-            #pragma warning restore IL2702
             _readers = new List<ReadElement>(fields.Length + properties.Length);
 
             // Gather the properties.

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -34,84 +34,84 @@ namespace Microsoft.Xna.Framework.Content
 
             // cache the most common type readers to avoid the most common AOT/trimming related issues
             // (especially on MonoGame standard content types)
-            AddTypeCreator(typeof(AlphaTestEffectReader).FullName, () => new AlphaTestEffectReader());
-            AddTypeCreator(typeof(ArrayReader<int>).FullName, () => new ArrayReader<int>());
-            AddTypeCreator(typeof(ArrayReader<float>).FullName, () => new ArrayReader<float>());
-            AddTypeCreator(typeof(ArrayReader<char>).FullName, () => new ArrayReader<char>());
-            AddTypeCreator(typeof(ArrayReader<string>).FullName, () => new ArrayReader<string>());
-            AddTypeCreator(typeof(ArrayReader<Point>).FullName, () => new ArrayReader<Point>());
-            AddTypeCreator(typeof(ArrayReader<Vector2>).FullName, () => new ArrayReader<Vector2>());
-            AddTypeCreator(typeof(ArrayReader<Vector3>).FullName, () => new ArrayReader<Vector3>());
-            AddTypeCreator(typeof(ArrayReader<Matrix>).FullName, () => new ArrayReader<Matrix>());
-            AddTypeCreator(typeof(ArrayReader<Rectangle>).FullName, () => new ArrayReader<Rectangle>());
-            AddTypeCreator(typeof(ArrayReader<Color>).FullName, () => new ArrayReader<Color>());
-            AddTypeCreator(typeof(ArrayReader<StringReader>).FullName, () => new ArrayReader<StringReader>());
-            AddTypeCreator(typeof(BasicEffectReader).FullName, () => new BasicEffectReader());
-            AddTypeCreator(typeof(BooleanReader).FullName, () => new BooleanReader());
-            AddTypeCreator(typeof(BoundingBoxReader).FullName, () => new BoundingBoxReader());
-            AddTypeCreator(typeof(BoundingFrustumReader).FullName, () => new BoundingFrustumReader());
-            AddTypeCreator(typeof(BoundingSphereReader).FullName, () => new BoundingSphereReader());
-            AddTypeCreator(typeof(ByteReader).FullName, () => new ByteReader());
-            AddTypeCreator(typeof(CharReader).FullName, () => new CharReader());
-            AddTypeCreator(typeof(ColorReader).FullName, () => new ColorReader());
-            AddTypeCreator(typeof(CurveReader).FullName, () => new CurveReader());
-            AddTypeCreator(typeof(DateTimeReader).FullName, () => new DateTimeReader());
-            AddTypeCreator(typeof(DecimalReader).FullName, () => new DecimalReader());
+            AddTypeCreator<AlphaTestEffectReader>(() => new AlphaTestEffectReader());
+            AddTypeCreator<ArrayReader<int>>(() => new ArrayReader<int>());
+            AddTypeCreator<ArrayReader<float>>(() => new ArrayReader<float>());
+            AddTypeCreator<ArrayReader<char>>(() => new ArrayReader<char>());
+            AddTypeCreator<ArrayReader<string>>(() => new ArrayReader<string>());
+            AddTypeCreator<ArrayReader<Point>>(() => new ArrayReader<Point>());
+            AddTypeCreator<ArrayReader<Vector2>>(() => new ArrayReader<Vector2>());
+            AddTypeCreator<ArrayReader<Vector3>>(() => new ArrayReader<Vector3>());
+            AddTypeCreator<ArrayReader<Matrix>>(() => new ArrayReader<Matrix>());
+            AddTypeCreator<ArrayReader<Rectangle>>(() => new ArrayReader<Rectangle>());
+            AddTypeCreator<ArrayReader<Color>>(() => new ArrayReader<Color>());
+            AddTypeCreator<ArrayReader<StringReader>>(() => new ArrayReader<StringReader>());
+            AddTypeCreator<BasicEffectReader>(() => new BasicEffectReader());
+            AddTypeCreator<BooleanReader>(() => new BooleanReader());
+            AddTypeCreator<BoundingBoxReader>(() => new BoundingBoxReader());
+            AddTypeCreator<BoundingFrustumReader>(() => new BoundingFrustumReader());
+            AddTypeCreator<BoundingSphereReader>(() => new BoundingSphereReader());
+            AddTypeCreator<ByteReader>(() => new ByteReader());
+            AddTypeCreator<CharReader>(() => new CharReader());
+            AddTypeCreator<ColorReader>(() => new ColorReader());
+            AddTypeCreator<CurveReader>(() => new CurveReader());
+            AddTypeCreator<DateTimeReader>(() => new DateTimeReader());
+            AddTypeCreator<DecimalReader>(() => new DecimalReader());
             // DictionaryReader<TKey, TValue>
-            AddTypeCreator(typeof(DoubleReader).FullName, () => new DoubleReader());
-            AddTypeCreator(typeof(DualTextureEffectReader).FullName, () => new DualTextureEffectReader());
-            AddTypeCreator(typeof(EffectMaterialReader).FullName, () => new EffectMaterialReader());
-            AddTypeCreator(typeof(ContentReader).Namespace + ".EffectReader, " + typeof(ContentReader).Assembly.FullName, () => new EffectReader());
-            AddTypeCreator(typeof(EnumReader<Graphics.SpriteEffects>).FullName, () => new EnumReader<Graphics.SpriteEffects>());
-            AddTypeCreator(typeof(EnumReader<Graphics.Blend>).FullName, () => new EnumReader<Graphics.Blend>());
-            AddTypeCreator(typeof(EnvironmentMapEffectReader).FullName, () => new EnvironmentMapEffectReader());
-            AddTypeCreator(typeof(ExternalReferenceReader).FullName, () => new ExternalReferenceReader());
-            AddTypeCreator(typeof(IndexBufferReader).FullName, () => new IndexBufferReader());
-            AddTypeCreator(typeof(Int16Reader).FullName, () => new Int16Reader());
-            AddTypeCreator(typeof(Int32Reader).FullName, () => new Int32Reader());
-            AddTypeCreator(typeof(Int64Reader).FullName, () => new Int64Reader());
-            AddTypeCreator(typeof(ListReader<int>).FullName, () => new ListReader<int>());
-            AddTypeCreator(typeof(ListReader<float>).FullName, () => new ListReader<float>());
-            AddTypeCreator(typeof(ListReader<char>).FullName, () => new ListReader<char>());
-            AddTypeCreator(typeof(ListReader<string>).FullName, () => new ListReader<string>());
-            AddTypeCreator(typeof(ListReader<Point>).FullName, () => new ListReader<Point>());
-            AddTypeCreator(typeof(ListReader<Vector2>).FullName, () => new ListReader<Vector2>());
-            AddTypeCreator(typeof(ListReader<Vector3>).FullName, () => new ListReader<Vector3>());
-            AddTypeCreator(typeof(ListReader<Matrix>).FullName, () => new ListReader<Matrix>());
-            AddTypeCreator(typeof(ListReader<Rectangle>).FullName, () => new ListReader<Rectangle>());
-            AddTypeCreator(typeof(ListReader<Color>).FullName, () => new ListReader<Color>());
-            AddTypeCreator(typeof(ListReader<StringReader>).FullName, () => new ListReader<StringReader>());
-            AddTypeCreator(typeof(MatrixReader).FullName, () => new MatrixReader());
-            AddTypeCreator(typeof(ModelReader).FullName, () => new ModelReader());
+            AddTypeCreator<DoubleReader>(() => new DoubleReader());
+            AddTypeCreator<DualTextureEffectReader>(() => new DualTextureEffectReader());
+            AddTypeCreator<EffectMaterialReader>(() => new EffectMaterialReader());
+            AddTypeCreator<EffectReader>(() => new EffectReader());
+            AddTypeCreator<EnumReader<Graphics.SpriteEffects>>(() => new EnumReader<Graphics.SpriteEffects>());
+            AddTypeCreator<EnumReader<Graphics.Blend>>(() => new EnumReader<Graphics.Blend>());
+            AddTypeCreator<EnvironmentMapEffectReader>(() => new EnvironmentMapEffectReader());
+            AddTypeCreator<ExternalReferenceReader>(() => new ExternalReferenceReader());
+            AddTypeCreator<IndexBufferReader>(() => new IndexBufferReader());
+            AddTypeCreator<Int16Reader>(() => new Int16Reader());
+            AddTypeCreator<Int32Reader>(() => new Int32Reader());
+            AddTypeCreator<Int64Reader>(() => new Int64Reader());
+            AddTypeCreator<ListReader<int>>(() => new ListReader<int>());
+            AddTypeCreator<ListReader<float>>(() => new ListReader<float>());
+            AddTypeCreator<ListReader<char>>(() => new ListReader<char>());
+            AddTypeCreator<ListReader<string>>(() => new ListReader<string>());
+            AddTypeCreator<ListReader<Point>>(() => new ListReader<Point>());
+            AddTypeCreator<ListReader<Vector2>>(() => new ListReader<Vector2>());
+            AddTypeCreator<ListReader<Vector3>>(() => new ListReader<Vector3>());
+            AddTypeCreator<ListReader<Matrix>>(() => new ListReader<Matrix>());
+            AddTypeCreator<ListReader<Rectangle>>(() => new ListReader<Rectangle>());
+            AddTypeCreator<ListReader<Color>>(() => new ListReader<Color>());
+            AddTypeCreator<ListReader<StringReader>>(() => new ListReader<StringReader>());
+            AddTypeCreator<MatrixReader>(() => new MatrixReader());
+            AddTypeCreator<ModelReader>(() => new ModelReader());
             // MultiArrayReader<T>
-            AddTypeCreator(typeof(NullableReader<Rectangle>).FullName, () => new NullableReader<Rectangle>());
-            AddTypeCreator(typeof(PlaneReader).FullName, () => new PlaneReader());
-            AddTypeCreator(typeof(PointReader).FullName, () => new PointReader());
-            AddTypeCreator(typeof(QuaternionReader).FullName, () => new QuaternionReader());
-            AddTypeCreator(typeof(RayReader).FullName, () => new RayReader());
-            AddTypeCreator(typeof(RectangleReader).FullName, () => new RectangleReader());
+            AddTypeCreator<NullableReader<Rectangle>>(() => new NullableReader<Rectangle>());
+            AddTypeCreator<PlaneReader>(() => new PlaneReader());
+            AddTypeCreator<PointReader>(() => new PointReader());
+            AddTypeCreator<QuaternionReader>(() => new QuaternionReader());
+            AddTypeCreator<RayReader>(() => new RayReader());
+            AddTypeCreator<RectangleReader>(() => new RectangleReader());
             // ReflectiveReader<T>
-            AddTypeCreator(typeof(SByteReader).FullName, () => new SByteReader());
-            AddTypeCreator(typeof(SingleReader).FullName, () => new SingleReader());
-            AddTypeCreator(typeof(SkinnedEffectReader).FullName, () => new SkinnedEffectReader());
-            AddTypeCreator(typeof(SongReader).FullName, () => new SongReader());
-            AddTypeCreator(typeof(SoundEffectReader).FullName, () => new SoundEffectReader());
-            AddTypeCreator(typeof(SpriteFontReader).FullName, () => new SpriteFontReader());
-            AddTypeCreator(typeof(StringReader).FullName, () => new StringReader());
-            AddTypeCreator(typeof(Texture2DReader).FullName, () => new Texture2DReader());
-            AddTypeCreator(typeof(Texture3DReader).FullName, () => new Texture3DReader());
-            AddTypeCreator(typeof(TextureCubeReader).FullName, () => new TextureCubeReader());
-            AddTypeCreator(typeof(TextureReader).FullName, () => new TextureReader());
-            AddTypeCreator(typeof(TimeSpanReader).FullName, () => new TimeSpanReader());
-            AddTypeCreator(typeof(UInt16Reader).FullName, () => new UInt16Reader());
-            AddTypeCreator(typeof(UInt32Reader).FullName, () => new UInt32Reader());
-            AddTypeCreator(typeof(UInt64Reader).FullName, () => new UInt64Reader());
-            AddTypeCreator(typeof(Vector2Reader).FullName, () => new Vector2Reader());
-            AddTypeCreator(typeof(Vector3Reader).FullName, () => new Vector3Reader());
-            AddTypeCreator(typeof(Vector4Reader).FullName, () => new Vector4Reader());
-            AddTypeCreator(typeof(VertexBufferReader).FullName, () => new VertexBufferReader());
-            AddTypeCreator(typeof(VertexDeclarationReader).FullName, () => new VertexDeclarationReader());
-            AddTypeCreator(typeof(VideoReader).FullName, () =>  new VideoReader());
+            AddTypeCreator<SByteReader>(() => new SByteReader());
+            AddTypeCreator<SingleReader>(() => new SingleReader());
+            AddTypeCreator<SkinnedEffectReader>(() => new SkinnedEffectReader());
+            AddTypeCreator<SongReader>(() => new SongReader());
+            AddTypeCreator<SoundEffectReader>(() => new SoundEffectReader());
+            AddTypeCreator<SpriteFontReader>(() => new SpriteFontReader());
+            AddTypeCreator<StringReader>(() => new StringReader());
+            AddTypeCreator<Texture2DReader>(() => new Texture2DReader());
+            AddTypeCreator<Texture3DReader>(() => new Texture3DReader());
+            AddTypeCreator<TextureCubeReader>(() => new TextureCubeReader());
+            AddTypeCreator<TextureReader>(() => new TextureReader());
+            AddTypeCreator<TimeSpanReader>(() => new TimeSpanReader());
+            AddTypeCreator<UInt16Reader>(() => new UInt16Reader());
+            AddTypeCreator<UInt32Reader>(() => new UInt32Reader());
+            AddTypeCreator<UInt64Reader>(() => new UInt64Reader());
+            AddTypeCreator<Vector2Reader>(() => new Vector2Reader());
+            AddTypeCreator<Vector3Reader>(() => new Vector3Reader());
+            AddTypeCreator<Vector4Reader>(() => new Vector4Reader());
+            AddTypeCreator<VertexBufferReader>(() => new VertexBufferReader());
+            AddTypeCreator<VertexDeclarationReader>(() => new VertexDeclarationReader());
+            AddTypeCreator<VideoReader>(() =>  new VideoReader());
         }
 
         /// <summary>
@@ -156,8 +156,20 @@ namespace Microsoft.Xna.Framework.Content
                     // string readerTypeString = reader.ReadString();
                     string originalReaderTypeString = reader.ReadString();
 
+                    // in AOT scenarios, unused readers cause an empty string to be returned.
+                    // This is fine, as it means that the reader is not needed for this content file.
+                    if (string.IsNullOrEmpty(originalReaderTypeString))
+                    {
+                        contentReaders[i] = null;
+                        needsInitialize[i] = false;
+                        continue;
+                    }
+
                     Func<ContentTypeReader> readerFunc;
-                    if (typeCreators.TryGetValue(originalReaderTypeString, out readerFunc))
+#pragma warning disable IL2057
+                    Type l_readerType = Type.GetType(originalReaderTypeString);
+#pragma warning restore IL2057
+                    if (l_readerType != null && typeCreators.TryGetValue(l_readerType, out readerFunc))
                     {
                         contentReaders[i] = readerFunc();
                         needsInitialize[i] = true;
@@ -171,7 +183,6 @@ namespace Microsoft.Xna.Framework.Content
 
                         readerTypeString = PrepareType(readerTypeString);
 
-                        Type l_readerType = null;
                         try
                         {
                             // this might fail in AOT context and we need to properly warn the user on what to do if it happens
@@ -211,9 +222,9 @@ namespace Microsoft.Xna.Framework.Content
                         }
                         else
                             throw new ContentLoadException(
-                                    "Could not find ContentTypeReader Type. Please ensure the name of the Assembly that contains the Type matches the assembly in the full type name: " +
-                                    originalReaderTypeString + " (" + readerTypeString + "). " +
-                                    " If you are using trimming, PublishAOT, or targeting mobile platforms, you should call ContentTypeReaderManager.AddTypeCreator() on that reader type somewhere in your code.");
+                                "Could not find ContentTypeReader Type. Please ensure the name of the Assembly that contains the Type matches the assembly in the full type name: " +
+                                originalReaderTypeString + " (" + readerTypeString + "). " +
+                                " If you are using trimming, PublishAOT, or targeting mobile platforms, you should call ContentTypeReaderManager.AddTypeCreator() on that reader type somewhere in your code.");
                     }
 
                     var targetType = contentReaders[i].TargetType;
@@ -227,16 +238,16 @@ namespace Microsoft.Xna.Framework.Content
                 }
 
                 // Initialize any new readers.
-                for (var i = 0; i < contentReaders.Length; i++)
+                for (var c = 0; c < contentReaders.Length; c++)
                 {
-                    if (needsInitialize.Get(i))
-                        contentReaders[i].Initialize(this);
+                    if (needsInitialize.Get(c))
+                        contentReaders[c].Initialize(this);
                 }
 
             } // lock (_locker)
 
             return contentReaders;
-        }
+        } 
 
         /// <summary>
         /// Removes the Version, Culture, and PublicKeyToken from a fully-qualified type name string.
@@ -275,24 +286,23 @@ namespace Microsoft.Xna.Framework.Content
         }
 
         // Static map of type names to creation functions. Required as iOS requires all types at compile time
-        private static Dictionary<string, Func<ContentTypeReader>> typeCreators = new Dictionary<string, Func<ContentTypeReader>>();
+        private static Dictionary<Type, Func<ContentTypeReader>> typeCreators = new Dictionary<Type, Func<ContentTypeReader>>();
 
         /// <summary>
         /// Registers a function to create a <see cref="ContentTypeReader"/> instance used to read an object of the
         /// type specified.
         /// Call this method to register content readers that may fail loading when trimming or PublishAot are used.
         /// </summary>
-        /// <param name='typeString'>A string containing the fully-qualified type name of the object type.</param>
+        /// <typeparam name="T">The content reader type.</typeparam>
         /// <param name='createFunction'>The function responsible for creating an instance of the <see cref="ContentTypeReader"/> class.</param>
         /// <exception cref="ArgumentNullException">If the <paramref name="typeString"/> parameter is null or an empty string.</exception>
-        public static void AddTypeCreator(string typeString, Func<ContentTypeReader> createFunction)
+        public static void AddTypeCreator<T>(Func<ContentTypeReader> createFunction) where T : ContentTypeReader
         {
-            if (!typeCreators.ContainsKey(typeString))
-                typeCreators.Add(typeString, createFunction);
+            typeCreators.TryAdd(typeof(T), createFunction);
         }
 
         /// <summary>
-        /// Clears all content type creators that were registered with <see cref="AddTypeCreator(string, Func{ContentTypeReader})"/>
+        /// Clears all content type creators that were registered with <see cref="AddTypeCreator(Type, Func{ContentTypeReader})"/>
         /// </summary>
         public static void ClearTypeCreators()
         {

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -295,7 +295,6 @@ namespace Microsoft.Xna.Framework.Content
         /// </summary>
         /// <typeparam name="T">The content reader type.</typeparam>
         /// <param name='createFunction'>The function responsible for creating an instance of the <see cref="ContentTypeReader"/> class.</param>
-        /// <exception cref="ArgumentNullException">If the <paramref name="typeString"/> parameter is null or an empty string.</exception>
         public static void AddTypeCreator<T>(Func<ContentTypeReader> createFunction) where T : ContentTypeReader
         {
             var type = typeof(T);

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -298,7 +298,9 @@ namespace Microsoft.Xna.Framework.Content
         /// <exception cref="ArgumentNullException">If the <paramref name="typeString"/> parameter is null or an empty string.</exception>
         public static void AddTypeCreator<T>(Func<ContentTypeReader> createFunction) where T : ContentTypeReader
         {
-            typeCreators.TryAdd(typeof(T), createFunction);
+            var type = typeof(T);
+            if (!typeCreators.ContainsKey(type))
+                typeCreators.Add(type, createFunction);
         }
 
         /// <summary>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -11,7 +11,6 @@
     <CopyContentFiles>True</CopyContentFiles>
     <IsAotCompatible>true</IsAotCompatible>
     <PackageReadmeFile>README-packages.md</PackageReadmeFile>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -11,10 +11,11 @@
     <CopyContentFiles>True</CopyContentFiles>
     <IsAotCompatible>true</IsAotCompatible>
     <PackageReadmeFile>README-packages.md</PackageReadmeFile>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\README-packages.md" Pack="true" PackagePath="\"/>
+    <None Include="..\README-packages.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -75,12 +76,18 @@ namespace MonoGame.Framework.Utilities
             return false;
         }
 
-        public static MethodInfo GetMethodInfo(Type type, string methodName)
+        /// <summary>
+        /// Retrieves the method info a given type and method name.
+        /// </summary>
+        /// <typeparam name="T">Type to retrieve the method from</typeparam>
+        /// <param name="methodName">Name of the method</param>
+        /// <returns>Retrieved method.</returns>
+        public static MethodInfo GetMethodInfo<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicMethods)]T>(string methodName)
         {
 #if NET45            
-            return type.GetTypeInfo().GetDeclaredMethod(methodName);
+            return typeof(T).GetTypeInfo().GetDeclaredMethod(methodName);
 #else
-            return type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            return typeof(T).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
 #endif
         }
 


### PR DESCRIPTION
Partial fix for issue https://github.com/MonoGame/MonoGame/issues/8104
(Otherwise this change would be too large)

### Reason for submission

For practice I was trying to create published builds that are AOT compiled and trimmed - which has issues as issue 8104 noted. The issue at hand is that ContentLoaders implementations are trimmed of specific parts of their class, breaking functionality when trying to load xnb files.
![2025-06-16 21_54_18-KingdomEngine - Microsoft Visual Studio](https://github.com/user-attachments/assets/3b4a8c83-e8a1-4e26-8a98-f3ea35b22103)

The XNB files would be at the correct location, but their loaders wouldn't function. Another is that if a ContentLoader isn't utilized, AOT would trim it, making loading it in impossible (and unnecessary, as things like _Assembly.Load_ will not happen anyway).

I've made a build where the ContentLoaders load in as required, which worked for my own project. **However**, my project is small in scope. It may be prudent to test this branch on projects with a ton of assets, to see it would break anything.

### Description of Change

In general:
1. Added XML summary documentation for methods that have been altered. (Based on what the roadmap told me is required https://docs.monogame.net/roadmap/) 
`Update to the XML API documentation, ensuring all of the API is covered. (A Massive task!)`
2. Added `[DynamicallyAccessedMembers(...)]` to specific methods where reflection is enacted for ContentLoaders.
3. For a few methods a generic type `<T>` was introduced in favor of a `Type type` parameter, because that works better with trimming/AOT compilation. (Compile time vs. runtime lookup, etc.)

In ReflectiveReader.cs
1. ReflectiveReader's `<T>` is always an implementation of ContentTypeReader and always needs specific parts of it, so I put them in the constraints/DynamicallyAccessedMembers. This is what likely fixed the bug the most.

In ContentTypeReaderManager.cs:
1. The readers are now stored by type rather than the type name for the sake of performance, and by how readers are added in code this ensures they aren't trimmed.
2. in AOT scenarios, if a loader isn't required during runtime (as no assets are utilized), the loader won't be written. This causes the reader to retrieve an empty string. if so, we can skip setting up that specific resource loader.
**EDIT:**  this may have been due to ReflectiveWriter using the Type ''blindly'', which was fixed after the results of the failed build came in. I fixed that now, and this may resolve this issue as well.

### How to reproduce 

Publish a project with trimming/AOT enabled and where assets are registered in the _.mgcb_ file. Then load those assets.

### Uncertainties / Thoughts

Here are a few uncertainties in the back of my head that one might want to take into account:
1. I do not know exactly what will happen with custom loaders. 
2. I've tested with a few images, an audio file and a spritefont. I have not tested with other resource types, custom types, or in bulk.
4. I do not know if this breaks .NET Framework 4.5 (it shouldn't?)
5. I've tested a win-x64 publish, I have no idea if this will fix the issue for Android/iOS/Linux/etc. (Although I wouldn't be surprised if it did). 
6. I've gotten successful builds for MonoGame.Tools.Windows.sln, MonoGame.Tools.Linux.sln, MonoGame.Framework.WindowsDX.sln and MonoGame.Framework.DesktopGL.sln. (But not the others as I don't have Android/iOS/etc. tooling going on)

Further:
1. I've not touched anything beyond functionality for loading content for the sake of keeping the PR simple.
3. According to a test I did, there are more than a dozen other reflection scenarios that need mediation, so I assume 8104 will be open for the foreseeable future.
4. There are calls to, for example, _MakeGenericMethod_. https://docs.monogame.net/articles/getting_started/preparing_for_consoles.html#no-runtime-compilation--il-emit However, i think that's for another day.