### PR TITLE
Bump OpenAL to 1.24.3.1

### DIFF
--- a/MonoGame.Framework/Platform/OpenAL.targets
+++ b/MonoGame.Framework/Platform/OpenAL.targets
@@ -5,6 +5,7 @@
 
   <!-- iOS has its own Song and Video implementation -->
   <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('IOS'))">
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.24.3.1" />
     <Compile Include="Platform\Media\Song.iOS.cs" />
 	
 	<Compile Include="Platform\Media\MediaLibrary.iOS.cs" />
@@ -20,7 +21,7 @@
   
   <!-- Android has its own Song and Video implementation, and need OpenAL binaries -->
   <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('ANDROID'))">
-    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.10" />
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.24.3.1" />
     <Compile Include="Platform\Media\Song.Android.cs" />
 	
 	<Compile Include="Platform\Media\MediaLibrary.Android.cs" />
@@ -36,7 +37,7 @@
   
   <!-- DesktopGL has its own Song implementation, and need OpenAL binaries -->
   <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('DESKTOPGL'))">
-    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.23.1.10" />
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.24.3.1" />
 	<PackageReference Include="NVorbis" Version="0.10.4" />
 
     <Compile Include="Platform\Media\OggStream.NVorbis.cs" />


### PR DESCRIPTION
Bump OpenAL to 1.24.3.1.
The brings in Android 16kb alignment.
Also removes iOS iPhone from the NuGet Package, but still has the simulator. This will allow developers to build and test and release.
