### PR TITLE
Fix 2 summary

### DIFF
--- a/MonoGame.Framework/PlayerIndex.cs
+++ b/MonoGame.Framework/PlayerIndex.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Xna.Framework
     /// Defines the index of player for various MonoGame components.
     /// </summary>
     /// <remarks>
-    /// Use <see cref="GamePad.MaximumGamePadCount" /> to determine the number of supported gamepads on the current 
+    /// Use <see cref="Microsoft.Xna.Framework.Input.GamePad.MaximumGamePadCount" /> to determine the number of supported gamepads on the current 
     /// platform to ensure that a valid <see cref="PlayerIndex" /> is used when accessing gamepad input.
     /// Not all platforms support all eight player indices.
     /// </remarks>

--- a/MonoGame.Framework/Random.cs
+++ b/MonoGame.Framework/Random.cs
@@ -71,7 +71,7 @@ public static partial class MathHelper
         }
 
         /// <summary>
-        /// Generate a uniformly distributed number, r, where 0 <= r < <paramref name="bound"/>.
+        /// Generate a uniformly distributed number, r, where 0 &lt;= r &lt; <paramref name="bound"/>.
         /// </summary>
         /// <param name="bound">Exclusive upper bound of the number to generate.</param>
         /// <returns>A uniformly distributed 32bit unsigned integer strictly less than <paramref name="bound"/>.</returns>


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fix 2 summary warnings.
`private uint PCG32(uint bound)` did not display its summary due to a warning inside the summary documentation.

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

The summary of `private uint PCG32(uint bound)` use `<` causing it to break.
The char `<` can not be use inside a summary, it get replaced by &lt;.

`GamePad.MaximumGamePadCount` was not found, changed to use the full name.

<!-- 
Enter description of the fix in this section.
Please be as descriptive as possible, future contributors will need to know *why* these changes are being made.
For inspiration review the commit/PR history in the MonoGame repository.
-->




