### PR TITLE
Fix XML compiler warnings.

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1965,7 +1965,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Calculates Hue & Saturation value from RGB, to avoid code duplication.
+        /// Calculates Hue and Saturation value from RGB, to avoid code duplication.
         /// </summary>
         /// <param name="h">Hue component value from 0.0f to 360.0f</param>
         /// <param name="s">Saturation component</param>

--- a/MonoGame.Framework/Random.cs
+++ b/MonoGame.Framework/Random.cs
@@ -71,7 +71,7 @@ public static partial class MathHelper
         }
 
         /// <summary>
-        /// Generate a uniformly distributed number, r, where 0 &lt;= r &lt; <paramref name="bound"/>.
+        /// Generate a uniformly distributed number, r, where 0 <= and r < <paramref name="bound"/>.
         /// </summary>
         /// <param name="bound">Exclusive upper bound of the number to generate.</param>
         /// <returns>A uniformly distributed 32bit unsigned integer strictly less than <paramref name="bound"/>.</returns>


### PR DESCRIPTION
Fix some low hanging XML compiler warnings. We have SOOO many warnings, we introduce silly ones all the time.
At some point we should try to reduce these warnings down to zero. Just so we can see real issues when we're being warned about them.