### PR TITLE
Fixed Relative Source Paths In Pipeline Builder

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PipelineManager.cs
@@ -959,6 +959,24 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 pipelineBuildEvents.Add(pipelineEvent);
         }
 
+        internal string ResolveSourceFilePath(string sourceFileName)
+        {
+            // If the source file is non-rooted we can assume it is relative
+            // to the project directory... if it is not then we should get a
+            // file not found error later in content processing.
+            if (!Path.IsPathRooted(sourceFileName))
+                sourceFileName = Path.Combine(ProjectDirectory, sourceFileName);
+
+            // Passing the path into GetFullPath resolves any relative pathing
+            // which can screw up the cache lookup below.
+            sourceFileName = Path.GetFullPath(sourceFileName);
+
+            // Get source file name, which is used for lookup in _pipelineBuildEvents.
+            sourceFileName = PathHelper.Normalize(sourceFileName);
+
+            return sourceFileName;
+        }
+
         /// <summary>
         /// Gets an automatic asset name, such as "AssetName_0".
         /// </summary>
@@ -969,14 +987,8 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         /// <returns>The asset name.</returns>
         public string GetAssetName(string sourceFileName, string importerName, string processorName, OpaqueDataDictionary processorParameters)
         {
-            // If the source file is non-rooted we can assume it is relative
-            // to the project directory... if it is not then we should get a
-            // file not found error later in content processing.
-            if (!Path.IsPathRooted(sourceFileName))
-                sourceFileName = Path.Combine(ProjectDirectory, sourceFileName);
-
             // Get source file name, which is used for lookup in _pipelineBuildEvents.
-            sourceFileName = PathHelper.Normalize(sourceFileName);
+            sourceFileName = ResolveSourceFilePath(sourceFileName);
             string relativeSourceFileName = PathHelper.GetRelativePath(ProjectDirectory, sourceFileName);
 
             List<PipelineBuildEvent> pipelineBuildEvents;

--- a/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PipelineProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PipelineProcessorContext.cs
@@ -156,6 +156,10 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                                                                                 string importerName,
                                                                                 string assetName)
         {
+            // Be sure we have a good absolute path to the source content
+            // or it may not cache correctly and create duplicates.
+            sourceAsset.Filename = _manager.ResolveSourceFilePath(sourceAsset.Filename);
+
             if (string.IsNullOrEmpty(assetName))
                 assetName = _manager.GetAssetName(sourceAsset.Filename, importerName, processorName, processorParameters);
 


### PR DESCRIPTION
In more complicated custom content processors you can trigger building of dependent content via code.

If you happen to use a relative path like `./foo.png` or `.\..\bar\foo.png` it could cause the pipeline to generate multiple copies of the same content.

This ensures incoming source file paths are fully resolved before they are processed and they are cached with the same path.