### PR TITLE
Use MSBuild task instead of Exec

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -122,7 +122,7 @@
 
   <Target Name="BuildMGCPW" Condition="'$(DisableNativeBuild)' != 'True' and '$(OS)' == 'Windows_NT'" BeforeTargets="CollectPackageReferences">
     <Exec Command="premake5 vs2022" WorkingDirectory="../native/pipeline/" />
-    <MSBuild Projects="../native/pipeline/pipeline.sln" Targets="Build" Properties="Configuration=$(Configuration);Platform=x64" />
+    <MSBuild Projects="../native/pipeline/pipeline.sln" Properties="Configuration=$(Configuration);Platform=x64" />
   </Target>
 
   <Target Name="BuildMGCPU" Condition="'$(DisableNativeBuild)' != 'True' and '$(OS)' != 'Windows_NT'" BeforeTargets="CollectPackageReferences">

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -122,7 +122,7 @@
 
   <Target Name="BuildMGCPW" Condition="'$(DisableNativeBuild)' != 'True' and '$(OS)' == 'Windows_NT'" BeforeTargets="CollectPackageReferences">
     <Exec Command="premake5 vs2022" WorkingDirectory="../native/pipeline/" />
-    <Exec Command="msbuild pipeline.sln /p:Configuration=$(Configuration) /p:Platform=x64" WorkingDirectory="../native/pipeline/" />
+    <MSBuild Projects="../native/pipeline/pipeline.sln" Targets="Build" Properties="Configuration=$(Configuration);Platform=x64" />
   </Target>
 
   <Target Name="BuildMGCPU" Condition="'$(DisableNativeBuild)' != 'True' and '$(OS)' != 'Windows_NT'" BeforeTargets="CollectPackageReferences">


### PR DESCRIPTION
For building the pipeline assembly, we can use an MSBuild task directly instead of calling msbuild manually (which may not work if you don't have msbuild on PATH).

cc @harry-cpp 




