### PR TITLE
[CI] Deploy step improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           dotnet run --project build/Build.csproj -- --target=Default
         env:
-          DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT: 1
+          DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT: 1 # android compilation is failing randomly due to downloads from microsofts website during it
 
       - name: Run Tools Tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Build
         run: |
           dotnet run --project build/Build.csproj -- --target=Default
+        env:
+          DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT: 1
 
       - name: Run Tools Tests
         run: |

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -66,7 +66,7 @@ public class BuildContext : FrostingContext
         };
         MSPackSettings.WithProperty(nameof(Version), Version);
         MSPackSettings.WithProperty(nameof(repositoryUrl), repositoryUrl);
-        MSPackSettings.WithProperty("OutputDirectory", NuGetsDirectory.FullPath);
+        MSPackSettings.WithProperty("OutputDirectory", NuGetsDirectory);
         MSPackSettings.WithTarget("Pack");
 
         DotNetPublishSettings = new DotNetPublishSettings
@@ -101,7 +101,7 @@ public class BuildContext : FrostingContext
 
     public string BuildOutput { get; }
 
-    public DirectoryPath NuGetsDirectory { get; }
+    public string NuGetsDirectory { get; }
 
     public DotNetMSBuildSettings DotNetMSBuildSettings { get; }
 
@@ -133,6 +133,16 @@ public class BuildContext : FrostingContext
         _ => throw new ArgumentOutOfRangeException(nameof(type))
     };
 
+    public string GetOutputPath(string path)
+    {
+        if (System.IO.Path.IsPathRooted(path) || path.StartsWith(BuildOutput))
+        {
+            return path;
+        }
+
+        return System.IO.Path.Combine(BuildOutput, path);
+    }
+
     public void Shell(string command, string args)
     {
         if (this.StartProcess(command, new ProcessSettings { WorkingDirectory = ShellWorkingDir, Arguments = args }) != 0)
@@ -156,7 +166,7 @@ public class BuildContext : FrostingContext
         return processOutput.Any(match => match.StartsWith($"{workload} "));
     }
 
-    public static string CalculateVersion(ICakeContext context)
+    private static string CalculateVersion(ICakeContext context)
     {
         var tags = GitAliases.GitTags(context, ".");
         foreach (var tag in tags)

--- a/build/BuildToolsTasks/BuildContentPipelineTask.cs
+++ b/build/BuildToolsTasks/BuildContentPipelineTask.cs
@@ -15,13 +15,13 @@ public sealed class BuildContentPipelineTask : FrostingTask<BuildContext>
         switch (context.Environment.Platform.Family)
         {
             case PlatformFamily.Windows:
-                StaticLibCheck.CheckWindows(context, "Artifacts/native/mgpipeline/windows/Release/mgpipeline.dll");
+                StaticLibCheck.CheckWindows(context, context.GetOutputPath("native/mgpipeline/windows/Release/mgpipeline.dll"));
                 break;
             case PlatformFamily.Linux:
-                StaticLibCheck.CheckLinux(context, "Artifacts/native/mgpipeline/linux/Release/mgpipeline.so");
+                StaticLibCheck.CheckLinux(context, context.GetOutputPath("native/mgpipeline/linux/Release/mgpipeline.so"));
                 break;
             case PlatformFamily.OSX:
-                StaticLibCheck.CheckMacOS(context, "Artifacts/native/mgpipeline/macosx/Release/mgpipeline.dylib");
+                StaticLibCheck.CheckMacOS(context, context.GetOutputPath("native/mgpipeline/macosx/Release/mgpipeline.dylib"));
                 break;
             default:
                 throw new NotSupportedException($"Platform {context.Environment.Platform.Family} is not supported for static library checks.");

--- a/build/DeployTasks/DeployNuGetsToGitHubTask.cs
+++ b/build/DeployTasks/DeployNuGetsToGitHubTask.cs
@@ -3,17 +3,19 @@ namespace BuildScripts;
 
 [TaskName("DeployNuGetsToGithub")]
 [IsDependentOn(typeof(RepackForDeployTask))]
-public sealed class DeployNuGetsToGitHubTask : FrostingTask<BuildContext>
+public sealed class DeployNuGetsToGitHubTask : AsyncFrostingTask<BuildContext>
 {
     public override bool ShouldRun(BuildContext context) => context.BuildSystem().IsRunningOnGitHubActions;
 
-    public override void Run(BuildContext context)
+    public override async Task RunAsync(BuildContext context)
     {
-        var repositoryOwner = context.GitHubActions().Environment.Workflow.RepositoryOwner;
-        context.DotNetNuGetPush($"nugets/*.nupkg", new()
+        var actions = context.GitHubActions();
+        context.Information($"Uploading nugets from {context.NuGetsDirectory}");
+        context.DotNetNuGetPush($"{context.NuGetsDirectory}*.nupkg", new()
         {
             ApiKey = context.EnvironmentVariable("GITHUB_TOKEN"),
-            Source = $"https://nuget.pkg.github.com/{repositoryOwner}/index.json"
+            Source = $"https://nuget.pkg.github.com/{actions.Environment.Workflow.RepositoryOwner}/index.json"
         });
+        await actions.Commands.UploadArtifact(new DirectoryPath(context.NuGetsDirectory), $"nuget-{context.Version}");
     }
 }

--- a/build/DeployTasks/DeployNuGetsToNuGetOrgTask.cs
+++ b/build/DeployTasks/DeployNuGetsToNuGetOrgTask.cs
@@ -22,7 +22,7 @@ public sealed class DeployNuGetsToNuGetOrgTask : FrostingTask<BuildContext>
 
     public override void Run(BuildContext context)
     {
-        context.DotNetNuGetPush($"nugets/*.nupkg", new()
+        context.DotNetNuGetPush($"{context.NuGetsDirectory}*.nupkg", new()
         {
             ApiKey = context.EnvironmentVariable("NUGET_API_KEY"),
             Source = $"https://api.nuget.org/v3/index.json"

--- a/build/DeployTasks/DownloadArtifactsTask.cs
+++ b/build/DeployTasks/DownloadArtifactsTask.cs
@@ -6,21 +6,24 @@ public sealed class DownloadArtifactsTask : AsyncFrostingTask<BuildContext>
 {
     public override bool ShouldRun(BuildContext context) => context.BuildSystem().IsRunningOnGitHubActions;
 
+    private static async Task DownloadArtifactAsync(BuildContext context, string artifactName, string path)
+    {
+        var fullPath = context.GetOutputPath(path);
+        context.Information($"Downloading {artifactName} to {fullPath}");
+        context.CreateDirectory(fullPath);
+        await context.GitHubActions().Commands.DownloadArtifact(artifactName, fullPath);
+    }
+
     public override async Task RunAsync(BuildContext context)
     {
-        var version = BuildContext.CalculateVersion(context);
-        var buildConf = context.Argument("build-configuration", "Release");
-        var mgDir = System.IO.Path.Combine(context.BuildOutput, "mgpipeline", buildConf);
+        await DownloadArtifactAsync(context, $"nuget-windows.{context.Version}", context.NuGetsDirectory);
+        await DownloadArtifactAsync(context, $"nuget-macos.{context.Version}", context.NuGetsDirectory);
+        await DownloadArtifactAsync(context, $"nuget-linux.{context.Version}", context.NuGetsDirectory);
 
-        context.CreateDirectory("nugets");
-        context.CreateDirectory(mgDir);
-        foreach (var os in new[] { "windows", "macos", "linux" })
-        {
-            await context.GitHubActions().Commands.DownloadArtifact($"nuget-{os}.{version}", "nugets");
-            await context.GitHubActions().Commands.DownloadArtifact($"mgpipeline-{os}.{version}", mgDir);
-        }
+        await DownloadArtifactAsync(context, $"mgpipeline-windows.{context.Version}", "native/mgpipeline/windows/Release/");
+        await DownloadArtifactAsync(context, $"mgpipeline-macos.{context.Version}", "native/mgpipeline/macosx/Release/");
+        await DownloadArtifactAsync(context, $"mgpipeline-linux.{context.Version}", "native/mgpipeline/linux/Release/");
 
-        context.CreateDirectory("vsix");
-        await context.GitHubActions().Commands.DownloadArtifact($"MonoGame.Templates.VSExtension.{version}.vsix", "vsix");
+        await DownloadArtifactAsync(context, $"MonoGame.Templates.VSExtension.{context.Version}.vsix", "vsix");
     }
 }

--- a/build/DeployTasks/RepackForDeployTask.cs
+++ b/build/DeployTasks/RepackForDeployTask.cs
@@ -19,6 +19,5 @@ public sealed class RepackForDeployTask : FrostingTask<BuildContext>
         context.DotNetPack(context.GetProjectPath(ProjectType.Tools, "MonoGame.Content.Builder"), context.DotNetPackSettings);
 
         context.DotNetPackSettings.MSBuildSettings.Properties.Remove("DisableNativeBuild");
-        context.CopyDirectory(new DirectoryPath(context.NuGetsDirectory.FullPath), "nugets");
     }
 }

--- a/build/DeployTasks/UploadArtifactsTask.cs
+++ b/build/DeployTasks/UploadArtifactsTask.cs
@@ -42,26 +42,24 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
             DeleteToolStore(context, path);
         }
 
-        var version = BuildContext.CalculateVersion(context);
-
         // Upload mgpipeline native libraries
         switch (context.Environment.Platform.Family)
         {
             case PlatformFamily.Windows:
-                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/windows/Release/"), $"mgpipeline-{os}.{version}");
+                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/windows/Release/"), $"mgpipeline-{os}.{context.Version}");
                 break;
             case PlatformFamily.Linux:
-                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/linux/Release/"), $"mgpipeline-{os}.{version}");
+                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/linux/Release/"), $"mgpipeline-{os}.{context.Version}");
                 break;
             case PlatformFamily.OSX:
-                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/macosx/Release/"), $"mgpipeline-{os}.{version}");
+                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/macosx/Release/"), $"mgpipeline-{os}.{context.Version}");
                 break;
             default:
                 throw new NotSupportedException($"Platform {context.Environment.Platform.Family} is not supported for static library checks.");
         }
 
         // Upload NuGet packages
-        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(context.NuGetsDirectory.FullPath), $"nuget-{os}.{version}");
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(context.NuGetsDirectory), $"nuget-{os}.{context.Version}");
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(System.IO.Path.Combine(context.BuildOutput, "Tests", "DesktopGL", "Release")), $"tests-desktopgl-{os}");
         if (context.IsRunningOnWindows())
         {
@@ -69,7 +67,7 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
 
             // Assuming that the .vsix file has already been created and is located at this exact path.
             var vsixFilePath = System.IO.Path.Combine(context.BuildOutput, "MonoGame.Templates.VSExtension", "net472", "MonoGame.Templates.VSExtension.vsix");
-            await context.GitHubActions().Commands.UploadArtifact(new FilePath(vsixFilePath), $"MonoGame.Templates.VSExtension.{version}.vsix");
+            await context.GitHubActions().Commands.UploadArtifact(new FilePath(vsixFilePath), $"MonoGame.Templates.VSExtension.{context.Version}.vsix");
         }
     }
 


### PR DESCRIPTION
Stuff done:
- Add DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT so that macOS doesn't randomly fail on us as Dean suggested
- Fix nuget preparation on Deploy step not properly including mgpipeline library
- Make deploy step create a nuget artefact containing the combined set of nuget packages for easier testing