### PR TITLE
Improved the .editorconfig as discussed with the contributors.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,35 @@ trim_trailing_whitespace = true
 [*.cs]
 indent_style = space
 indent_size = 4
+
+#XML Summary Errors (prevent malformed summaries)
+dotnet_diagnostic.CS1570.severity = error
+dotnet_diagnostic.CS1571.severity = error
+dotnet_diagnostic.CS1572.severity = error
+dotnet_diagnostic.CS1573.severity = error
+dotnet_diagnostic.CS1574.severity = error
+dotnet_diagnostic.CS1580.severity = error
+
+#Obsolete attributes should have a message
+dotnet_diagnostic.CA1041.severity = error
+
+#Do not declare protected items in a sealed class
+dotnet_diagnostic.CA1047.severity = error
+
+#Declare types in namespaces
+dotnet_diagnostic.CA1050.severity = error
+
+#Specify IFormatProvider in .ToString() methods.
+dotnet_diagnostic.CA1304.severity = warning
+dotnet_diagnostic.CA1305.severity = warning
+
+#Use properties of collections over Linq Enumerable methods
+dotnet_diagnostic.CA1826.severity = warning
+dotnet_diagnostic.CA1827.severity = warning
+dotnet_diagnostic.CA1829.severity = warning
+
+#use StringBuilder.Append(char) for single character strings.
+dotnet_diagnostic.CA1834.severity = warning
+
+#specificy StringComparison for correctness and performance.
+dotnet_diagnostic.CA1319.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -40,5 +40,5 @@ dotnet_diagnostic.CA1829.severity = warning
 #use StringBuilder.Append(char) for single character strings.
 dotnet_diagnostic.CA1834.severity = warning
 
-#specificy StringComparison for correctness and performance.
+#Specify StringComparison for correctness and performance.
 dotnet_diagnostic.CA1319.severity = warning

--- a/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
@@ -66,7 +66,7 @@ internal struct BasisUFormat
 
 
     /// <summary>
-    /// <see cref="SurfaceFormat.ASTC_4x4"/>
+    /// <see cref="SurfaceFormat.Astc4X4Rgba"/>
     /// // Opaque+alpha, ASTC 4x4, alpha channel will be opaque for opaque .basis files. Transcoder uses RGB/RGBA/L/LA modes, void extent, and up to two ([0,47] and [0,255]) endpoint precisions.
     /// </summary>
     public static readonly BasisUFormat Astc_4x4_Rgba = new BasisUFormat(
@@ -214,7 +214,7 @@ internal static class BasisU
     /// <para>
     ///     Convert a <see cref="SurfaceFormat"/> into a <see cref="BasisUFormat"/>.
     ///     Not all surface formats are supported. If the given format is not supported,
-    ///     then this method returns false, and the <see cref="error"/> out param will
+    ///     then this method returns false, and the <paramref name="error"/> out param will
     ///     include an explanation of why the format isn't supported.
     /// </para>
     /// <para>
@@ -222,12 +222,12 @@ internal static class BasisU
     ///     https://github.com/BinomialLLC/basis_universal/blob/master/transcoder/basisu_transcoder.h#L49
     /// </para>
     /// </summary>
-    /// <param name="format"></param>
-    /// <param name="basisUFormat"></param>
-    /// <param name="error"></param>
+    /// <param name="format">The format to retrieve the basis u format for.</param>
+    /// <param name="basisUFormat">The retrieved basis u format</param>
+    /// <param name="error">Error message (only relevant if the method returns <see langword="true" />).</param>
     /// <returns>
     ///     True if the <see cref="BasisUFormat"/> out param has been set.
-    ///     False otherwise, and the <see cref="error"/> out param will include an error message.
+    ///     False otherwise, and the <paramref name="error"/> out param will include an error message.
     /// </returns>
     public static bool TryGetBasisUFormat(SurfaceFormat format, out BasisUFormat basisUFormat, out string error)
     {

--- a/MonoGame.Framework.Content.Pipeline/Utilities/BcnHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/BcnHelpers.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 internal static class BcnUtil
 {
     /// <summary>
-    /// Compress the given <see cref="sourceBitmap"/> to the desired block format <see cref="destinationFormat"/>.
+    /// Compress the given <paramref name="sourceBitmap"/> to the desired block format <paramref name="destinationFormat"/>.
     /// No files will be written to disk, and no external tools are invoked.
     /// </summary>
-    /// <param name="sourceBitmap"></param>
-    /// <param name="destinationFormat"></param>
-    /// <param name="compressedBytes"></param>
+    /// <param name="sourceBitmap">Source bitmap to encode</param>
+    /// <param name="destinationFormat">The format to encode the bitmap with</param>
+    /// <param name="compressedBytes">The resulting encoded bitmap, in the form of a byte array.</param>
     public static void Encode(
         BitmapContent sourceBitmap,
         CompressionFormat destinationFormat,

--- a/MonoGame.Framework.Content.Pipeline/Utilities/CrunchHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/CrunchHelpers.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities
     internal static class CrunchHelpers
     {
         /// <summary>
-        /// This method will use Crunch to compress the <see cref="sourceBitmap"/> into the
+        /// This method will use Crunch to compress the <paramref name="sourceBitmap"/> into the
         /// desired <see cref="CrunchFormat"/>.
         ///
         /// <para>

--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1969,6 +1969,8 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="h">Hue component value from 0.0f to 360.0f</param>
         /// <param name="s">Saturation component</param>
+        /// <param name="max">Returns the highest value of the <see cref="R"/>, <see cref="G"/> and <see cref="B"/> values</param>
+        /// <param name="min">Returns the lowest value of the <see cref="R"/>, <see cref="G"/> and <see cref="B"/> values</param>
         private void ToHS(out float h, out float s, out double max, out double min)
         {
             double r = R / 255f;

--- a/MonoGame.Framework/Graphics/Vertices/ImmutableVertexInputLayout.cs
+++ b/MonoGame.Framework/Graphics/Vertices/ImmutableVertexInputLayout.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
     /// Immutable version of <see cref="VertexInputLayout"/>. Can be used as a key in the
-    /// <see cref="InputLayoutCache"/>.
+    /// input layout cache.
     /// </summary>
     internal sealed class ImmutableVertexInputLayout : VertexInputLayout
     {

--- a/MonoGame.Framework/Graphics/Vertices/VertexBufferBindings.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBufferBindings.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         /// <summary>
         /// Creates an <see cref="ImmutableVertexInputLayout"/> that can be used as a key in the
-        /// <see cref="InputLayoutCache"/>.
+        /// input layout cache.
         /// </summary>
         /// <returns>The <see cref="ImmutableVertexInputLayout"/>.</returns>
         internal ImmutableVertexInputLayout ToImmutable()

--- a/MonoGame.Framework/TextInputEventArgs.cs
+++ b/MonoGame.Framework/TextInputEventArgs.cs
@@ -8,7 +8,7 @@ using Microsoft.Xna.Framework.Input;
 namespace Microsoft.Xna.Framework
 {
     /// <summary>
-    /// This class is used in the <see cref="GameWindow.TextInput"/> event as <see cref="EventArgs"/>.
+    /// This class is used in <see cref="GameWindow"/>'s TextInput event as <see cref="EventArgs"/>.
     /// </summary>
     public struct TextInputEventArgs
     {

--- a/Tools/MonoGame.Tools.Tests/AssetTestClasses.cs
+++ b/Tools/MonoGame.Tools.Tests/AssetTestClasses.cs
@@ -12,7 +12,7 @@ using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 
 // Disable lack of namespace warning for the types used for unit tests.
-#pragma warning disable CA0105
+#pragma warning disable CA1050
 
 #region The Basics
 
@@ -650,3 +650,5 @@ namespace MonoGame.Tests.SomethingElse.ContentPipeline
         public bool Value;
     }
 }
+
+#pragma warning restore CA1050

--- a/Tools/MonoGame.Tools.Tests/AssetTestClasses.cs
+++ b/Tools/MonoGame.Tools.Tests/AssetTestClasses.cs
@@ -11,527 +11,580 @@ using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 
-#region The Basics
-public class TheBasics
+namespace MonoGame.Tests
 {
-    public int PublicField;
-    protected int ProtectedField;
-    private int PrivateField;
-    internal int InternalField;
 
-    public string GetSetProperty
+    #region The Basics
+
+    public class TheBasics
     {
-        get;
-        set;
+        public int PublicField;
+        protected int ProtectedField;
+        private int PrivateField;
+        internal int InternalField;
+
+        public string GetSetProperty { get; set; }
+
+        public string GetOnlyProperty
+        {
+            get { return "Hello World"; }
+        }
+
+        public string SetOnlyProperty { set; private get; }
+
+        public NestedClass Nested;
+        public NestedClass Nested2;
+
+        public TheBasics()
+        {
+            Nested = Nested2 = new NestedClass();
+        }
     }
 
-    public string GetOnlyProperty
+    public class NestedClass
     {
-        get { return "Hello World"; }
+        public string Name;
+        public bool IsEnglish;
     }
 
-    public string SetOnlyProperty { set; private get; }
+    #endregion
 
-    public NestedClass Nested;
-    public NestedClass Nested2;
+    #region Inheritance
 
-    public TheBasics()
+    public class InheritanceBase
     {
-        Nested = Nested2 = new NestedClass();
-    }
-}
-
-public class NestedClass
-{
-    public string Name;
-    public bool IsEnglish;
-}
-#endregion
-
-#region Inheritance
-public class InheritanceBase
-{
-    public int elf;
-}
-
-public class Inheritance : InheritanceBase
-{
-    public string hello;
-}
-#endregion
-
-#region IncludingPrivateMembers
-public class IncludingPrivateMembers
-{
-    public IncludingPrivateMembers()
-    {
+        public int elf;
     }
 
-    public IncludingPrivateMembers(int elf)
+    public class Inheritance : InheritanceBase
     {
-        this.elf = elf;
+        public string hello;
     }
 
-    [ContentSerializer]
-    private int elf; // will be serialized
+    #endregion
 
-    public int GetElfValue()
+    #region IncludingPrivateMembers
+
+    public class IncludingPrivateMembers
     {
-        return elf;
-    }
-}
-#endregion
+        public IncludingPrivateMembers()
+        {
+        }
 
-#region ExcludingPublicMembers
-public class ExcludingPublicMembers
-{
-    [ContentSerializerIgnore]
-    public int elf; // will not be serialized
-}
-#endregion
+        public IncludingPrivateMembers(int elf)
+        {
+            this.elf = elf;
+        }
 
-#region RenamingXmlElements
-public class RenamingXmlElements
-{
-    [ContentSerializer(ElementName = "ShawnSaysHello")]
-    public string hello;
+        [ContentSerializer]
+        private int elf; // will be serialized
 
-    [ContentSerializer(ElementName = "ElvesAreCool")]
-    public int elf;
-
-    [ContentSerializer(ElementName = "Speed")]
-    public float speed;
-
-    [ContentSerializer(ElementName = "Organic")]
-    public bool isOrganic;
-
-    [ContentSerializer(ElementName = "Dimensions")]
-    private Vector2 dimensions;
-
-    public Vector2 Dimensions
-    {
-        get { return dimensions; }
+        public int GetElfValue()
+        {
+            return elf;
+        }
     }
 
-    internal void SetDimensions(Vector2 value)
+    #endregion
+
+    #region ExcludingPublicMembers
+
+    public class ExcludingPublicMembers
     {
-        dimensions = value;
+        [ContentSerializerIgnore]
+        public int elf; // will not be serialized
     }
-}
-#endregion
 
-#region NullReferences
-public class NullReferences
-{
-    public string hello = "world";
-}
-#endregion
+    #endregion
 
-#region OptionalElements
-public class OptionalElements
-{
-    [ContentSerializer(Optional = true)]
-    public string a = null;
+    #region RenamingXmlElements
 
-    public string b = "b";
-
-    [ContentSerializer(Optional = true)]
-    public string c = "c";
-
-    [ContentSerializer(Optional = true)]
-    public CullMode? d = null;
-
-    [ContentSerializer(Optional = true)]
-    public CullMode? e = CullMode.CullClockwiseFace;
-
-    public CullMode? f = CullMode.CullCounterClockwiseFace;
-
-    public CullMode g = CullMode.CullClockwiseFace;
-}
-#endregion
-
-#region AllowNull
-public class AllowNull
-{
-    [ContentSerializer(AllowNull = false)]
-    string a;
-}
-#endregion
-
-#region Collections
-
-public enum CustomEnum
-{
-    Val1,
-    Val2
-}
-
-public class CustomItem
-{
-    public CustomEnum EnumVal;
-}
-
-public class CustomItemBase
-{
-    public double DoubleVal;
-    public Nullable<float> NullableFloatVal;
-}
-
-public class CustomItemInherited : CustomItemBase
-{
-    public char[] CharArrayVal;
-}
-
-public class Collections
-{
-    public string[] StringArray;
-    public List<string> StringList;
-    public int[] IntArray;
-    public Color[] ColorArray;
-    public List<CustomItem> CustomItemList;
-    public List<CustomItemInherited> CustomItemInheritedList;
-
-    // Indexer - should be ignored by intermediate serializer.
-    public Color this[int i]
+    public class RenamingXmlElements
     {
-        get { return ColorArray[i]; }
-        set { ColorArray[i] = value; }
+        [ContentSerializer(ElementName = "ShawnSaysHello")]
+        public string hello;
+
+        [ContentSerializer(ElementName = "ElvesAreCool")]
+        public int elf;
+
+        [ContentSerializer(ElementName = "Speed")]
+        public float speed;
+
+        [ContentSerializer(ElementName = "Organic")]
+        public bool isOrganic;
+
+        [ContentSerializer(ElementName = "Dimensions")]
+        private Vector2 dimensions;
+
+        public Vector2 Dimensions
+        {
+            get { return dimensions; }
+        }
+
+        internal void SetDimensions(Vector2 value)
+        {
+            dimensions = value;
+        }
     }
-}
-#endregion
 
-#region CollectionItemName
-public class CollectionItemName
-{
-    [ContentSerializer(ElementName = "w00t", CollectionItemName = "Flibble")]
-    public string[] StringArray;
-}
-#endregion
+    #endregion
 
-#region Dictionaries
-public class Dictionaries
-{
-    public Dictionary<int, bool> TestDictionary = new Dictionary<int, bool>();
-}
-#endregion
+    #region NullReferences
 
-#region Primitive Types
-public class PrimitiveTypes
-{
-    public char Char;
-    public char Char2;
-    public char Char3;
-    public byte Byte;
-    public sbyte SByte;
-    public short Short;
-    public ushort UShort;
-    public int Int;
-    public uint UInt;
-    public long Long;
-    public ulong ULong;
-    public float Float;
-    public double Double;
-    public char? NullChar;                        
-    public char? NotNullChar;
-}
-#endregion
+    public class NullReferences
+    {
+        public string hello = "world";
+    }
 
-#region MathTypes
-public class MathTypes
-{
-    public Point Point;
-    public Rectangle Rectangle;
-    public Vector2 Vector2;
-    public Vector3 Vector3;
-    public Vector4 Vector4;
-    public Quaternion Quaternion;
-    public Plane Plane;
-    public Matrix Matrix;
-    public Color Color;
-    public Vector2[] Vector2Array = new Vector2[0];
-    public List<Vector2> Vector2List = new List<Vector2>();
-    public List<Vector2> Vector2ListEmpty = new List<Vector2>();
-}
-#endregion
+    #endregion
 
-#region PolymorphicTypes
-public class PolymorphicA
-{
-    public bool Value;
-}
+    #region OptionalElements
 
-public class PolymorphicB : PolymorphicA { }
-public class PolymorphicC : PolymorphicA { }
+    public class OptionalElements
+    {
+        [ContentSerializer(Optional = true)]
+        public string a = null;
 
-public class PolymorphicTypes
-{
-    public object Hello;
-    public object Elf;
-    public PolymorphicA[] TypedArray;
-    public Array UntypedArray;
-    public ICollection<int> IntCollection;
-    public object UntypedDictionary;
-}
-#endregion
+        public string b = "b";
 
-#region FlattenContent
-public class FlattenContent
-{
-    [ContentSerializer(FlattenContent = true)]
-    public NestedClass Nested;
+        [ContentSerializer(Optional = true)]
+        public string c = "c";
 
-    [ContentSerializer(FlattenContent = true, CollectionItemName = "Boo")]
-    public string[] Collection;
-}
-#endregion
+        [ContentSerializer(Optional = true)]
+        public CullMode? d = null;
 
-#region SharedResources
-public class SharedResources
-{
-    [ContentSerializer(SharedResource = true)]
-    public Linked Head;
+        [ContentSerializer(Optional = true)]
+        public CullMode? e = CullMode.CullClockwiseFace;
 
-    public Linked2[] LinkedArray;
-}
+        public CullMode? f = CullMode.CullCounterClockwiseFace;
 
-public class Linked
-{
-    public int Value;
+        public CullMode g = CullMode.CullClockwiseFace;
+    }
 
-    [ContentSerializer(SharedResource = true)]
-    public Linked Next;
-}
+    #endregion
 
-public class Linked2
-{
-    [ContentSerializer(SharedResource = true)]
-    public Linked2[] Next;
-}
+    #region AllowNull
 
-#endregion
+    public class AllowNull
+    {
+        [ContentSerializer(AllowNull = false)]
+        string a;
+    }
 
-#region CircularReferences
-public class CircularReferences
-{
-    public CircularLinked Head;
-}
+    #endregion
 
-public class CircularLinked
-{
-    public int Value;
+    #region Collections
 
-    public CircularLinked Next;
-}
-#endregion
+    public enum CustomEnum
+    {
+        Val1,
+        Val2
+    }
 
-#region ExternalReferences
-public class ExternalReferences
-{
-    public ExternalReference<Texture2D> Texture;
-    public ExternalReference<Texture2D> Texture2;
-    public ExternalReference<Effect> Shader;
-}
-#endregion
+    public class CustomItem
+    {
+        public CustomEnum EnumVal;
+    }
 
-#region FontDescription
-class ExtendedFontDescription : FontDescription
-{
-    public ExtendedFontDescription()
-        : base("Arial", 14, 0)
+    public class CustomItemBase
+    {
+        public double DoubleVal;
+        public Nullable<float> NullableFloatVal;
+    }
+
+    public class CustomItemInherited : CustomItemBase
+    {
+        public char[] CharArrayVal;
+    }
+
+    public class Collections
+    {
+        public string[] StringArray;
+        public List<string> StringList;
+        public int[] IntArray;
+        public Color[] ColorArray;
+        public List<CustomItem> CustomItemList;
+        public List<CustomItemInherited> CustomItemInheritedList;
+
+        // Indexer - should be ignored by intermediate serializer.
+        public Color this[int i]
+        {
+            get { return ColorArray[i]; }
+            set { ColorArray[i] = value; }
+        }
+    }
+
+    #endregion
+
+    #region CollectionItemName
+
+    public class CollectionItemName
+    {
+        [ContentSerializer(ElementName = "w00t", CollectionItemName = "Flibble")]
+        public string[] StringArray;
+    }
+
+    #endregion
+
+    #region Dictionaries
+
+    public class Dictionaries
+    {
+        public Dictionary<int, bool> TestDictionary = new Dictionary<int, bool>();
+    }
+
+    #endregion
+
+    #region Primitive Types
+
+    public class PrimitiveTypes
+    {
+        public char Char;
+        public char Char2;
+        public char Char3;
+        public byte Byte;
+        public sbyte SByte;
+        public short Short;
+        public ushort UShort;
+        public int Int;
+        public uint UInt;
+        public long Long;
+        public ulong ULong;
+        public float Float;
+        public double Double;
+        public char? NullChar;
+        public char? NotNullChar;
+    }
+
+    #endregion
+
+    #region MathTypes
+
+    public class MathTypes
+    {
+        public Point Point;
+        public Rectangle Rectangle;
+        public Vector2 Vector2;
+        public Vector3 Vector3;
+        public Vector4 Vector4;
+        public Quaternion Quaternion;
+        public Plane Plane;
+        public Matrix Matrix;
+        public Color Color;
+        public Vector2[] Vector2Array = new Vector2[0];
+        public List<Vector2> Vector2List = new List<Vector2>();
+        public List<Vector2> Vector2ListEmpty = new List<Vector2>();
+    }
+
+    #endregion
+
+    #region PolymorphicTypes
+
+    public class PolymorphicA
+    {
+        public bool Value;
+    }
+
+    public class PolymorphicB : PolymorphicA
     {
     }
 
-    [ContentSerializer(Optional = true, CollectionItemName = "Item")]
-    public List<string> ExtendedListProperty
-    {
-        get { return _list; }
-    }
-
-    private List<string> _list = new List<string>();
-}
-#endregion
-
-#region SystemTypes
-class SystemTypes
-{
-    public TimeSpan TimeSpan;
-}
-#endregion
-
-#region GetterOnlyProperties
-class GetterOnlyProperties
-{
-    private readonly List<int> _intList;
-    private readonly Dictionary<int, string> _intStringDictionary;
-    private readonly AnotherClass _customClass;
-    private readonly AnotherClass[] _customClassArray;
-    private readonly AnotherStruct _customStruct;
-
-    public int IntValue
-    {
-        get { return 0; }
-    }
-
-    public Vector2 Dimensions
-    {
-        get { return new Vector2(16, 16); }
-    }
-
-    public List<int> IntList
-    {
-        get { return _intList; }
-    }
-
-    public Dictionary<int, string> IntStringDictionaryWithPrivateSetter { get; private set; }
-
-    public Dictionary<int, string> IntStringDictionary
-    {
-        get { return _intStringDictionary; }
-    }
-
-    public class AnotherClass
-    {
-        public int A;
-    }
-
-    public AnotherClass CustomClass
-    {
-        get { return _customClass; }
-    }
-
-    public object UntypedCustomClass
-    {
-        get { return _customClass; }
-    }
-
-    public AnotherClass[] CustomClassArray
-    {
-        get { return _customClassArray; }
-    }
-
-    public object UntypedCustomClassArray
-    {
-        get { return _customClassArray; }
-    }
-
-    public struct AnotherStruct
-    {
-        public int A;
-    }
-
-    public AnotherStruct CustomStruct
-    {
-        get { return _customStruct; }
-    }
-
-    public GetterOnlyProperties()
-    {
-        _intList = new List<int>();
-        IntStringDictionaryWithPrivateSetter = new Dictionary<int, string>();
-        _intStringDictionary = new Dictionary<int, string>();
-        _customClass = new AnotherClass();
-        _customClassArray = new [] { new AnotherClass { A = 42 } };
-        _customStruct = new AnotherStruct();
-    }
-}
-#endregion
-
-#region GetterOnlyPolymorphicArrayProperties
-class GetterOnlyPolymorphicArrayProperties
-{
-    private readonly AnotherClass[] _customClassArray;
-
-    public class AnotherClass
-    {
-        public int A;
-    }
-
-    public IList CustomClassArrayAsIList
-    {
-        get { return _customClassArray; }
-    }
-
-    public GetterOnlyPolymorphicArrayProperties()
-    {
-        _customClassArray = new[] { new AnotherClass { A = 42 } };
-    }
-}
-#endregion
-
-#region GenericTypes
-class GenericTypes
-{
-    public GenericClass<int> A;
-    public GenericClass<float> B;
-    public GenericClass<GenericArg> C;
-}
-
-class GenericClass<T>
-{
-    public T Value;
-}
-public class GenericArg
-{
-    public int Value;
-}
-#endregion
-
-#region ChildCollections
-public class ChildCollections
-{
-    private readonly ChildrenCollection _children;
-
-    [ContentSerializer]
-    public ChildrenCollection Children
-    {
-        get { return _children; }
-    }
-
-    public ChildCollections()
-    {
-        _children = new ChildrenCollection(this);
-    }
-}
-
-public class ChildrenCollection : ChildCollection<ChildCollections, ChildCollectionChild>
-{
-    public ChildrenCollection(ChildCollections parent) : base(parent)
+    public class PolymorphicC : PolymorphicA
     {
     }
 
-    protected override ChildCollections GetParent(ChildCollectionChild child)
+    public class PolymorphicTypes
     {
-        return child.Parent;
+        public object Hello;
+        public object Elf;
+        public PolymorphicA[] TypedArray;
+        public Array UntypedArray;
+        public ICollection<int> IntCollection;
+        public object UntypedDictionary;
     }
 
-    protected override void SetParent(ChildCollectionChild child, ChildCollections parent)
+    #endregion
+
+    #region FlattenContent
+
+    public class FlattenContent
     {
-        child.Parent = parent;
+        [ContentSerializer(FlattenContent = true)]
+        public NestedClass Nested;
+
+        [ContentSerializer(FlattenContent = true, CollectionItemName = "Boo")]
+        public string[] Collection;
     }
-}
 
-public class ChildCollectionChild : ContentItem
-{
-    [ContentSerializerIgnore]
-    public ChildCollections Parent { get; set; }
-}
-#endregion
+    #endregion
 
-#region Colors
-public class Colors
-{
-    public Color White { get; set; }
-    public Color Black { get; set; }
-    public Color Transparent { get; set; }
-    public Color Red { get; set; }
-    public Color Green { get; set; }
-    public Color Blue { get; set; }
-}
-#endregion
+    #region SharedResources
 
-class StructArrayNoElements
-{
-    public Vector2[] Vector2ArrayNoElements = new Vector2[] {};
+    public class SharedResources
+    {
+        [ContentSerializer(SharedResource = true)]
+        public Linked Head;
+
+        public Linked2[] LinkedArray;
+    }
+
+    public class Linked
+    {
+        public int Value;
+
+        [ContentSerializer(SharedResource = true)]
+        public Linked Next;
+    }
+
+    public class Linked2
+    {
+        [ContentSerializer(SharedResource = true)]
+        public Linked2[] Next;
+    }
+
+    #endregion
+
+    #region CircularReferences
+
+    public class CircularReferences
+    {
+        public CircularLinked Head;
+    }
+
+    public class CircularLinked
+    {
+        public int Value;
+
+        public CircularLinked Next;
+    }
+
+    #endregion
+
+    #region ExternalReferences
+
+    public class ExternalReferences
+    {
+        public ExternalReference<Texture2D> Texture;
+        public ExternalReference<Texture2D> Texture2;
+        public ExternalReference<Effect> Shader;
+    }
+
+    #endregion
+
+    #region FontDescription
+
+    class ExtendedFontDescription : FontDescription
+    {
+        public ExtendedFontDescription() : base("Arial", 14, 0)
+        {
+        }
+
+        [ContentSerializer(Optional = true, CollectionItemName = "Item")]
+        public List<string> ExtendedListProperty
+        {
+            get { return _list; }
+        }
+
+        private List<string> _list = new List<string>();
+    }
+
+    #endregion
+
+    #region SystemTypes
+
+    class SystemTypes
+    {
+        public TimeSpan TimeSpan;
+    }
+
+    #endregion
+
+    #region GetterOnlyProperties
+
+    class GetterOnlyProperties
+    {
+        private readonly List<int> _intList;
+        private readonly Dictionary<int, string> _intStringDictionary;
+        private readonly AnotherClass _customClass;
+        private readonly AnotherClass[] _customClassArray;
+        private readonly AnotherStruct _customStruct;
+
+        public int IntValue
+        {
+            get { return 0; }
+        }
+
+        public Vector2 Dimensions
+        {
+            get { return new Vector2(16, 16); }
+        }
+
+        public List<int> IntList
+        {
+            get { return _intList; }
+        }
+
+        public Dictionary<int, string> IntStringDictionaryWithPrivateSetter { get; private set; }
+
+        public Dictionary<int, string> IntStringDictionary
+        {
+            get { return _intStringDictionary; }
+        }
+
+        public class AnotherClass
+        {
+            public int A;
+        }
+
+        public AnotherClass CustomClass
+        {
+            get { return _customClass; }
+        }
+
+        public object UntypedCustomClass
+        {
+            get { return _customClass; }
+        }
+
+        public AnotherClass[] CustomClassArray
+        {
+            get { return _customClassArray; }
+        }
+
+        public object UntypedCustomClassArray
+        {
+            get { return _customClassArray; }
+        }
+
+        public struct AnotherStruct
+        {
+            public int A;
+        }
+
+        public AnotherStruct CustomStruct
+        {
+            get { return _customStruct; }
+        }
+
+        public GetterOnlyProperties()
+        {
+            _intList = new List<int>();
+            IntStringDictionaryWithPrivateSetter = new Dictionary<int, string>();
+            _intStringDictionary = new Dictionary<int, string>();
+            _customClass = new AnotherClass();
+            _customClassArray = new[] { new AnotherClass { A = 42 } };
+            _customStruct = new AnotherStruct();
+        }
+    }
+
+    #endregion
+
+    #region GetterOnlyPolymorphicArrayProperties
+
+    class GetterOnlyPolymorphicArrayProperties
+    {
+        private readonly AnotherClass[] _customClassArray;
+
+        public class AnotherClass
+        {
+            public int A;
+        }
+
+        public IList CustomClassArrayAsIList
+        {
+            get { return _customClassArray; }
+        }
+
+        public GetterOnlyPolymorphicArrayProperties()
+        {
+            _customClassArray = new[] { new AnotherClass { A = 42 } };
+        }
+    }
+
+    #endregion
+
+    #region GenericTypes
+
+    class GenericTypes
+    {
+        public GenericClass<int> A;
+        public GenericClass<float> B;
+        public GenericClass<GenericArg> C;
+    }
+
+    class GenericClass<T>
+    {
+        public T Value;
+    }
+
+    public class GenericArg
+    {
+        public int Value;
+    }
+
+    #endregion
+
+    #region ChildCollections
+
+    public class ChildCollections
+    {
+        private readonly ChildrenCollection _children;
+
+        [ContentSerializer]
+        public ChildrenCollection Children
+        {
+            get { return _children; }
+        }
+
+        public ChildCollections()
+        {
+            _children = new ChildrenCollection(this);
+        }
+    }
+
+    public class ChildrenCollection : ChildCollection<ChildCollections, ChildCollectionChild>
+    {
+        public ChildrenCollection(ChildCollections parent) : base(parent)
+        {
+        }
+
+        protected override ChildCollections GetParent(ChildCollectionChild child)
+        {
+            return child.Parent;
+        }
+
+        protected override void SetParent(ChildCollectionChild child, ChildCollections parent)
+        {
+            child.Parent = parent;
+        }
+    }
+
+    public class ChildCollectionChild : ContentItem
+    {
+        [ContentSerializerIgnore]
+        public ChildCollections Parent { get; set; }
+    }
+
+    #endregion
+
+    #region Colors
+
+    public class Colors
+    {
+        public Color White { get; set; }
+        public Color Black { get; set; }
+        public Color Transparent { get; set; }
+        public Color Red { get; set; }
+        public Color Green { get; set; }
+        public Color Blue { get; set; }
+    }
+
+    #endregion
+
+    class StructArrayNoElements
+    {
+        public Vector2[] Vector2ArrayNoElements = new Vector2[] { };
+    }
 }
 
 namespace MonoGame.Tests.ContentPipeline

--- a/Tools/MonoGame.Tools.Tests/AssetTestClasses.cs
+++ b/Tools/MonoGame.Tools.Tests/AssetTestClasses.cs
@@ -11,581 +11,581 @@ using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 
-namespace MonoGame.Tests
+// Disable lack of namespace warning for the types used for unit tests.
+#pragma warning disable CA0105
+
+#region The Basics
+
+public class TheBasics
 {
+    public int PublicField;
+    protected int ProtectedField;
+    private int PrivateField;
+    internal int InternalField;
 
-    #region The Basics
+    public string GetSetProperty { get; set; }
 
-    public class TheBasics
+    public string GetOnlyProperty
     {
-        public int PublicField;
-        protected int ProtectedField;
-        private int PrivateField;
-        internal int InternalField;
-
-        public string GetSetProperty { get; set; }
-
-        public string GetOnlyProperty
-        {
-            get { return "Hello World"; }
-        }
-
-        public string SetOnlyProperty { set; private get; }
-
-        public NestedClass Nested;
-        public NestedClass Nested2;
-
-        public TheBasics()
-        {
-            Nested = Nested2 = new NestedClass();
-        }
+        get { return "Hello World"; }
     }
 
-    public class NestedClass
+    public string SetOnlyProperty { set; private get; }
+
+    public NestedClass Nested;
+    public NestedClass Nested2;
+
+    public TheBasics()
     {
-        public string Name;
-        public bool IsEnglish;
-    }
-
-    #endregion
-
-    #region Inheritance
-
-    public class InheritanceBase
-    {
-        public int elf;
-    }
-
-    public class Inheritance : InheritanceBase
-    {
-        public string hello;
-    }
-
-    #endregion
-
-    #region IncludingPrivateMembers
-
-    public class IncludingPrivateMembers
-    {
-        public IncludingPrivateMembers()
-        {
-        }
-
-        public IncludingPrivateMembers(int elf)
-        {
-            this.elf = elf;
-        }
-
-        [ContentSerializer]
-        private int elf; // will be serialized
-
-        public int GetElfValue()
-        {
-            return elf;
-        }
-    }
-
-    #endregion
-
-    #region ExcludingPublicMembers
-
-    public class ExcludingPublicMembers
-    {
-        [ContentSerializerIgnore]
-        public int elf; // will not be serialized
-    }
-
-    #endregion
-
-    #region RenamingXmlElements
-
-    public class RenamingXmlElements
-    {
-        [ContentSerializer(ElementName = "ShawnSaysHello")]
-        public string hello;
-
-        [ContentSerializer(ElementName = "ElvesAreCool")]
-        public int elf;
-
-        [ContentSerializer(ElementName = "Speed")]
-        public float speed;
-
-        [ContentSerializer(ElementName = "Organic")]
-        public bool isOrganic;
-
-        [ContentSerializer(ElementName = "Dimensions")]
-        private Vector2 dimensions;
-
-        public Vector2 Dimensions
-        {
-            get { return dimensions; }
-        }
-
-        internal void SetDimensions(Vector2 value)
-        {
-            dimensions = value;
-        }
-    }
-
-    #endregion
-
-    #region NullReferences
-
-    public class NullReferences
-    {
-        public string hello = "world";
-    }
-
-    #endregion
-
-    #region OptionalElements
-
-    public class OptionalElements
-    {
-        [ContentSerializer(Optional = true)]
-        public string a = null;
-
-        public string b = "b";
-
-        [ContentSerializer(Optional = true)]
-        public string c = "c";
-
-        [ContentSerializer(Optional = true)]
-        public CullMode? d = null;
-
-        [ContentSerializer(Optional = true)]
-        public CullMode? e = CullMode.CullClockwiseFace;
-
-        public CullMode? f = CullMode.CullCounterClockwiseFace;
-
-        public CullMode g = CullMode.CullClockwiseFace;
-    }
-
-    #endregion
-
-    #region AllowNull
-
-    public class AllowNull
-    {
-        [ContentSerializer(AllowNull = false)]
-        string a;
-    }
-
-    #endregion
-
-    #region Collections
-
-    public enum CustomEnum
-    {
-        Val1,
-        Val2
-    }
-
-    public class CustomItem
-    {
-        public CustomEnum EnumVal;
-    }
-
-    public class CustomItemBase
-    {
-        public double DoubleVal;
-        public Nullable<float> NullableFloatVal;
-    }
-
-    public class CustomItemInherited : CustomItemBase
-    {
-        public char[] CharArrayVal;
-    }
-
-    public class Collections
-    {
-        public string[] StringArray;
-        public List<string> StringList;
-        public int[] IntArray;
-        public Color[] ColorArray;
-        public List<CustomItem> CustomItemList;
-        public List<CustomItemInherited> CustomItemInheritedList;
-
-        // Indexer - should be ignored by intermediate serializer.
-        public Color this[int i]
-        {
-            get { return ColorArray[i]; }
-            set { ColorArray[i] = value; }
-        }
-    }
-
-    #endregion
-
-    #region CollectionItemName
-
-    public class CollectionItemName
-    {
-        [ContentSerializer(ElementName = "w00t", CollectionItemName = "Flibble")]
-        public string[] StringArray;
-    }
-
-    #endregion
-
-    #region Dictionaries
-
-    public class Dictionaries
-    {
-        public Dictionary<int, bool> TestDictionary = new Dictionary<int, bool>();
-    }
-
-    #endregion
-
-    #region Primitive Types
-
-    public class PrimitiveTypes
-    {
-        public char Char;
-        public char Char2;
-        public char Char3;
-        public byte Byte;
-        public sbyte SByte;
-        public short Short;
-        public ushort UShort;
-        public int Int;
-        public uint UInt;
-        public long Long;
-        public ulong ULong;
-        public float Float;
-        public double Double;
-        public char? NullChar;
-        public char? NotNullChar;
-    }
-
-    #endregion
-
-    #region MathTypes
-
-    public class MathTypes
-    {
-        public Point Point;
-        public Rectangle Rectangle;
-        public Vector2 Vector2;
-        public Vector3 Vector3;
-        public Vector4 Vector4;
-        public Quaternion Quaternion;
-        public Plane Plane;
-        public Matrix Matrix;
-        public Color Color;
-        public Vector2[] Vector2Array = new Vector2[0];
-        public List<Vector2> Vector2List = new List<Vector2>();
-        public List<Vector2> Vector2ListEmpty = new List<Vector2>();
-    }
-
-    #endregion
-
-    #region PolymorphicTypes
-
-    public class PolymorphicA
-    {
-        public bool Value;
-    }
-
-    public class PolymorphicB : PolymorphicA
-    {
-    }
-
-    public class PolymorphicC : PolymorphicA
-    {
-    }
-
-    public class PolymorphicTypes
-    {
-        public object Hello;
-        public object Elf;
-        public PolymorphicA[] TypedArray;
-        public Array UntypedArray;
-        public ICollection<int> IntCollection;
-        public object UntypedDictionary;
-    }
-
-    #endregion
-
-    #region FlattenContent
-
-    public class FlattenContent
-    {
-        [ContentSerializer(FlattenContent = true)]
-        public NestedClass Nested;
-
-        [ContentSerializer(FlattenContent = true, CollectionItemName = "Boo")]
-        public string[] Collection;
-    }
-
-    #endregion
-
-    #region SharedResources
-
-    public class SharedResources
-    {
-        [ContentSerializer(SharedResource = true)]
-        public Linked Head;
-
-        public Linked2[] LinkedArray;
-    }
-
-    public class Linked
-    {
-        public int Value;
-
-        [ContentSerializer(SharedResource = true)]
-        public Linked Next;
-    }
-
-    public class Linked2
-    {
-        [ContentSerializer(SharedResource = true)]
-        public Linked2[] Next;
-    }
-
-    #endregion
-
-    #region CircularReferences
-
-    public class CircularReferences
-    {
-        public CircularLinked Head;
-    }
-
-    public class CircularLinked
-    {
-        public int Value;
-
-        public CircularLinked Next;
-    }
-
-    #endregion
-
-    #region ExternalReferences
-
-    public class ExternalReferences
-    {
-        public ExternalReference<Texture2D> Texture;
-        public ExternalReference<Texture2D> Texture2;
-        public ExternalReference<Effect> Shader;
-    }
-
-    #endregion
-
-    #region FontDescription
-
-    class ExtendedFontDescription : FontDescription
-    {
-        public ExtendedFontDescription() : base("Arial", 14, 0)
-        {
-        }
-
-        [ContentSerializer(Optional = true, CollectionItemName = "Item")]
-        public List<string> ExtendedListProperty
-        {
-            get { return _list; }
-        }
-
-        private List<string> _list = new List<string>();
-    }
-
-    #endregion
-
-    #region SystemTypes
-
-    class SystemTypes
-    {
-        public TimeSpan TimeSpan;
-    }
-
-    #endregion
-
-    #region GetterOnlyProperties
-
-    class GetterOnlyProperties
-    {
-        private readonly List<int> _intList;
-        private readonly Dictionary<int, string> _intStringDictionary;
-        private readonly AnotherClass _customClass;
-        private readonly AnotherClass[] _customClassArray;
-        private readonly AnotherStruct _customStruct;
-
-        public int IntValue
-        {
-            get { return 0; }
-        }
-
-        public Vector2 Dimensions
-        {
-            get { return new Vector2(16, 16); }
-        }
-
-        public List<int> IntList
-        {
-            get { return _intList; }
-        }
-
-        public Dictionary<int, string> IntStringDictionaryWithPrivateSetter { get; private set; }
-
-        public Dictionary<int, string> IntStringDictionary
-        {
-            get { return _intStringDictionary; }
-        }
-
-        public class AnotherClass
-        {
-            public int A;
-        }
-
-        public AnotherClass CustomClass
-        {
-            get { return _customClass; }
-        }
-
-        public object UntypedCustomClass
-        {
-            get { return _customClass; }
-        }
-
-        public AnotherClass[] CustomClassArray
-        {
-            get { return _customClassArray; }
-        }
-
-        public object UntypedCustomClassArray
-        {
-            get { return _customClassArray; }
-        }
-
-        public struct AnotherStruct
-        {
-            public int A;
-        }
-
-        public AnotherStruct CustomStruct
-        {
-            get { return _customStruct; }
-        }
-
-        public GetterOnlyProperties()
-        {
-            _intList = new List<int>();
-            IntStringDictionaryWithPrivateSetter = new Dictionary<int, string>();
-            _intStringDictionary = new Dictionary<int, string>();
-            _customClass = new AnotherClass();
-            _customClassArray = new[] { new AnotherClass { A = 42 } };
-            _customStruct = new AnotherStruct();
-        }
-    }
-
-    #endregion
-
-    #region GetterOnlyPolymorphicArrayProperties
-
-    class GetterOnlyPolymorphicArrayProperties
-    {
-        private readonly AnotherClass[] _customClassArray;
-
-        public class AnotherClass
-        {
-            public int A;
-        }
-
-        public IList CustomClassArrayAsIList
-        {
-            get { return _customClassArray; }
-        }
-
-        public GetterOnlyPolymorphicArrayProperties()
-        {
-            _customClassArray = new[] { new AnotherClass { A = 42 } };
-        }
-    }
-
-    #endregion
-
-    #region GenericTypes
-
-    class GenericTypes
-    {
-        public GenericClass<int> A;
-        public GenericClass<float> B;
-        public GenericClass<GenericArg> C;
-    }
-
-    class GenericClass<T>
-    {
-        public T Value;
-    }
-
-    public class GenericArg
-    {
-        public int Value;
-    }
-
-    #endregion
-
-    #region ChildCollections
-
-    public class ChildCollections
-    {
-        private readonly ChildrenCollection _children;
-
-        [ContentSerializer]
-        public ChildrenCollection Children
-        {
-            get { return _children; }
-        }
-
-        public ChildCollections()
-        {
-            _children = new ChildrenCollection(this);
-        }
-    }
-
-    public class ChildrenCollection : ChildCollection<ChildCollections, ChildCollectionChild>
-    {
-        public ChildrenCollection(ChildCollections parent) : base(parent)
-        {
-        }
-
-        protected override ChildCollections GetParent(ChildCollectionChild child)
-        {
-            return child.Parent;
-        }
-
-        protected override void SetParent(ChildCollectionChild child, ChildCollections parent)
-        {
-            child.Parent = parent;
-        }
-    }
-
-    public class ChildCollectionChild : ContentItem
-    {
-        [ContentSerializerIgnore]
-        public ChildCollections Parent { get; set; }
-    }
-
-    #endregion
-
-    #region Colors
-
-    public class Colors
-    {
-        public Color White { get; set; }
-        public Color Black { get; set; }
-        public Color Transparent { get; set; }
-        public Color Red { get; set; }
-        public Color Green { get; set; }
-        public Color Blue { get; set; }
-    }
-
-    #endregion
-
-    class StructArrayNoElements
-    {
-        public Vector2[] Vector2ArrayNoElements = new Vector2[] { };
+        Nested = Nested2 = new NestedClass();
     }
 }
+
+public class NestedClass
+{
+    public string Name;
+    public bool IsEnglish;
+}
+
+#endregion
+
+#region Inheritance
+
+public class InheritanceBase
+{
+    public int elf;
+}
+
+public class Inheritance : InheritanceBase
+{
+    public string hello;
+}
+
+#endregion
+
+#region IncludingPrivateMembers
+
+public class IncludingPrivateMembers
+{
+    public IncludingPrivateMembers()
+    {
+    }
+
+    public IncludingPrivateMembers(int elf)
+    {
+        this.elf = elf;
+    }
+
+    [ContentSerializer]
+    private int elf; // will be serialized
+
+    public int GetElfValue()
+    {
+        return elf;
+    }
+}
+
+#endregion
+
+#region ExcludingPublicMembers
+
+public class ExcludingPublicMembers
+{
+    [ContentSerializerIgnore]
+    public int elf; // will not be serialized
+}
+
+#endregion
+
+#region RenamingXmlElements
+
+public class RenamingXmlElements
+{
+    [ContentSerializer(ElementName = "ShawnSaysHello")]
+    public string hello;
+
+    [ContentSerializer(ElementName = "ElvesAreCool")]
+    public int elf;
+
+    [ContentSerializer(ElementName = "Speed")]
+    public float speed;
+
+    [ContentSerializer(ElementName = "Organic")]
+    public bool isOrganic;
+
+    [ContentSerializer(ElementName = "Dimensions")]
+    private Vector2 dimensions;
+
+    public Vector2 Dimensions
+    {
+        get { return dimensions; }
+    }
+
+    internal void SetDimensions(Vector2 value)
+    {
+        dimensions = value;
+    }
+}
+
+#endregion
+
+#region NullReferences
+
+public class NullReferences
+{
+    public string hello = "world";
+}
+
+#endregion
+
+#region OptionalElements
+
+public class OptionalElements
+{
+    [ContentSerializer(Optional = true)]
+    public string a = null;
+
+    public string b = "b";
+
+    [ContentSerializer(Optional = true)]
+    public string c = "c";
+
+    [ContentSerializer(Optional = true)]
+    public CullMode? d = null;
+
+    [ContentSerializer(Optional = true)]
+    public CullMode? e = CullMode.CullClockwiseFace;
+
+    public CullMode? f = CullMode.CullCounterClockwiseFace;
+
+    public CullMode g = CullMode.CullClockwiseFace;
+}
+
+#endregion
+
+#region AllowNull
+
+public class AllowNull
+{
+    [ContentSerializer(AllowNull = false)]
+    string a;
+}
+
+#endregion
+
+#region Collections
+
+public enum CustomEnum
+{
+    Val1,
+    Val2
+}
+
+public class CustomItem
+{
+    public CustomEnum EnumVal;
+}
+
+public class CustomItemBase
+{
+    public double DoubleVal;
+    public Nullable<float> NullableFloatVal;
+}
+
+public class CustomItemInherited : CustomItemBase
+{
+    public char[] CharArrayVal;
+}
+
+public class Collections
+{
+    public string[] StringArray;
+    public List<string> StringList;
+    public int[] IntArray;
+    public Color[] ColorArray;
+    public List<CustomItem> CustomItemList;
+    public List<CustomItemInherited> CustomItemInheritedList;
+
+    // Indexer - should be ignored by intermediate serializer.
+    public Color this[int i]
+    {
+        get { return ColorArray[i]; }
+        set { ColorArray[i] = value; }
+    }
+}
+
+#endregion
+
+#region CollectionItemName
+
+public class CollectionItemName
+{
+    [ContentSerializer(ElementName = "w00t", CollectionItemName = "Flibble")]
+    public string[] StringArray;
+}
+
+#endregion
+
+#region Dictionaries
+
+public class Dictionaries
+{
+    public Dictionary<int, bool> TestDictionary = new Dictionary<int, bool>();
+}
+
+#endregion
+
+#region Primitive Types
+
+public class PrimitiveTypes
+{
+    public char Char;
+    public char Char2;
+    public char Char3;
+    public byte Byte;
+    public sbyte SByte;
+    public short Short;
+    public ushort UShort;
+    public int Int;
+    public uint UInt;
+    public long Long;
+    public ulong ULong;
+    public float Float;
+    public double Double;
+    public char? NullChar;
+    public char? NotNullChar;
+}
+
+#endregion
+
+#region MathTypes
+
+public class MathTypes
+{
+    public Point Point;
+    public Rectangle Rectangle;
+    public Vector2 Vector2;
+    public Vector3 Vector3;
+    public Vector4 Vector4;
+    public Quaternion Quaternion;
+    public Plane Plane;
+    public Matrix Matrix;
+    public Color Color;
+    public Vector2[] Vector2Array = new Vector2[0];
+    public List<Vector2> Vector2List = new List<Vector2>();
+    public List<Vector2> Vector2ListEmpty = new List<Vector2>();
+}
+
+#endregion
+
+#region PolymorphicTypes
+
+public class PolymorphicA
+{
+    public bool Value;
+}
+
+public class PolymorphicB : PolymorphicA
+{
+}
+
+public class PolymorphicC : PolymorphicA
+{
+}
+
+public class PolymorphicTypes
+{
+    public object Hello;
+    public object Elf;
+    public PolymorphicA[] TypedArray;
+    public Array UntypedArray;
+    public ICollection<int> IntCollection;
+    public object UntypedDictionary;
+}
+
+#endregion
+
+#region FlattenContent
+
+public class FlattenContent
+{
+    [ContentSerializer(FlattenContent = true)]
+    public NestedClass Nested;
+
+    [ContentSerializer(FlattenContent = true, CollectionItemName = "Boo")]
+    public string[] Collection;
+}
+
+#endregion
+
+#region SharedResources
+
+public class SharedResources
+{
+    [ContentSerializer(SharedResource = true)]
+    public Linked Head;
+
+    public Linked2[] LinkedArray;
+}
+
+public class Linked
+{
+    public int Value;
+
+    [ContentSerializer(SharedResource = true)]
+    public Linked Next;
+}
+
+public class Linked2
+{
+    [ContentSerializer(SharedResource = true)]
+    public Linked2[] Next;
+}
+
+#endregion
+
+#region CircularReferences
+
+public class CircularReferences
+{
+    public CircularLinked Head;
+}
+
+public class CircularLinked
+{
+    public int Value;
+
+    public CircularLinked Next;
+}
+
+#endregion
+
+#region ExternalReferences
+
+public class ExternalReferences
+{
+    public ExternalReference<Texture2D> Texture;
+    public ExternalReference<Texture2D> Texture2;
+    public ExternalReference<Effect> Shader;
+}
+
+#endregion
+
+#region FontDescription
+
+class ExtendedFontDescription : FontDescription
+{
+    public ExtendedFontDescription() : base("Arial", 14, 0)
+    {
+    }
+
+    [ContentSerializer(Optional = true, CollectionItemName = "Item")]
+    public List<string> ExtendedListProperty
+    {
+        get { return _list; }
+    }
+
+    private List<string> _list = new List<string>();
+}
+
+#endregion
+
+#region SystemTypes
+
+class SystemTypes
+{
+    public TimeSpan TimeSpan;
+}
+
+#endregion
+
+#region GetterOnlyProperties
+
+class GetterOnlyProperties
+{
+    private readonly List<int> _intList;
+    private readonly Dictionary<int, string> _intStringDictionary;
+    private readonly AnotherClass _customClass;
+    private readonly AnotherClass[] _customClassArray;
+    private readonly AnotherStruct _customStruct;
+
+    public int IntValue
+    {
+        get { return 0; }
+    }
+
+    public Vector2 Dimensions
+    {
+        get { return new Vector2(16, 16); }
+    }
+
+    public List<int> IntList
+    {
+        get { return _intList; }
+    }
+
+    public Dictionary<int, string> IntStringDictionaryWithPrivateSetter { get; private set; }
+
+    public Dictionary<int, string> IntStringDictionary
+    {
+        get { return _intStringDictionary; }
+    }
+
+    public class AnotherClass
+    {
+        public int A;
+    }
+
+    public AnotherClass CustomClass
+    {
+        get { return _customClass; }
+    }
+
+    public object UntypedCustomClass
+    {
+        get { return _customClass; }
+    }
+
+    public AnotherClass[] CustomClassArray
+    {
+        get { return _customClassArray; }
+    }
+
+    public object UntypedCustomClassArray
+    {
+        get { return _customClassArray; }
+    }
+
+    public struct AnotherStruct
+    {
+        public int A;
+    }
+
+    public AnotherStruct CustomStruct
+    {
+        get { return _customStruct; }
+    }
+
+    public GetterOnlyProperties()
+    {
+        _intList = new List<int>();
+        IntStringDictionaryWithPrivateSetter = new Dictionary<int, string>();
+        _intStringDictionary = new Dictionary<int, string>();
+        _customClass = new AnotherClass();
+        _customClassArray = new[] { new AnotherClass { A = 42 } };
+        _customStruct = new AnotherStruct();
+    }
+}
+
+#endregion
+
+#region GetterOnlyPolymorphicArrayProperties
+
+class GetterOnlyPolymorphicArrayProperties
+{
+    private readonly AnotherClass[] _customClassArray;
+
+    public class AnotherClass
+    {
+        public int A;
+    }
+
+    public IList CustomClassArrayAsIList
+    {
+        get { return _customClassArray; }
+    }
+
+    public GetterOnlyPolymorphicArrayProperties()
+    {
+        _customClassArray = new[] { new AnotherClass { A = 42 } };
+    }
+}
+
+#endregion
+
+#region GenericTypes
+
+class GenericTypes
+{
+    public GenericClass<int> A;
+    public GenericClass<float> B;
+    public GenericClass<GenericArg> C;
+}
+
+class GenericClass<T>
+{
+    public T Value;
+}
+
+public class GenericArg
+{
+    public int Value;
+}
+
+#endregion
+
+#region ChildCollections
+
+public class ChildCollections
+{
+    private readonly ChildrenCollection _children;
+
+    [ContentSerializer]
+    public ChildrenCollection Children
+    {
+        get { return _children; }
+    }
+
+    public ChildCollections()
+    {
+        _children = new ChildrenCollection(this);
+    }
+}
+
+public class ChildrenCollection : ChildCollection<ChildCollections, ChildCollectionChild>
+{
+    public ChildrenCollection(ChildCollections parent) : base(parent)
+    {
+    }
+
+    protected override ChildCollections GetParent(ChildCollectionChild child)
+    {
+        return child.Parent;
+    }
+
+    protected override void SetParent(ChildCollectionChild child, ChildCollections parent)
+    {
+        child.Parent = parent;
+    }
+}
+
+public class ChildCollectionChild : ContentItem
+{
+    [ContentSerializerIgnore]
+    public ChildCollections Parent { get; set; }
+}
+
+#endregion
+
+#region Colors
+
+public class Colors
+{
+    public Color White { get; set; }
+    public Color Black { get; set; }
+    public Color Transparent { get; set; }
+    public Color Red { get; set; }
+    public Color Green { get; set; }
+    public Color Blue { get; set; }
+}
+
+#endregion
+
+class StructArrayNoElements
+{
+    public Vector2[] Vector2ArrayNoElements = new Vector2[] { };
+}
+
 
 namespace MonoGame.Tests.ContentPipeline
 {


### PR DESCRIPTION
As discussed in https://github.com/MonoGame/MonoGame/issues/8899, here's a simple .editorconfig to start with.

1) XML Summary mistakes, except for ''XML summaries are missing entirely'' are now marked as errors, not warnings; this is because it can brick exports to the documentation website, and besides, a good API contract requires proper formatting.
2) Added a few other common issues as warnings.

This has been tested against all solutions to check for errors that now spring up; a few malformed XML summaries were detected and dealt with:
1) Color.ToHS didn't have documentation for all its parameters
2) TextInputEventArgs' XML summary fails in Android builds because the element it's pointing at does not exist in that configuration (due to macro #if and #endif statements)
3) ImmutableVertexInputLayout refers to something called InputLayoutCache which no longer exists. Well, ImmutableVertexInputLayout itself is internal and no longer in use, so it might be an idea to remove it entirely. But that's not in the scope of this task nor do I know if it may be used elsewhere, so I left it be.
4. A number of classes in the test suite were without a namespace. However, as those are only there for performing a number of unittests, they're #pragma disabled in this case.
5. A number of XML summaries in the content pipeline had incorrect references to parameters or to an enum value that has since been renamed.

**As a result of this PR, you might notice _a ton more warnings popping up. This is fine._**

Examples:
<img width="1107" height="417" alt="image" src="https://github.com/user-attachments/assets/d79103d4-592f-4bcd-96ab-560093d6b8fa" />

In this case, the string is serialized based on the culture of the local machine, which causes comma's as the delimiter on many European desktops and dots in invariant cultures or US desktops. In this case it's relatively harmless, but this is the pinnacle of "but it works on my machine!" bug. 

<img width="694" height="320" alt="image" src="https://github.com/user-attachments/assets/95287a9c-65b7-4a15-a92d-940ed864950a" />

In this case it might be less harmless, based on what the user is doing with the output. In most cases, a simple `CultureInfo.InvariantCulture` ensures the same behavior on all machines.

