### PR TITLE
Fixed IL Trimming warnings on DesktopGL/WindowsDX

### DIFF
--- a/MonoGame.Framework/Content/ContentExtensions.cs
+++ b/MonoGame.Framework/Content/ContentExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Linq;
 
@@ -6,7 +7,7 @@ namespace Microsoft.Xna.Framework.Content
 {
     internal static class ContentExtensions
     {
-        public static ConstructorInfo GetDefaultConstructor(this Type type)
+        public static ConstructorInfo GetDefaultConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] this Type type)
         {
 #if NET45
             var typeInfo = type.GetTypeInfo();
@@ -18,7 +19,7 @@ namespace Microsoft.Xna.Framework.Content
 #endif
         }
 
-        public static PropertyInfo[] GetAllProperties(this Type type)
+        public static PropertyInfo[] GetAllProperties([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicProperties)] this Type type)
         {
 
             // Sometimes, overridden properties of abstract classes can show up even with 
@@ -42,7 +43,7 @@ namespace Microsoft.Xna.Framework.Content
         }
 
 
-        public static FieldInfo[] GetAllFields(this Type type)
+        public static FieldInfo[] GetAllFields([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicFields)] this Type type)
         {
 #if NET45
             FieldInfo[] fields= type.GetTypeInfo().DeclaredFields.ToArray();

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -628,11 +628,9 @@ namespace Microsoft.Xna.Framework.Content
 
                 var methodInfo = ReflectionHelpers.GetMethodInfo(typeof(ContentManager), "ReloadAsset");
                 // Up the callstack, it is ensured that the type of asset.Value can be used to make a generic method for.
-                #pragma warning disable IL2060
-                #pragma warning disable IL3050
+                #pragma warning disable IL2060, IL3050
                 var genericMethod = methodInfo.MakeGenericMethod(asset.Value.GetType());
-                #pragma warning restore IL2060
-                #pragma warning restore IL3050
+                #pragma warning restore IL2060, IL3050
                 genericMethod.Invoke(this, new object[] { asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()) });
             }
         }

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -627,7 +627,12 @@ namespace Microsoft.Xna.Framework.Content
                     ReloadAsset(asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()));
 
                 var methodInfo = ReflectionHelpers.GetMethodInfo(typeof(ContentManager), "ReloadAsset");
+                // Up the callstack, it is ensured that the type of asset.Value can be used to make a generic method for.
+                #pragma warning disable IL2060
+                #pragma warning disable IL3050
                 var genericMethod = methodInfo.MakeGenericMethod(asset.Value.GetType());
+                #pragma warning restore IL2060
+                #pragma warning restore IL3050
                 genericMethod.Invoke(this, new object[] { asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()) });
             }
         }

--- a/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/MultiArrayReader.cs
@@ -4,6 +4,7 @@
 
 using System;
 using MonoGame.Framework.Utilities;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Content
 {
@@ -12,8 +13,8 @@ namespace Microsoft.Xna.Framework.Content
     /// Its purpose is to allow to work-around AOT issues when loading assets with the ContentManager fail due to the absence of runtime-reflection support in that context (i.e. missing types due to trimming and inability to statically discover them at compile-time).
     /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    public class MultiArrayReader<T> : ContentTypeReader<Array>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    public class MultiArrayReader<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : ContentTypeReader<Array>
     {
         ContentTypeReader elementReader;
 
@@ -40,12 +41,14 @@ namespace Microsoft.Xna.Framework.Content
                 count *= dimensions[d] = input.ReadInt32();
 
 
+            // The programmer utilizing this function must ensure that the type T is not trimmed.
+#pragma warning disable IL3050 
             var array = existingInstance;
             if (array == null)
                 array = Array.CreateInstance(typeof(T), dimensions);//new T[count];
             else if (dimensions.Length != array.Rank)
                 throw new RankException("existingInstance");
-
+#pragma warning restore IL3050
             var indices = new int[rank];
 
             for (int i = 0; i < count; i++)

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -57,8 +57,7 @@ namespace Microsoft.Xna.Framework.Content
             if (baseType != null && baseType != typeof(object))
 				_baseTypeReader = manager.GetTypeReader(baseType);
 
-            // Reader types cannot be dynamically ensured to have their required items not be trimmed;
-            // The programmer must ensure that the type is preserved.
+            // TargetType is the typeof(T) of the generic type parameter of this class.
             #pragma warning disable IL2072
             _constructor = TargetType.GetDefaultConstructor();
 

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Xna.Framework.Content
     /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    public class ReflectiveReader<T> : ContentTypeReader
+    public class ReflectiveReader<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : ContentTypeReader
     {
         delegate void ReadElement(ContentReader input, object parent);
 
@@ -48,10 +48,14 @@ namespace Microsoft.Xna.Framework.Content
             if (baseType != null && baseType != typeof(object))
 				_baseTypeReader = manager.GetTypeReader(baseType);
 
+            // Reader types cannot be dynamically ensured to have their required items not be trimmed;
+            // The programmer must ensure that the type is preserved.
+            #pragma warning disable IL2072
             _constructor = TargetType.GetDefaultConstructor();
 
             var properties = TargetType.GetAllProperties();
             var fields = TargetType.GetAllFields();
+            #pragma warning restore IL2072
             _readers = new List<ReadElement>(fields.Length + properties.Length);
 
             // Gather the properties.

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -8,16 +8,25 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using MonoGame.Framework.Utilities;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Content
 {
     /// <summary>
     /// This type is not meant to be used directly by MonoGame users.
-    /// Its purpose is to allow to work-around AOT issues when loading assets with the ContentManager fail due to the absence of runtime-reflection support in that context (i.e. missing types due to trimming and inability to statically discover them at compile-time).
-    /// If ContentManager.Load() throws an NotSupportedExeception, the message should provide insights on how to fix it.
+    /// Its purpose is to allow to work-around AOT issues when loading assets with the <see cref="ContentManager"/> fail due to the absence of runtime-reflection support in that context (i.e. missing types due to trimming and inability to statically discover them at compile-time).
+    /// If <see cref="ContentManager.Load{T}"/> throws an <see cref="NotSupportedException"/>, the message should provide insights on how to fix it.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
-    public class ReflectiveReader<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : ContentTypeReader
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    public class ReflectiveReader<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
+                                    | DynamicallyAccessedMemberTypes.NonPublicConstructors
+                                    | DynamicallyAccessedMemberTypes.PublicConstructors
+                                    | DynamicallyAccessedMemberTypes.NonPublicFields
+                                    | DynamicallyAccessedMemberTypes.PublicFields
+                                    | DynamicallyAccessedMemberTypes.NonPublicProperties
+                                    | DynamicallyAccessedMemberTypes.PublicProperties)] T
+    > : ContentTypeReader
     {
         delegate void ReadElement(ContentReader input, object parent);
 

--- a/MonoGame.Framework/Design/Byte4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Byte4TypeConverter.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework.Graphics.PackedVector;
 using System;
 using System.ComponentModel;
 using System.Globalization;
-using System.Text.RegularExpressions;
+
+ 
+#pragma warning disable IL2067
 
 namespace Microsoft.Xna.Framework.Design
 {
@@ -14,7 +16,12 @@ namespace Microsoft.Xna.Framework.Design
     /// Provides a unified way of converting <see cref="Byte4"/> value to other types, as well as for accessing
     /// standard values and subproperties.
     /// </summary>
-    public class Byte4TypeConverter : TypeConverter
+    /// <remarks>
+    /// Because of the way TypeConverters are used - sometimes simply by dynamically requesting the TypeConverter
+    /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
+    /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
+    /// </remarks>
+    public sealed class Byte4TypeConverter : TypeConverter
     {
         /// <inheritdoc />
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
@@ -74,3 +81,5 @@ namespace Microsoft.Xna.Framework.Design
         }
     }
 }
+
+#pragma warning restore IL2067

--- a/MonoGame.Framework/Design/Byte4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Byte4TypeConverter.cs
@@ -5,6 +5,7 @@
 using Microsoft.Xna.Framework.Graphics.PackedVector;
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
  
@@ -21,6 +22,7 @@ namespace Microsoft.Xna.Framework.Design
     /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
     /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
     /// </remarks>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     public sealed class Byte4TypeConverter : TypeConverter
     {
         /// <inheritdoc />

--- a/MonoGame.Framework/Design/Byte4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Byte4TypeConverter.cs
@@ -17,11 +17,6 @@ namespace Microsoft.Xna.Framework.Design
     /// Provides a unified way of converting <see cref="Byte4"/> value to other types, as well as for accessing
     /// standard values and subproperties.
     /// </summary>
-    /// <remarks>
-    /// Because of the way TypeConverters are used - sometimes simply by dynamically requesting the TypeConverter
-    /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
-    /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
-    /// </remarks>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     public sealed class Byte4TypeConverter : TypeConverter
     {

--- a/MonoGame.Framework/Design/Byte4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Byte4TypeConverter.cs
@@ -7,7 +7,6 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-
  
 #pragma warning disable IL2067
 

--- a/MonoGame.Framework/Design/Vector2TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector2TypeConverter.cs
@@ -6,13 +6,20 @@ using System;
 using System.ComponentModel;
 using System.Globalization;
 
+#pragma warning disable IL2067
+
 namespace Microsoft.Xna.Framework.Design
 {
     /// <summary>
     /// Provides a unified way of converting <see cref="Vector2"/> values to other  types, as well as for accessing
     /// standard values and subproperties.
     /// </summary>
-    public class Vector2TypeConverter : TypeConverter
+    /// <remarks>
+    /// Because of the way TypeConverters are used - sometimes simply by dynamically requesting the TypeConverter
+    /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
+    /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
+    /// </remarks>
+    public sealed class Vector2TypeConverter : TypeConverter
     {
         /// <inheritdoc />
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
@@ -78,3 +85,5 @@ namespace Microsoft.Xna.Framework.Design
         }
     }
 }
+
+#pragma warning restore IL2067

--- a/MonoGame.Framework/Design/Vector2TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector2TypeConverter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 #pragma warning disable IL2067
@@ -19,6 +20,7 @@ namespace Microsoft.Xna.Framework.Design
     /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
     /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
     /// </remarks>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     public sealed class Vector2TypeConverter : TypeConverter
     {
         /// <inheritdoc />

--- a/MonoGame.Framework/Design/Vector2TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector2TypeConverter.cs
@@ -15,11 +15,6 @@ namespace Microsoft.Xna.Framework.Design
     /// Provides a unified way of converting <see cref="Vector2"/> values to other  types, as well as for accessing
     /// standard values and subproperties.
     /// </summary>
-    /// <remarks>
-    /// Because of the way TypeConverters are used - sometimes simply by dynamically requesting the TypeConverter
-    /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
-    /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
-    /// </remarks>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     public sealed class Vector2TypeConverter : TypeConverter
     {

--- a/MonoGame.Framework/Design/Vector3TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector3TypeConverter.cs
@@ -3,7 +3,8 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.ComponentModel; 
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 
@@ -24,6 +25,7 @@ namespace Microsoft.Xna.Framework.Design
     /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
     /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
     /// </remarks>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     public sealed class Vector3TypeConverter : TypeConverter
     {
         /// <inheritdoc />      

--- a/MonoGame.Framework/Design/Vector3TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector3TypeConverter.cs
@@ -3,8 +3,15 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.ComponentModel;
+using System.ComponentModel; 
 using System.Globalization;
+
+
+// Because of the way TypeConverters are used - sometimes simply by dynamically requesting the TypeConverter
+// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
+// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
+#pragma warning disable IL2067
+
 
 namespace Microsoft.Xna.Framework.Design
 {
@@ -12,7 +19,12 @@ namespace Microsoft.Xna.Framework.Design
     /// Provides a unified way of converting <see cref="Vector3"/> values to other  types, as well as for accessing
     /// standard values and subproperties.
     /// </summary>
-    public class Vector3TypeConverter : TypeConverter
+    /// <remarks>
+    /// Because of the way TypeConverters are used - sometimes simply by dynamically requesting the TypeConverter
+    /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
+    /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
+    /// </remarks>
+    public sealed class Vector3TypeConverter : TypeConverter
     {
         /// <inheritdoc />      
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
@@ -80,3 +92,5 @@ namespace Microsoft.Xna.Framework.Design
         }
     }
 }
+
+#pragma warning restore IL2067

--- a/MonoGame.Framework/Design/Vector3TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector3TypeConverter.cs
@@ -20,11 +20,6 @@ namespace Microsoft.Xna.Framework.Design
     /// Provides a unified way of converting <see cref="Vector3"/> values to other  types, as well as for accessing
     /// standard values and subproperties.
     /// </summary>
-    /// <remarks>
-    /// Because of the way TypeConverters are used - sometimes simply by dynamically requesting the TypeConverter
-    /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
-    /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
-    /// </remarks>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     public sealed class Vector3TypeConverter : TypeConverter
     {

--- a/MonoGame.Framework/Design/Vector3TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector3TypeConverter.cs
@@ -7,12 +7,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
-
-// Because of the way TypeConverters are used - sometimes simply by dynamically requesting the TypeConverter
-// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
-// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
 #pragma warning disable IL2067
-
 
 namespace Microsoft.Xna.Framework.Design
 {

--- a/MonoGame.Framework/Design/Vector4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector4TypeConverter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
  
 #pragma warning disable IL2067
@@ -19,6 +20,7 @@ namespace Microsoft.Xna.Framework.Design
     /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
     /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
     /// </remarks>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     public sealed class Vector4TypeConverter : TypeConverter
     {
         /// <inheritdoc /> 

--- a/MonoGame.Framework/Design/Vector4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector4TypeConverter.cs
@@ -15,11 +15,6 @@ namespace Microsoft.Xna.Framework.Design
     /// Provides a unified way of converting <see cref="Vector4"/> values to other types, as well as for accessing
     /// standard values and subproperties.
     /// </summary>    
-    /// <remarks>
-    /// Because of the way TypeConverters are used - sometimes simply by dynamically requesting the TypeConverter
-    /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
-    /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
-    /// </remarks>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     public sealed class Vector4TypeConverter : TypeConverter
     {

--- a/MonoGame.Framework/Design/Vector4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector4TypeConverter.cs
@@ -5,6 +5,8 @@
 using System;
 using System.ComponentModel;
 using System.Globalization;
+ 
+#pragma warning disable IL2067
 
 namespace Microsoft.Xna.Framework.Design
 {
@@ -12,7 +14,12 @@ namespace Microsoft.Xna.Framework.Design
     /// Provides a unified way of converting <see cref="Vector4"/> values to other types, as well as for accessing
     /// standard values and subproperties.
     /// </summary>    
-    public class Vector4TypeConverter : TypeConverter
+    /// <remarks>
+    /// Because of the way TypeConverters are used - sometimes simply by dynamically requesting the TypeConverter
+    /// of an object type, rather than instantiating the convert itself - we cannot use DynamicallyAccessedMembersAttribute here,
+    /// as the compiler would simply ignore it. The programmer must ensure that the type's interfaces and public parameterless constructor are preserved.
+    /// </remarks>
+    public sealed class Vector4TypeConverter : TypeConverter
     {
         /// <inheritdoc /> 
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
@@ -81,3 +88,5 @@ namespace Microsoft.Xna.Framework.Design
         }
     }
 }
+
+#pragma warning restore IL2067

--- a/MonoGame.Framework/Design/VectorConversion.cs
+++ b/MonoGame.Framework/Design/VectorConversion.cs
@@ -2,12 +2,13 @@
 using System.ComponentModel;
 using System.Globalization;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Design
 {
     internal static class VectorConversion
     {
-        public static bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        public static bool CanConvertTo(ITypeDescriptorContext context, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type destinationType)
         {
             if (destinationType == typeof(float))
                 return true;
@@ -23,7 +24,7 @@ namespace Microsoft.Xna.Framework.Design
             return false;
         }
 
-        public static object ConvertToFromVector4(ITypeDescriptorContext context, CultureInfo culture, Vector4 value, Type destinationType)
+        public static object ConvertToFromVector4(ITypeDescriptorContext context, CultureInfo culture, Vector4 value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type destinationType)
         {
             if (destinationType == typeof(float))
                 return value.X;

--- a/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
@@ -3,12 +3,16 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing a single 8 bit normalized W values that is ranging from 0 to 1.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct Alpha8 : IPackedVector<byte>, IEquatable<Alpha8>, IPackedVector
     {
         private byte packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
@@ -3,12 +3,16 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing unsigned normalized values ranging from 0 to 1. The x and z components use 5 bits, and the y component uses 6 bits.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct Bgr565 : IPackedVector<UInt16>, IEquatable<Bgr565>, IPackedVector
     {
         UInt16 _packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
@@ -3,12 +3,16 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing unsigned normalized values, ranging from 0 to 1, using 4 bits each for x, y, z, and w.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct Bgra4444 : IPackedVector<UInt16>, IEquatable<Bgra4444>
     {
         UInt16 _packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -10,6 +11,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
     /// Packed vector type containing unsigned normalized values ranging from 0 to 1.
     /// The x , y and z components use 5 bits, and the w component uses 1 bit.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct Bgra5551 : IPackedVector<UInt16>, IEquatable<Bgra5551>, IPackedVector
     {
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
@@ -3,16 +3,29 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing four 8-bit unsigned integer values, ranging from 0 to 255.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [System.ComponentModel.TypeConverter(typeof(Microsoft.Xna.Framework.Design.Byte4TypeConverter))]
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct Byte4 : IPackedVector<uint>, IEquatable<Byte4>, IPackedVector
     {
         uint packedValue;
 
+        /// <summary>
+        /// Initializes a new instance of this structure.
+        /// </summary>
+        public Byte4()
+        {
+            
+        }
+        
         /// <summary>
         /// Initializes a new instance of this structure.
         /// </summary>

--- a/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
@@ -3,12 +3,16 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing a single 16-bit floating point
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct HalfSingle : IPackedVector<UInt16>, IEquatable<HalfSingle>, IPackedVector
     {
         UInt16 packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
@@ -3,12 +3,16 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing two 16-bit floating-point values.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct HalfVector2 : IPackedVector<uint>, IPackedVector, IEquatable<HalfVector2>
     {
         private uint packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
@@ -3,12 +3,16 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing four 16-bit floating-point values.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct HalfVector4 : IPackedVector<ulong>, IPackedVector, IEquatable<HalfVector4>
     {
         ulong packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
@@ -4,12 +4,16 @@
 
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing two 8-bit signed normalized values, ranging from −1 to 1.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct NormalizedByte2 : IPackedVector<ushort>, IEquatable<NormalizedByte2>
     {
         private ushort _packed;

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
@@ -4,12 +4,16 @@
 
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing four 8-bit signed normalized values, ranging from −1 to 1.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct NormalizedByte4 : IPackedVector<uint>, IEquatable<NormalizedByte4>
     {
         private uint _packed;

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
@@ -4,13 +4,17 @@
 
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing two 16-bit signed normalized values, ranging from −1 to 1.
     /// </summary>
-	public struct NormalizedShort2 : IPackedVector<uint>, IEquatable<NormalizedShort2>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+    public struct NormalizedShort2 : IPackedVector<uint>, IEquatable<NormalizedShort2>
 	{
 		private uint short2Packed;
 

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
@@ -4,12 +4,16 @@
 
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing four 16-bit signed normalized values, ranging from −1 to 1.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct NormalizedShort4 : IPackedVector<ulong>, IEquatable<NormalizedShort4>
 	{
 		private ulong short4Packed;

--- a/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
@@ -3,12 +3,16 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing two 16-bit unsigned normalized values ranging from 0 to 1.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct Rg32 : IPackedVector<uint>, IEquatable<Rg32>, IPackedVector
     {
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -10,6 +11,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
     /// Packed vector type containing unsigned normalized values ranging from 0 to 1.
     /// The x, y and z components use 10 bits, and the w component uses 2 bits.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct Rgba1010102 : IPackedVector<uint>, IEquatable<Rgba1010102>, IPackedVector
     {
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
@@ -3,13 +3,17 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
-	/// <summary>
+    /// <summary>
     /// Packed vector type containing four 16-bit unsigned normalized values ranging from 0 to 1.
-	/// </summary>
-	public struct Rgba64 : IPackedVector<ulong>, IEquatable<Rgba64>, IPackedVector
+    /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+    public struct Rgba64 : IPackedVector<ulong>, IEquatable<Rgba64>, IPackedVector
 	{
         /// <inheritdoc />
 		public ulong PackedValue

--- a/MonoGame.Framework/Graphics/PackedVector/Short2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short2.cs
@@ -4,13 +4,17 @@
 
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing two 16-bit signed integer values.
     /// </summary>
-	public struct Short2 : IPackedVector<uint>, IEquatable<Short2>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+    public struct Short2 : IPackedVector<uint>, IEquatable<Short2>
 	{
 		private uint _short2Packed;
 

--- a/MonoGame.Framework/Graphics/PackedVector/Short4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short4.cs
@@ -3,12 +3,16 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
     /// <summary>
     /// Packed vector type containing four 16-bit signed integer values.
     /// </summary>
+#if XNADESIGNPROVIDED
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public struct Short4 : IPackedVector<ulong>, IEquatable<Short4>
     {
         ulong packedValue;

--- a/MonoGame.Framework/Graphics/Vertices/DynamicVertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/DynamicVertexBuffer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using MonoGame.Framework.Utilities;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -82,7 +83,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <paramref name="type"/> parameter.
         /// </exception>
         /// <exception cref="InvalidOperationException">This resource could not be created.</exception>
-		public DynamicVertexBuffer(GraphicsDevice graphicsDevice, Type type, int vertexCount, BufferUsage bufferUsage)
+		public DynamicVertexBuffer(GraphicsDevice graphicsDevice, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, int vertexCount, BufferUsage bufferUsage)
             : base(graphicsDevice, VertexDeclaration.FromType(type), vertexCount, bufferUsage, true)
         {
         }

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using MonoGame.Framework.Utilities;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -80,7 +81,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="vertexCount">The number of vertices.</param>
         /// <param name="bufferUsage">Behavior options.</param>
         /// <exception cref="ArgumentNullException"><paramref name="graphicsDevice"/> is <see langword="null"/></exception>
-        public VertexBuffer(GraphicsDevice graphicsDevice, Type type, int vertexCount, BufferUsage bufferUsage) :
+        public VertexBuffer(GraphicsDevice graphicsDevice, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, int vertexCount, BufferUsage bufferUsage) :
 			this(graphicsDevice, VertexDeclaration.FromType(type), vertexCount, bufferUsage, false)
 		{
         }
@@ -117,7 +118,9 @@ namespace Microsoft.Xna.Framework.Graphics
         /// For vertexStride we pass the size of a <see cref="VertexPositionTexture"/>.
         /// </p>
         /// </remarks>
-        public void GetData<T> (int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride = 0) where T : struct
+        public void GetData<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T
+        > (int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride = 0) where T : struct
         {
             var elementSizeInBytes = ReflectionHelpers.FastSizeOf<T>();
             if (vertexStride == 0)
@@ -140,13 +143,17 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         /// <inheritdoc cref="GetData{T}(int, T[], int, int, int)"/>
-        public void GetData<T>(T[] data, int startIndex, int elementCount) where T : struct
+        public void GetData<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T
+        >(T[] data, int startIndex, int elementCount) where T : struct
         {
             this.GetData<T>(0, data, startIndex, elementCount, 0);
         }
 
         /// <inheritdoc cref="GetData{T}(int, T[], int, int, int)"/>
-        public void GetData<T>(T[] data) where T : struct
+        public void GetData<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T
+        >(T[] data) where T : struct
         {
             var elementSizeInByte = ReflectionHelpers.FastSizeOf<T>();
             this.GetData<T>(0, data, 0, data.Length, elementSizeInByte);

--- a/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using MonoGame.Framework.Utilities;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -201,7 +202,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Prefer to use VertexDeclarationCache when the declaration lookup
         /// can be performed with a templated type.
         /// </remarks>
-		internal static VertexDeclaration FromType(Type vertexType)
+		internal static VertexDeclaration FromType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type vertexType)
 		{
 			if (vertexType == null)
 				throw new ArgumentNullException("vertexType", "Cannot be null");

--- a/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Runtime.InteropServices;
 using MonoGame.OpenGL;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -43,7 +44,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        private void PlatformGetData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride)
+        private void PlatformGetData<
+           [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T
+        >(int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride)
             where T : struct
         {
 #if GLES
@@ -57,7 +60,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #if !GLES
 
-        private void GetBufferData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride)
+        private void GetBufferData<
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T
+        >(int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride)
             where T : struct
         {
             GL.BindBuffer(BufferTarget.ArrayBuffer, vbo);

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -75,7 +76,7 @@ namespace MonoGame.Framework.Utilities
             return false;
         }
 
-        public static MethodInfo GetMethodInfo(Type type, string methodName)
+        public static MethodInfo GetMethodInfo([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicMethods)] Type type, string methodName)
         {
 #if NET45            
             return type.GetTypeInfo().GetDeclaredMethod(methodName);
@@ -189,7 +190,9 @@ namespace MonoGame.Framework.Utilities
         internal static int ManagedSizeOf(Type type)
         {
             // to make this AOT-compliant, we should be using Marshal.SizeOf<T>() but it isn't possible here without using reflection (which we can't if we want AOT compatibility)
+            #pragma warning disable IL3050
             return Marshal.SizeOf(type);
+            #pragma warning restore IL3050
         }
 
     }


### PR DESCRIPTION
Fixes #

The goal is simple: Publish builds that are AOT/Trimmed will not break randomly anymore at build/trim/publish time.
All IL Warnings in DesktopGL/WindowsDX are resolved. (Not Android/iOS) They are gone from the build and resolved by either tackling the problem or applying a "good enough" bandaid.

### Description of Change

Fixing IL trimmer warnings boils down to the API Contract; if we know at the time trimming happens (during AOT compilation) what shouldn't be trimmed from a specific type, we're golden. However, if a type's elements are needed because it gets dynamically invoked during runtime, and the trimmer doesn't know the type will be utilized for that, it can break. 

And yes, I am aware `[DynamicallyAccessedMembers(..)]` isn't magic; it doesn't check if X is in a type, it only ensures X won't be trimmed. (if it knows which type it shouldn't perform that action on).

So, this PR can be broken down into several sections where different trimming problems get resolved:

**1) "Pass the parcel" (VertexBuffer.cs, VertexDeclaration.cs,)**

These are simple; just send up the callstack what we need from the generic type `T` or `Type type` that is being utilized; it usually becomes the problem of the assembly that is consuming the project now (e.g. through the NuGet Package).  In most cases, the compiler of the consumer will take the hint and not trim the required bits of the type the user puts in there. In other cases, the compiler will throw a warning the user can resolve themselves. This should resolve any problem anyone may have regarding VertexBuffers.

**2) ContentReaders**

These are a bit trickier, but basically boil down to "anyone writing custom readers must ensure nothing gets trimmed from these readers". Unfortunately, we can't really throw warnings like "if you use `ContentTypeReader<T>`, please ensure nothing gets trimmed". So that's just a warning to put in the manual. I recommend adding a section to the following document to reflect that: https://docs.monogame.net/articles/getting_started/preparing_for_consoles.html

**3) TypeConverters** 

The problem with `TypeConverter`s is that they were designed to be utilized during runtime by default, not set up during compile time. Which creates issues like: `TypeConverter conv = TypeDescriptor.GetConverter(typeof(Foo));`
Of course the trimmer won't have a clue that it's not supposed to trim `FooConverter` (hence why all converters have a "retain everything" sticker on them), but _also_ that it shouldn't trim the bits and pieces of `Foo` the converter needs. 

In the case of MonoGame, this problem emerges because the converters try to convert from/to types that are derived from `IPackedVector`. Meaning: types derived from `IPackedVector` must still retain their interfaces and their public parameterless constructors. To resolve this, I've placed ''retain interfaces/public parameterless constructor'' on the types that derive from `IPackedVector` to ensure it wouldn't break that function.  (But only if XNADESIGNPROVIDED is set, given that the type converters won't be used otherwise anyway)

_(But so many of the types derived from `IPackedVector` don't even have public parameterless constructors for use by `Activator.CreateInstance(typeof(T))` in VectorConversions.cs->ConvertToFromVector4? But, naturally, anyone who wants to produce AOT/Trimmed versions of their product in MonoGame wouldn't likely even touch TypeConverters, but here we are, just in case)_

**4) Obsolete methods**
A few method calls are obsolete, stating they shouldn't be used, in part because of the trimming problem of the actions inside the method. I just put a "disable the warning" on there - it's not a problem, it'll get dealt with anyway. Given that the `[Obsolete(...)]` throws a warning anyway, we can blindfold the compiler for the IL warnings without issue.

### Not changed

**Android**

Android has 2 unique IL warnings which boil down to the fact it has to utilize .NET Framework 4.5 methods and not their cleaner, better alternatives which were introduced in 4.5.1. Better to leave them there. There is nothing gained by blindfolding the compiler.

**iOS**

iOS has the same issue as Android; 2 unique IL warnings, but ''More modern alternatives exist, but .NET Framework 4.5 requirements''. (`AppContext.BaseDirectory` was introduced in .NET Framework 4.6,  `Marshal.GetDelegateForFunctionPointer` has a better alternative in 4.5.1, as a comment above the method call laments this fact)


