### PR TITLE
Upgrade Android and iOS to use modern Methods.

### DIFF
--- a/MonoGame.Framework/Platform/Android/Input/Keyboard.cs
+++ b/MonoGame.Framework/Platform/Android/Input/Keyboard.cs
@@ -42,8 +42,7 @@ namespace Microsoft.Xna.Framework.Input
         private static IDictionary<Keycode, Keys> LoadKeyMap()
         {
             // create a map for every Keycode and default it to none so that every possible key is mapped
-            var maps = Enum.GetValues(typeof (Keycode))
-                .Cast<Keycode>()
+            var maps = Enum.GetValues<Keycode>()
                 .ToDictionary(key => key, key => Keys.None);
 
             // then update it with the actual mappings

--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -218,10 +218,10 @@ namespace MonoGame.OpenAL
             }
 
             return ret;
-#else
+#else // iOS
             var ret =  FuncLoader.LoadLibrary("libopenal.dylib");
             if (ret ==IntPtr.Zero)
-                ret = FuncLoader.LoadLibrary(Path.Combine (Path.GetDirectoryName (typeof (AL).Assembly.Location), "libopenal.dylib"));
+                ret = FuncLoader.LoadLibrary(Path.Combine (Path.GetDirectoryName (AppContext.BaseDirectory), "libopenal.dylib"));
             return ret;
 #endif
         }

--- a/MonoGame.Framework/Platform/Utilities/FuncLoader.Android.cs
+++ b/MonoGame.Framework/Platform/Utilities/FuncLoader.Android.cs
@@ -52,11 +52,7 @@ namespace MonoGame.Framework.Utilities
                 return default(T);
             }
 
-            // TODO: Use the function bellow once Protobuild gets axed
-            // requires .NET Framework 4.5.1 and its useful for corert
-            // return Marshal.GetDelegateForFunctionPointer<T>(ret);
-
-            return (T)(object)Marshal.GetDelegateForFunctionPointer(ret, typeof(T));
+            return Marshal.GetDelegateForFunctionPointer<T>(ret);
         }
     }
 }

--- a/MonoGame.Framework/Platform/Utilities/FuncLoader.iOS.cs
+++ b/MonoGame.Framework/Platform/Utilities/FuncLoader.iOS.cs
@@ -23,11 +23,7 @@ namespace MonoGame.Framework.Utilities
                 return default(T);
             }
 
-            // TODO: Use the function bellow once Protobuild gets axed
-            // requires .NET Framework 4.5.1 and its useful for corert
-            // return Marshal.GetDelegateForFunctionPointer<T>(ret);
-
-            return (T)(object)Marshal.GetDelegateForFunctionPointer(ret, typeof(T));
+            return Marshal.GetDelegateForFunctionPointer<T>(ret);
         }
     }
 }


### PR DESCRIPTION
Both Android and iOS using old .net 4.5 methods for `Enum.GetValues` and `Marshal.GetFunctionPointerForDelegate`. This commit updates them to use the modern
`Enum.GetValues<T>()` and `Marshal.GetFunctionPointerForDelegate<T>()` methods.

We also update iOS to use `AppContext.BaseDirectory` instead of `typeof(AL).Assembly.Location`, which is the correct property to use in .NET 6+.

Context #8915