### PR TITLE
Supported platforms update

### DIFF
--- a/README-packages.md
+++ b/README-packages.md
@@ -41,7 +41,7 @@ We support a growing list of platforms across the desktop, mobile, and console s
 
 [^1]An experimental Vulkan implementation is available to source code users.
 [^2]An experimental DirectX 12 implementation is available to source code users.
-[^3]Requires a distribution with glibc 2.27 or up. This includes SteamOS 3.0 and up, Ubuntu 18.04 and up, Debian 11 and up, CentOS 9 and up among other unlisted distributions.
+[^3]Requires a distribution with glibc 2.27 or up. This includes SteamOS 3.0 and up, Ubuntu 22.04 and up, Debian 12 and up, CentOS 9 and up among other unlisted distributions.
 
 ## Resources
 

--- a/README-packages.md
+++ b/README-packages.md
@@ -27,17 +27,21 @@ It is an open-source re-implementation of the discontinued [Microsoft's XNA Fram
 We support a growing list of platforms across the desktop, mobile, and console space. If there is a platform we do not support, please [make a request](https://github.com/MonoGame/MonoGame/issues) or [come help us](CONTRIBUTING.md) add it.
 
 * Desktop PCs
-  * Windows 8.1 and up (OpenGL & DirectX)
-  * Linux (OpenGL)
-  * macOS 10.15 and up (OpenGL)
+  * Windows 10 (22H2+) and up (OpenGL[^1] & DirectX 10[^2])
+  * Linux[^3] and up (OpenGL[^1])
+  * macOS 13 "Ventura" and up (OpenGL[^1])
 * Mobile/Tablet Devices
-  * Android 6.0 and up (OpenGL)
-  * iPhone/iPad 10.0 and up (OpenGL)
+  * Android 6 (API 23) and up (OpenGL)
+  * iOS/iPadOS 12.2 and up (OpenGL)
 * [Consoles (for registered developers)](https://docs.monogame.net/articles/console_access.html)
   * PlayStation 4
   * PlayStation 5
-  * Xbox One (XDK only) (GDK coming soon)
+  * Xbox (GDK & XDK)
   * Nintendo Switch
+
+[^1]An experimental Vulkan implementation is available to source code users.
+[^2]An experimental DirectX 12 implementation is available to source code users.
+[^3]Requires a distribution with glibc 2.27 or up. This includes SteamOS 3.0 and up, Ubuntu 18.04 and up, Debian 11 and up, CentOS 9 and up among other unlisted distributions.
 
 ## Resources
 

--- a/README-packages.md
+++ b/README-packages.md
@@ -36,7 +36,7 @@ We support a growing list of platforms across the desktop, mobile, and console s
 * [Consoles (for registered developers)](https://docs.monogame.net/articles/console_access.html)
   * PlayStation 4
   * PlayStation 5
-  * Xbox (GDK & XDK)
+  * Xbox (GDKX & XDK)
   * Nintendo Switch
 
 [^1]An experimental Vulkan implementation is available to source code users.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We support a growing list of platforms across the desktop, mobile, and console s
 
 [^1]An experimental Vulkan implementation is available to source code users.
 [^2]An experimental DirectX 12 implementation is available to source code users.
-[^3]Requires a distribution with glibc 2.27 or up. This includes SteamOS 3.0 and up, Ubuntu 18.04 and up, Debian 11 and up, CentOS 9 and up among other unlisted distributions.
+[^3]Requires a distribution with glibc 2.27 or up. This includes SteamOS 3.0 and up, Ubuntu 22.04 and up, Debian 12 and up, CentOS 9 and up among other unlisted distributions.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -30,17 +30,21 @@ It is an open-source re-implementation of the discontinued [Microsoft's XNA Fram
 We support a growing list of platforms across the desktop, mobile, and console space. If there is a platform we do not support, please [make a request](https://github.com/MonoGame/MonoGame/issues) or [come help us](CONTRIBUTING.md) add it.
 
 * Desktop PCs
-  * Windows 8.1 and up (OpenGL & DirectX)
-  * Linux (OpenGL)
-  * macOS 10.15 and up (OpenGL)
+  * Windows 10 (22H2+) and up (OpenGL[^1] & DirectX 10[^2])
+  * Linux[^3] and up (OpenGL[^1])
+  * macOS 13 "Ventura" and up (OpenGL[^1])
 * Mobile/Tablet Devices
-  * Android 6.0 and up (OpenGL)
-  * iPhone/iPad 10.0 and up (OpenGL)
+  * Android 6 (API 23) and up (OpenGL)
+  * iOS/iPadOS 12.2 and up (OpenGL)
 * [Consoles (for registered developers)](https://docs.monogame.net/articles/console_access.html)
   * PlayStation 4
   * PlayStation 5
-  * Xbox One (XDK only) (GDK coming soon)
+  * Xbox (GDK & XDK)
   * Nintendo Switch
+
+[^1]An experimental Vulkan implementation is available to source code users.
+[^2]An experimental DirectX 12 implementation is available to source code users.
+[^3]Requires a distribution with glibc 2.27 or up. This includes SteamOS 3.0 and up, Ubuntu 18.04 and up, Debian 11 and up, CentOS 9 and up among other unlisted distributions.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We support a growing list of platforms across the desktop, mobile, and console s
 * [Consoles (for registered developers)](https://docs.monogame.net/articles/console_access.html)
   * PlayStation 4
   * PlayStation 5
-  * Xbox (GDK & XDK)
+  * Xbox (GDKX & XDK)
   * Nintendo Switch
 
 [^1]An experimental Vulkan implementation is available to source code users.


### PR DESCRIPTION
Proposal to update the supported platforms.

This is to mimic [.NET's own minimal requirements](https://github.com/dotnet/core/blob/main/release-notes/9.0/supported-os.md) to run.

Also renaming ```Xbox One``` to just ```Xbox``` as the modern SDK and branding doesn't make a difference, it's all just one target.




