### PR TITLE
More robust GL extension loading

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsCapabilities.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsCapabilities.OpenGL.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformInitialize(GraphicsDevice device)
         {
 #if GLES
-            SupportsNonPowerOfTwo = GL.Extensions.Contains("GL_OES_texture_npot") ||
-                GL.Extensions.Contains("GL_ARB_texture_non_power_of_two") ||
-                GL.Extensions.Contains("GL_IMG_texture_npot") ||
-                GL.Extensions.Contains("GL_NV_texture_npot_2D_mipmap");
+            SupportsNonPowerOfTwo = GL.HasExtension("GL_OES_texture_npot") ||
+                GL.HasExtension("GL_ARB_texture_non_power_of_two") ||
+                GL.HasExtension("GL_IMG_texture_npot") ||
+                GL.HasExtension("GL_NV_texture_npot_2D_mipmap");
 #else
             // Unfortunately non PoT texture support is patchy even on desktop systems and we can't
             // rely on the fact that GL2.0+ supposedly supports npot in the core.
@@ -42,13 +42,13 @@ namespace Microsoft.Xna.Framework.Graphics
             SupportsNonPowerOfTwo = device._maxTextureSize >= 8192;
 #endif
 
-            SupportsTextureFilterAnisotropic = GL.Extensions.Contains("GL_EXT_texture_filter_anisotropic");
+            SupportsTextureFilterAnisotropic = GL.HasExtension("GL_EXT_texture_filter_anisotropic");
 
 #if GLES
-			SupportsDepth24 = GL.Extensions.Contains("GL_OES_depth24");
-			SupportsPackedDepthStencil = GL.Extensions.Contains("GL_OES_packed_depth_stencil");
-			SupportsDepthNonLinear = GL.Extensions.Contains("GL_NV_depth_nonlinear");
-            SupportsTextureMaxLevel = GL.Extensions.Contains("GL_APPLE_texture_max_level");
+			SupportsDepth24 = GL.HasExtension("GL_OES_depth24");
+			SupportsPackedDepthStencil = GL.HasExtension("GL_OES_packed_depth_stencil");
+			SupportsDepthNonLinear = GL.HasExtension("GL_NV_depth_nonlinear");
+            SupportsTextureMaxLevel = GL.HasExtension("GL_APPLE_texture_max_level");
 #else
             SupportsDepth24 = true;
             SupportsPackedDepthStencil = true;
@@ -56,15 +56,15 @@ namespace Microsoft.Xna.Framework.Graphics
             SupportsTextureMaxLevel = true;
 #endif
             // Texture compression
-            SupportsS3tc = GL.Extensions.Contains("GL_EXT_texture_compression_s3tc") ||
-                           GL.Extensions.Contains("GL_OES_texture_compression_S3TC") ||
-                           GL.Extensions.Contains("GL_EXT_texture_compression_dxt3") ||
-                           GL.Extensions.Contains("GL_EXT_texture_compression_dxt5");
-            SupportsDxt1 = SupportsS3tc || GL.Extensions.Contains("GL_EXT_texture_compression_dxt1");
-            SupportsPvrtc = GL.Extensions.Contains("GL_IMG_texture_compression_pvrtc");
-            SupportsEtc1 = GL.Extensions.Contains("GL_OES_compressed_ETC1_RGB8_texture");
-            SupportsAtitc = GL.Extensions.Contains("GL_ATI_texture_compression_atitc") ||
-                            GL.Extensions.Contains("GL_AMD_compressed_ATC_texture");
+            SupportsS3tc = GL.HasExtension("GL_EXT_texture_compression_s3tc") ||
+                           GL.HasExtension("GL_OES_texture_compression_S3TC") ||
+                           GL.HasExtension("GL_EXT_texture_compression_dxt3") ||
+                           GL.HasExtension("GL_EXT_texture_compression_dxt5");
+            SupportsDxt1 = SupportsS3tc || GL.HasExtension("GL_EXT_texture_compression_dxt1");
+            SupportsPvrtc = GL.HasExtension("GL_IMG_texture_compression_pvrtc");
+            SupportsEtc1 = GL.HasExtension("GL_OES_compressed_ETC1_RGB8_texture");
+            SupportsAtitc = GL.HasExtension("GL_ATI_texture_compression_atitc") ||
+                            GL.HasExtension("GL_AMD_compressed_ATC_texture");
 
             if (GL.BoundApi == GL.RenderApi.ES)
             {
@@ -74,17 +74,17 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Framebuffer objects
 #if GLES
-            SupportsFramebufferObjectARB = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 2 || GL.Extensions.Contains("GL_ARB_framebuffer_object")); // always supported on GLES 2.0+
-            SupportsFramebufferObjectEXT = GL.Extensions.Contains("GL_EXT_framebuffer_object");;
-            SupportsFramebufferObjectIMG = GL.Extensions.Contains("GL_IMG_multisampled_render_to_texture") |
-                                                 GL.Extensions.Contains("GL_APPLE_framebuffer_multisample") |
-                                                 GL.Extensions.Contains("GL_EXT_multisampled_render_to_texture") |
-                                                 GL.Extensions.Contains("GL_NV_framebuffer_multisample");
+            SupportsFramebufferObjectARB = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 2 || GL.HasExtension("GL_ARB_framebuffer_object")); // always supported on GLES 2.0+
+            SupportsFramebufferObjectEXT = GL.HasExtension("GL_EXT_framebuffer_object");;
+            SupportsFramebufferObjectIMG = GL.HasExtension("GL_IMG_multisampled_render_to_texture") |
+                                                 GL.HasExtension("GL_APPLE_framebuffer_multisample") |
+                                                 GL.HasExtension("GL_EXT_multisampled_render_to_texture") |
+                                                 GL.HasExtension("GL_NV_framebuffer_multisample");
 #else
             // if we're on GL 3.0+, frame buffer extensions are guaranteed to be present, but extensions may be missing
             // it is then safe to assume that GL_ARB_framebuffer_object is present so that the standard function are loaded
-            SupportsFramebufferObjectARB = device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_ARB_framebuffer_object");
-            SupportsFramebufferObjectEXT = GL.Extensions.Contains("GL_EXT_framebuffer_object");
+            SupportsFramebufferObjectARB = device.glMajorVersion >= 3 || GL.HasExtension("GL_ARB_framebuffer_object");
+            SupportsFramebufferObjectEXT = GL.HasExtension("GL_EXT_framebuffer_object");
 #endif
             // Anisotropic filtering
             int anisotropy = 0;
@@ -97,22 +97,22 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // sRGB
 #if GLES
-            SupportsSRgb = GL.Extensions.Contains("GL_EXT_sRGB");
-            SupportsFloatTextures = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_EXT_color_buffer_float"));
-            SupportsHalfFloatTextures = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_EXT_color_buffer_half_float"));
-            SupportsNormalized = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 && GL.Extensions.Contains("GL_EXT_texture_norm16"));
+            SupportsSRgb = GL.HasExtension("GL_EXT_sRGB");
+            SupportsFloatTextures = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 || GL.HasExtension("GL_EXT_color_buffer_float"));
+            SupportsHalfFloatTextures = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 || GL.HasExtension("GL_EXT_color_buffer_half_float"));
+            SupportsNormalized = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 && GL.HasExtension("GL_EXT_texture_norm16"));
 #else
-            SupportsSRgb = GL.Extensions.Contains("GL_EXT_texture_sRGB") && GL.Extensions.Contains("GL_EXT_framebuffer_sRGB");
-            SupportsFloatTextures = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_ARB_texture_float"));
-            SupportsHalfFloatTextures = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_ARB_half_float_pixel"));;
-            SupportsNormalized = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.Extensions.Contains("GL_EXT_texture_norm16"));;
+            SupportsSRgb = GL.HasExtension("GL_EXT_texture_sRGB") && GL.HasExtension("GL_EXT_framebuffer_sRGB");
+            SupportsFloatTextures = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.HasExtension("GL_ARB_texture_float"));
+            SupportsHalfFloatTextures = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.HasExtension("GL_ARB_half_float_pixel"));;
+            SupportsNormalized = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.HasExtension("GL_EXT_texture_norm16"));;
 #endif
 
             // TODO: Implement OpenGL support for texture arrays
             // once we can author shaders that use texture arrays.
             SupportsTextureArrays = false;
 
-            SupportsDepthClamp = GL.Extensions.Contains("GL_ARB_depth_clamp");
+            SupportsDepthClamp = GL.HasExtension("GL_ARB_depth_clamp");
 
             SupportsVertexTextures = false; // For now, until we implement vertex textures in OpenGL.
 
@@ -126,7 +126,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #if GLES
             SupportsSeparateBlendStates = false;
 #else
-            SupportsSeparateBlendStates = device.glMajorVersion >= 4 || GL.Extensions.Contains("GL_ARB_draw_buffers_blend");
+            SupportsSeparateBlendStates = device.glMajorVersion >= 4 || GL.HasExtension("GL_ARB_draw_buffers_blend");
 #endif
         }
 

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -1426,7 +1426,7 @@ namespace MonoGame.OpenGL
             LoadExtensions ();
         }
 
-        internal static List<string> Extensions = new List<string> ();
+        internal static List<string> Extensions;
 
         //[Conditional("DEBUG")]
         //[DebuggerHidden]
@@ -1439,8 +1439,19 @@ namespace MonoGame.OpenGL
 #endif
         }
 
+        internal static bool HasExtension(string name)
+        {
+            if (Extensions != null)
+                return Extensions.Contains(name);
+
+            return false;
+        }
+
         internal static void LoadExtensions()
         {
+            if (Extensions == null)
+                Extensions = new List<string>();
+
             if (Extensions.Count == 0)
             {
                 string extstring = GL.GetString(StringName.Extensions);
@@ -1450,39 +1461,39 @@ namespace MonoGame.OpenGL
             }
             LogExtensions();
             // now load Extensions :)
-            if (GL.GenRenderbuffers == null && Extensions.Contains("GL_EXT_framebuffer_object"))
+            if (GL.GenRenderbuffers == null && HasExtension("GL_EXT_framebuffer_object"))
             {
                 GL.LoadFrameBufferObjectEXTEntryPoints();
             }
             if (GL.RenderbufferStorageMultisample == null)
             {                
-                if (Extensions.Contains("GL_APPLE_framebuffer_multisample"))
+                if (HasExtension("GL_APPLE_framebuffer_multisample"))
                 {
                     GL.RenderbufferStorageMultisample = LoadFunction<GL.RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleAPPLE");
                     GL.BlitFramebuffer = LoadFunction<GL.BlitFramebufferDelegate>("glResolveMultisampleFramebufferAPPLE");
                 }
-                else if (Extensions.Contains("GL_EXT_multisampled_render_to_texture"))
+                else if (HasExtension("GL_EXT_multisampled_render_to_texture"))
                 {
                     GL.RenderbufferStorageMultisample = LoadFunction<GL.RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleEXT");
                     GL.FramebufferTexture2DMultiSample = LoadFunction<GL.FramebufferTexture2DMultiSampleDelegate>("glFramebufferTexture2DMultisampleEXT");
 
                 }
-                else if (Extensions.Contains("GL_IMG_multisampled_render_to_texture"))
+                else if (HasExtension("GL_IMG_multisampled_render_to_texture"))
                 {
                     GL.RenderbufferStorageMultisample = LoadFunction<GL.RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleIMG");
                     GL.FramebufferTexture2DMultiSample = LoadFunction<GL.FramebufferTexture2DMultiSampleDelegate>("glFramebufferTexture2DMultisampleIMG");
                 }
-                else if (Extensions.Contains("GL_NV_framebuffer_multisample"))
+                else if (HasExtension("GL_NV_framebuffer_multisample"))
                 {
                     GL.RenderbufferStorageMultisample = LoadFunction<GL.RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleNV");
                     GL.BlitFramebuffer = LoadFunction<GL.BlitFramebufferDelegate>("glBlitFramebufferNV");
                 }
             }
-            if (GL.BlendFuncSeparatei == null && Extensions.Contains("GL_ARB_draw_buffers_blend"))
+            if (GL.BlendFuncSeparatei == null && HasExtension("GL_ARB_draw_buffers_blend"))
             {
                 GL.BlendFuncSeparatei = LoadFunction<GL.BlendFuncSeparateiDelegate>("BlendFuncSeparateiARB");
             }
-            if (GL.BlendEquationSeparatei == null && Extensions.Contains("GL_ARB_draw_buffers_blend"))
+            if (GL.BlendEquationSeparatei == null && HasExtension("GL_ARB_draw_buffers_blend"))
             {
                 GL.BlendEquationSeparatei = LoadFunction<GL.BlendEquationSeparateiDelegate>("BlendEquationSeparateiARB");
             }


### PR DESCRIPTION
We received a bug report from a studio that something fishy might be going on with static initializers inside ```GL.LoadExtentions()```.

This PR makes this code less prone to static initializers issues (which might hide the actual issue).