### PR TITLE
Fix readme footnotes

### DIFF
--- a/README-packages.md
+++ b/README-packages.md
@@ -39,9 +39,11 @@ We support a growing list of platforms across the desktop, mobile, and console s
   * Xbox (GDKX & XDK)
   * Nintendo Switch
 
-[^1]An experimental Vulkan implementation is available to source code users.
-[^2]An experimental DirectX 12 implementation is available to source code users.
-[^3]Requires a distribution with glibc 2.27 or up. This includes SteamOS 3.0 and up, Ubuntu 22.04 and up, Debian 12 and up, CentOS 9 and up among other unlisted distributions.
+[^1]: An experimental Vulkan implementation is available to source code users.
+
+[^2]: An experimental DirectX 12 implementation is available to source code users.
+
+[^3]: Requires a distribution with glibc 2.27 or up. This includes SteamOS 3.0 and up, Ubuntu 22.04 and up, Debian 12 and up, CentOS 9 and up among other unlisted distributions.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ We support a growing list of platforms across the desktop, mobile, and console s
   * Xbox (GDKX & XDK)
   * Nintendo Switch
 
-[^1]An experimental Vulkan implementation is available to source code users.
-[^2]An experimental DirectX 12 implementation is available to source code users.
-[^3]Requires a distribution with glibc 2.27 or up. This includes SteamOS 3.0 and up, Ubuntu 22.04 and up, Debian 12 and up, CentOS 9 and up among other unlisted distributions.
+[^1]: An experimental Vulkan implementation is available to source code users.
+
+[^2]: An experimental DirectX 12 implementation is available to source code users.
+
+[^3]: Requires a distribution with glibc 2.27 or up. This includes SteamOS 3.0 and up, Ubuntu 22.04 and up, Debian 12 and up, CentOS 9 and up among other unlisted distributions.
 
 ## Resources
 


### PR DESCRIPTION
Sorry, footnotes in the readme were broken. Although I'm not sure if I like how this looks, they appear at the bottom of the readme and not at the bottom of the section.

@SimonDarksideJ What do you think? You can check how that looks [here](https://github.com/FlyingOakGames/MonoGame/tree/footnotes?tab=readme-ov-file#supported-platforms).




