### PR TITLE
Make a Better Error Message for Audio Imports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,7 +53,7 @@
             "name": "Attach to Process",
             "type": "coreclr",
             "request": "attach",
-            "processId": "${input.processid}",
+            "processId": "${command:pickProcess}",
         },
         {
             "name": "MonoGame.Tests",
@@ -69,12 +69,4 @@
             "stopAtEntry": false
         }
     ],
-    "inputs": [
-        {
-            "id": "processid",
-            "type": "promptString",
-            "default": "0",
-            "description": "Enter Process Id of process to attach to."
-        }
-    ]
 }

--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
@@ -122,7 +123,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                 // the type is WAV... else it is ok.
                 if (    (audioFileType == AudioFileType.Wav || _fileType == AudioFileType.Wav) &&
                         audioFileType != _fileType)
-                    throw new ArgumentException("Incorrect file type!", "audioFileType");
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Incorrect file type! Expected '.wav' but found '.{0}'. Did you mean to use the Mp3Importer?", _fileType), "audioFileType");
 
                 // Only provide the data for WAV files.
                 if (audioFileType == AudioFileType.Wav)
@@ -157,7 +158,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
             }
             catch (Exception ex)
             {
-                var message = string.Format("Failed to open file {0}. Ensure the file is a valid audio file and is not DRM protected.", Path.GetFileNameWithoutExtension(audioFileName));
+                var message = string.Format(CultureInfo.InvariantCulture, "There was an error processing '{0}'\n {1}", Path.GetFileNameWithoutExtension(audioFileName), ex.Message);
                 throw new InvalidContentException(message, ex);
             }
         }

--- a/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                             sampleFormat = kv[1].Trim('"').ToLowerInvariant();
                             break;
                         case "streams.stream.0.bit_rate":
-                            averageBytesPerSecond = (int.Parse(kv[1].Trim('"'), numberFormat)/8);
+                            averageBytesPerSecond = (int)long.Parse(kv[1].Trim('"'), numberFormat)/8;
                             break;
                         case "format.format_name":
                             formatName = kv[1].Trim('"').ToLowerInvariant();


### PR DESCRIPTION
We currently get a really odd error message if we hit a problem processing audio files.

`Ensure the file is a valid audio file and is not DRM protected`

Allot of the time it has nothing to do with DRM. The underlying errors are ignored. 
This commit reworks the error messaging to produce a error message which includes the actual error. 

Also updated an error message that would give some weird error when using mp3/ogg with the WavImporter. We can do better there.

Fixed an bug in the launch.json so that we get a process list to pick the process we want to attach to. Very handy for debugging mgcb.



