### PR TITLE
Link CoreAudio and AudioToolbox when using OpenAL on iOS [WIP]

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.iOS.targets
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.targets
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <MonoGamePlatform>iOS</MonoGamePlatform>
+    <AppBundleExtraOptions>$(AppBundleExtraOptions) -gcc_flags '-framework CoreAudio -framework AudioToolbox'</AppBundleExtraOptions>
   </PropertyGroup>
 
 </Project>

--- a/MonoGame.Framework/Platform/OpenAL.targets
+++ b/MonoGame.Framework/Platform/OpenAL.targets
@@ -3,11 +3,6 @@
     <DefineConstants>$(DefineConstants);OPENAL</DefineConstants>
   </PropertyGroup>
 
-  <!-- iOS needs to link CoreAudio.framework for OpenAL -->
-  <PropertyGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('IOS'))">
-     <AppBundleExtraOptions>$(AppBundleExtraOptions) -gcc_flags '-framework CoreAudio -framework AudioToolbox'</AppBundleExtraOptions>
-  </PropertyGroup>
-
   <!-- iOS has its own Song and Video implementation -->
   <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('IOS'))">
     <PackageReference Include="MonoGame.Library.OpenAL" Version="1.24.3.2" />

--- a/MonoGame.Framework/Platform/OpenAL.targets
+++ b/MonoGame.Framework/Platform/OpenAL.targets
@@ -3,6 +3,11 @@
     <DefineConstants>$(DefineConstants);OPENAL</DefineConstants>
   </PropertyGroup>
 
+  <!-- iOS needs to link CoreAudio.framework for OpenAL -->
+  <PropertyGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('IOS'))">
+     <MtouchExtraArgs>$(MtouchExtraArgs) -framework CoreAudio</MtouchExtraArgs>
+  </PropertyGroup>
+
   <!-- iOS has its own Song and Video implementation -->
   <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('IOS'))">
     <PackageReference Include="MonoGame.Library.OpenAL" Version="1.24.3.2" />

--- a/MonoGame.Framework/Platform/OpenAL.targets
+++ b/MonoGame.Framework/Platform/OpenAL.targets
@@ -5,7 +5,7 @@
 
   <!-- iOS needs to link CoreAudio.framework for OpenAL -->
   <PropertyGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('IOS'))">
-     <AppBundleExtraOptions>$(AppBundleExtraOptions) -framework CoreAudio</AppBundleExtraOptions>
+     <AppBundleExtraOptions>$(AppBundleExtraOptions) -framework CoreAudio -framework AudioToolbox</AppBundleExtraOptions>
   </PropertyGroup>
 
   <!-- iOS has its own Song and Video implementation -->

--- a/MonoGame.Framework/Platform/OpenAL.targets
+++ b/MonoGame.Framework/Platform/OpenAL.targets
@@ -5,7 +5,7 @@
 
   <!-- iOS needs to link CoreAudio.framework for OpenAL -->
   <PropertyGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('IOS'))">
-     <AppBundleExtraOptions>$(AppBundleExtraOptions) -framework CoreAudio -framework AudioToolbox</AppBundleExtraOptions>
+     <AppBundleExtraOptions>$(AppBundleExtraOptions) -gcc_flags '-framework CoreAudio -framework AudioToolbox'</AppBundleExtraOptions>
   </PropertyGroup>
 
   <!-- iOS has its own Song and Video implementation -->

--- a/MonoGame.Framework/Platform/OpenAL.targets
+++ b/MonoGame.Framework/Platform/OpenAL.targets
@@ -5,7 +5,7 @@
 
   <!-- iOS needs to link CoreAudio.framework for OpenAL -->
   <PropertyGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('IOS'))">
-     <MtouchExtraArgs>$(MtouchExtraArgs) -framework CoreAudio</MtouchExtraArgs>
+     <AppBundleExtraOptions>$(AppBundleExtraOptions) -framework CoreAudio</AppBundleExtraOptions>
   </PropertyGroup>
 
   <!-- iOS has its own Song and Video implementation -->


### PR DESCRIPTION
Fixes the following issue

```
3>Xamarin.Shared.Sdk.targets(1648,3): Error  : clang++ exited with code 1:
Undefined symbols for architecture arm64:
  "_AudioComponentFindNext", referenced from:
      (anonymous namespace)::CoreAudioPlayback::open(std::__1::basic_string_view<char, std::__1::char_traits<char>>) in libopenal.a[32](coreaudio.o)
      (anonymous namespace)::CoreAudioCapture::open(std::__1::basic_string_view<char, std::__1::char_traits<char>>) in libopenal.a[32](coreaudio.o)
  "_AudioComponentInstanceDispose", referenced from:
      (anonymous namespace)::CoreAudioPlayback::open(std::__1::basic_string_view<char, std::__1::char_traits<char>>) in libopenal.a[32](coreaudio.o)
      (anonymous namespace)::CoreAudioPlayback::~CoreAudioPlayback() in libopenal.a[32](coreaudio.o)
      (anonymous namespace)::CoreAudioPlayback::~CoreAudioPlayback() in libopenal.a[32](coreaudio.o)
      (anonymous namespace)::CoreAudioCapture::~CoreAudioCapture() in libopenal.a[32](coreaudio.o)
  "_AudioComponentInstanceNew", referenced from:
      (anonymous namespace)::CoreAudioPlayback::open(std::__1::basic_string_view<char, std::__1::char_traits<char>>) in libopenal.a[32](coreaudio.o)
      (anonymous namespace)::CoreAudioCapture::open(std::__1::basic_string_view<char, std::__1::char_traits<char>>) in libopenal.a[32](coreaudio.o)
  "_AudioOutputUnitStart", referenced from:
      (anonymous namespace)::CoreAudioPlayback::start() in libopenal.a[32](coreaudio.o)
      (anonymous namespace)::CoreAudioCapture::start() in libopenal.a[32](coreaudio.o)
  "_AudioOutputUnitStop", referenced from:
      (anonymous namespace)::CoreAudioPlayback::stop() in libopenal.a[32](coreaudio.o)
      (anonymous namespace)::CoreAudioCapture::stop() in libopenal.a[32](coreaudio.o)
  "_AudioUnitGetProperty", referenced from:
      (anonymous namespace)::CoreAudioPlayback::reset() in libopenal.a[32](coreaudio.o)
      (anonymous namespace)::CoreAudioPlayback::reset() in libopenal.a[32](coreaudio.o)
      (anonymous namespace)::CoreAudioCapture::open(std::__1::basic_string_view<char, std::__1::char_traits<char>>) in libopenal.a[32](coreaudio.o)
      (anonymous namespace)::CoreAudioCapture::open(std::__1::basic_string_view<char, std::__1::char_traits<char>>) in libopenal.a[32](coreaudio.o)
  "_AudioUnitGetPropertyInfo", referenced from:
      (anonymous namespace)::CoreAudioPlayback::reset() in libopenal.a[32](coreaudio.o)
3>------- Finished building project: DungeonSlime.iOS. Succeeded: False. Errors: 1. Warnings: 0

```