### PR TITLE
Fixes DirectX 12 shader building

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessor.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                 case TargetPlatform.WindowsGDK:
                 case TargetPlatform.XboxOne:
                 case TargetPlatform.XboxSeries:
-                    return "GDK";
+                    return "DirectX_12";
             }
 
             return platform.ToString();


### PR DESCRIPTION
This PR fixes MGCB ability to build ```WindowsGDK```, ```XboxOne```, and ```XboxSeries``` shaders.

The MGFX profile was wrongly set when building shaders through MGCB.