### PR TITLE
Add all platforms to stock shader building tests

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.Win32;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline
 {
@@ -158,6 +159,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             // Expand any environment variables.
             command = Environment.ExpandEnvironmentVariables(command);
 
+            // Add .exe if needed
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !command.ToLowerInvariant().EndsWith(".exe"))
+                command += ".exe";
+
             // If we have a full path just pass it through.
             if (File.Exists(command))
                 return command;
@@ -189,6 +194,37 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                     var fullExeName = string.Concat(fullName, ".exe");
                     if (File.Exists(fullExeName))
                         return fullExeName;
+                }
+            }
+
+            // Ultimately, we may search if it is a Windows SDK tool
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // We expect the Windows SDK 10 or 11 (which both are "v10.0") and only for x64
+                string winSDKRegistry = @"SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0";
+                // Workaround so that the registry lookup works no matter if the process is 32 or 64bit
+                using (RegistryKey baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, Environment.Is64BitOperatingSystem ? RegistryView.Registry64 : RegistryView.Registry32))
+                {
+                    if (baseKey != null)
+                    {
+                        using (RegistryKey key = baseKey.OpenSubKey(winSDKRegistry))
+                        {
+                            if (key != null)
+                            {
+                                string winSDKFolder = key.GetValue("InstallationFolder") as string;
+                                string version = key.GetValue("ProductVersion") as string;
+                                if (!string.IsNullOrEmpty(winSDKFolder) & !string.IsNullOrEmpty(version))
+                                {
+                                    // Build the full path.
+                                    command = Path.Combine(winSDKFolder, "bin", version + ".0", "x64", command);
+
+                                    // Is this it?
+                                    if (File.Exists(command))
+                                        return command;
+                                }
+                            }
+                        }
+                    }
                 }
             }
 

--- a/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
+++ b/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
@@ -32,9 +32,18 @@
 
   <ItemGroup>
     <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.7" />
+    <PackageReference Include="Microsoft.Direct3D.DXC" Version="1.8.2505.32" />
     <PackageReference Include="SharpDX" Version="4.0.1" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" />
   </ItemGroup>
+
+  <Target Name="CopyNuGetToolFiles" AfterTargets="Build">
+    <ItemGroup>
+      <ToolFiles Include="$(NuGetPackageRoot)Microsoft.Direct3D.DXC\1.8.2505.32\build\native\bin\x64\*.dll" />
+      <ToolFiles Include="$(NuGetPackageRoot)Microsoft.Direct3D.DXC\1.8.2505.32\build\native\bin\x64\*.exe" />
+    </ItemGroup>
+    <Copy SourceFiles="@(ToolFiles)" DestinationFolder="$(OutputPath)" />
+  </Target>
 
   <ItemGroup>
     <Reference Include="..\..\ThirdParty\Dependencies\CppNet\CppNet.dll" />

--- a/Tools/MonoGame.Tools.Tests/EffectProcessorTests.cs
+++ b/Tools/MonoGame.Tools.Tests/EffectProcessorTests.cs
@@ -111,12 +111,16 @@ namespace MonoGame.Tests.ContentPipeline
         [TestCase("Assets/Effects/Stock/EnvironmentMapEffect.fx", TargetPlatform.DesktopGL)]
         [TestCase("Assets/Effects/Stock/SkinnedEffect.fx", TargetPlatform.DesktopGL)]
         [TestCase("Assets/Effects/Stock/SpriteEffect.fx", TargetPlatform.DesktopGL)]
+#if WINDOWS
+        // DirectX 12 shaders will only build on Windows due to DXC having the signing bits only in the Microsoft-built dxc.exe
+        // but DXC is used to compile the VK shaders, so at least we have DXC validating them in some way
         [TestCase("Assets/Effects/Stock/AlphaTestEffect.fx", TargetPlatform.WindowsGDK)]
         [TestCase("Assets/Effects/Stock/BasicEffect.fx", TargetPlatform.WindowsGDK)]
         [TestCase("Assets/Effects/Stock/DualTextureEffect.fx", TargetPlatform.WindowsGDK)]
         [TestCase("Assets/Effects/Stock/EnvironmentMapEffect.fx", TargetPlatform.WindowsGDK)]
         [TestCase("Assets/Effects/Stock/SkinnedEffect.fx", TargetPlatform.WindowsGDK)]
         [TestCase("Assets/Effects/Stock/SpriteEffect.fx", TargetPlatform.WindowsGDK)]
+#endif
         [TestCase("Assets/Effects/Stock/AlphaTestEffect.fx", TargetPlatform.DesktopVK)]
         [TestCase("Assets/Effects/Stock/BasicEffect.fx", TargetPlatform.DesktopVK)]
         [TestCase("Assets/Effects/Stock/DualTextureEffect.fx", TargetPlatform.DesktopVK)]

--- a/Tools/MonoGame.Tools.Tests/EffectProcessorTests.cs
+++ b/Tools/MonoGame.Tools.Tests/EffectProcessorTests.cs
@@ -99,15 +99,33 @@ namespace MonoGame.Tests.ContentPipeline
         }
 
         [Test]
-        [TestCase("Assets/Effects/Stock/AlphaTestEffect.fx")]
-        [TestCase("Assets/Effects/Stock/BasicEffect.fx")]
-        [TestCase("Assets/Effects/Stock/DualTextureEffect.fx")]
-        [TestCase("Assets/Effects/Stock/EnvironmentMapEffect.fx")]
-        [TestCase("Assets/Effects/Stock/SkinnedEffect.fx")]
-        [TestCase("Assets/Effects/Stock/SpriteEffect.fx")]
-        public void BuildStockEffect(string effectFile)
+        [TestCase("Assets/Effects/Stock/AlphaTestEffect.fx", TargetPlatform.Windows)]
+        [TestCase("Assets/Effects/Stock/BasicEffect.fx", TargetPlatform.Windows)]
+        [TestCase("Assets/Effects/Stock/DualTextureEffect.fx", TargetPlatform.Windows)]
+        [TestCase("Assets/Effects/Stock/EnvironmentMapEffect.fx", TargetPlatform.Windows)]
+        [TestCase("Assets/Effects/Stock/SkinnedEffect.fx", TargetPlatform.Windows)]
+        [TestCase("Assets/Effects/Stock/SpriteEffect.fx", TargetPlatform.Windows)]
+        [TestCase("Assets/Effects/Stock/AlphaTestEffect.fx", TargetPlatform.DesktopGL)]
+        [TestCase("Assets/Effects/Stock/BasicEffect.fx", TargetPlatform.DesktopGL)]
+        [TestCase("Assets/Effects/Stock/DualTextureEffect.fx", TargetPlatform.DesktopGL)]
+        [TestCase("Assets/Effects/Stock/EnvironmentMapEffect.fx", TargetPlatform.DesktopGL)]
+        [TestCase("Assets/Effects/Stock/SkinnedEffect.fx", TargetPlatform.DesktopGL)]
+        [TestCase("Assets/Effects/Stock/SpriteEffect.fx", TargetPlatform.DesktopGL)]
+        [TestCase("Assets/Effects/Stock/AlphaTestEffect.fx", TargetPlatform.WindowsGDK)]
+        [TestCase("Assets/Effects/Stock/BasicEffect.fx", TargetPlatform.WindowsGDK)]
+        [TestCase("Assets/Effects/Stock/DualTextureEffect.fx", TargetPlatform.WindowsGDK)]
+        [TestCase("Assets/Effects/Stock/EnvironmentMapEffect.fx", TargetPlatform.WindowsGDK)]
+        [TestCase("Assets/Effects/Stock/SkinnedEffect.fx", TargetPlatform.WindowsGDK)]
+        [TestCase("Assets/Effects/Stock/SpriteEffect.fx", TargetPlatform.WindowsGDK)]
+        [TestCase("Assets/Effects/Stock/AlphaTestEffect.fx", TargetPlatform.DesktopVK)]
+        [TestCase("Assets/Effects/Stock/BasicEffect.fx", TargetPlatform.DesktopVK)]
+        [TestCase("Assets/Effects/Stock/DualTextureEffect.fx", TargetPlatform.DesktopVK)]
+        [TestCase("Assets/Effects/Stock/EnvironmentMapEffect.fx", TargetPlatform.DesktopVK)]
+        [TestCase("Assets/Effects/Stock/SkinnedEffect.fx", TargetPlatform.DesktopVK)]
+        [TestCase("Assets/Effects/Stock/SpriteEffect.fx", TargetPlatform.DesktopVK)]
+        public void BuildStockEffect(string effectFile, TargetPlatform platform)
         {
-            BuildEffect(effectFile, TargetPlatform.Windows);
+            BuildEffect(effectFile, platform);
         }
 
         private void BuildEffect(string effectFile, TargetPlatform targetPlatform, string defines = null)

--- a/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
+++ b/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
@@ -24,7 +24,16 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.7" />
+    <PackageReference Include="Microsoft.Direct3D.DXC" Version="1.8.2505.32" />
   </ItemGroup>
+
+  <Target Name="CopyNuGetToolFiles" AfterTargets="Build">
+    <ItemGroup>
+      <ToolFiles Include="$(NuGetPackageRoot)Microsoft.Direct3D.DXC\1.8.2505.32\build\native\bin\x64\*.dll" />
+      <ToolFiles Include="$(NuGetPackageRoot)Microsoft.Direct3D.DXC\1.8.2505.32\build\native\bin\x64\*.exe" />
+    </ItemGroup>
+    <Copy SourceFiles="@(ToolFiles)" DestinationFolder="$(OutputPath)" />
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\..\MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj" />

--- a/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
+++ b/Tools/MonoGame.Tools.Tests/MonoGame.Tools.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="NUnitLite" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -34,8 +34,17 @@
     <PackageReference Include="Cake.Frosting" Version="5.0.0" />
     <PackageReference Include="Cake.Git" Version="4.0.0" />
     <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.7" />
+    <PackageReference Include="Microsoft.Direct3D.DXC" Version="1.8.2505.32" />
     <PackageReference Include="NuGet.Packaging" Version="6.11.1" />
     <PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
   </ItemGroup>
+
+  <Target Name="CopyNuGetToolFiles" AfterTargets="Build">
+    <ItemGroup>
+      <ToolFiles Include="$(NuGetPackageRoot)Microsoft.Direct3D.DXC\1.8.2505.32\build\native\bin\x64\*.dll" />
+      <ToolFiles Include="$(NuGetPackageRoot)Microsoft.Direct3D.DXC\1.8.2505.32\build\native\bin\x64\*.exe" />
+    </ItemGroup>
+    <Copy SourceFiles="@(ToolFiles)" DestinationFolder="$(OutputPath)" />
+  </Target>
 
 </Project>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -33,18 +33,9 @@
     <PackageReference Include="Cake.FileHelpers" Version="7.0.0" />
     <PackageReference Include="Cake.Frosting" Version="5.0.0" />
     <PackageReference Include="Cake.Git" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Direct3D.DXC" Version="1.8.2505.32" />
     <PackageReference Include="MonoGame.Tool.Dxc" Version="1.8.2505.7" />
     <PackageReference Include="NuGet.Packaging" Version="6.11.1" />
     <PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
   </ItemGroup>
-
-  <Target Name="CopyNuGetToolFiles" AfterTargets="Build">
-    <ItemGroup>
-      <ToolFiles Include="$(NuGetPackageRoot)Microsoft.Direct3D.DXC\1.8.2505.32\build\native\bin\x64\*.dll" />
-	    <ToolFiles Include="$(NuGetPackageRoot)Microsoft.Direct3D.DXC\1.8.2505.32\build\native\bin\x64\*.exe" />
-    </ItemGroup>
-    <Copy SourceFiles="@(ToolFiles)" DestinationFolder="$(OutputPath)" />
-  </Target>
 
 </Project>


### PR DESCRIPTION
This PR enables the tools unit tests to build the stock effects for all platforms (it previously only tested DirectX 11).

This will likely fail the tests as I don't comprehend why ```libmojoshader_64.dll``` doesn't seem to load when building OpenGL shaders (edit: this is due to #8942).

EDIT: this depends on #8939 and will need a rebase.

I also wasn't aware that the tool tests are running on Linux, so this will fail DirectX 12 shaders no matter what. I need to disable them for testing.