### PR TITLE
Specifying culture to use when serializing value types in MonoGame

### DIFF
--- a/MonoGame.Framework/BoundingBox.cs
+++ b/MonoGame.Framework/BoundingBox.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -877,7 +878,17 @@ namespace Microsoft.Xna.Framework
         /// <returns>A <see cref="String"/> representation of this <see cref="BoundingBox"/>.</returns>
         public override string ToString()
         {
-            return "{{Min:" + this.Min.ToString() + " Max:" + this.Max.ToString() + "}}";
+            return "{{Min:" + this.Min.ToString(CultureInfo.CurrentCulture) + " Max:" + this.Max.ToString(CultureInfo.CurrentCulture) + "}}";
+        }
+
+        /// <summary>
+        /// Serializes the <see cref="BoundingBox"/> to a string using the specified format provider.
+        /// </summary>
+        /// <param name="formatProvider">Format provider to utilise</param>
+        /// <returns>String representation of this <see cref="BoundingBox"/></returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return "{{Min:" + this.Min.ToString(formatProvider) + " Max:" + this.Max.ToString(formatProvider) + "}}";
         }
 
         /// <summary>

--- a/MonoGame.Framework/BoundingSphere.cs
+++ b/MonoGame.Framework/BoundingSphere.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -40,7 +41,7 @@ namespace Microsoft.Xna.Framework
             {
                 return string.Concat(
                     "Center( ", this.Center.DebugDisplayString, " )  \r\n",
-                    "Radius( ", this.Radius.ToString(), " )"
+                    "Radius( ", this.Radius.ToString(CultureInfo.InvariantCulture), " )"
                     );
             }
         }

--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -6,6 +6,7 @@ using System;
 using System.Text;
 using System.Runtime.Serialization;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework
 {
@@ -1842,10 +1843,10 @@ namespace Microsoft.Xna.Framework
             get
             {
                 return string.Concat(
-                    this.R.ToString(), "  ",
-                    this.G.ToString(), "  ",
-                    this.B.ToString(), "  ",
-                    this.A.ToString()
+                    this.R.ToString(CultureInfo.InvariantCulture), "  ",
+                    this.G.ToString(CultureInfo.InvariantCulture), "  ",
+                    this.B.ToString(CultureInfo.InvariantCulture), "  ",
+                    this.A.ToString(CultureInfo.InvariantCulture)
                 );
             }
         }
@@ -1867,7 +1868,7 @@ namespace Microsoft.Xna.Framework
             sb.Append(B);
             sb.Append(" A:");
             sb.Append(A);
-            sb.Append("}");
+            sb.Append('}');
             return sb.ToString();
         }
 

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -624,14 +624,14 @@ namespace Microsoft.Xna.Framework.Content
                 // This never executes as asset.Key is never null.  This just forces the
                 // linker to include the ReloadAsset function when AOT compiled.
                 if (asset.Key == null)
-                    ReloadAsset(asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()));
+                    ReloadAsset(asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType(), CultureInfo.InvariantCulture));
 
                 var methodInfo = ReflectionHelpers.GetMethodInfo(typeof(ContentManager), "ReloadAsset");
                 // Up the callstack, it is ensured that the type of asset.Value can be used to make a generic method for.
                 #pragma warning disable IL2060, IL3050
                 var genericMethod = methodInfo.MakeGenericMethod(asset.Value.GetType());
                 #pragma warning restore IL2060, IL3050
-                genericMethod.Invoke(this, new object[] { asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType()) });
+                genericMethod.Invoke(this, new object[] { asset.Key, Convert.ChangeType(asset.Value, asset.Value.GetType(), CultureInfo.InvariantCulture) });
             }
         }
 

--- a/MonoGame.Framework/Content/ContentReader.cs
+++ b/MonoGame.Framework/Content/ContentReader.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using MonoGame.Framework.Utilities;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Content
 {
@@ -393,7 +394,7 @@ namespace Microsoft.Xna.Framework.Content
                     {
                         if (!(v is T))
                         {
-                            throw new ContentLoadException(String.Format("Error loading shared resource. Expected type {0}, received type {1}", typeof(T).Name, v.GetType().Name));
+                            throw new ContentLoadException(String.Format(CultureInfo.InvariantCulture, "Error loading shared resource. Expected type {0}, received type {1}", typeof(T).Name, v.GetType().Name));
                         }
                         fixup((T)v);
                     }));

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -2,13 +2,14 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using MonoGame.Framework.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using MonoGame.Framework.Utilities;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Xna.Framework.Content
 {
@@ -169,7 +170,7 @@ namespace Microsoft.Xna.Framework.Content
                 if (elementType == typeof(System.Array))
                     reader = new ArrayReader<Array>();
                 else
-                    throw new ContentLoadException(string.Format("Content reader could not be found for {0} type.", elementType.FullName));
+                    throw new ContentLoadException(String.Format(CultureInfo.InvariantCulture, "Content reader could not be found for {0} type.", elementType.FullName));
 
             // We use the construct delegate to pick the correct existing 
             // object to be the target of deserialization.

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -2,12 +2,13 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using MonoGame.Framework.Utilities;
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using System.Collections.Generic;
-using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
 {
@@ -266,9 +267,9 @@ namespace Microsoft.Xna.Framework.Content
             if (preparedType.Contains("PublicKeyToken"))
                 preparedType = Regex.Replace(preparedType, @"(.+?), Version=.+?$", "$1");
 
-            preparedType = preparedType.Replace(", Microsoft.Xna.Framework.Graphics", string.Format(", {0}", _assemblyName));
-            preparedType = preparedType.Replace(", Microsoft.Xna.Framework.Video", string.Format(", {0}", _assemblyName));
-            preparedType = preparedType.Replace(", Microsoft.Xna.Framework", string.Format(", {0}", _assemblyName));
+            preparedType = preparedType.Replace(", Microsoft.Xna.Framework.Graphics", string.Format(CultureInfo.InvariantCulture, ", {0}", _assemblyName));
+            preparedType = preparedType.Replace(", Microsoft.Xna.Framework.Video", string.Format(CultureInfo.InvariantCulture, ", {0}", _assemblyName));
+            preparedType = preparedType.Replace(", Microsoft.Xna.Framework", string.Format(CultureInfo.InvariantCulture, ", {0}", _assemblyName));
 
             if (_isRunningOnNetCore)
                 preparedType = preparedType.Replace("mscorlib", "System.Private.CoreLib");

--- a/MonoGame.Framework/Content/ResourceContentManager.cs
+++ b/MonoGame.Framework/Content/ResourceContentManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Resources;
 
@@ -42,7 +43,7 @@ namespace Microsoft.Xna.Framework.Content
         /// </exception>
         protected override System.IO.Stream OpenStream(string assetName)
         {
-            object obj = this.resource.GetObject(assetName);
+            object obj = this.resource.GetObject(assetName, CultureInfo.InvariantCulture);
             if (obj == null)
             {
                 throw new ContentLoadException("Resource not found");

--- a/MonoGame.Framework/Design/Byte4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Byte4TypeConverter.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Xna.Framework.Design
 
             if (destinationType == typeof(string))
             {
-                return vec.PackedValue.ToString();
+                return vec.PackedValue.ToString(culture);
             }
 
             return base.ConvertTo(context, culture, value, destinationType);

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -2,13 +2,14 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input.Touch;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 
 
 namespace Microsoft.Xna.Framework
@@ -164,7 +165,7 @@ namespace Microsoft.Xna.Framework
             {
                 string name = GetType().Name;
                 throw new ObjectDisposedException(
-                    name, string.Format("The {0} object was used after being Disposed.", name));
+                    name, string.Format(CultureInfo.InvariantCulture, "The {0} object was used after being Disposed.", name));
             }
         }
 
@@ -487,7 +488,7 @@ namespace Microsoft.Xna.Framework
                 Platform.RunLoop();
                 break;
             default:
-                throw new ArgumentException(string.Format(
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture,
                     "Handling for the run behavior {0} is not implemented.", runBehavior));
             }
         }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (adapter == null)
                 throw new ArgumentNullException("adapter");
             if (!adapter.IsProfileSupported(graphicsProfile))
-                throw new NoSuitableGraphicsDeviceException(String.Format("Adapter '{0}' does not support the {1} profile.", adapter.Description, graphicsProfile));
+                throw new NoSuitableGraphicsDeviceException(String.Format(CultureInfo.InvariantCulture, "Adapter '{0}' does not support the {1} profile.", adapter.Description, graphicsProfile));
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
             Adapter = adapter;
@@ -311,7 +311,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (adapter == null)
                 throw new ArgumentNullException("adapter");
             if (!adapter.IsProfileSupported(graphicsProfile))
-                throw new NoSuitableGraphicsDeviceException(String.Format("Adapter '{0}' does not support the {1} profile.", adapter.Description, graphicsProfile));
+                throw new NoSuitableGraphicsDeviceException(String.Format(CultureInfo.InvariantCulture, "Adapter '{0}' does not support the {1} profile.", adapter.Description, graphicsProfile));
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
 #if DIRECTX
@@ -1621,7 +1621,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var dataByteSize = width * height * fSize;
 
             if (elementCount * tSize != dataByteSize)
-                throw new ArgumentException(string.Format("elementCount is not the right size, " +
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "elementCount is not the right size, " +
                                             "elementCount * sizeof(T) is {0}, but data size is {1} bytes.",
                                             elementCount * tSize, dataByteSize), "elementCount");
 

--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 #if OPENGL
 #if DESKTOPGL || GLES
@@ -761,7 +762,7 @@ namespace Microsoft.Xna.Framework.Graphics
 				break;
             case InvalidFormat: 
             default:
-                    throw new NotSupportedException(string.Format("The requested SurfaceFormat `{0}` is not supported.", format));
+                    throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, "The requested SurfaceFormat `{0}` is not supported.", format));
 			}
 		}
 

--- a/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -80,7 +81,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return (packedValue / 255.0f).ToString();
+            return (packedValue / 255.0f).ToString(CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="Alpha8"/> using the specified format provider.
+        /// </summary>
+        /// <param name="provider">Format provider to utilize</param>
+        /// <returns>String representation of <see langword="this" />.</returns>
+        public string ToString(IFormatProvider provider)
+        {
+            return (packedValue / 255.0f).ToString(provider);
         }
 
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -102,7 +103,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return ToVector3().ToString();
+            return ToVector3().ToString(CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Serializes the packed vector to a string using the specified format provider.
+        /// </summary>
+        /// <param name="formatProvider">Format provider to utilise</param>
+        /// <returns>String representation of this <see cref="Bgr565"/></returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToVector3().ToString(formatProvider);
         }
 
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -95,7 +96,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return ToVector4().ToString();
+            return ToVector4().ToString(CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Serializes the packed vector to a string using the specified format provider.
+        /// </summary>
+        /// <param name="formatProvider">Format provider to utilise</param>
+        /// <returns>String representation of this <see cref="Bgra4444"/></returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToVector4().ToString(formatProvider);
         }
 
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -86,7 +87,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return ToVector4().ToString();
+            return ToVector4().ToString(CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Serializes the packed vector to a string using the specified format provider.
+        /// </summary>
+        /// <param name="formatProvider">Format provider to utilise</param>
+        /// <returns>String representation of this <see cref="Bgra5551"/></returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToVector4().ToString(formatProvider);
         }
 
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -108,7 +109,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return packedValue.ToString("x8");
+            return packedValue.ToString("x8", CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="Byte4"/> using the specified format provider.
+        /// </summary>
+        /// <param name="provider">Format provider to utilize</param>
+        /// <returns>String representation of <see langword="this" />.</returns>
+        public string ToString(IFormatProvider provider)
+        {
+            return packedValue.ToString("x8", provider);
         }
 
         static uint Pack(ref Vector4 vector)

--- a/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -80,7 +81,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return this.ToSingle().ToString();
+            return this.ToSingle().ToString(CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="HalfSingle"/> using the specified format provider.
+        /// </summary>
+        /// <param name="provider">Format provider to utilize</param>
+        /// <returns>String representation of <see langword="this" />.</returns>
+        public string ToString(IFormatProvider provider)
+        {
+            return packedValue.ToString(provider);
         }
 
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <returns>String representation of <see langword="this" />.</returns>
         public string ToString(IFormatProvider provider)
         {
-            return packedValue.ToString(provider);
+            return this.ToSingle().ToString(provider);
         }
 
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -86,7 +87,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return this.ToVector2().ToString();
+            return this.ToVector2().ToString(CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the packed vector using the specified format provider.
+        /// </summary>
+        /// <param name="formatProvider">Format provider to utilise</param>
+        /// <returns>String representation of this <see cref="HalfVector2"/></returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return this.ToVector2().ToString(formatProvider);
         }
 
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -82,7 +83,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return ToVector4().ToString();
+            return ToVector4().ToString(CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Serializes the packed vector to a string using the specified format provider.
+        /// </summary>
+        /// <param name="formatProvider">Format provider to utilise</param>
+        /// <returns>String representation of this <see cref="HalfVector4"/></returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToVector4().ToString(formatProvider);
         }
 
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -96,7 +97,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return _packed.ToString("X");
+            return _packed.ToString("X", CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="NormalizedByte2"/> using the specified format provider.
+        /// </summary>
+        /// <param name="provider">Format provider to utilize</param>
+        /// <returns>String representation of <see langword="this" />.</returns>
+        public string ToString(IFormatProvider provider)
+        {
+            return _packed.ToString("X", provider);
         }
 
         private static ushort Pack(float x, float y)

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -98,7 +99,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return _packed.ToString("X");
+            return _packed.ToString("X", CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="NormalizedByte4"/> using the specified format provider.
+        /// </summary>
+        /// <param name="provider">Format provider to utilize</param>
+        /// <returns>String representation of <see langword="this" />.</returns>
+        public string ToString(IFormatProvider provider)
+        {
+            return _packed.ToString("X", provider);
         }
 
         private static uint Pack(float x, float y, float z, float w)

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -96,8 +97,18 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString ()
 		{
-            return short2Packed.ToString("X");
+            return short2Packed.ToString("X", CultureInfo.CurrentCulture);
 		}
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="NormalizedShort2"/> using the specified format provider.
+        /// </summary>
+        /// <param name="provider">Format provider to utilize</param>
+        /// <returns>String representation of <see langword="this" />.</returns>
+        public string ToString(IFormatProvider provider)
+        {
+            return short2Packed.ToString("X", provider);
+        }
 
         /// <summary>
         /// Expands the packed representation to a <see cref="Vector2"/>.

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -97,8 +98,18 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
 		public override string ToString ()
 		{
-            return short4Packed.ToString("X");
+            return short4Packed.ToString("X", CultureInfo.CurrentCulture);
 		}
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="NormalizedShort4"/> using the specified format provider.
+        /// </summary>
+        /// <param name="provider">Format provider to utilize</param>
+        /// <returns>String representation of <see langword="this" />.</returns>
+        public string ToString(IFormatProvider provider)
+        {
+            return short4Packed.ToString("X", provider);
+        }
 
         private static ulong PackInFour(float vectorX, float vectorY, float vectorZ, float vectorW)
 		{

--- a/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -90,7 +91,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return ToVector2().ToString();
+            return ToVector2().ToString(CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Serializes the packed vector to a string using the specified format provider.
+        /// </summary>
+        /// <param name="formatProvider">Format provider to utilise</param>
+        /// <returns>String representation of this <see cref="Rg32"/></returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToVector2().ToString(formatProvider);
         }
 
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -86,7 +87,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return ToVector4().ToString();
+            return ToVector4().ToString(CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Serializes the packed vector to a string using the specified format provider.
+        /// </summary>
+        /// <param name="formatProvider">Format provider to utilise</param>
+        /// <returns>String representation of this <see cref="Rgba1010102"/></returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToVector4().ToString(formatProvider);
         }
 
         /// <inheritdoc />

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -85,8 +86,19 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
 		public override string ToString()
 		{
-			return ToVector4().ToString();
+			return ToVector4().ToString(CultureInfo.CurrentCulture);
 		}
+
+
+        /// <summary>
+        /// Returns a string representation of the packed vector using the specified format provider.
+        /// </summary>
+        /// <param name="formatProvider">Format provider to utilise</param>
+        /// <returns>String representation of this <see cref="HalfVector2"/></returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ToVector4().ToString(formatProvider);
+        }
 
         /// <inheritdoc />
 		public override int GetHashCode()

--- a/MonoGame.Framework/Graphics/PackedVector/Short2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short2.cs
@@ -2,9 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -98,8 +98,18 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
 		public override string ToString ()
 		{
-            return _short2Packed.ToString("x8");
+            return _short2Packed.ToString("x8", CultureInfo.CurrentCulture);
 		}
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="Short2"/> using the specified format provider.
+        /// </summary>
+        /// <param name="provider">Format provider to utilize</param>
+        /// <returns>String representation of <see langword="this" />.</returns>
+        public string ToString(IFormatProvider provider)
+        {
+            return _short2Packed.ToString("X", provider);
+        }
 
         /// <summary>
         /// Expands the packed representation to a <see cref="Vector2"/>.

--- a/MonoGame.Framework/Graphics/PackedVector/Short4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short4.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -99,7 +100,17 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <inheritdoc />
         public override string ToString()
         {
-            return packedValue.ToString("x16");
+            return packedValue.ToString("x16", CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="Short4"/> using the specified format provider.
+        /// </summary>
+        /// <param name="provider">Format provider to utilize</param>
+        /// <returns>String representation of <see langword="this" />.</returns>
+        public string ToString(IFormatProvider provider)
+        {
+            return packedValue.ToString("X", provider);
         }
 
         static ulong Pack(ref Vector4 vector)

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 
 namespace Microsoft.Xna.Framework.Graphics 
@@ -268,7 +269,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 if(!TryGetRegionIdx(c, pRegions, out int regionIdx))
                 {
-                    c = char.IsUpper(c) ? char.ToLower(c) : char.ToUpper(c);
+                    c = char.IsUpper(c) ? char.ToLower(c, CultureInfo.InvariantCulture) : char.ToUpper(c, CultureInfo.InvariantCulture);
                     TryGetRegionIdx(c, pRegions, out regionIdx);
                 }
 

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics.PackedVector;
 using MonoGame.Framework.Utilities;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -835,7 +836,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 dataByteSize = checkedRect.Width * checkedRect.Height * fSize;
             }
             if (elementCount * tSize != dataByteSize)
-                throw new ArgumentException(string.Format("elementCount is not the right size, " +
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "elementCount is not the right size, " +
                                             "elementCount * sizeof(T) is {0}, but data size is {1}.",
                                             elementCount * tSize, dataByteSize), "elementCount");
         }

--- a/MonoGame.Framework/Graphics/Texture3D.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.cs
@@ -2,11 +2,12 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.IO;
-using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework.Content;
 using MonoGame.Framework.Utilities;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -421,7 +422,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             var dataByteSize = width*height*depth*fSize;
             if (elementCount * tSize != dataByteSize)
-                throw new ArgumentException(string.Format("elementCount is not the right size, " +
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "elementCount is not the right size, " +
                                             "elementCount * sizeof(T) is {0}, but data size is {1}.",
                                             elementCount * tSize, dataByteSize), "elementCount");
         }

--- a/MonoGame.Framework/Graphics/TextureCube.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.cs
@@ -2,9 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.Runtime.InteropServices;
 using MonoGame.Framework.Utilities;
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -344,7 +345,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 dataByteSize = checkedRect.Width * checkedRect.Height * fSize;
             }
             if (elementCount * tSize != dataByteSize)
-                throw new ArgumentException(string.Format("elementCount is not the right size, " +
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "elementCount is not the right size, " +
                                             "elementCount * sizeof(T) is {0}, but data size is {1}.",
                                             elementCount * tSize, dataByteSize), "elementCount");
         }

--- a/MonoGame.Framework/Input/GamePadState.cs
+++ b/MonoGame.Framework/Input/GamePadState.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Globalization;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
@@ -217,7 +219,7 @@ namespace Microsoft.Xna.Framework.Input
                 return "[GamePadState: IsConnected = 0]";
 
             return "[GamePadState: IsConnected=" + (IsConnected ? "1" : "0") +
-                   ", PacketNumber=" + PacketNumber.ToString("00000") +
+                   ", PacketNumber=" + PacketNumber.ToString("00000", CultureInfo.InvariantCulture) +
                    ", Buttons=" + Buttons +
                    ", DPad=" + DPad +
                    ", ThumbSticks=" + ThumbSticks +

--- a/MonoGame.Framework/Input/JoystickState.cs
+++ b/MonoGame.Framework/Input/JoystickState.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -114,7 +115,7 @@ namespace Microsoft.Xna.Framework.Input
             {
                 ret.Append(", Axes=");
                 foreach (var axis in Axes)
-                    ret.Append((axis > 0 ? "+" : "") + axis.ToString("00000") + " ");
+                    ret.Append((axis > 0 ? "+" : "") + axis.ToString("00000", CultureInfo.InvariantCulture) + " ");
                 ret.Length--;
 
                 ret.Append(", Buttons=");
@@ -127,7 +128,7 @@ namespace Microsoft.Xna.Framework.Input
                 ret.Length--;
             }
 
-            ret.Append("]");
+            ret.Append(']');
             return ret.ToString();
         }
     }

--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -2398,10 +2399,10 @@ namespace Microsoft.Xna.Framework
                 }
 
                 return string.Concat(
-                     "( ", this.M11.ToString(), "  ", this.M12.ToString(), "  ", this.M13.ToString(), "  ", this.M14.ToString(), " )  \r\n",
-                     "( ", this.M21.ToString(), "  ", this.M22.ToString(), "  ", this.M23.ToString(), "  ", this.M24.ToString(), " )  \r\n",
-                     "( ", this.M31.ToString(), "  ", this.M32.ToString(), "  ", this.M33.ToString(), "  ", this.M34.ToString(), " )  \r\n",
-                     "( ", this.M41.ToString(), "  ", this.M42.ToString(), "  ", this.M43.ToString(), "  ", this.M44.ToString(), " )");
+                     "( ", this.M11.ToString(CultureInfo.InvariantCulture), "  ", this.M12.ToString(CultureInfo.InvariantCulture), "  ", this.M13.ToString(CultureInfo.InvariantCulture), "  ", this.M14.ToString(CultureInfo.InvariantCulture), " )  \r\n",
+                     "( ", this.M21.ToString(CultureInfo.InvariantCulture), "  ", this.M22.ToString(CultureInfo.InvariantCulture), "  ", this.M23.ToString(CultureInfo.InvariantCulture), "  ", this.M24.ToString(CultureInfo.InvariantCulture), " )  \r\n",
+                     "( ", this.M31.ToString(CultureInfo.InvariantCulture), "  ", this.M32.ToString(CultureInfo.InvariantCulture), "  ", this.M33.ToString(CultureInfo.InvariantCulture), "  ", this.M34.ToString(CultureInfo.InvariantCulture), " )  \r\n",
+                     "( ", this.M41.ToString(CultureInfo.InvariantCulture), "  ", this.M42.ToString(CultureInfo.InvariantCulture), "  ", this.M43.ToString(CultureInfo.InvariantCulture), "  ", this.M44.ToString(CultureInfo.InvariantCulture), " )");
             }
         }
 

--- a/MonoGame.Framework/Plane.cs
+++ b/MonoGame.Framework/Plane.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -446,7 +447,7 @@ namespace Microsoft.Xna.Framework
             {
                 return string.Concat(
                     this.Normal.DebugDisplayString, "  ",
-                    this.D.ToString()
+                    this.D.ToString(CultureInfo.InvariantCulture)
                     );
             }
         }

--- a/MonoGame.Framework/Platform/Audio/AudioLoader.cs
+++ b/MonoGame.Framework/Platform/Audio/AudioLoader.cs
@@ -2,9 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.IO;
 using MonoGame.OpenAL;
+using System;
+using System.Globalization;
+using System.IO;
 
 namespace Microsoft.Xna.Framework.Audio
 {
@@ -52,7 +53,7 @@ namespace Microsoft.Xna.Framework.Audio
                         default: throw new NotSupportedException("The specified channel count is not supported.");
                     }
                 default:
-                    throw new NotSupportedException("The specified sound format (" + format.ToString() + ") is not supported.");
+                    throw new NotSupportedException("The specified sound format (" + format.ToString(CultureInfo.InvariantCulture) + ") is not supported.");
             }
         }
 

--- a/MonoGame.Framework/Platform/Audio/Microphone.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/Microphone.OpenAL.cs
@@ -2,12 +2,12 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using MonoGame.Framework.Utilities;
+using MonoGame.OpenAL;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.InteropServices;
-using MonoGame.Framework.Utilities;
-
-using MonoGame.OpenAL;
 #if IOS || MONOMAC
 using AudioToolbox;
 using AudioUnit;
@@ -32,9 +32,9 @@ namespace Microsoft.Xna.Framework.Audio
 
             string errorFmt = "OpenAL Error: {0}";
 
-            throw new NoMicrophoneConnectedException(String.Format("{0} - {1}",
+            throw new NoMicrophoneConnectedException(String.Format(CultureInfo.InvariantCulture, "{0} - {1}",
                             operation,
-                            string.Format(errorFmt, error)));
+                            String.Format(CultureInfo.InvariantCulture, errorFmt, error)));
         }
 
         internal static void PopulateCaptureDevices()

--- a/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
@@ -1,11 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.IO;
-using System.Runtime.InteropServices;
 using MonoGame.Framework.Utilities;
 using MonoGame.OpenAL;
 using MonoGame.OpenGL;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 #if ANDROID
 using System.Globalization;
@@ -31,7 +32,7 @@ namespace Microsoft.Xna.Framework.Audio
             if ((error = AL.GetError()) != ALError.NoError)
             {
                 if (args != null && args.Length > 0)
-                    message = String.Format(message, args);
+                    message = String.Format(CultureInfo.InvariantCulture, message, args);
                 
                 throw new InvalidOperationException(message + " (Reason: " + AL.GetErrorString(error) + ")");
             }
@@ -57,7 +58,7 @@ namespace Microsoft.Xna.Framework.Audio
             if ((error = Alc.GetError()) != AlcError.NoError)
             {
                 if (args != null && args.Length > 0)
-                    message = String.Format(message, args);
+                    message = String.Format(CultureInfo.InvariantCulture, message, args);
 
                 throw new InvalidOperationException(message + " (Reason: " + error.ToString() + ")");
             }

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+using System.Globalization;
 
 #if ANGLE
 using OpenTK.Graphics;
@@ -309,8 +310,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (string.IsNullOrEmpty(version))
                     throw new NoSuitableGraphicsDeviceException("Unable to retrieve OpenGL version");
 
-                glMajorVersion = Convert.ToInt32(version.Substring(0, 1));
-                glMinorVersion = Convert.ToInt32(version.Substring(2, 1));
+                glMajorVersion = Convert.ToInt32(version.Substring(0, 1), CultureInfo.InvariantCulture);
+                glMinorVersion = Convert.ToInt32(version.Substring(2, 1), CultureInfo.InvariantCulture);
             }
             catch (FormatException)
             {

--- a/MonoGame.Framework/Point.cs
+++ b/MonoGame.Framework/Point.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -57,8 +58,8 @@ namespace Microsoft.Xna.Framework
             get
             {
                 return string.Concat(
-                    this.X.ToString(), "  ",
-                    this.Y.ToString()
+                    this.X.ToString(CultureInfo.InvariantCulture), "  ",
+                    this.Y.ToString(CultureInfo.InvariantCulture)
                 );
             }
         }

--- a/MonoGame.Framework/Quaternion.cs
+++ b/MonoGame.Framework/Quaternion.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -117,10 +118,10 @@ namespace Microsoft.Xna.Framework
                 }
 
                 return string.Concat(
-                    this.X.ToString(), " ",
-                    this.Y.ToString(), " ",
-                    this.Z.ToString(), " ",
-                    this.W.ToString()
+                    this.X.ToString(CultureInfo.InvariantCulture), " ",
+                    this.Y.ToString(CultureInfo.InvariantCulture), " ",
+                    this.Z.ToString(CultureInfo.InvariantCulture), " ",
+                    this.W.ToString(CultureInfo.InvariantCulture)
                 );
             }
         }

--- a/MonoGame.Framework/Ray.cs
+++ b/MonoGame.Framework/Ray.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -346,7 +347,17 @@ namespace Microsoft.Xna.Framework
         /// <returns>A <see cref="String"/> representation of this <see cref="Ray"/>.</returns>
         public override string ToString()
         {
-            return "{{Position:" + Position.ToString() + " Direction:" + Direction.ToString() + "}}";
+            return "{{Position:" + Position.ToString(CultureInfo.CurrentCulture) + " Direction:" + Direction.ToString(CultureInfo.CurrentCulture) + "}}";
+        }
+
+        /// <summary>
+        /// Serializes the <see cref="Ray"/> to a string using the specified format provider.
+        /// </summary>
+        /// <param name="formatProvider">Format provider to utilise</param>
+        /// <returns>String representation of this <see cref="Ray"/></returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return "{{Position:" + Position.ToString(formatProvider) + " Direction:" + Direction.ToString(formatProvider) + "}}";
         }
 
         /// <summary>

--- a/MonoGame.Framework/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework/Utilities/FileHelpers.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -77,8 +78,8 @@ namespace MonoGame.Framework.Utilities
 
                     foreach (var num in bytes)
                     {
-                        safeline.Append("%");
-                        safeline.Append(num.ToString("X"));
+                        safeline.Append('%');
+                        safeline.Append(num.ToString("X", CultureInfo.InvariantCulture));
                     }
                 }
             }

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -989,6 +989,17 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Returns a <see cref="String"/> representation of this <see cref="Vector2"/> in the format:
+        /// {X:[<see cref="X"/>] Y:[<see cref="Y"/>]}
+        /// </summary>
+        /// <param name="formatProvider">Format provider for <see cref="X"/> and <see cref="Y"/></param>
+        /// <returns>A <see cref="String"/> representation of this <see cref="Vector2"/>.</returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return "{X:" + X.ToString(formatProvider) + " Y:" + Y.ToString(formatProvider) + "}";
+        }
+
+        /// <summary>
         /// Gets a <see cref="Point"/> representation for this object.
         /// </summary>
         /// <returns>A <see cref="Point"/> representation for this object.</returns>

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -87,8 +88,8 @@ namespace Microsoft.Xna.Framework
             get
             {
                 return string.Concat(
-                    this.X.ToString(), "  ",
-                    this.Y.ToString()
+                    this.X.ToString(CultureInfo.InvariantCulture), "  ",
+                    this.Y.ToString(CultureInfo.InvariantCulture)
                 );
             }
         }

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -4,8 +4,9 @@
 
 using System;
 using System.Diagnostics;
-using System.Text;
+using System.Globalization;
 using System.Runtime.Serialization;
+using System.Text;
 
 namespace Microsoft.Xna.Framework
 {
@@ -156,9 +157,9 @@ namespace Microsoft.Xna.Framework
             get
             {
                 return string.Concat(
-                    this.X.ToString(), "  ",
-                    this.Y.ToString(), "  ",
-                    this.Z.ToString()
+                    this.X.ToString(CultureInfo.InvariantCulture), "  ",
+                    this.Y.ToString(CultureInfo.InvariantCulture), "  ",
+                    this.Z.ToString(CultureInfo.InvariantCulture)
                 );
             }
         }
@@ -1028,7 +1029,7 @@ namespace Microsoft.Xna.Framework
             sb.Append(this.Y);
             sb.Append(" Z:");
             sb.Append(this.Z);
-            sb.Append("}");
+            sb.Append('}');
             return sb.ToString();
         }
 

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -1033,6 +1033,25 @@ namespace Microsoft.Xna.Framework
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Returns a <see cref="String"/> representation of this <see cref="Vector3"/> in the format:
+        /// {X:[<see cref="X"/>] Y:[<see cref="Y"/>] Z:[<see cref="Z"/>]}
+        /// </summary>
+        /// <param name="formatProvider">Provider to format the string with</param>
+        /// <returns>A <see cref="String"/> representation of this <see cref="Vector3"/>.</returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            StringBuilder sb = new StringBuilder(32);
+            sb.Append("{X:");
+            sb.Append(this.X.ToString(formatProvider));
+            sb.Append(" Y:");
+            sb.Append(this.Y.ToString(formatProvider));
+            sb.Append(" Z:");
+            sb.Append(this.Z.ToString(formatProvider));
+            sb.Append('}');
+            return sb.ToString();
+        }
+
         #region Transform
 
         /// <summary>

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -1248,6 +1248,17 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Returns a <see cref="String"/> representation of this <see cref="Vector4"/> in the format:
+        /// {X:[<see cref="X"/>] Y:[<see cref="Y"/>] Z:[<see cref="Z"/>] W:[<see cref="W"/>]}
+        /// </summary>
+        /// <param name="formatProvider">Format provider for <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/> and <see cref="W"/>.</param>
+        /// <returns>A <see cref="String"/> representation of this <see cref="Vector4"/>.</returns>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return "{X:" + X.ToString(formatProvider) + " Y:" + Y.ToString(formatProvider) + " Z:" + Z.ToString(formatProvider) + " W:" + W.ToString(formatProvider) + "}";
+        }
+
+        /// <summary>
         /// Deconstruction method for <see cref="Vector4"/>.
         /// </summary>
         /// <param name="x"></param>

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -3,8 +3,9 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.Runtime.Serialization;
 using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
 {
@@ -116,10 +117,10 @@ namespace Microsoft.Xna.Framework
             get
             {
                 return string.Concat(
-                    this.X.ToString(), "  ",
-                    this.Y.ToString(), "  ",
-                    this.Z.ToString(), "  ",
-                    this.W.ToString()
+                    this.X.ToString(CultureInfo.InvariantCulture), "  ",
+                    this.Y.ToString(CultureInfo.InvariantCulture), "  ",
+                    this.Z.ToString(CultureInfo.InvariantCulture), "  ",
+                    this.W.ToString(CultureInfo.InvariantCulture)
                 );
             }
         }

--- a/Tests/Framework/Components/DrawFrameNumberComponent.cs
+++ b/Tests/Framework/Components/DrawFrameNumberComponent.cs
@@ -2,13 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System.Globalization;
 
 namespace MonoGame.Tests.Components {
 	class DrawFrameNumberComponent : DrawableGameComponent {
@@ -41,7 +37,7 @@ namespace MonoGame.Tests.Components {
 
 			// TODO: Add support for different placements and colors.
 			_batch.Begin ();
-			_batch.DrawString (_font, frameInfo.DrawNumber.ToString(), Vector2.Zero, Color.White);
+			_batch.DrawString (_font, frameInfo.DrawNumber.ToString(CultureInfo.InvariantCulture), Vector2.Zero, Color.White);
 			_batch.End ();
 		}
 	}

--- a/Tests/Framework/Components/FrameCompareComponent.cs
+++ b/Tests/Framework/Components/FrameCompareComponent.cs
@@ -5,17 +5,14 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 using NUnit.Framework;
+using System.Globalization;
 
 // TODO: It's likely that a more sophisticated approach will be required for
 //       comparing images.  In particular, comparing pixel deltas would give
@@ -242,7 +239,7 @@ namespace MonoGame.Tests.Components {
 
 				var frameInfo = Game.Services.RequireService<IFrameInfoSource> ().FrameInfo;
 
-				var fileName = string.Format (_fileNameFormat, frameInfo.DrawNumber);
+				var fileName = string.Format (CultureInfo.InvariantCulture, _fileNameFormat, frameInfo.DrawNumber);
 
 				string frameOutputPath = null;
 				if (OutputDirectory != null)

--- a/Tests/Framework/Components/ImplicitDrawOrderComponent.cs
+++ b/Tests/Framework/Components/ImplicitDrawOrderComponent.cs
@@ -2,12 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
+using System.Globalization;
 
 namespace MonoGame.Tests.Components {
 	class ImplicitDrawOrderComponent : VisualTestDrawableGameComponent {
@@ -68,7 +66,7 @@ namespace MonoGame.Tests.Components {
 
 			_spriteBatch.Begin ();
 			DrawStatusString (
-			    string.Format ("{0} drawables", _drawables.Count),
+			    string.Format (CultureInfo.InvariantCulture, "{0} drawables", _drawables.Count),
 			    0, _drawablesOrderedCorrectly);
 			_spriteBatch.End ();
 		}
@@ -135,7 +133,7 @@ namespace MonoGame.Tests.Components {
 				var position = new Vector2 (_number * halfEx, 0);
 
 				_spriteBatch.Begin (SpriteSortMode.Immediate, BlendState.AlphaBlend);
-				_spriteBatch.DrawString (_owner._font, _number.ToString (), position, _color);
+				_spriteBatch.DrawString (_owner._font, _number.ToString (CultureInfo.InvariantCulture), position, _color);
 				_spriteBatch.End ();
 			}
 		}

--- a/Tests/Framework/GameTest.cs
+++ b/Tests/Framework/GameTest.cs
@@ -2,14 +2,13 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using Microsoft.Xna.Framework;
+using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
-using System.Threading;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using NUnit.Framework;
 
 namespace MonoGame.Tests {
 	static partial class GameTest {
@@ -492,8 +491,8 @@ namespace MonoGame.Tests {
 					default: throw new NotSupportedException (Action.ToString ());
 					}
 
-					return string.Format (
-						       "{0}({1:0}{2})",
+					return string.Format (CultureInfo.InvariantCulture,
+                               "{0}({1:0}{2})",
 						       actionInitial,
 						       ElapsedGameTime.TotalMilliseconds,
 						       WasRunningSlowly ? "!" : "");

--- a/Tests/Framework/Graphics/GraphicsDeviceTestFixtureBase.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceTestFixtureBase.cs
@@ -2,19 +2,18 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Tests.Components;
 using MonoGame.Tests.Utilities;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
 
 namespace MonoGame.Tests.Graphics
 {
@@ -175,8 +174,8 @@ namespace MonoGame.Tests.Graphics
             {
                 var frame = _submittedFrames[i];
 
-                var capturedPath = string.Format(capturedImagePath, i + 1);
-                var referencePath = string.Format(referenceImagePath, i + 1);
+                var capturedPath = string.Format(CultureInfo.InvariantCulture, capturedImagePath, i + 1);
+                var referencePath = string.Format(CultureInfo.InvariantCulture, referenceImagePath, i + 1);
 
                 if (!File.Exists(referencePath))
                 {
@@ -216,7 +215,7 @@ namespace MonoGame.Tests.Graphics
 
                 if (result.SaveDiff)
                 {
-                    var name = string.Format(fileName, i + 1);
+                    var name = string.Format(CultureInfo.InvariantCulture, fileName, i + 1);
                     var path = GetDiffPath(name);
                     result.DiffPath = path;
                     Directory.CreateDirectory(Path.GetDirectoryName(path));
@@ -308,7 +307,7 @@ namespace MonoGame.Tests.Graphics
         {
 			var folderName = TestContext.CurrentContext.GetTestFolderName();
             var directory = Paths.CapturedFrameDiff(folderName);
-            var diffFileName = string.Format("diff-{0}", name);
+            var diffFileName = string.Format(CultureInfo.InvariantCulture, "diff-{0}", name);
             return Path.Combine (directory, diffFileName);
         }
 

--- a/Tests/Framework/Graphics/Texture3DNonVisualTest.cs
+++ b/Tests/Framework/Graphics/Texture3DNonVisualTest.cs
@@ -2,10 +2,11 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using NUnit.Framework;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using NUnit.Framework;
+using System;
+using System.Globalization;
 
 namespace MonoGame.Tests.Graphics
 {
@@ -95,11 +96,11 @@ namespace MonoGame.Tests.Graphics
             for (int i = 0; i < a; i++)
             {
                 if (i < startIndex)
-                    Assert.AreNotEqual(reference[i], written[i], string.Format("Color written from before startIndex"));
+                    Assert.AreNotEqual(reference[i], written[i], "Color written from before startIndex");
                 else if (i < elementCount + startIndex)
-                    Assert.AreEqual(write[i + startIndex], written[i], string.Format("bad color in position {0}", i));
+                    Assert.AreEqual(write[i + startIndex], written[i], string.Format(CultureInfo.InvariantCulture, "bad color in position {0}", i));
                 else
-                    Assert.AreEqual(reference[i], written[i], string.Format("Color written after elementCount"));
+                    Assert.AreEqual(reference[i], written[i], "Color written after elementCount");
             }
 
         }
@@ -144,9 +145,9 @@ namespace MonoGame.Tests.Graphics
                 cy = (i / Texture3DNonVisualTest.w) % Texture3DNonVisualTest.h;
                 cz = ((i / Texture3DNonVisualTest.w) / Texture3DNonVisualTest.h) % Texture3DNonVisualTest.d;
                 if (cx >= x && cx < w + x && cy >= y && cy < h + y && cz >= z && cz < d + z)
-                    Assert.AreEqual(write[startIndex + j++], written[i], string.Format("bad color in position x:{0};y:{1};z:{2};i:{3}", cx, cy, cz, i));
+                    Assert.AreEqual(write[startIndex + j++], written[i], string.Format(CultureInfo.InvariantCulture, "bad color in position x:{0};y:{1};z:{2};i:{3}", cx, cy, cz, i));
                 else
-                    Assert.AreEqual(reference[i], written[i], string.Format("bad color in position x:{0};y:{1};z:{2};i:{3}, outside requested area", cx, cy, cz, i));
+                    Assert.AreEqual(reference[i], written[i], string.Format(CultureInfo.InvariantCulture, "bad color in position x:{0};y:{1};z:{2};i:{3}, outside requested area", cx, cy, cz, i));
             }
         }
 

--- a/Tests/Framework/SerializationTest.cs
+++ b/Tests/Framework/SerializationTest.cs
@@ -1,0 +1,293 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics.PackedVector;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Globalization; 
+
+namespace MonoGame.Tests.Framework
+{
+    /// <summary>
+    /// Performs a series of tests on MonoGame's value types ToString() methods,
+    /// ensuring they always behave appropriately depending on the utilised <see cref="CultureInfo"/>.
+    /// </summary>
+    /// <remarks>
+    /// All values to test on have been picked randomly.
+    /// </remarks>
+    internal class SerializationTest
+    {
+        #region Cultures to test on
+        private static readonly CultureInfo AmericanCulture = new CultureInfo("en-US");
+        private static readonly CultureInfo BritishCulture = new CultureInfo("en-GB");
+        private static readonly CultureInfo ChineseCulture = new CultureInfo("zh-CN");
+        private static readonly CultureInfo DutchCulture = new CultureInfo("nl-NL");
+        private static readonly CultureInfo FrenchCulture = new CultureInfo("fr-FR");
+        private static readonly CultureInfo GermanCulture = new CultureInfo("de-DE");
+        private static readonly CultureInfo ItalianCulture = new CultureInfo("it-IT");
+        private static readonly CultureInfo JapaneseCulture = new CultureInfo("ja-JP");
+        #endregion
+
+        /// <summary>
+        /// We utilise <see cref="Convert.ChangeType(object, Type, IFormatProvider)"/> now with the invariant culture,
+        /// to prevent rare issues with culture when converting from one type to another. 
+        /// </summary>
+        [Test]
+        public void TestChangeType()
+        {
+            const string commaValue = "3,14";
+
+            var commaResult = Convert.ChangeType(commaValue, typeof(double), GermanCulture);
+            Assert.That(Math.Abs(3.14 - (double)commaResult) < double.Epsilon);
+
+            // 3,14 in cultures like en-US or ja-JP is parsed as 314, as the comma is ignored.
+            Assert.That(Math.Abs((double)Convert.ChangeType(commaValue, typeof(double), JapaneseCulture) - 3.14) > double.Epsilon);
+
+            const string thousandValue = "1,234.56";
+
+            var thousandResult = Convert.ChangeType(thousandValue, typeof(decimal), ChineseCulture);
+            Assert.That(Math.Abs(1234.56d - (double)(decimal)thousandResult) < double.Epsilon);
+
+            // this is not a valid format in Dutch culture, as it uses a comma for decimal separator.
+            Assert.Throws<FormatException>(() => Convert.ChangeType(thousandValue, typeof(decimal), DutchCulture));
+
+            const string dateValue = "31/12/2023";
+
+            var dateResult = (DateTime)Convert.ChangeType(dateValue, typeof(DateTime), BritishCulture);
+            Assert.That(new DateTime(2023, 12, 31), Is.EqualTo(dateResult));
+
+            Assert.Throws<FormatException>(() => Convert.ChangeType(dateValue, typeof(DateTime), AmericanCulture));
+
+            const string dateTimeValue = "05/31/2025 01:30 PM";
+
+            // 2025-05-31 13:30:00
+            var dateTimeResult = Convert.ChangeType(dateTimeValue, typeof(DateTime), AmericanCulture);
+            Assert.That(new DateTime(2025, 5, 31, 13, 30, 0), Is.EqualTo(dateTimeResult));
+
+            // FormatException (expects 24h clock, not "PM")
+            Assert.Throws<FormatException>(() => Convert.ChangeType(dateTimeValue, typeof(DateTime), FrenchCulture));
+        }
+
+        /// <summary>
+        /// Tests the <see cref="Alpha8.ToString()" /> and <see cref="Alpha8.ToString(IFormatProvider)"/> methods.
+        /// </summary>
+        [Test]
+        public void TestAlpha8()
+        {
+            var item = new Alpha8(0.25f);
+            // serialize with the culture explicitly set.
+            var invariant = item.ToString(CultureInfo.InvariantCulture);
+            var american = item.ToString(AmericanCulture);
+            var british = item.ToString(BritishCulture);
+            var chinese = item.ToString(ChineseCulture);
+            var dutch = item.ToString(DutchCulture);
+            var french = item.ToString(FrenchCulture);
+            var german = item.ToString(GermanCulture);
+            var italian = item.ToString(ItalianCulture);
+            var japanese = item.ToString(JapaneseCulture);
+
+            var originalCulture = CultureInfo.CurrentCulture;
+
+            // serialize by setting the culture to utilise.
+            CultureInfo.CurrentCulture = AmericanCulture;
+            var americanCurrent = item.ToString();
+            Assert.That(american, Is.EqualTo(americanCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = BritishCulture;
+            var britishCurrent = item.ToString();
+            Assert.That(british, Is.EqualTo(britishCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = ChineseCulture;
+            var chineseCurrent = item.ToString();
+            Assert.That(chinese, Is.EqualTo(chineseCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = DutchCulture;
+            var dutchCurrent = item.ToString();
+            Assert.That(dutch, Is.EqualTo(dutchCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = FrenchCulture;
+            var frenchCurrent = item.ToString();
+            Assert.That(french, Is.EqualTo(frenchCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = GermanCulture;
+            var germanCurrent = item.ToString();
+            Assert.That(german, Is.EqualTo(germanCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = ItalianCulture;
+            var italianCurrent = item.ToString();
+            Assert.That(italian, Is.EqualTo(italianCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = JapaneseCulture;
+            var japaneseCurrent = item.ToString();
+            Assert.That(japanese, Is.EqualTo(japaneseCurrent).Using(StringComparer.InvariantCulture as IComparer));
+
+            // Observe that the invariant culture is not equal to specific other cultures.
+            Assert.That(invariant, Is.Not.EqualTo(dutch).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(french).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(german).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(italian).Using(StringComparer.InvariantCulture as IComparer));
+
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+
+
+        /// <summary>
+        /// Tests the <see cref="HalfSingle.ToString()" /> and <see cref="HalfSingle.ToString(IFormatProvider)"/> methods.
+        /// </summary>
+        [Test]
+        public void TestHalfSingle()
+        {
+            var item = new HalfSingle(12.55f);
+            // serialize with the culture explicitly set.
+            var invariant = item.ToString(CultureInfo.InvariantCulture);
+            var american = item.ToString(AmericanCulture);
+            var british = item.ToString(BritishCulture);
+            var chinese = item.ToString(ChineseCulture);
+            var dutch = item.ToString(DutchCulture);
+            var french = item.ToString(FrenchCulture);
+            var german = item.ToString(GermanCulture);
+            var italian = item.ToString(ItalianCulture);
+            var japanese = item.ToString(JapaneseCulture);
+
+            var originalCulture = CultureInfo.CurrentCulture;
+
+            // serialize by setting the culture to utilise.
+            CultureInfo.CurrentCulture = AmericanCulture;
+            var americanCurrent = item.ToString();
+            Assert.That(american, Is.EqualTo(americanCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = BritishCulture;
+            var britishCurrent = item.ToString();
+            Assert.That(british, Is.EqualTo(britishCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = ChineseCulture;
+            var chineseCurrent = item.ToString();
+            Assert.That(chinese, Is.EqualTo(chineseCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = DutchCulture;
+            var dutchCurrent = item.ToString();
+            Assert.That(dutch, Is.EqualTo(dutchCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = FrenchCulture;
+            var frenchCurrent = item.ToString();
+            Assert.That(french, Is.EqualTo(frenchCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = GermanCulture;
+            var germanCurrent = item.ToString();
+            Assert.That(german, Is.EqualTo(germanCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = ItalianCulture;
+            var italianCurrent = item.ToString();
+            Assert.That(italian, Is.EqualTo(italianCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = JapaneseCulture;
+            var japaneseCurrent = item.ToString();
+            Assert.That(japanese, Is.EqualTo(japaneseCurrent).Using(StringComparer.InvariantCulture as IComparer));
+
+            // Observe that the invariant culture is not equal to specific other cultures.
+            Assert.That(invariant, Is.Not.EqualTo(dutch).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(french).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(german).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(italian).Using(StringComparer.InvariantCulture as IComparer));
+
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+
+
+
+        /// <summary>
+        /// Tests the <see cref="HalfVector2.ToString()" /> and <see cref="HalfVector2.ToString(IFormatProvider)"/> methods.
+        /// </summary>
+        [Test]
+        public void TestHalfVector2()
+        {
+            var item = new HalfVector2(new Vector2(1.5f, 2.4f));
+            // serialize with the culture explicitly set.
+            var invariant = item.ToString(CultureInfo.InvariantCulture);
+            var american = item.ToString(AmericanCulture);
+            var british = item.ToString(BritishCulture);
+            var chinese = item.ToString(ChineseCulture);
+            var dutch = item.ToString(DutchCulture);
+            var french = item.ToString(FrenchCulture);
+            var german = item.ToString(GermanCulture);
+            var italian = item.ToString(ItalianCulture);
+            var japanese = item.ToString(JapaneseCulture);
+
+            var originalCulture = CultureInfo.CurrentCulture;
+
+            // serialize by setting the culture to utilise.
+            CultureInfo.CurrentCulture = AmericanCulture;
+            var americanCurrent = item.ToString();
+            Assert.That(american, Is.EqualTo(americanCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = BritishCulture;
+            var britishCurrent = item.ToString();
+            Assert.That(british, Is.EqualTo(britishCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = ChineseCulture;
+            var chineseCurrent = item.ToString();
+            Assert.That(chinese, Is.EqualTo(chineseCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = DutchCulture;
+            var dutchCurrent = item.ToString();
+            Assert.That(dutch, Is.EqualTo(dutchCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = FrenchCulture;
+            var frenchCurrent = item.ToString();
+            Assert.That(french, Is.EqualTo(frenchCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = GermanCulture;
+            var germanCurrent = item.ToString();
+            Assert.That(german, Is.EqualTo(germanCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = ItalianCulture;
+            var italianCurrent = item.ToString();
+            Assert.That(italian, Is.EqualTo(italianCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = JapaneseCulture;
+            var japaneseCurrent = item.ToString();
+            Assert.That(japanese, Is.EqualTo(japaneseCurrent).Using(StringComparer.InvariantCulture as IComparer));
+
+            // Observe that the invariant culture is not equal to specific other cultures.
+            Assert.That(invariant, Is.Not.EqualTo(dutch).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(french).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(german).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(italian).Using(StringComparer.InvariantCulture as IComparer));
+
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+
+        /// <summary>
+        /// Tests the <see cref="HalfVector4.ToString()" /> and <see cref="HalfVector4.ToString(IFormatProvider)"/> methods.
+        /// </summary>
+        [Test]
+        public void TestHalfVector4()
+        {
+            var item = new HalfVector4(1.5f, 2.4f, 3.5f, 0.5f);
+            // serialize with the culture explicitly set.
+            var invariant = item.ToString(CultureInfo.InvariantCulture);
+            var american = item.ToString(AmericanCulture);
+            var british = item.ToString(BritishCulture);
+            var chinese = item.ToString(ChineseCulture);
+            var dutch = item.ToString(DutchCulture);
+            var french = item.ToString(FrenchCulture);
+            var german = item.ToString(GermanCulture);
+            var italian = item.ToString(ItalianCulture);
+            var japanese = item.ToString(JapaneseCulture);
+
+            var originalCulture = CultureInfo.CurrentCulture;
+
+            // serialize by setting the culture to utilise.
+            CultureInfo.CurrentCulture = AmericanCulture;
+            var americanCurrent = item.ToString();
+            Assert.That(american, Is.EqualTo(americanCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = BritishCulture;
+            var britishCurrent = item.ToString();
+            Assert.That(british, Is.EqualTo(britishCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = ChineseCulture;
+            var chineseCurrent = item.ToString();
+            Assert.That(chinese, Is.EqualTo(chineseCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = DutchCulture;
+            var dutchCurrent = item.ToString();
+            Assert.That(dutch, Is.EqualTo(dutchCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = FrenchCulture;
+            var frenchCurrent = item.ToString();
+            Assert.That(french, Is.EqualTo(frenchCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = GermanCulture;
+            var germanCurrent = item.ToString();
+            Assert.That(german, Is.EqualTo(germanCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = ItalianCulture;
+            var italianCurrent = item.ToString();
+            Assert.That(italian, Is.EqualTo(italianCurrent).Using(StringComparer.InvariantCulture as IComparer));
+            CultureInfo.CurrentCulture = JapaneseCulture;
+            var japaneseCurrent = item.ToString();
+            Assert.That(japanese, Is.EqualTo(japaneseCurrent).Using(StringComparer.InvariantCulture as IComparer));
+
+            // Observe that the invariant culture is not equal to specific other cultures.
+            Assert.That(invariant, Is.Not.EqualTo(dutch).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(french).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(german).Using(StringComparer.InvariantCulture as IComparer));
+            Assert.That(invariant, Is.Not.EqualTo(italian).Using(StringComparer.InvariantCulture as IComparer));
+
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+}

--- a/Tests/Framework/Visual/VisualTestFixtureBase.cs
+++ b/Tests/Framework/Visual/VisualTestFixtureBase.cs
@@ -11,6 +11,7 @@ using Microsoft.Xna.Framework;
 using NUnit.Framework;
 
 using MonoGame.Tests.Components;
+using System.Globalization;
 
 namespace MonoGame.Tests.Visual {
 	class VisualTestFixtureBase {
@@ -182,8 +183,8 @@ namespace MonoGame.Tests.Visual {
 
 			foreach (var result in results) {
 
-				string diffFileName = string.Format (
-					"diff-{0}-{1}.png",
+				string diffFileName = string.Format (CultureInfo.InvariantCulture,
+                    "diff-{0}-{1}.png",
 					Path.GetFileNameWithoutExtension (result.ReferenceImagePath),
 					Path.GetFileNameWithoutExtension (result.CapturedImagePath));
 

--- a/Tests/Runner/Extensions.cs
+++ b/Tests/Runner/Extensions.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -11,7 +9,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
+using System.Globalization;
 
 namespace MonoGame.Tests {
 	static class Extensions {
@@ -25,7 +23,7 @@ namespace MonoGame.Tests {
 
 		public static Color ToColor (this string self)
 		{
-			return (Color)typeof (Color).InvokeMember (self, BindingFlags.GetProperty, null, null, null);
+			return (Color)typeof (Color).InvokeMember (self, BindingFlags.GetProperty, null, null, null, CultureInfo.InvariantCulture);
 		}
 
 	    public static FramePixelData ToPixelData(this Texture2D texture)
@@ -146,7 +144,7 @@ namespace MonoGame.Tests {
 
 	class ServiceNotFoundException : Exception {
 		public ServiceNotFoundException (Type serviceType)
-			: base(string.Format("Required service of type '{0}' was not found.", serviceType))
+			: base(string.Format(CultureInfo.InvariantCulture, "Required service of type '{0}' was not found.", serviceType))
 		{
 			if (serviceType == null)
 				throw new ArgumentNullException ("serviceType");


### PR DESCRIPTION
This PR contains a few solutions to (potential) issues with serializing value types, as discussed in detail in https://github.com/MonoGame/MonoGame/issues/8923

1) ValueTypes (like `Quaternion`) now have an overload to their ToString() methods where one can provide their desired `IFormatProvider`
2) All existing usages of ToString, String.Format or other features that may have different behavior based on their culture are now specified as using `CultureInfo.InvariantCulture`, to ensure we get the same behavior regardless of whatever unknown culture rules are in use on someone's machine. 
3) StringBuilder methods where a single char was appended are now done as adding a char rather than a string of 1 char in length.