### PR TITLE
Fix Vulkan descriptor cache

### DIFF
--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -40,6 +40,47 @@
 	}																					\
 }
 
+#if defined(DEBUG)
+template <typename... FmtArgs>
+static void setObjectNameVariadic(
+    VkDevice device, uint64_t object, VkObjectType type,
+    const char* file, int line,
+    const char* nameOrFormat, FmtArgs&&... fmtArgs)
+{
+    if (!device || !object || !vkSetDebugUtilsObjectNameEXT) return;
+
+    const char* baseName = nullptr;
+    char formattedNameBuffer[256];
+
+    if constexpr (sizeof...(FmtArgs) > 0)
+    {
+        snprintf(formattedNameBuffer, sizeof(formattedNameBuffer), nameOrFormat, std::forward<FmtArgs>(fmtArgs)...);
+        baseName = formattedNameBuffer;
+    }
+    else
+    {
+        baseName = nameOrFormat;
+    }
+
+    char finalName[256];
+    snprintf(finalName, sizeof(finalName), "%s (%s:%d)", baseName, file, line);
+
+    VkDebugUtilsObjectNameInfoEXT info = {};
+    info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+    info.pNext = VK_NULL_HANDLE;
+    info.objectType = type;
+    info.objectHandle = object;
+    info.pObjectName = finalName;
+
+    vkSetDebugUtilsObjectNameEXT(device, &info);
+}
+
+#define VK_SET_OBJECT_NAME(device, object, type, ...) \
+    setObjectNameVariadic(device, (uint64_t)(object), type, __FILE__, __LINE__, __VA_ARGS__)
+#else
+#define VK_SET_OBJECT_NAME(...) ((void)0)
+#endif
+
 template<class T>
 T MG_AlignUp(T value, const T alignment)
 {

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -50,7 +50,7 @@ struct MGVK_Program;
 
 typedef uint32_t FrameCounter;
 
-const FrameCounter kFreeFrames = 2;
+const FrameCounter kFreeFrames = 3;
 const FrameCounter kConcurrentFrameCount = 2;
 
 
@@ -2129,6 +2129,27 @@ static void MGVK_UpdateRenderPass(MGG_GraphicsDevice* device, FrameCounter curre
 	device->pipelineStateDirty = true;
 }
 
+static const int DefaultPoolSize = 1024;
+
+static void MGVK_FillDescriptorSetCache(MGG_GraphicsDevice* device, MGG_Shader* shader)
+{
+	// Pre-fill the free descriptor sets now.
+	VkDescriptorSetAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
+	alloc_info.descriptorPool = shader->pool;
+	alloc_info.descriptorSetCount = 1;
+	alloc_info.pSetLayouts = &shader->setLayout;
+	for (int i = 0; i < DefaultPoolSize; i++)
+	{
+		MGVK_DescriptorInfo* info = new MGVK_DescriptorInfo;
+		info->frame = 0;
+		shader->freeSets.push(info);
+
+		VkResult res = vkAllocateDescriptorSets(device->device, &alloc_info, &info->set);
+		VK_CHECK_RESULT(res);
+		VK_SET_OBJECT_NAME(device->device, info->set, VK_OBJECT_TYPE_DESCRIPTOR_SET, "MGVK_DescriptorInfo.set (Shader id: %u, index: %d)", shader->id, i);
+	}
+}
+
 static void MGVK_UpdateDescriptors(MGG_GraphicsDevice* device, FrameCounter currentFrame, MGG_Shader* shader, VkDescriptorSet* current, uint32_t* dynamicOffset)
 {
 	// If nothing is dirty then skip the update.
@@ -2170,7 +2191,15 @@ static void MGVK_UpdateDescriptors(MGG_GraphicsDevice* device, FrameCounter curr
 		if (!dirty)
 			break;
 	}
-	//hash = MG_ComputeHash(frame_index);
+	// We hash the frameIndex because each frame in the swap chain has its
+	// own uniforms buffer (device->frames[frameIndex].uniforms) that gets
+	// bound to the descriptor set. If we don't, some frame will use the
+	// wrong buffer if the descriptor is retrieved from the cache (and will
+	// result in flickers/broken rendering).
+	// 
+	// TO DO: refactor the descriptor cache and uniforms buffer handling so
+	// that we don't create twice as much descriptor due to this.
+	hash = MG_ComputeHash(frameIndex, hash);
 
 	// Do we have this same descriptor cached?
 	info = shader->usedSets[hash];
@@ -2178,16 +2207,16 @@ static void MGVK_UpdateDescriptors(MGG_GraphicsDevice* device, FrameCounter curr
 	{
 		// The descriptor wasn't cached... so we need to
 		// create a new one from the free sets.
-		if (shader->freeSets.size() > 0)
+		if (shader->freeSets.size() == 0)
 		{
-			info = shader->freeSets.front();
-			shader->freeSets.pop();
+			// Allocate more cache if empty.
+			MGVK_FillDescriptorSetCache(device, shader);
 		}
-		else
-		{
-			// TODO: We're out of free sets... allocate more?
-			assert(0);
-		}
+
+		assert(shader->freeSets.size() > 0);
+		
+		info = shader->freeSets.front();
+		shader->freeSets.pop();
 
 		// Cache the new or recycled set for later use.
 		shader->usedSets[hash] = info;
@@ -3782,8 +3811,6 @@ void MGG_InputLayout_Destroy(MGG_GraphicsDevice* device, MGG_InputLayout* layout
 	delete layout;
 }
 
-static const int DefaultPoolSize = 1024;
-
 MGG_Shader* MGG_Shader_Create(MGG_GraphicsDevice* device, MGShaderStage stage, mgbyte* bytecode, mgint sizeInBytes)
 {
 	assert(device != nullptr);
@@ -3865,19 +3892,7 @@ MGG_Shader* MGG_Shader_Create(MGG_GraphicsDevice* device, MGShaderStage stage, m
 	}
 
 	// Pre-fill the free descriptor sets now.
-	VkDescriptorSetAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
-	alloc_info.descriptorPool = shader->pool;
-	alloc_info.descriptorSetCount = 1;
-	alloc_info.pSetLayouts = &shader->setLayout;
-	for (int i = 0; i < DefaultPoolSize; i++)
-	{
-		MGVK_DescriptorInfo* info = new MGVK_DescriptorInfo;
-		info->frame = 0;
-		shader->freeSets.push(info);
-
-		res = vkAllocateDescriptorSets(device->device, &alloc_info, &info->set);
-		VK_CHECK_RESULT(res);
-	}
+	MGVK_FillDescriptorSetCache(device, shader);
 
 	// Prepare the write descriptor set for updates at runtime.
 	VkWriteDescriptorSet* write = shader->writes = new VkWriteDescriptorSet[layoutBindings.size()];


### PR DESCRIPTION
This PR fixes the flickering/corrupt frames of the Vulkan backend (see #8944).

@tomspilman Note that I have increased the retention of unused resources to 3 frames (because 2 was not working for descriptors due to the uniforms buffer flip/flop).




