### PR TITLE
Fix the Native backend SDL platform issues

### DIFF
--- a/MonoGame.Framework/Platform/Native/GamePad.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GamePad.Native.cs
@@ -142,8 +142,8 @@ static partial class GamePad
 
     private static float FromAxisValue(short axis)
     {
-        if (axis < 0)
-            return axis / 32768f;
+        // The native implementation returns -32767 to 32767 range
+        // (-32768 is excluded to avoid overflows from max 16bit range conversions)
         return axis / 32767f;
     }
 

--- a/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
@@ -178,8 +178,8 @@ class NativeGamePlatform : GamePlatform
                     var window = NativeGameWindow.FromHandle(event_.MouseWheel.Window);
                     if (window != null)
                     {
-                        window.MouseState.ScrollWheelValue = event_.MouseWheel.Scroll;
-                        window.MouseState.HorizontalScrollWheelValue = event_.MouseWheel.ScrollH;
+                        window.MouseState.ScrollWheelValue += event_.MouseWheel.Scroll;
+                        window.MouseState.HorizontalScrollWheelValue += event_.MouseWheel.ScrollH;
                     }
                     break;
                 }

--- a/MonoGame.Framework/Platform/Native/MessageBox.Native.cs
+++ b/MonoGame.Framework/Platform/Native/MessageBox.Native.cs
@@ -13,8 +13,12 @@ public static partial class MessageBox
 {
     internal static unsafe MGP_Window* _window;
 
+    private static TaskCompletionSource<int?> _taskCompletionSource;
+
     private static unsafe Task<int?> PlatformShow(string title, string description, List<string> buttons)
     {
+        _taskCompletionSource = new TaskCompletionSource<int?>();
+
         var button_bytes = new List<nint>();
 
         byte* _title = stackalloc byte[StringInterop.GetMaxSize(title)];
@@ -26,11 +30,14 @@ public static partial class MessageBox
 
         int result = MGP.Window_ShowMessageBox(_window, _title, _description, _buttons, buttons.Count);
 
-        return Task.FromResult<int?>(result);
+        _taskCompletionSource.SetResult(result);
+
+        return _taskCompletionSource.Task;
     }
 
     private static void PlatformCancel(int? result)
     {
-        // TODO: How should we do this?
+        if (_taskCompletionSource != null)
+            _taskCompletionSource.SetResult(result);
     }
 }

--- a/native/monogame/sdl/MGP_sdl.cpp
+++ b/native/monogame/sdl/MGP_sdl.cpp
@@ -851,11 +851,15 @@ void MGP_Window_ExitFullScreen(MGP_Window* window)
 mgint MGP_Window_ShowMessageBox(MGP_Window* window, mgbyte* title, mgbyte* description, mgbyte* buttons, mgint count)
 {
     SDL_MessageBoxData data;
-    data.window = window->window;
+    data.window = (window != nullptr ? window->window : nullptr);
     data.title = (const char*)title;
     data.message = (const char*)description;
     data.colorScheme = nullptr;
     data.flags = SDL_MESSAGEBOX_BUTTONS_LEFT_TO_RIGHT;
+#ifndef _WIN32
+    // Convention is to reverse buttons display order on non-Windows systems.
+    data.flags = SDL_MESSAGEBOX_BUTTONS_RIGHT_TO_LEFT;
+#endif
 
     auto bdata = new SDL_MessageBoxButtonData[count];
     for (int i = 0; i < count; i++)

--- a/native/monogame/sdl/MGP_sdl.cpp
+++ b/native/monogame/sdl/MGP_sdl.cpp
@@ -461,6 +461,16 @@ mgbyte MGP_Platform_PollEvent(MGP_Platform* platform, MGP_Event& event_)
             event_.Controller.Id = ev.caxis.which;
             event_.Controller.Input = FromSDLAxis(ev.caxis.axis);
             event_.Controller.Value = ev.caxis.value;
+            if (event_.Controller.Input == MGControllerInput::LeftStickY || event_.Controller.Input == MGControllerInput::RightStickY)
+            {
+                // MonoGame has an inverted Y value convention compared to SDL, and we
+                // need to take care of the special case of -32768 because it would otherwise
+                // overflow into -32768 when inverted.
+                // (This maps the range of values to -32767:32767 instead of SDL's -32768:32767)
+                event_.Controller.Value = (event_.Controller.Value == -32768 ? 32767 : ~event_.Controller.Value + 1);
+            }
+            else
+
             return true;
             break;
 

--- a/native/monogame/sdl/MGP_sdl.cpp
+++ b/native/monogame/sdl/MGP_sdl.cpp
@@ -421,25 +421,33 @@ mgbyte MGP_Platform_PollEvent(MGP_Platform* platform, MGP_Event& event_)
         case SDL_EventType::SDL_CONTROLLERDEVICEADDED:
         {
             auto controller = SDL_GameControllerOpen(ev.cdevice.which);
-            platform->controllers.emplace(ev.cdevice.which, controller);
-            event_.Type = MGEventType::ControllerAdded;
-            event_.Timestamp = ev.cdevice.timestamp;
-            event_.Controller.Id = ev.cdevice.which;
-            event_.Controller.Input = MGControllerInput::INVALID;
-            event_.Controller.Value = 0;
-            return true;
+            if (controller != nullptr)
+            {
+                platform->controllers.emplace(ev.cdevice.which, controller);
+                event_.Type = MGEventType::ControllerAdded;
+                event_.Timestamp = ev.cdevice.timestamp;
+                event_.Controller.Id = ev.cdevice.which;
+                event_.Controller.Input = MGControllerInput::INVALID;
+                event_.Controller.Value = 0;
+                return true;
+            }
+            break;
         }
         case SDL_EventType::SDL_CONTROLLERDEVICEREMOVED:
         {
             auto controller = platform->controllers[ev.cdevice.which];
-            platform->controllers.erase(ev.cdevice.which);
-            SDL_GameControllerClose(controller);
-            event_.Type = MGEventType::ControllerRemoved;
-            event_.Timestamp = ev.cdevice.timestamp;
-            event_.Controller.Id = ev.cdevice.which;
-            event_.Controller.Input = MGControllerInput::INVALID;
-            event_.Controller.Value = 0;
-            return true;
+            if (controller != nullptr)
+            {
+                platform->controllers.erase(ev.cdevice.which);
+                SDL_GameControllerClose(controller);
+                event_.Type = MGEventType::ControllerRemoved;
+                event_.Timestamp = ev.cdevice.timestamp;
+                event_.Controller.Id = ev.cdevice.which;
+                event_.Controller.Input = MGControllerInput::INVALID;
+                event_.Controller.Value = 0;
+                return true;
+            }
+            break;
         }
         case SDL_EventType::SDL_CONTROLLERBUTTONUP:
             event_.Type = MGEventType::ControllerStateChange;


### PR DESCRIPTION
This PR fixes the SDL issues identified on the Native backend (and listed in #8944).

Namely:
- Fixes inverted ```GamePad``` Y thumbsticks
- Fixes ```GamePad``` hot-plug (courtesy of @sepcnt 's patch)
- Fixes ```Mouse``` wheel value
- Fixes ```MessageBox```