### PR TITLE
Initial binaries packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,12 @@ jobs:
         env:
           ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}
           ACTIONS_RUNTIME_URL: "${{ env.ACTIONS_RUNTIME_URL }}"
+
+      - name: Upload Binaries package
+        run: dotnet run --project build/Build.csproj -- --target=DeployBinaries
+        env:
+          ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}
+          ACTIONS_RUNTIME_URL: "${{ env.ACTIONS_RUNTIME_URL }}"
   deploy:
       name: Deploy
       needs: [ build, tests ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,50 +120,69 @@ jobs:
           ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}
           ACTIONS_RUNTIME_URL: "${{ env.ACTIONS_RUNTIME_URL }}"
 
-      - name: Upload Binaries package
-        run: dotnet run --project build/Build.csproj -- --target=DeployBinaries
-        env:
-          ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}
-          ACTIONS_RUNTIME_URL: "${{ env.ACTIONS_RUNTIME_URL }}"
+  package-binaries:
+    name: PackageBinaries
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+        - name: Clone Repository
+          uses: actions/checkout@v4
+          with:
+            submodules: recursive
+
+        - name: Setup .NET
+          uses: actions/setup-dotnet@v4
+          with:
+            dotnet-version: '8.0.x'
+
+        - name: Expose GitHub Runtime
+          uses: crazy-max/ghaction-github-runtime@v3
+
+        - name: Upload Binaries package
+          run: dotnet run --project build/Build.csproj -- --target=DeployBinaries
+          env:
+            ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}
+            ACTIONS_RUNTIME_URL: "${{ env.ACTIONS_RUNTIME_URL }}"
+
   deploy:
-      name: Deploy
-      needs: [ build, tests ]
-      runs-on: ubuntu-latest
-      if: ${{ github.event_name == 'push' }}
-      permissions:
-          packages: write
-          contents: write
-      steps:
-          - name: Clone Repository
-            uses: actions/checkout@v4
-            with:
-              submodules: recursive
+    name: Deploy
+    needs: [ build, tests ]
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+    permissions:
+        packages: write
+        contents: write
+    steps:
+        - name: Clone Repository
+          uses: actions/checkout@v4
+          with:
+            submodules: recursive
 
-          - name: Setup .NET
-            uses: actions/setup-dotnet@v4
-            with:
-              dotnet-version: '8.0.x'
+        - name: Setup .NET
+          uses: actions/setup-dotnet@v4
+          with:
+            dotnet-version: '8.0.x'
 
-          - name: Expose GitHub Runtime
-            uses: crazy-max/ghaction-github-runtime@v3
+        - name: Expose GitHub Runtime
+          uses: crazy-max/ghaction-github-runtime@v3
 
-          - name: Push Nugets
-            run: dotnet run --project build/Build.csproj -- --target=Deploy
-            env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-              MARKETPLACE_PAT: ${{ secrets.MARKETPLACE_PAT }}
+        - name: Push Nugets
+          run: dotnet run --project build/Build.csproj -- --target=Deploy
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+            MARKETPLACE_PAT: ${{ secrets.MARKETPLACE_PAT }}
 
-          - name: Make a Release
-            if: github.ref_type == 'tag'
-            uses: ncipollo/release-action@v1
-            with:
-              name: 'MonoGame ${{ github.ref_name }}'
-              tag: ${{ github.ref_name }}
-              allowUpdates: true
-              removeArtifacts: true
-              artifacts: "nugets/*.nupkg;vsix/MonoGame.Templates.VSExtension.vsix"
-              token: ${{ secrets.GITHUB_TOKEN }}
+        - name: Make a Release
+          if: github.ref_type == 'tag'
+          uses: ncipollo/release-action@v1
+          with:
+            name: 'MonoGame ${{ github.ref_name }}'
+            tag: ${{ github.ref_name }}
+            allowUpdates: true
+            removeArtifacts: true
+            artifacts: "nugets/*.nupkg;vsix/MonoGame.Templates.VSExtension.vsix"
+            token: ${{ secrets.GITHUB_TOKEN }}
 
   choose-runner:
     runs-on: ubuntu-latest

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -31,6 +31,7 @@ public class BuildContext : FrostingContext
         var buildConfiguration = context.Argument("build-configuration", "Release");
         BuildOutput = context.Argument("build-output", "Artifacts");
         NuGetsDirectory = $"{BuildOutput}/NuGet/";
+        BinariesDirectory = $"{BuildOutput}/Binaries/";
 
         Version = CalculateVersion(context);
 
@@ -94,6 +95,14 @@ public class BuildContext : FrostingContext
             Configuration = "Release"
         };
 
+        DotNetBinariesPublishSettings = new DotNetPublishSettings
+        {
+            MSBuildSettings = DotNetMSBuildSettings,
+            Verbosity = DotNetVerbosity.Diagnostic,
+            Configuration = buildConfiguration,
+            OutputDirectory = BinariesDirectory
+        };
+
         Console.WriteLine($"Version: {Version}");
         Console.WriteLine($"RepositoryUrl: {repositoryUrl}");
         Console.WriteLine($"BuildConfiguration: {buildConfiguration}");
@@ -120,6 +129,8 @@ public class BuildContext : FrostingContext
 
     public string NuGetsDirectory { get; }
 
+    public string BinariesDirectory { get; }
+
     public DotNetMSBuildSettings DotNetMSBuildSettings { get; }
 
     public DotNetBuildSettings DotNetBuildSettings { get; }
@@ -129,6 +140,8 @@ public class BuildContext : FrostingContext
     public DotNetPublishSettings DotNetPublishSettings { get; }
 
     public DotNetPublishSettings DotNetPublishSettingsForMac { get; }
+
+    public DotNetPublishSettings DotNetBinariesPublishSettings { get; }
 
     public DotNetRunSettings DotNetRunSettings { get; }
 
@@ -263,5 +276,15 @@ public class BuildContext : FrostingContext
         {
             return context.Argument("build-version", VersionBase + ".1-develop");
         }
+    }
+}
+
+public static class BuildContextExtensions
+{
+    public static void PublishBinaries(this BuildContext context, string platformName)
+    {
+        context.Information($"Packaging Binaries {platformName}...");
+        context.DotNetBinariesPublishSettings.OutputDirectory = $"{context.BinariesDirectory}/{platformName}/";
+        context.DotNetPublish(context.GetProjectPath(ProjectType.Framework, platformName), context.DotNetBinariesPublishSettings);
     }
 }

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -288,6 +288,13 @@ public static class BuildContextExtensions
         context.DotNetPublish(context.GetProjectPath(ProjectType.Framework, platformName), context.DotNetBinariesPublishSettings);
     }
 
+    public static void PublishToolsBinaries(this BuildContext context, string inputPath)
+    {
+        context.Information($"Packaging Tools Binaries {inputPath}...");
+        context.DotNetBinariesPublishSettings.OutputDirectory = $"{context.BinariesDirectory}/MonoGame.Framework.Content.Pipeline/";
+        context.DotNetPublish(inputPath, context.DotNetBinariesPublishSettings);
+    }
+
     public static void DeleteDirectory(this BuildContext context, DirectoryPath fullPath)
     {
         context.DeleteDirectory(fullPath, new DeleteDirectorySettings { Recursive = true, Force = true });

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -287,4 +287,9 @@ public static class BuildContextExtensions
         context.DotNetBinariesPublishSettings.OutputDirectory = $"{context.BinariesDirectory}/{platformName}/";
         context.DotNetPublish(context.GetProjectPath(ProjectType.Framework, platformName), context.DotNetBinariesPublishSettings);
     }
+
+    public static void DeleteDirectory(this BuildContext context, DirectoryPath fullPath)
+    {
+        context.DeleteDirectory(fullPath, new DeleteDirectorySettings { Recursive = true, Force = true });
+    }
 }

--- a/build/BuildFrameworksTasks/BuildAndroidTask.cs
+++ b/build/BuildFrameworksTasks/BuildAndroidTask.cs
@@ -5,6 +5,7 @@ namespace BuildScripts;
 [IsDependentOn(typeof(BuildShadersOGLTask))]
 public sealed class BuildAndroidTask : FrostingTask<BuildContext>
 {
+    private string platformName = "Android";
     public override bool ShouldRun(BuildContext context) => context.IsWorkloadInstalled("android");
 
     public override void Run(BuildContext context)
@@ -19,7 +20,10 @@ public sealed class BuildAndroidTask : FrostingTask<BuildContext>
             Verbosity = DotNetVerbosity.Minimal,
             Configuration = context.DotNetPackSettings.Configuration,
         };
-        context.DotNetBuild(context.GetProjectPath(ProjectType.Framework, "Android"), installSettings);
-        context.DotNetPack(context.GetProjectPath(ProjectType.Framework, "Android"), context.DotNetPackSettings);
+
+        context.DotNetBuild(context.GetProjectPath(ProjectType.Framework, platformName), installSettings);
+        context.DotNetPack(context.GetProjectPath(ProjectType.Framework, platformName), context.DotNetPackSettings);
+
+        context.PublishBinaries(platformName);
     }
 }

--- a/build/BuildFrameworksTasks/BuildAndroidTask.cs
+++ b/build/BuildFrameworksTasks/BuildAndroidTask.cs
@@ -23,7 +23,5 @@ public sealed class BuildAndroidTask : FrostingTask<BuildContext>
 
         context.DotNetBuild(context.GetProjectPath(ProjectType.Framework, platformName), installSettings);
         context.DotNetPack(context.GetProjectPath(ProjectType.Framework, platformName), context.DotNetPackSettings);
-
-        context.PublishBinaries(platformName);
     }
 }

--- a/build/BuildFrameworksTasks/BuildDesktopGLTask.cs
+++ b/build/BuildFrameworksTasks/BuildDesktopGLTask.cs
@@ -5,6 +5,11 @@ namespace BuildScripts;
 [IsDependentOn(typeof(BuildShadersOGLTask))]
 public sealed class BuildDesktopGLTask : FrostingTask<BuildContext>
 {
+    private string platformName = "DesktopGL";
     public override void Run(BuildContext context)
-        => context.DotNetPack(context.GetProjectPath(ProjectType.Framework, "DesktopGL"), context.DotNetPackSettings);
+    {
+        context.DotNetPack(context.GetProjectPath(ProjectType.Framework, platformName), context.DotNetPackSettings);
+
+        context.PublishBinaries(platformName);
+    }
 }

--- a/build/BuildFrameworksTasks/BuildNativeTask.cs
+++ b/build/BuildFrameworksTasks/BuildNativeTask.cs
@@ -5,6 +5,11 @@ namespace BuildScripts;
 [IsDependentOn(typeof(BuildMGFXCTask))]
 public sealed class BuildNativeTask : FrostingTask<BuildContext>
 {
+    private string platformName = "Native";
     public override void Run(BuildContext context)
-        => context.DotNetPack(context.GetProjectPath(ProjectType.Framework, "Native"), context.DotNetPackSettings);
+    {
+        context.DotNetPack(context.GetProjectPath(ProjectType.Framework, platformName), context.DotNetPackSettings);
+
+        context.PublishBinaries(platformName);
+    }
 }

--- a/build/BuildFrameworksTasks/BuildWindowsDXTask.cs
+++ b/build/BuildFrameworksTasks/BuildWindowsDXTask.cs
@@ -5,8 +5,13 @@ namespace BuildScripts;
 [IsDependentOn(typeof(BuildShadersDX11Task))]
 public sealed class BuildWindowsDXTask : FrostingTask<BuildContext>
 {
+    private string platformName = "WindowsDX";
     public override bool ShouldRun(BuildContext context) => context.IsRunningOnWindows();
 
     public override void Run(BuildContext context)
-        => context.DotNetPack(context.GetProjectPath(ProjectType.Framework, "WindowsDX"), context.DotNetPackSettings);
+    {
+        context.DotNetPack(context.GetProjectPath(ProjectType.Framework, platformName), context.DotNetPackSettings);
+
+        context.PublishBinaries(platformName);
+    }
 }

--- a/build/BuildFrameworksTasks/BuildiOSTask.cs
+++ b/build/BuildFrameworksTasks/BuildiOSTask.cs
@@ -8,11 +8,6 @@ public sealed class BuildiOSTask : FrostingTask<BuildContext>
     private string platformName = "iOS";
     public override bool ShouldRun(BuildContext context) => context.IsWorkloadInstalled("ios");
 
-    public override void Run(BuildContext context)
-    {
-        context.DotNetPack(context.GetProjectPath(ProjectType.Framework, platformName), context.DotNetPackSettings);
-
-        context.PublishBinaries(platformName);
-    }
+    public override void Run(BuildContext context) => context.DotNetPack(context.GetProjectPath(ProjectType.Framework, platformName), context.DotNetPackSettings);
 }
 

--- a/build/BuildFrameworksTasks/BuildiOSTask.cs
+++ b/build/BuildFrameworksTasks/BuildiOSTask.cs
@@ -5,9 +5,14 @@ namespace BuildScripts;
 [IsDependentOn(typeof(BuildShadersOGLTask))]
 public sealed class BuildiOSTask : FrostingTask<BuildContext>
 {
+    private string platformName = "iOS";
     public override bool ShouldRun(BuildContext context) => context.IsWorkloadInstalled("ios");
 
     public override void Run(BuildContext context)
-        => context.DotNetPack(context.GetProjectPath(ProjectType.Framework, "iOS"), context.DotNetPackSettings);
+    {
+        context.DotNetPack(context.GetProjectPath(ProjectType.Framework, platformName), context.DotNetPackSettings);
+
+        context.PublishBinaries(platformName);
+    }
 }
 

--- a/build/BuildToolsTasks/BuildContentPipelineTask.cs
+++ b/build/BuildToolsTasks/BuildContentPipelineTask.cs
@@ -10,6 +10,7 @@ public sealed class BuildContentPipelineTask : FrostingTask<BuildContext>
         var builderPath = context.GetProjectPath(ProjectType.ContentPipeline);
         context.DotNetPackSettings.MSBuildSettings.WithProperty("DisableMonoGameToolAssets", "True");
         context.DotNetPack(builderPath, context.DotNetPackSettings);
+        context.PublishToolsBinaries(builderPath);
         context.DotNetPackSettings.MSBuildSettings.Properties.Remove("DisableMonoGameToolAssets");
 
         switch (context.Environment.Platform.Family)

--- a/build/BuildToolsTasks/BuildMGFXCTask.cs
+++ b/build/BuildToolsTasks/BuildMGFXCTask.cs
@@ -5,5 +5,8 @@ namespace BuildScripts;
 public sealed class BuildMGFXCTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
-        => context.DotNetPack(context.GetProjectPath(ProjectType.Tools, "MonoGame.Effect.Compiler"), context.DotNetPackSettings);
+    {
+        context.DotNetPack(context.GetProjectPath(ProjectType.Tools, "MonoGame.Effect.Compiler"), context.DotNetPackSettings);
+        context.PublishToolsBinaries(context.GetProjectPath(ProjectType.Tools, "MonoGame.Effect.Compiler"));
+    }
 }

--- a/build/DeployTasks/DeployBinariesTask.cs
+++ b/build/DeployTasks/DeployBinariesTask.cs
@@ -9,6 +9,6 @@ public sealed class DeployBinariesTask : AsyncFrostingTask<BuildContext>
 
     public override async Task RunAsync(BuildContext context)
     {
-        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("binaries"), $"MonoGame.{context.Version}");
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/binaries"), $"MonoGame.{context.Version}");
     }
 }

--- a/build/DeployTasks/DeployBinariesTask.cs
+++ b/build/DeployTasks/DeployBinariesTask.cs
@@ -9,6 +9,6 @@ public sealed class DeployBinariesTask : AsyncFrostingTask<BuildContext>
 
     public override async Task RunAsync(BuildContext context)
     {
-        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/binaries"), $"MonoGame.{context.Version}");
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/binPackaging"), $"MonoGame.{context.Version}");
     }
 }

--- a/build/DeployTasks/DeployBinariesTask.cs
+++ b/build/DeployTasks/DeployBinariesTask.cs
@@ -1,0 +1,14 @@
+
+namespace BuildScripts;
+
+[TaskName("DeployBinaries")]
+[IsDependentOn(typeof(DownloadBinariesTask))]
+public sealed class DeployBinariesTask : FrostingTask<BuildContext>
+{
+    public override bool ShouldRun(BuildContext context) => context.BuildSystem().IsRunningOnGitHubActions;
+
+    public override async Task RunAsync(BuildContext context)
+    {
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("binaries"), $"MonoGame.{context.Version}");
+    }
+}

--- a/build/DeployTasks/DeployBinariesTask.cs
+++ b/build/DeployTasks/DeployBinariesTask.cs
@@ -3,7 +3,7 @@ namespace BuildScripts;
 
 [TaskName("DeployBinaries")]
 [IsDependentOn(typeof(DownloadBinariesTask))]
-public sealed class DeployBinariesTask : FrostingTask<BuildContext>
+public sealed class DeployBinariesTask : AsyncFrostingTask<BuildContext>
 {
     public override bool ShouldRun(BuildContext context) => context.BuildSystem().IsRunningOnGitHubActions;
 

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -42,14 +42,14 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
         // Post tasks due to issues with Android / iOS "publish" steps
         // Copy MonoGame.Framework/Android to Binaries/MonoGame.Framework
         context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/Android");
-        context.CopyDirectory($"/Artifacts/MonoGame.Framework/Android", $"{binariesPackagingFolder}MonoGame.Framework/");
+        context.CopyDirectory($"Artifacts/MonoGame.Framework/Android", $"{binariesPackagingFolder}MonoGame.Framework/");
         context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/Android/runtimes");
         context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{binariesPackagingFolder}MonoGame.Framework/Android");
 
 
         // Copy MonoGame.Framework/IOS to Binaries/MonoGame.Framework
         context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/iOS");
-        context.CopyDirectory($"/Artifacts/MonoGame.Framework/iOS", $"{binariesPackagingFolder}MonoGame.Framework/");
+        context.CopyDirectory($"Artifacts/MonoGame.Framework/iOS", $"{binariesPackagingFolder}MonoGame.Framework/");
         context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/iOS/runtimes");
         context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{binariesPackagingFolder}MonoGame.Framework/iOS");
 

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -36,7 +36,7 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
         await DownloadArtifactAsync(context, $"mgnative-windows.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/");
 
         // Clean up duplicate "publish" folder from NuGet cp packaging
-        DeleteDirectory(context, context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/publish"));
+        context.DeleteDirectory(context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/publish"));
 
         // Post tasks due to issues with Android / iOS "publish" steps
         var processingPath = context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework/");

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -41,14 +41,16 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
 
         // Post tasks due to issues with Android / iOS "publish" steps
         // Copy MonoGame.Framework/Android to Binaries/MonoGame.Framework
-        //context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/Android");
+        context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/Android");
         context.CopyDirectory($"/Artifacts/MonoGame.Framework/Android", $"{binariesPackagingFolder}MonoGame.Framework/");
+        context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/Android/runtimes");
         context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{binariesPackagingFolder}MonoGame.Framework/Android");
 
 
         // Copy MonoGame.Framework/IOS to Binaries/MonoGame.Framework
-        //context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/iOS");
+        context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/iOS");
         context.CopyDirectory($"/Artifacts/MonoGame.Framework/iOS", $"{binariesPackagingFolder}MonoGame.Framework/");
+        context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/iOS/runtimes");
         context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{binariesPackagingFolder}MonoGame.Framework/iOS");
 
     }

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -46,7 +46,7 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
         foreach (var platform in targets)
         {
             context.Information($"Post Processing platform: {platform}");
-            context.CopyDirectory($"{sourcePath}{platform}/Release", $"{processingPath}{platform}");
+            context.CopyFiles($"{sourcePath}{platform}/Release/*.*", $"{processingPath}{platform}");
             context.DeleteDirectory(context.GetOutputPath($"{processingPath}{platform}/Release"));
             context.CreateDirectory($"{processingPath}{platform}/runtimes");
             context.CopyDirectory($"{processingPath}MonoGame.Framework/DesktopGL/runtimes", $"{processingPath}{platform}/runtimes");

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -25,19 +25,13 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
                 PlatformFamily.OSX => "macos",
                 _ => "linux"
             };
-            await DownloadArtifactAsync(context, $"mgcontentbuilder-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
-            await DownloadArtifactAsync(context, $"mgeffectcompiler-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
-            await DownloadArtifactAsync(context, $"mgcontentpipeline-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
-            await DownloadArtifactAsync(context, $"mgpipeline-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
-            await DownloadArtifactAsync(context, $"mgbinaries-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/");
             await DownloadArtifactAsync(context, $"mgframework-{platformStr}.{context.Version}", $"Artifacts/MonoGame.Framework/");
+            await DownloadArtifactAsync(context, $"mgbinaries-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/");
+            await DownloadArtifactAsync(context, $"mgpipeline-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
         }
 
         // Manually download native Windows binaries, once Linux/Mac are available, they will move the the loop above.
         await DownloadArtifactAsync(context, $"mgnative-windows.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/");
-
-        // Clean up duplicate "publish" folder from NuGet cp packaging
-        context.DeleteDirectory(context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/publish"));
 
         // Post tasks due to issues with Android / iOS "publish" steps
         var sourcePath = context.GetOutputPath("Artifacts/MonoGame.Framework/");

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -1,0 +1,32 @@
+﻿
+namespace BuildScripts;
+
+[TaskName("DownloadBinaries")]
+public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
+{
+    public override bool ShouldRun(BuildContext context) => context.BuildSystem().IsRunningOnGitHubActions;
+
+    private static async Task DownloadArtifactAsync(BuildContext context, string artifactName, string path)
+    {
+        var fullPath = context.GetOutputPath(path);
+        context.Information($"Downloading {artifactName} to {fullPath}");
+        context.CreateDirectory(fullPath);
+        await context.GitHubActions().Commands.DownloadArtifact(artifactName, fullPath);
+    }
+
+    public override async Task RunAsync(BuildContext context)
+    {
+        await DownloadArtifactAsync(context, $"mgcontentbuilder-{os}.{context.Version}", "binaries/MonoGame.Content.Builder/");
+        await DownloadArtifactAsync(context, $"mgeffectcompiler-{os}.{context.Version}", "binaries/MonoGame.Effect.Compiler/");
+        await DownloadArtifactAsync(context, $"mgframework-{os}.{context.Version}", "binaries/MonoGame.Framework/");
+        await DownloadArtifactAsync(context, $"mgcontentpipeline-{os}.{context.Version}", "binaries/MonoGame.Framework.Content.Pipeline/");
+
+        await DownloadArtifactAsync(context, $"mgpipeline-windows.{context.Version}", "binaries/mgpipeline/windows/Release/");
+        await DownloadArtifactAsync(context, $"mgpipeline-macos.{context.Version}", "binaries/mgpipeline/macosx/Release/");
+        await DownloadArtifactAsync(context, $"mgpipeline-linux.{context.Version}", "binaries/mgpipeline/linux/Release/");
+
+        await DownloadArtifactAsync(context, $"mgnative-windows.{context.Version}", "binaries/mgnative/windows/Release/");
+        await DownloadArtifactAsync(context, $"mgnative-macos.{context.Version}", "binaries/mgnative/macosx/Release/");
+        await DownloadArtifactAsync(context, $"mgnative-linux.{context.Version}", "binaries/mgnative/linux/Release/");
+    }
+}

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -46,6 +46,7 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
         foreach (var platform in targets)
         {
             context.Information($"Post Processing platform: {platform}");
+            context.CreateDirectory($"{processingPath}{platform}");
             context.CopyFiles($"{sourcePath}{platform}/Release/*.*", $"{processingPath}{platform}");
             context.CreateDirectory($"{processingPath}{platform}/runtimes");
             context.CopyDirectory($"{processingPath}DesktopGL/runtimes", $"{processingPath}{platform}/runtimes");

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -16,6 +16,13 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
 
     public override async Task RunAsync(BuildContext context)
     {
+        var os = context.Environment.Platform.Family switch
+        {
+            PlatformFamily.Windows => "windows",
+            PlatformFamily.OSX => "macos",
+            _ => "linux"
+        };
+
         await DownloadArtifactAsync(context, $"mgcontentbuilder-{os}.{context.Version}", "binaries/MonoGame.Content.Builder/");
         await DownloadArtifactAsync(context, $"mgeffectcompiler-{os}.{context.Version}", "binaries/MonoGame.Effect.Compiler/");
         await DownloadArtifactAsync(context, $"mgframework-{os}.{context.Version}", "binaries/MonoGame.Framework/");

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -24,18 +24,15 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
                 PlatformFamily.OSX => "macos",
                 _ => "linux"
             };
-            await DownloadArtifactAsync(context, $"mgcontentbuilder-{platformStr}.{context.Version}", "binaries/MonoGame.Content.Builder/");
-            await DownloadArtifactAsync(context, $"mgeffectcompiler-{platformStr}.{context.Version}", "binaries/MonoGame.Effect.Compiler/");
-            await DownloadArtifactAsync(context, $"mgframework-{platformStr}.{context.Version}", "binaries/MonoGame.Framework/");
+            await DownloadArtifactAsync(context, $"mgcontentbuilder-{platformStr}.{context.Version}", "binaries/MonoGame.Framework.Content.Pipeline/");
+            await DownloadArtifactAsync(context, $"mgeffectcompiler-{platformStr}.{context.Version}", "binaries/MonoGame.Framework.Content.Pipeline/");
             await DownloadArtifactAsync(context, $"mgcontentpipeline-{platformStr}.{context.Version}", "binaries/MonoGame.Framework.Content.Pipeline/");
+            await DownloadArtifactAsync(context, $"mgpipeline-{platformStr}.{context.Version}", "binaries/MonoGame.Framework.Content.Pipeline/");
+            await DownloadArtifactAsync(context, $"mgframework-{platformStr}.{context.Version}", "binaries/MonoGame.Framework/");
         }
 
-        await DownloadArtifactAsync(context, $"mgpipeline-windows.{context.Version}", "binaries/mgpipeline/windows/Release/");
-        await DownloadArtifactAsync(context, $"mgpipeline-macos.{context.Version}", "binaries/mgpipeline/macosx/Release/");
-        await DownloadArtifactAsync(context, $"mgpipeline-linux.{context.Version}", "binaries/mgpipeline/linux/Release/");
-
-        await DownloadArtifactAsync(context, $"mgnative-windows.{context.Version}", "binaries/mgnative/windows/Release/");
-        //await DownloadArtifactAsync(context, $"mgnative-macos.{context.Version}", "binaries/mgnative/macosx/Release/");
-        //await DownloadArtifactAsync(context, $"mgnative-linux.{context.Version}", "binaries/mgnative/linux/Release/");
+        await DownloadArtifactAsync(context, $"mgnative-windows.{context.Version}", "binaries/MonoGame.Framework/");
+        //await DownloadArtifactAsync(context, $"mgnative-macos.{context.Version}", "binaries/MonoGame.Framework/");
+        //await DownloadArtifactAsync(context, $"mgnative-linux.{context.Version}", "binaries/MonoGame.Framework/");
     }
 }

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -33,6 +33,8 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
         // Manually download native Windows binaries, once Linux/Mac are available, they will move the the loop above.
         await DownloadArtifactAsync(context, $"mgnative-windows.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/");
 
+        context.MoveDirectory(context.GetOutputPath($"{binariesPackagingFolder}/MonoGame.Framework/MonoGame.Framework.Content.Pipeline/"), context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/"));
+
         // Post tasks due to issues with Android / iOS "publish" steps
         var sourcePath = context.GetOutputPath("Artifacts/MonoGame.Framework/");
         var processingPath = context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework/");

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -35,21 +35,23 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
         await DownloadArtifactAsync(context, $"mgnative-windows.{context.Version}", "binaries/MonoGame.Framework/");
 
         // Clean up duplicate "publish" folder from NuGet packaging
-        context.DeleteDirectory(context.GetOutputPath("binaries/MonoGame.Framework.Content.Pipeline/publish"));
+        DeleteDirectory(context, context.GetOutputPath("binaries/MonoGame.Framework.Content.Pipeline/publish"));
         var mgfPath = context.GetOutputPath("binaries/MonoGame.Framework/");
-        // loop through the mgf path and locate folders named "release" and move their contents to their parent folder
-        foreach (var releaseDir in Directory.GetDirectories(mgfPath, "release", SearchOption.AllDirectories))
+        // loop through the mgf path and locate folders named "release" and move their contents to their parent folder using only Cake Frosting Context methods
+        // Find all "release" folders under the mgfPath using Cake's globbing and move their contents up one folder
+        foreach (var releaseDir in context.GetDirectories($"{mgfPath}/**/release"))
         {
-            var parentDir = Directory.GetParent(releaseDir);
-            if (parentDir != null)
-            {
-                foreach (var file in Directory.GetFiles(releaseDir))
-                {
-                    var destFile = Path.Combine(parentDir.FullName, Path.GetFileName(file));
-                    File.Move(file, destFile);
-                }
-                Directory.Delete(releaseDir, true);
-            }
+            var parentFullPath = System.IO.Path.GetDirectoryName(releaseDir.FullPath);
+            if (string.IsNullOrEmpty(parentFullPath))
+                continue;
+
+            context.MoveFiles($"{releaseDir.FullPath}/*.*", parentFullPath);
+            DeleteDirectory(context, releaseDir.FullPath);
         }
+    }
+
+    private void DeleteDirectory(BuildContext context, string fullPath)
+    {
+        context.DeleteDirectory(fullPath, new DeleteDirectorySettings { Recursive = true, Force = true });
     }
 }

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -37,20 +37,20 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
         // Clean up duplicate "publish" folder from NuGet packaging
         DeleteDirectory(context, context.GetOutputPath("binaries/MonoGame.Framework.Content.Pipeline/publish"));
         var mgfPath = context.GetOutputPath("binaries/MonoGame.Framework/");
-        // loop through the mgf path and locate folders named "release" and move their contents to their parent folder using only Cake Frosting Context methods
-        // Find all "release" folders under the mgfPath using Cake's globbing and move their contents up one folder
         foreach (var releaseDir in context.GetDirectories($"{mgfPath}/**/release"))
         {
-            var parentFullPath = System.IO.Path.GetDirectoryName(releaseDir.FullPath);
-            if (string.IsNullOrEmpty(parentFullPath))
+            var parentDir = releaseDir.GetParent();
+            if (parentDir == null)
                 continue;
 
-            context.MoveFiles($"{releaseDir.FullPath}/*.*", parentFullPath);
-            DeleteDirectory(context, releaseDir.FullPath);
+            context.Information($"Moving contents of '{releaseDir.FullPath}' to '{parentDir.FullPath}'");
+
+            context.MoveFiles($"{releaseDir}/*.*", parentDir);
+            DeleteDirectory(context, releaseDir);
         }
     }
 
-    private void DeleteDirectory(BuildContext context, string fullPath)
+    private void DeleteDirectory(BuildContext context, DirectoryPath fullPath)
     {
         context.DeleteDirectory(fullPath, new DeleteDirectorySettings { Recursive = true, Force = true });
     }

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -47,7 +47,6 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
         {
             context.Information($"Post Processing platform: {platform}");
             context.CopyFiles($"{sourcePath}{platform}/Release/*.*", $"{processingPath}{platform}");
-            context.DeleteDirectory(context.GetOutputPath($"{processingPath}{platform}/Release"));
             context.CreateDirectory($"{processingPath}{platform}/runtimes");
             context.CopyDirectory($"{processingPath}MonoGame.Framework/DesktopGL/runtimes", $"{processingPath}{platform}/runtimes");
         }

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -37,6 +37,20 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
 
         // Clean up duplicate "publish" folder from NuGet cp packaging
         DeleteDirectory(context, context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/publish"));
+
+
+        // Post tasks due to issues with Android / iOS "publish" steps
+        // Copy MonoGame.Framework/Android to Binaries/MonoGame.Framework
+        //context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/Android");
+        context.CopyDirectory($"/Artifacts/MonoGame.Framework/Android", $"{binariesPackagingFolder}MonoGame.Framework/");
+        context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{binariesPackagingFolder}MonoGame.Framework/Android");
+
+
+        // Copy MonoGame.Framework/IOS to Binaries/MonoGame.Framework
+        //context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/iOS");
+        context.CopyDirectory($"/Artifacts/MonoGame.Framework/iOS", $"{binariesPackagingFolder}MonoGame.Framework/");
+        context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{binariesPackagingFolder}MonoGame.Framework/iOS");
+
     }
 
     private void DeleteDirectory(BuildContext context, DirectoryPath fullPath)

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -16,17 +16,19 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
 
     public override async Task RunAsync(BuildContext context)
     {
-        var os = context.Environment.Platform.Family switch
+        foreach (PlatformFamily platform in Enum.GetValues(typeof(PlatformFamily)))
         {
-            PlatformFamily.Windows => "windows",
-            PlatformFamily.OSX => "macos",
-            _ => "linux"
-        };
-
-        await DownloadArtifactAsync(context, $"mgcontentbuilder-{os}.{context.Version}", "binaries/MonoGame.Content.Builder/");
-        await DownloadArtifactAsync(context, $"mgeffectcompiler-{os}.{context.Version}", "binaries/MonoGame.Effect.Compiler/");
-        await DownloadArtifactAsync(context, $"mgframework-{os}.{context.Version}", "binaries/MonoGame.Framework/");
-        await DownloadArtifactAsync(context, $"mgcontentpipeline-{os}.{context.Version}", "binaries/MonoGame.Framework.Content.Pipeline/");
+            string platformStr = platform switch
+            {
+                PlatformFamily.Windows => "windows",
+                PlatformFamily.OSX => "macos",
+                _ => "linux"
+            };
+            await DownloadArtifactAsync(context, $"mgcontentbuilder-{platformStr}.{context.Version}", "binaries/MonoGame.Content.Builder/");
+            await DownloadArtifactAsync(context, $"mgeffectcompiler-{platformStr}.{context.Version}", "binaries/MonoGame.Effect.Compiler/");
+            await DownloadArtifactAsync(context, $"mgframework-{platformStr}.{context.Version}", "binaries/MonoGame.Framework/");
+            await DownloadArtifactAsync(context, $"mgcontentpipeline-{platformStr}.{context.Version}", "binaries/MonoGame.Framework.Content.Pipeline/");
+        }
 
         await DownloadArtifactAsync(context, $"mgpipeline-windows.{context.Version}", "binaries/mgpipeline/windows/Release/");
         await DownloadArtifactAsync(context, $"mgpipeline-macos.{context.Version}", "binaries/mgpipeline/macosx/Release/");

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -36,18 +36,6 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
 
         // Clean up duplicate "publish" folder from NuGet packaging
         DeleteDirectory(context, context.GetOutputPath("binaries/MonoGame.Framework.Content.Pipeline/publish"));
-        var mgfPath = context.GetOutputPath("binaries/MonoGame.Framework/");
-        foreach (var releaseDir in context.GetDirectories($"{mgfPath}/**/release"))
-        {
-            var parentDir = releaseDir.GetParent();
-            if (parentDir == null)
-                continue;
-
-            context.Information($"Moving contents of '{releaseDir.FullPath}' to '{parentDir.FullPath}'");
-
-            context.MoveFiles($"{releaseDir}/*.*", parentDir);
-            DeleteDirectory(context, releaseDir);
-        }
     }
 
     private void DeleteDirectory(BuildContext context, DirectoryPath fullPath)

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -48,7 +48,7 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
             context.Information($"Post Processing platform: {platform}");
             context.CopyFiles($"{sourcePath}{platform}/Release/*.*", $"{processingPath}{platform}");
             context.CreateDirectory($"{processingPath}{platform}/runtimes");
-            context.CopyDirectory($"{processingPath}MonoGame.Framework/DesktopGL/runtimes", $"{processingPath}{platform}/runtimes");
+            context.CopyDirectory($"{processingPath}DesktopGL/runtimes", $"{processingPath}{platform}/runtimes");
         }
     }
 }

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -4,6 +4,7 @@ namespace BuildScripts;
 [TaskName("DownloadBinaries")]
 public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
 {
+    private string binariesPackagingFolder = "binPackaging/";
     public override bool ShouldRun(BuildContext context) => context.BuildSystem().IsRunningOnGitHubActions;
 
     private static async Task DownloadArtifactAsync(BuildContext context, string artifactName, string path)
@@ -24,18 +25,18 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
                 PlatformFamily.OSX => "macos",
                 _ => "linux"
             };
-            await DownloadArtifactAsync(context, $"mgcontentbuilder-{platformStr}.{context.Version}", "binaries/MonoGame.Framework.Content.Pipeline/");
-            await DownloadArtifactAsync(context, $"mgeffectcompiler-{platformStr}.{context.Version}", "binaries/MonoGame.Framework.Content.Pipeline/");
-            await DownloadArtifactAsync(context, $"mgcontentpipeline-{platformStr}.{context.Version}", "binaries/MonoGame.Framework.Content.Pipeline/");
-            await DownloadArtifactAsync(context, $"mgpipeline-{platformStr}.{context.Version}", "binaries/MonoGame.Framework.Content.Pipeline/");
-            await DownloadArtifactAsync(context, $"mgframework-{platformStr}.{context.Version}", "binaries/MonoGame.Framework/");
+            await DownloadArtifactAsync(context, $"mgcontentbuilder-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
+            await DownloadArtifactAsync(context, $"mgeffectcompiler-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
+            await DownloadArtifactAsync(context, $"mgcontentpipeline-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
+            await DownloadArtifactAsync(context, $"mgpipeline-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
+            await DownloadArtifactAsync(context, $"mgbinaries-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/");
         }
 
         // Manually download native Windows binaries, once Linux/Mac are available, they will move the the loop above.
-        await DownloadArtifactAsync(context, $"mgnative-windows.{context.Version}", "binaries/MonoGame.Framework/");
+        await DownloadArtifactAsync(context, $"mgnative-windows.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/");
 
-        // Clean up duplicate "publish" folder from NuGet packaging
-        DeleteDirectory(context, context.GetOutputPath("binaries/MonoGame.Framework.Content.Pipeline/publish"));
+        // Clean up duplicate "publish" folder from NuGet cp packaging
+        DeleteDirectory(context, context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/publish"));
     }
 
     private void DeleteDirectory(BuildContext context, DirectoryPath fullPath)

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -27,7 +27,7 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
             };
             await DownloadArtifactAsync(context, $"mgframework-{platformStr}.{context.Version}", $"Artifacts/MonoGame.Framework/");
             await DownloadArtifactAsync(context, $"mgbinaries-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/");
-            await DownloadArtifactAsync(context, $"mgpipeline-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
+            await DownloadArtifactAsync(context, $"mgpipeline-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/MonoGame.Framework.Content.Pipeline/");
         }
 
         // Manually download native Windows binaries, once Linux/Mac are available, they will move the the loop above.

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -30,6 +30,7 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
             await DownloadArtifactAsync(context, $"mgcontentpipeline-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
             await DownloadArtifactAsync(context, $"mgpipeline-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/");
             await DownloadArtifactAsync(context, $"mgbinaries-{platformStr}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/");
+            await DownloadArtifactAsync(context, $"mgframework-{platformStr}.{context.Version}", $"Artifacts/MonoGame.Framework/");
         }
 
         // Manually download native Windows binaries, once Linux/Mac are available, they will move the the loop above.
@@ -39,13 +40,13 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
         context.DeleteDirectory(context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/publish"));
 
         // Post tasks due to issues with Android / iOS "publish" steps
+        var sourcePath = context.GetOutputPath("Artifacts/MonoGame.Framework/");
         var processingPath = context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework/");
         string[] targets = ["Android", "iOS"];
         foreach (var platform in targets)
         {
-            await DownloadArtifactAsync(context, $"mgframework-{platform}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/");
             context.Information($"Post Processing platform: {platform}");
-            context.CopyDirectory($"{processingPath}{platform}/Release", $"{processingPath}{platform}");
+            context.CopyDirectory($"{sourcePath}{platform}/Release", $"{processingPath}{platform}");
             context.DeleteDirectory(context.GetOutputPath($"{processingPath}{platform}/Release"));
             context.CreateDirectory($"{processingPath}{platform}/runtimes");
             context.CopyDirectory($"{processingPath}MonoGame.Framework/DesktopGL/runtimes", $"{processingPath}{platform}/runtimes");

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -38,26 +38,17 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
         // Clean up duplicate "publish" folder from NuGet cp packaging
         DeleteDirectory(context, context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework.Content.Pipeline/publish"));
 
-
         // Post tasks due to issues with Android / iOS "publish" steps
-        var inputPath = context.GetOutputPath($"Artifacts/MonoGame.Framework/");
-        var outputPath = context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework/");
-        // Copy MonoGame.Framework/Android to Binaries/MonoGame.Framework
-        context.CreateDirectory($"{outputPath}Android");
-        context.CopyDirectory($"{inputPath}Android", $"{outputPath}Android");
-        context.CreateDirectory($"{outputPath}Android/runtimes");
-        context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{outputPath}Android/runtimes");
-
-
-        // Copy MonoGame.Framework/IOS to Binaries/MonoGame.Framework
-        context.CreateDirectory($"{outputPath}iOS");
-        context.CopyDirectory($"{inputPath}iOS", $"{outputPath}iOS");
-        context.CreateDirectory($"{outputPath}iOS/runtimes");
-        context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{outputPath}iOS/runtimes");
-    }
-
-    private void DeleteDirectory(BuildContext context, DirectoryPath fullPath)
-    {
-        context.DeleteDirectory(fullPath, new DeleteDirectorySettings { Recursive = true, Force = true });
+        var processingPath = context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework/");
+        string[] targets = ["Android", "iOS"];
+        foreach (var platform in targets)
+        {
+            await DownloadArtifactAsync(context, $"mgframework-{platform}.{context.Version}", $"{binariesPackagingFolder}MonoGame.Framework/");
+            context.Information($"Post Processing platform: {platform}");
+            context.CopyDirectory($"{processingPath}{platform}/Release", $"{processingPath}{platform}");
+            context.DeleteDirectory(context.GetOutputPath($"{processingPath}{platform}/Release"));
+            context.CreateDirectory($"{processingPath}{platform}/runtimes");
+            context.CopyDirectory($"{processingPath}MonoGame.Framework/DesktopGL/runtimes", $"{processingPath}{platform}/runtimes");
+        }
     }
 }

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -31,8 +31,25 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
             await DownloadArtifactAsync(context, $"mgframework-{platformStr}.{context.Version}", "binaries/MonoGame.Framework/");
         }
 
+        // Manually download native Windows binaries, once Linux/Mac are available, they will move the the loop above.
         await DownloadArtifactAsync(context, $"mgnative-windows.{context.Version}", "binaries/MonoGame.Framework/");
-        //await DownloadArtifactAsync(context, $"mgnative-macos.{context.Version}", "binaries/MonoGame.Framework/");
-        //await DownloadArtifactAsync(context, $"mgnative-linux.{context.Version}", "binaries/MonoGame.Framework/");
+
+        // Clean up duplicate "publish" folder from NuGet packaging
+        context.DeleteDirectory(context.GetOutputPath("binaries/MonoGame.Framework.Content.Pipeline/publish"));
+        var mgfPath = context.GetOutputPath("binaries/MonoGame.Framework/");
+        // loop through the mgf path and locate folders named "release" and move their contents to their parent folder
+        foreach (var releaseDir in Directory.GetDirectories(mgfPath, "release", SearchOption.AllDirectories))
+        {
+            var parentDir = Directory.GetParent(releaseDir);
+            if (parentDir != null)
+            {
+                foreach (var file in Directory.GetFiles(releaseDir))
+                {
+                    var destFile = Path.Combine(parentDir.FullName, Path.GetFileName(file));
+                    File.Move(file, destFile);
+                }
+                Directory.Delete(releaseDir, true);
+            }
+        }
     }
 }

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -40,19 +40,20 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
 
 
         // Post tasks due to issues with Android / iOS "publish" steps
+        var inputPath = context.GetOutputPath($"Artifacts/MonoGame.Framework/");
+        var outputPath = context.GetOutputPath($"{binariesPackagingFolder}MonoGame.Framework/");
         // Copy MonoGame.Framework/Android to Binaries/MonoGame.Framework
-        context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/Android");
-        context.CopyDirectory($"Artifacts/MonoGame.Framework/Android", $"{binariesPackagingFolder}MonoGame.Framework/");
-        context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/Android/runtimes");
-        context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{binariesPackagingFolder}MonoGame.Framework/Android");
+        context.CreateDirectory($"{outputPath}Android");
+        context.CopyDirectory($"{inputPath}Android", $"{outputPath}Android");
+        context.CreateDirectory($"{outputPath}Android/runtimes");
+        context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{outputPath}Android/runtimes");
 
 
         // Copy MonoGame.Framework/IOS to Binaries/MonoGame.Framework
-        context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/iOS");
-        context.CopyDirectory($"Artifacts/MonoGame.Framework/iOS", $"{binariesPackagingFolder}MonoGame.Framework/");
-        context.CreateDirectory($"{binariesPackagingFolder}MonoGame.Framework/iOS/runtimes");
-        context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{binariesPackagingFolder}MonoGame.Framework/iOS");
-
+        context.CreateDirectory($"{outputPath}iOS");
+        context.CopyDirectory($"{inputPath}iOS", $"{outputPath}iOS");
+        context.CreateDirectory($"{outputPath}iOS/runtimes");
+        context.CopyDirectory($"{binariesPackagingFolder}MonoGame.Framework/runtimes", $"{outputPath}iOS/runtimes");
     }
 
     private void DeleteDirectory(BuildContext context, DirectoryPath fullPath)

--- a/build/DeployTasks/DownloadBinariesTask.cs
+++ b/build/DeployTasks/DownloadBinariesTask.cs
@@ -35,7 +35,7 @@ public sealed class DownloadBinariesTask : AsyncFrostingTask<BuildContext>
         await DownloadArtifactAsync(context, $"mgpipeline-linux.{context.Version}", "binaries/mgpipeline/linux/Release/");
 
         await DownloadArtifactAsync(context, $"mgnative-windows.{context.Version}", "binaries/mgnative/windows/Release/");
-        await DownloadArtifactAsync(context, $"mgnative-macos.{context.Version}", "binaries/mgnative/macosx/Release/");
-        await DownloadArtifactAsync(context, $"mgnative-linux.{context.Version}", "binaries/mgnative/linux/Release/");
+        //await DownloadArtifactAsync(context, $"mgnative-macos.{context.Version}", "binaries/mgnative/macosx/Release/");
+        //await DownloadArtifactAsync(context, $"mgnative-linux.{context.Version}", "binaries/mgnative/linux/Release/");
     }
 }

--- a/build/DeployTasks/RepackForDeployTask.cs
+++ b/build/DeployTasks/RepackForDeployTask.cs
@@ -13,6 +13,7 @@ public sealed class RepackForDeployTask : FrostingTask<BuildContext>
         //  MonoGame.Framework.Content.Pipeline
         context.DotNetPackSettings.MSBuildSettings.WithProperty("DisableMonoGameToolAssets", "True");
         context.DotNetPack(context.GetProjectPath(ProjectType.ContentPipeline), context.DotNetPackSettings);
+        context.PublishToolsBinaries(context.GetProjectPath(ProjectType.ContentPipeline));
         context.DotNetPackSettings.MSBuildSettings.Properties.Remove("DisableMonoGameToolAssets");
 
         // mgcb

--- a/build/DeployTasks/UploadArtifactsTask.cs
+++ b/build/DeployTasks/UploadArtifactsTask.cs
@@ -62,9 +62,6 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
         }
 
         // Upload Binaries
-        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Content.Builder/Release/"), $"mgcontentbuilder-{os}.{context.Version}");
-        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Effect.Compiler/Release/"), $"mgeffectcompiler-{os}.{context.Version}");
-        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Framework.Content.Pipeline/Release"), $"mgcontentpipeline-{os}.{context.Version}");
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Framework/"), $"mgframework-{os}.{context.Version}");
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/Binaries/"), $"mgbinaries-{os}.{context.Version}");
 

--- a/build/DeployTasks/UploadArtifactsTask.cs
+++ b/build/DeployTasks/UploadArtifactsTask.cs
@@ -47,15 +47,15 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
         {
             case PlatformFamily.Windows:
                 await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/windows/Release/"), $"mgpipeline-{os}.{context.Version}");
-                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/windows/Release/"), $"mgnative-{os}.{context.Version}");
+                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/windows/"), $"mgnative-{os}.{context.Version}");
                 break;
             case PlatformFamily.Linux:
                 await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/linux/Release/"), $"mgpipeline-{os}.{context.Version}");
-                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/linux/Release/"), $"mgnative-{os}.{context.Version}");
+                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/linux/"), $"mgnative-{os}.{context.Version}");
                 break;
             case PlatformFamily.OSX:
                 await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/macosx/Release/"), $"mgpipeline-{os}.{context.Version}");
-                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/macosx/Release/"), $"mgnative-{os}.{context.Version}");
+                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/macosx/"), $"mgnative-{os}.{context.Version}");
                 break;
             default:
                 throw new NotSupportedException($"Platform {context.Environment.Platform.Family} is not supported for static library checks.");

--- a/build/DeployTasks/UploadArtifactsTask.cs
+++ b/build/DeployTasks/UploadArtifactsTask.cs
@@ -51,11 +51,11 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
                 break;
             case PlatformFamily.Linux:
                 await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/linux/Release/"), $"mgpipeline-{os}.{context.Version}");
-                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/linux/"), $"mgnative-{os}.{context.Version}");
+                //await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/linux/"), $"mgnative-{os}.{context.Version}");
                 break;
             case PlatformFamily.OSX:
                 await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/macosx/Release/"), $"mgpipeline-{os}.{context.Version}");
-                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/macosx/"), $"mgnative-{os}.{context.Version}");
+                //await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/macosx/"), $"mgnative-{os}.{context.Version}");
                 break;
             default:
                 throw new NotSupportedException($"Platform {context.Environment.Platform.Family} is not supported for static library checks.");

--- a/build/DeployTasks/UploadArtifactsTask.cs
+++ b/build/DeployTasks/UploadArtifactsTask.cs
@@ -65,7 +65,7 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Content.Builder/Release/"), $"mgcontentbuilder-{os}.{context.Version}");
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Effect.Compiler/Release/"), $"mgeffectcompiler-{os}.{context.Version}");
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Framework/"), $"mgframework-{os}.{context.Version}");
-        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Framework.Content.Pipeline/"), $"mgcontentpipeline-{os}.{context.Version}");
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Framework.Content.Pipeline/Release"), $"mgcontentpipeline-{os}.{context.Version}");
 
 
         // Upload NuGet packages

--- a/build/DeployTasks/UploadArtifactsTask.cs
+++ b/build/DeployTasks/UploadArtifactsTask.cs
@@ -47,16 +47,26 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
         {
             case PlatformFamily.Windows:
                 await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/windows/Release/"), $"mgpipeline-{os}.{context.Version}");
+                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/windows/Release/"), $"mgnative-{os}.{context.Version}");
                 break;
             case PlatformFamily.Linux:
                 await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/linux/Release/"), $"mgpipeline-{os}.{context.Version}");
+                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/linux/Release/"), $"mgnative-{os}.{context.Version}");
                 break;
             case PlatformFamily.OSX:
                 await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/macosx/Release/"), $"mgpipeline-{os}.{context.Version}");
+                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/macosx/Release/"), $"mgnative-{os}.{context.Version}");
                 break;
             default:
                 throw new NotSupportedException($"Platform {context.Environment.Platform.Family} is not supported for static library checks.");
         }
+
+        // Upload Binaries
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Content.Builder/Release/"), $"mgcontentbuilder-{os}.{context.Version}");
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Effect.Compiler/Release/"), $"mgeffectcompiler-{os}.{context.Version}");
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Framework/"), $"mgframework-{os}.{context.Version}");
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Framework.Content.Pipeline/"), $"mgcontentpipeline-{os}.{context.Version}");
+
 
         // Upload NuGet packages
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(context.NuGetsDirectory), $"nuget-{os}.{context.Version}");
@@ -90,7 +100,7 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
                     context.Log.Information($"Deleting: {file}");
                     System.IO.File.Delete(file);
                 }
-                
+
             }
         }
     }

--- a/build/DeployTasks/UploadArtifactsTask.cs
+++ b/build/DeployTasks/UploadArtifactsTask.cs
@@ -64,9 +64,9 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
         // Upload Binaries
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Content.Builder/Release/"), $"mgcontentbuilder-{os}.{context.Version}");
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Effect.Compiler/Release/"), $"mgeffectcompiler-{os}.{context.Version}");
-        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Framework/"), $"mgframework-{os}.{context.Version}");
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Framework.Content.Pipeline/Release"), $"mgcontentpipeline-{os}.{context.Version}");
-
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/MonoGame.Framework/"), $"mgframework-{os}.{context.Version}");
+        await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/Binaries/"), $"mgbinaries-{os}.{context.Version}");
 
         // Upload NuGet packages
         await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath(context.NuGetsDirectory), $"nuget-{os}.{context.Version}");


### PR DESCRIPTION
# Summary

New packaging delivery to ship MonoGame as a Binaries delivery

## Aims

To produce a pre-packaged version of all MonoGame deployments and dependencies in a single download.

## Usage

Full docs are in the process for use, in the meantime, here is a sample/updated desktopgl project

```
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>WinExe</OutputType>
    <TargetFramework>net8.0</TargetFramework>
    <PublishReadyToRun>false</PublishReadyToRun>
    <TieredCompilation>false</TieredCompilation>
    <ApplicationManifest>app.manifest</ApplicationManifest>
    <ApplicationIcon>../binariestest.Core/Content/Icon.ico</ApplicationIcon>
    <AssemblyName>binariestest</AssemblyName>
    <MonoGamePlatform>DesktopGL</MonoGamePlatform>
    <MonoGameBinariesPath Condition="'$(MonoGameBinariesPath)' == ''">$(MSBuildThisFileDirectory)..\..\MonoGame.3.8.4.2764-develop\MonoGame.Framework\</MonoGameBinariesPath>
  </PropertyGroup>
  <ItemGroup>
    <MonoGameContentReference Include="..\binariestest.Core\Content\binariestest.mgcb">
      <Link>Content\binariestest.mgcb</Link>
    </MonoGameContentReference>
  </ItemGroup>
  <ItemGroup>
    <ProjectReference Include="..\binariestest.Core\binariestest.Core.csproj" />
  </ItemGroup>
  <ItemGroup>
    <None Include="$(MonoGameBinariesPath)$(MonoGamePlatform)\runtimes\win-x64\native\*">
      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
    </None>
  </ItemGroup>
  <ItemGroup>
    <Reference Include="MonoGame.Framework">
      <HintPath>$(MonoGameBinariesPath)$(MonoGamePlatform)\MonoGame.Framework.dll</HintPath>
    </Reference>
  </ItemGroup>  
  <ItemGroup>
    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
  </ItemGroup>
</Project>
```

As well as an updated Content Builder Project usage, for content reference (platform specific) inclusions:

```
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net8.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
    <MonoGameBinariesPath Condition="'$(MonoGameBinariesPath)' == ''">$(MSBuildThisFileDirectory)..\..\MonoGame.3.8.4.2764-develop\</MonoGameBinariesPath>    
  </PropertyGroup>

  <ItemGroup>
	<None Include="Assets/*" />
  </ItemGroup>
  <ItemGroup>
    <None Include="$(MonoGameBinariesPath)MonoGame.Framework.Content.Pipeline\*">
      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
    </None>
    <None Include="$(MonoGameBinariesPath)MonoGame.Framework.Content.Pipeline\windows-x64\bin\*">
      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
    </None>
    <None Include="$(MonoGameBinariesPath)MonoGame.Framework.Content.Pipeline\runtimes\win-x64\native\*">
      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
    </None>
  </ItemGroup>
  <ItemGroup>
    <PackageReference Include="MIConvexHull" Version="1.1.19.1019" />
  </ItemGroup>
  <ItemGroup>
    <Reference Include="MonoGame.Framework">
      <HintPath>$(MonoGameBinariesPath)MonoGame.Framework\Native\Release\MonoGame.Framework.dll</HintPath>
    </Reference>
    <Reference Include="MonoGame.Framework.Content.Pipeline">
      <HintPath>$(MonoGameBinariesPath)MonoGame.Framework.Content.Pipeline\MonoGame.Framework.Content.Pipeline.dll</HintPath>
    </Reference>
  </ItemGroup>
  
</Project>
```

## Future updates

Current structure aligns with MonoGame output current deployment. Future work will restructure the output for easier consumption.