### PR TITLE
Added missing references for MGCB editor

### DIFF
--- a/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Linux.csproj
+++ b/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Linux.csproj
@@ -38,6 +38,12 @@
     <PackageReference Include="Eto.Forms" Version="2.8.3" />
     <PackageReference Include="Eto.Platform.Gtk" Version="2.8.3" />
     <PackageReference Include="GtkSharp" Version="3.24.24.95" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="YamlDotNet" Version="16.3.0">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj
+++ b/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Mac.csproj
@@ -32,6 +32,12 @@
   <ItemGroup>
     <PackageReference Include="Eto.Forms" Version="2.8.3" />
     <PackageReference Include="Eto.Platform.macOS" Version="2.8.3" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="YamlDotNet" Version="16.3.0">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Windows.csproj
+++ b/Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.Windows.csproj
@@ -32,6 +32,12 @@
   <ItemGroup>
     <PackageReference Include="Eto.Forms" Version="2.8.3" />
     <PackageReference Include="Eto.Platform.Wpf" Version="2.8.3" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="YamlDotNet" Version="16.3.0">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Summary

New references were added to the Content Pipeline in recent updates for Content Builder support, however these are also required in the editors which also consume the pipeline, namely:

- System.CommandLine
- YamlDotNet

This PR adds the missing refernces enabling the MGCB editor(s) to be able to resolve dependencies for the `.mgcb` content files