### PR TITLE
Updating the checkout for the VulkanMemoryAllocator as it was moved

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "src/monogame/external/volk"]
 	path = native/monogame/external/volk
 	url = https://github.com/zeux/volk.git
-[submodule "src/monogame/external/vma"]
-	path = native/monogame/external/vma
-	url = https://github.com/LunarG/VulkanMemoryAllocator.git
 [submodule "external/MonoGame.Templates"]
 	path = external/MonoGame.Templates
 	url = https://github.com/MonoGame/MonoGame.Templates.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "external/CppNet"]
 	path = external/CppNet
 	url = https://github.com/MonoGame/CppNet.git
+[submodule "native/monogame/external/vma"]
+	path = native/monogame/external/vma
+	url = https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git


### PR DESCRIPTION
# Summary

The `VulkanMemoryAllocator` dependency was recently moved, which broke a critical MonoGame dependency.

This PR updates the checkout to the new source