### PR TITLE
[Pipeline] Refactor the content builder

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
@@ -28,7 +28,7 @@ public abstract class ContentBuilder
 
     private readonly Queue<ContentRequest> _contentRequestQueue = [];
     private readonly object _contentRequestLock = new();
-    private readonly Dictionary<string, ContentInfo> _content = [];
+    private readonly Dictionary<string, List<ContentInfo>> _content = [];
     private readonly Dictionary<string, string> _outputContent = [];
 
     /// <summary>
@@ -68,16 +68,15 @@ public abstract class ContentBuilder
     /// <summary>
     /// Initiates a build of the specified asset and then writes down the result to disk..
     /// </summary>
-    /// <param name="relativePath">A relative path to the source asset.</param>
+    /// <param name="relativeSrcPath">A relative path to the source asset.</param>
     /// <param name="contentInfo">The desired <see cref="ContentInfo"/> to be used for the content building.</param>
-    /// <returns></returns>
-    public ContentFileCache? BuildAndWriteContent(string relativePath, ContentInfo contentInfo)
+    /// <param name="relativeDstPath">The desired relative output path.</param>
+    public void BuildAndWriteContent(string relativeSrcPath, ContentInfo contentInfo, string? relativeDstPath = null)
     {
-        ContentFileCache? contentFileCache = null;
-        Logger.PushFile(relativePath);
+        Logger.PushFile(relativeSrcPath);
         try
         {
-            contentFileCache = ProcessContent(relativePath, contentInfo, true).contentFileCache;
+            ProcessContent(relativeSrcPath, contentInfo, true, relativeDstPath);
             SucceededToBuild++;
         }
         catch (Exception ex)
@@ -86,21 +85,21 @@ public abstract class ContentBuilder
             FailedToBuild++;
         }
         Logger.PopFile();
-        return contentFileCache;
     }
 
     /// <summary>
     /// Initiates a build of the specified asset and then loads the result into memory.
     /// </summary>
-    /// <param name="relativePath">A relative path to the source asset.</param>
+    /// <param name="relativeSrcPath">A relative path to the source asset.</param>
     /// <param name="contentInfo">The desired <see cref="ContentInfo"/> to be used for the content building.</param>
-    /// <returns></returns>
-    public (ContentFileCache? contentFileCache, object? processedObject) BuildAndLoadContent(string relativePath, ContentInfo contentInfo)
+    /// <param name="relativeDstPath">The desired relative output path.</param>
+    /// <returns>The built object that the <see cref="IContentProcessor.Process(object, ContentProcessorContext)"/> returned.</returns>
+    public object? BuildAndLoadContent(string relativeSrcPath, ContentInfo contentInfo, string? relativeDstPath = null)
     {
-        Logger.PushFile(relativePath);
+        Logger.PushFile(relativeSrcPath);
         try
         {
-            var content = ProcessContent(relativePath, contentInfo, false);
+            var content = ProcessContent(relativeSrcPath, contentInfo, false, relativeDstPath);
             SucceededToBuild++;
             return content;
         }
@@ -110,20 +109,19 @@ public abstract class ContentBuilder
             FailedToBuild++;
         }
         Logger.PopFile();
-        return (null, null);
+        return null;
     }
 
-    private (ContentFileCache? contentFileCache, object? processedObject) ProcessContent(string relativePath, ContentInfo contentInfo, bool writeToDisk)
+    private object? ProcessContent(string relativePath, ContentInfo contentInfo, bool writeToDisk, string? relativeOutputPath)
     {
-        ContentFileCache? contentFileCache = null;
         var filePath = Path.Combine(Parameters.RootedSourceDirectory, relativePath);
-        var relativeDestPath = Path.Combine(contentInfo.ContentRoot, contentInfo.GetOutputPath(relativePath));
+        var relativeDestPath = Path.Combine(contentInfo.ContentRoot, string.IsNullOrEmpty(relativeOutputPath) ? relativePath.GetDestinationPath(contentInfo.ShouldBuild, contentInfo.GetOutputPath) : relativeOutputPath);
         var outputPath = Path.Combine(Parameters.RootedOutputDirectory, relativeDestPath);
         var outputDir = Path.GetDirectoryName(outputPath);
 
         if (string.IsNullOrWhiteSpace(outputDir))
         {
-            return (contentFileCache, null);
+            return null;
         }
 
         if (!Directory.Exists(outputDir))
@@ -131,15 +129,20 @@ public abstract class ContentBuilder
             Directory.CreateDirectory(outputDir);
         }
 
-        if (!contentInfo.ShouldBuild)
+        Logger.Log($"Output: {relativeDestPath}");
+        if (!Parameters.Rebuild)
         {
-            Logger.Log($"Output: {relativeDestPath}");
-            contentFileCache = ContentCache.ReadContentFileCache(this, relativePath, contentInfo.ContentRoot);
-            if (contentFileCache != null)
+            var fileCache = ContentCache.ReadContentFileCache(this, relativeDestPath);
+            if (fileCache != null && fileCache.IsValid(this, contentInfo))
             {
                 Logger.Log($"Cache: Found");
-                return (contentFileCache, null);
+                ContentCache.MarkUsed(fileCache);
+                return null;
             }
+        }
+
+        if (!contentInfo.ShouldBuild)
+        {
             Logger.Log($"Cache: Not Found");
 
             if (File.Exists(outputPath))
@@ -148,54 +151,35 @@ public abstract class ContentBuilder
             }
             File.Copy(filePath, outputPath);
 
-            contentFileCache = new ContentFileCache
-            {
-                ContentRoot = contentInfo.ContentRoot
-            };
-            contentFileCache.AddDependency(this, relativePath);
-            contentFileCache.AddOutputFile(this, outputPath);
-            ContentCache.WriteContentFileCache(this, relativePath, contentFileCache);
-            return (contentFileCache, null);
+            var fileCache = ContentCache.CreateContentFileCache(this, contentInfo);
+            fileCache.AddDependency(this, relativePath);
+            fileCache.AddOutputFile(this, outputPath);
+            ContentCache.WriteContentFileCache(this, relativeDestPath, fileCache);
+            ContentCache.MarkUsed(fileCache);
+            return null;
         }
 
         if (!ContentBuilderHelper.GetImporter(relativePath, contentInfo.Importer, out IContentImporter importer))
         {
             Logger.Log(LogLevel.Warning, "Importer: Not found :(");
-            return (contentFileCache, null);
+            return null;
         }
         Logger.Log($"Imposter: {importer.GetType().Name}");
         if (!ContentBuilderHelper.GetProcessor(importer, contentInfo.Processor, out IContentProcessor processor))
         {
             Logger.Log(LogLevel.Warning, "Processor: Not found :(");
-            return (contentFileCache, null);
+            return null;
         }
         Logger.Log($"Processor: {processor.GetType().Name}");
-        Logger.Log($"Output: {relativeDestPath}");
-
-        contentFileCache = ContentCache.ReadContentFileCache(this, relativePath, contentInfo.ContentRoot, true, importer, processor);
-        if (contentFileCache != null)
-        {
-            Logger.Log($"Cache: Found");
-            return (contentFileCache, null);
-        }
         Logger.Log($"Cache: Not Found");
 
-        contentFileCache = new ContentFileCache
-        {
-            ContentRoot = contentInfo.ContentRoot,
-            CompressContent = Parameters.CompressContent,
-            GraphicsProfile = Parameters.GraphicsProfile,
-            ShouldBuild = true,
-            Importer = importer,
-            Processor = processor
-        };
+        var contentFileCache = ContentCache.CreateContentFileCache(this, contentInfo);
         contentFileCache.AddDependency(this, relativePath);
-        contentFileCache.AddOutputFile(this, outputPath);
 
         var importContext = new ContentBuilderImporterContext(this, contentFileCache);
         var importedObject = importer.Import(filePath, importContext);
 
-        var processorContext = new ContentBuilderProcessorContext(this, contentFileCache, contentInfo.ContentRoot, outputPath);
+        var processorContext = new ContentBuilderProcessorContext(this, relativePath, contentInfo, contentFileCache, outputPath);
         var processedObject = processor.Process(importedObject, processorContext);
 
         if (writeToDisk)
@@ -203,26 +187,12 @@ public abstract class ContentBuilder
             var compiler = new ContentCompiler();
             using var stream = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.None);
             compiler.Compile(stream, processedObject, Parameters.Platform, Parameters.GraphicsProfile, Parameters.CompressContent, Parameters.RootedOutputDirectory, outputDir);
-            ContentCache.WriteContentFileCache(this, relativePath, contentFileCache);
+            contentFileCache.AddOutputFile(this, outputPath);
+            ContentCache.WriteContentFileCache(this, relativeDestPath, contentFileCache);
+            ContentCache.MarkUsed(contentFileCache);
         }
 
-        return (contentFileCache, processedObject);
-    }
-
-    private ContentFileCache? CheckContentCache(string relativePath, ContentInfo contentInfo)
-    {
-        if (!contentInfo.ShouldBuild)
-        {
-            return ContentCache.ReadContentFileCache(this, relativePath, contentInfo.ContentRoot);
-        }
-
-        if (!ContentBuilderHelper.GetImporter(relativePath, contentInfo.Importer, out IContentImporter importer) ||
-            !ContentBuilderHelper.GetProcessor(importer, contentInfo.Processor, out IContentProcessor processor))
-        {
-            return null;
-        }
-
-        return ContentCache.ReadContentFileCache(this, relativePath, contentInfo.ContentRoot, true, importer, processor);
+        return processedObject;
     }
 
     /// <summary>
@@ -293,12 +263,15 @@ public abstract class ContentBuilder
 
         foreach (var filePath in Directory.GetFiles(directory))
         {
-            ContentInfo? contentInfo = null;
             var relativePath = Path.GetRelativePath(Parameters.RootedSourceDirectory, filePath);
-            if (contentCollection.GetContentInfo(relativePath, ref contentInfo) && contentInfo != null)
+            relativePath = relativePath.Sanitize();
+            if (contentCollection.GetContentInfo(relativePath, out List<ContentInfo> contentInfos) && contentInfos.Count > 0)
             {
-                _content[relativePath] = contentInfo;
-                _outputContent[Path.Combine(contentInfo.ContentRoot, contentInfo.GetOutputPath(relativePath))] = relativePath;
+                _content[relativePath] = contentInfos;
+                foreach (var contentInfo in contentInfos)
+                {
+                    _outputContent[Path.Combine(contentInfo.ContentRoot, contentInfo.GetOutputPath(relativePath))] = relativePath;
+                }
             }
         }
     }
@@ -307,7 +280,7 @@ public abstract class ContentBuilder
     {
         foreach (var pair in _content)
         {
-            if (_content.TryGetValue(pair.Key, out ContentInfo? contentInfo))
+            foreach(var contentInfo in pair.Value)
             {
                 BuildAndWriteContent(pair.Key, contentInfo);
             }
@@ -383,28 +356,36 @@ public abstract class ContentBuilder
 
         if (_outputContent.TryGetValue(args.ContentPath, out var inputPath))
         {
-            if (_content.TryGetValue(inputPath, out ContentInfo? contentInfo))
+            if (_content.TryGetValue(inputPath, out List<ContentInfo>? contentInfos))
             {
-                if (CheckContentCache(inputPath, contentInfo) is not null)
+                foreach (var contentInfo in contentInfos)
                 {
-                    // we've already found a valid cached version of content, so no need for any compilation here
-                    args.FilePath = Path.Combine(Parameters.RootedOutputDirectory, Path.Combine(contentInfo.ContentRoot, contentInfo.GetOutputPath(inputPath)));
-                    return;
-                }
+                    if (contentInfo.GetOutputPath(inputPath) != args.ContentPath)
+                    {
+                        continue;
+                    }
 
-                args.CompilationStarted = true;
-                lock (_contentRequestQueue)
-                {
-                    _contentRequestQueue.Enqueue(new ContentRequest
+                    if (ContentCache.ReadContentFileCache(this, args.ContentPath) is not null)
                     {
-                        InputPath = inputPath,
-                        ContentInfo = contentInfo,
-                        Server = contentServer,
-                        Args = args
-                    });
-                    lock (_contentRequestLock)
+                        // we've already found a valid cached version of content, so no need for any compilation here
+                        args.FilePath = Path.Combine(Parameters.RootedOutputDirectory, args.ContentPath);
+                        return;
+                    }
+
+                    args.CompilationStarted = true;
+                    lock (_contentRequestQueue)
                     {
-                        Monitor.Pulse(_contentRequestLock);
+                        _contentRequestQueue.Enqueue(new ContentRequest
+                        {
+                            InputPath = inputPath,
+                            ContentInfo = contentInfo,
+                            Server = contentServer,
+                            Args = args
+                        });
+                        lock (_contentRequestLock)
+                        {
+                            Monitor.Pulse(_contentRequestLock);
+                        }
                     }
                 }
             }

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
@@ -14,7 +14,7 @@ using MonoGame.Framework.Content.Pipeline.Builder.Server;
 
 namespace MonoGame.Framework.Content.Pipeline.Builder;
 
-class ContentBuilderHelper
+static class ContentBuilderHelper
 {
     sealed class ColorConverter : IYamlTypeConverter
     {
@@ -286,4 +286,56 @@ class ContentBuilderHelper
             }
         }
     }
+
+    public static string GetDestinationPath(this string filePath, bool build, Func<string, string>? outputFunc = null)
+    {
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return filePath;
+        }
+
+        if (build)
+        {
+            int extensionEnd = filePath.Length - 1;
+            for (int i = extensionEnd; i >= 0; i--)
+            {
+                if (filePath[i] == '.')
+                {
+                    extensionEnd = i;
+                }
+
+                if (filePath[i] == '/' || filePath[i] == '\\')
+                {
+                    break;
+                }
+            }
+
+            filePath = filePath[..extensionEnd];
+        }
+
+        filePath = filePath.Sanitize();
+
+        if (outputFunc != null)
+        {
+            filePath = outputFunc(filePath);
+        }
+
+        if (build)
+        {
+            filePath += ".xnb";
+        }
+
+        return filePath;
+    }
+
+    public static string Sanitize(this string filePath)
+    {
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return filePath;
+        }
+
+        return filePath.Replace('\\', '/');
+    }
 }
+

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderImporterContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderImporterContext.cs
@@ -6,11 +6,11 @@ using Microsoft.Xna.Framework.Content.Pipeline;
 
 namespace MonoGame.Framework.Content.Pipeline.Builder;
 
-class ContentBuilderImporterContext(ContentBuilder builder, ContentFileCache contentFileCache) : ContentImporterContext
+class ContentBuilderImporterContext(ContentBuilder builder, IContentFileCache contentFileCache) : ContentImporterContext
 {
     private readonly ContentBuilder _builder = builder;
 
-    private readonly ContentFileCache _contentFileCache = contentFileCache;
+    private readonly IContentFileCache _contentFileCache = contentFileCache;
 
     public override string IntermediateDirectory => _builder.Parameters.RootedIntermediateDirectory;
 

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderParams.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderParams.cs
@@ -17,7 +17,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder;
 /// A list of arguments used by <see cref="ContentBuilder"/>.
 /// <para>Use <see cref="ContentBuilderParams.Parse"/> to acquire the arguments from the passed cli args.</para>
 /// </summary>
-public record ContentBuilderParams
+public class ContentBuilderParams
 {
     class RootOptions : BinderBase<ContentBuilderParams>
     {
@@ -151,19 +151,19 @@ public record ContentBuilderParams
     /// Set the mode in which the content builder is run in. See <see cref="ContentBuilderMode"/> for available modes.
     /// </summary>
     /// <value><see cref="ContentBuilderMode.None"/> by default.</value>
-    public ContentBuilderMode Mode { get; init; } = ContentBuilderMode.None;
+    public ContentBuilderMode Mode { get; set; } = ContentBuilderMode.None;
 
     /// <summary>
     /// Gets or sets the working directory of the <see cref="ContentBuilder"/>.
     /// </summary>
     /// <value><see cref="Directory.GetCurrentDirectory"/> by default.</value>
-    public string WorkingDirectory { get; init; } = Directory.GetCurrentDirectory();
+    public string WorkingDirectory { get; set; } = Directory.GetCurrentDirectory();
 
     /// <summary>
     /// Gets or sets the location of the content relative to the <see cref="WorkingDirectory"/>.
     /// </summary>
     /// <value><c>Content</c> by default.</value>
-    public string SourceDirectory { get; init; } = "Content";
+    public string SourceDirectory { get; set; } = "Content";
 
     /// <summary>
     /// Gets the rooted location of <see cref="SourceDirectory"/>.
@@ -174,7 +174,7 @@ public record ContentBuilderParams
     /// Gets or sets the location for the content output relative to the <see cref="WorkingDirectory"/>.
     /// </summary>
     /// <value><c>bin/Content</c> by default.</value>
-    public string OutputDirectory { get; init; } = "bin/Content";
+    public string OutputDirectory { get; set; } = "bin/Content";
 
     /// <summary>
     /// Gets the rooted location of <see cref="OutputDirectory"/>.
@@ -185,7 +185,7 @@ public record ContentBuilderParams
     /// Gets or sets the location for the intermediate files for content build relative to the <see cref="WorkingDirectory"/>.
     /// </summary>
     /// <value><c>obj/Content</c> by default.</value>
-    public string IntermediateDirectory { get; init; } = "obj/Content";
+    public string IntermediateDirectory { get; set; } = "obj/Content";
 
     /// <summary>
     /// Gets the rooted location of <see cref="IntermediateDirectory"/>.
@@ -196,37 +196,43 @@ public record ContentBuilderParams
     /// Gets or sets the desired platform for <see cref="ContentBuilder"/> to build the content for.
     /// </summary>
     /// <value><see cref="TargetPlatform.DesktopGL"/> by default.</value>
-    public TargetPlatform Platform { get; init; } = TargetPlatform.DesktopGL;
+    public TargetPlatform Platform { get; set; } = TargetPlatform.DesktopGL;
 
     /// <summary>
     /// Gets or sets the desired graphics profile for <see cref="ContentBuilder"/> to build the content for.
     /// </summary>
     /// <value><see cref="GraphicsProfile.HiDef"/> by default.</value>
-    public GraphicsProfile GraphicsProfile { get; init; } = GraphicsProfile.HiDef;
+    public GraphicsProfile GraphicsProfile { get; set; } = GraphicsProfile.HiDef;
 
     /// <summary>
     /// Gets or sets if <see cref="ContentBuilder"/> should compress each built content file.
     /// </summary>
     /// <value><c>false</c> by default.</value>
-    public bool CompressContent { get; init; } = false;
+    public bool CompressContent { get; set; } = false;
 
     /// <summary>
     /// Gets or sets the logging level of information that <see cref="ContentBuilder"/> will display to console.
     /// </summary>
     /// <value><see cref="LogLevel.Info"/> by default.</value>
-    public LogLevel LogLevel { get; init; } = LogLevel.Info;
+    public LogLevel LogLevel { get; set; } = LogLevel.Info;
 
     /// <summary>
-    /// Should the content builder skip cleaning up old content cache data after the build is finished in <see cref="ContentBuilderMode.Builder"/> mode.
+    /// Should the <see cref="ContentBuilder"/> rebuild all the assets and ignore the content cache.
     /// </summary>
     /// <value><c>false</c> by default.</value>
-    public bool SkipClean { get; init; } = false;
+    public bool Rebuild { get; set; } = false;
+
+    /// <summary>
+    /// Should the <see cref="ContentBuilder"/> skip cleaning up old content cache data after the build is finished in <see cref="ContentBuilderMode.Builder"/> mode.
+    /// </summary>
+    /// <value><c>false</c> by default.</value>
+    public bool SkipClean { get; set; } = false;
 
     /// <summary>
     /// A list of servers to start up when the <see cref="Mode"/> is set to <see cref="ContentBuilderMode.Server"/>.
     /// </summary>
     /// <value>A collection of <see cref="ContentServer"/> classes found by scaning all referenced assemblies.</value>
-    public List<ContentServer> Servers { get; init; } = []; // TODO: Fix command line display
+    public List<ContentServer> Servers { get; set; } = []; // TODO: Fix command line display
 
     /// <summary>
     /// Parses out the main entry point args into a <see cref="ContentBuilderParams"/> to be used by <see cref="ContentBuilder"/>.
@@ -243,21 +249,38 @@ public record ContentBuilderParams
         var rootOptions = new RootOptions(rootCommand);
 
         var buildCommand = new Command("build", "Build all the content.");
+        var rebuildOption = new Option<bool>(
+                name: "--rebuild",
+                description: "Should the builder rebuild all the assets and ignore the content cache.",
+                getDefaultValue: () => defaultValues.Rebuild);
+        buildCommand.AddOption(rebuildOption);
         var skipCleanOption = new Option<bool>(
                 name: "--skip-clean",
                 description: "Should the builder skip cleaning up old content cache data after the build is finished.",
                 getDefaultValue: () => defaultValues.SkipClean);
         buildCommand.AddOption(skipCleanOption);
         buildCommand.SetHandler(
-            (contentBuilder, skipCleanOption) => ret = contentBuilder with { Mode = ContentBuilderMode.Builder, SkipClean = skipCleanOption },
+            (contentBuilder, rebuildOption, skipCleanOption) =>
+            {
+                ret = contentBuilder;
+                ret.Mode = ContentBuilderMode.Builder;
+                ret.Rebuild = rebuildOption;
+                ret.SkipClean = skipCleanOption;
+            },
             rootOptions,
+            rebuildOption,
             skipCleanOption);
         rootCommand.AddCommand(buildCommand);
 
         var serverCommand = new Command("server", "Start a content server.");
         var sererOptions = new ServerOptions(serverCommand);
         serverCommand.SetHandler(
-            (contentBuilder, sererOptions) => ret = contentBuilder with { Mode = ContentBuilderMode.Server, Servers = sererOptions },
+            (contentBuilder, sererOptions) =>
+            {
+                ret = contentBuilder;
+                ret.Mode = ContentBuilderMode.Server;
+                ret.Servers = sererOptions;
+            },
             rootOptions,
             sererOptions);
         rootCommand.AddCommand(serverCommand);
@@ -271,7 +294,7 @@ public record ContentBuilderParams
 
         if (helpShown)
         {
-            ret = ret with { Mode = ContentBuilderMode.None };
+            ret.Mode = ContentBuilderMode.None;
         }
 
         return ret;

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderProcessorContext.cs
@@ -7,13 +7,19 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Framework.Content.Pipeline.Builder;
 
-class ContentBuilderProcessorContext(ContentBuilder builder, ContentFileCache contentFileCache, string outputRoot = "", string outputFilename = "") : ContentProcessorContext
+class ContentBuilderProcessorContext(ContentBuilder builder, string relativePath, ContentInfo contentInfo, IContentFileCache contentFileCache, string outputFilename = "") : ContentProcessorContext
 {
     private readonly ContentBuilder _builder = builder;
 
-    private readonly ContentFileCache _contentFileCache = contentFileCache;
+    private readonly string _relativeContentPath = relativePath;
 
-    private readonly string _outputRoot = outputRoot;
+    private readonly ContentInfo _contentInfo = contentInfo;
+
+    private readonly IContentFileCache _contentFileCache = contentFileCache;
+
+    private int _contentIndex = 0;
+
+    private readonly ContentBuilderProcessorContext? _parentContext = ContextScopeFactory.HasActiveContext ? ContextScopeFactory.ActiveContext as ContentBuilderProcessorContext : null;
 
     public override string BuildConfiguration { get; } = "";
 
@@ -35,10 +41,40 @@ class ContentBuilderProcessorContext(ContentBuilder builder, ContentFileCache co
 
     public override GraphicsProfile TargetProfile => _builder.Parameters.GraphicsProfile;
 
-    public override void AddDependency(string filename) => _contentFileCache.AddDependency(_builder, filename);
+    public override void AddDependency(string filename)
+    {
+        if (_parentContext != null)
+        {
+            _parentContext.AddDependency(filename);
+            return;
+        }
 
-    public override void AddOutputFile(string filename) => _contentFileCache.AddOutputFile(_builder, filename);
+        _contentFileCache.AddDependency(_builder, filename);
+    }
 
+    public override void AddOutputFile(string filename)
+    {
+        if (_parentContext != null)
+        {
+            _parentContext.AddOutputFile(filename);
+            return;
+        }
+
+        _contentFileCache.AddOutputFile(_builder, filename);
+    }
+
+    public string GetNextOutputPath()
+    {
+        if (_parentContext != null)
+        {
+            return _parentContext.GetNextOutputPath();
+        }
+
+        _contentIndex++;
+        return $"{_relativeContentPath.GetDestinationPath(true, _contentInfo.GetOutputPath)[0..^4]}_{_contentIndex}.xnb";
+    }
+
+    [Obsolete]
     public override TOutput BuildAndLoadAsset<TInput, TOutput>(ExternalReference<TInput> sourceAsset,
         string processorName, OpaqueDataDictionary processorParameters, string importerName)
     {
@@ -49,24 +85,11 @@ class ContentBuilderProcessorContext(ContentBuilder builder, ContentFileCache co
 
     public override TOutput BuildAndLoadAsset<TInput, TOutput>(ExternalReference<TInput> sourceAsset, IContentImporter importer, IContentProcessor processor)
     {
-        var content = _builder.BuildAndLoadContent(sourceAsset.Filename, new ContentInfo(_outputRoot, true, importer, processor));
-        if (content.contentFileCache is ContentFileCache contentFileCache)
-        {
-            // Add its dependencies and built assets to ours.
-            foreach (var (dependencyFile, _) in contentFileCache.Dependencies)
-            {
-                AddDependency(dependencyFile);
-            }
-
-            foreach (var outputFile in contentFileCache.Outputs)
-            {
-                AddOutputFile(outputFile);
-            }
-        }
-
-        return (TOutput)content.processedObject!;
+        var processedObject = _builder.BuildAndLoadContent(sourceAsset.Filename, new ContentInfo(_contentInfo.ContentRoot, true, importer, processor), GetNextOutputPath());
+        return (TOutput)processedObject!;
     }
 
+    [Obsolete]
     public override ExternalReference<TOutput> BuildAsset<TInput, TOutput>(ExternalReference<TInput> sourceAsset,
         string processorName, OpaqueDataDictionary processorParameters, string importerName, string assetName)
     {
@@ -78,28 +101,13 @@ class ContentBuilderProcessorContext(ContentBuilder builder, ContentFileCache co
     public override ExternalReference<TOutput> BuildAsset<TInput, TOutput>(ExternalReference<TInput> sourceAsset,
         IContentImporter importer, IContentProcessor processor, string? assetName)
     {
-        var outputRelativePath = string.IsNullOrWhiteSpace(assetName) ?
-            ContentInfo.GetDefaultOutputPath(Path.GetRelativePath(_builder.Parameters.RootedSourceDirectory, sourceAsset.Filename)) :
-            assetName;
-        var content = _builder.BuildAndWriteContent(sourceAsset.Filename, new ContentInfo(_outputRoot, true, importer, processor, o => outputRelativePath));
-
-        if (content is ContentFileCache contentFileCache)
-        {
-            // Add its dependencies and built assets to ours.
-            foreach (var (dependencyFile, _) in contentFileCache.Dependencies)
-            {
-                AddDependency(dependencyFile);
-            }
-
-            foreach (var outputFile in contentFileCache.Outputs)
-            {
-                AddOutputFile(outputFile);
-            }
-        }
+        var outputRelativePath = string.IsNullOrWhiteSpace(assetName) ? GetNextOutputPath() : assetName;
+        _builder.BuildAndWriteContent(sourceAsset.Filename, new ContentInfo(_contentInfo.ContentRoot, true, importer, processor), outputRelativePath);
 
         return new ExternalReference<TOutput>(Path.Combine(_builder.Parameters.RootedOutputDirectory, outputRelativePath));
     }
 
+    [Obsolete]
     public override TOutput Convert<TInput, TOutput>(TInput input, string processorName, OpaqueDataDictionary processorParameters)
     {
         throw new NotSupportedException(@"Converting from processorName is not supported with the ContentBuilder.
@@ -108,21 +116,9 @@ class ContentBuilderProcessorContext(ContentBuilder builder, ContentFileCache co
 
     public override TOutput Convert<TInput, TOutput>(TInput input, IContentProcessor processor)
     {
-        var contentFileCache = new ContentFileCache();
-        var processContext = new ContentBuilderProcessorContext(_builder, contentFileCache, _outputRoot);
+        var processContext = new ContentBuilderProcessorContext(_builder, _relativeContentPath, _contentInfo, _contentFileCache);
         using var _ = ContextScopeFactory.BeginContext(processContext);
         var processedObject = processor.Process(input!, processContext);
-
-        // Add its dependencies and built assets to ours.
-        foreach (var (dependencyFile, _) in processContext._contentFileCache.Dependencies)
-        {
-            AddDependency(dependencyFile);
-        }
-
-        foreach (var outputFile in processContext._contentFileCache.Outputs)
-        {
-            AddOutputFile(outputFile);
-        }
 
         return (TOutput)processedObject;
     }

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentCache.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentCache.cs
@@ -11,13 +11,11 @@ class ContentCache : IContentCache
     private const string CacheFileName = "cache.yaml";
 
     private Dictionary<string, ContentFileCache> _cache = [];
-    private readonly HashSet<string> _unusedDependencies = [];
     private readonly HashSet<string> _unusedOutputs = [];
 
     public void LoadCache(ContentBuilder builder)
     {
         _cache.Clear();
-        _unusedDependencies.Clear();
         _unusedOutputs.Clear();
 
         var cacheFilePath = Path.Combine(builder.Parameters.RootedIntermediateDirectory, CacheFileName);
@@ -39,64 +37,11 @@ class ContentCache : IContentCache
 
         foreach (var (_, fileCache) in _cache)
         {
-            foreach (var (depFile, _) in fileCache.Dependencies)
+            foreach (var (outputPath, _) in fileCache.Outputs)
             {
-                _unusedDependencies.Add(depFile);
-            }
-
-            foreach (var output in fileCache.Outputs)
-            {
-                _unusedOutputs.Add(output);
+                _unusedOutputs.Add(outputPath);
             }
         }
-    }
-
-    public ContentFileCache? ReadContentFileCache(ContentBuilder builder, string relativePath, string contentRoot, bool shouldBuild = false, IContentImporter? importer = null, IContentProcessor? processor = null)
-    {
-        if (!_cache.TryGetValue(relativePath, out ContentFileCache? fileCache))
-        {
-            return null;
-        }
-
-        if (builder.Parameters.GraphicsProfile != fileCache.GraphicsProfile ||
-            builder.Parameters.CompressContent != fileCache.CompressContent ||
-            contentRoot != fileCache.ContentRoot ||
-            shouldBuild != fileCache.ShouldBuild ||
-            !ContentBuilderHelper.ArePropsEqual(fileCache.Importer, importer) ||
-            !ContentBuilderHelper.ArePropsEqual(fileCache.Processor, processor))
-        {
-            return null;
-        }
-
-        foreach (var (dependencyFile, cachedModifiedTime) in fileCache.Dependencies)
-        {
-            var dependencyFullPath = Path.Combine(builder.Parameters.RootedSourceDirectory, dependencyFile);
-            var modifiedTime = File.GetLastWriteTimeUtc(dependencyFullPath);
-
-            if (modifiedTime != cachedModifiedTime)
-            {
-                return null;
-            }
-        }
-
-        foreach (var outputPath in fileCache.Outputs)
-        {
-            var fullOutputPath = Path.Combine(builder.Parameters.RootedOutputDirectory, outputPath);
-
-            if (!File.Exists(fullOutputPath))
-            {
-                return null;
-            }
-        }
-
-        MarkUsed(fileCache);
-        return fileCache;
-    }
-
-    public void WriteContentFileCache(ContentBuilder builder, string relativePath, ContentFileCache fileCache)
-    {
-        _cache[relativePath] = fileCache;
-        MarkUsed(fileCache);
     }
 
     public void FlushCache(ContentBuilder builder)
@@ -117,37 +62,84 @@ class ContentCache : IContentCache
         File.WriteAllText(cacheFilePath, text);
     }
 
-    private void MarkUsed(ContentFileCache fileCache)
+    public IContentFileCache CreateContentFileCache(ContentBuilder builder, ContentInfo info) => new ContentFileCache
     {
-        foreach (var (depFile, _) in fileCache.Dependencies)
+        ContentRoot = info.ContentRoot,
+        CompressContent = builder.Parameters.CompressContent,
+        GraphicsProfile = builder.Parameters.GraphicsProfile,
+        ShouldBuild = info.ShouldBuild,
+        Importer = info.Importer,
+        Processor = info.Processor
+    };
+
+    public IContentFileCache? ReadContentFileCache(ContentBuilder builder, string relativeOutputPath)
+    {
+        if (!_cache.TryGetValue(relativeOutputPath.Sanitize(), out ContentFileCache? fileCache))
         {
-            _unusedDependencies.Remove(depFile);
+            return null;
+        }
+        return fileCache;
+    }
+
+    public void WriteContentFileCache(ContentBuilder builder, string relativeOutputPath, IContentFileCache? fileCache)
+    {
+        if (fileCache is ContentFileCache builderFileCache)
+        {
+            _cache[relativeOutputPath.Sanitize()] = builderFileCache;
+        }
+    }
+
+    public void MarkUsed(IContentFileCache fileCache)
+    {
+        if (fileCache is not ContentFileCache builderFileCache)
+        {
+            return;
         }
 
-        foreach (var output in fileCache.Outputs)
+        foreach (var (outputPath, _) in builderFileCache.Outputs)
         {
-            _unusedOutputs.Remove(output);
+            _unusedOutputs.Remove(outputPath);
         }
     }
 
     public void CleanCache(ContentBuilder builder)
     {
-        foreach (var depFile in _unusedDependencies)
+        foreach (var outputPath in _unusedOutputs)
         {
-            _cache.Remove(depFile);
+            _cache.Remove(outputPath);
         }
 
-        foreach (var outputFile in _unusedOutputs)
+        foreach (var outputPath in _unusedOutputs)
         {
-            var outputFilePath = Path.Combine(builder.Parameters.RootedOutputDirectory, outputFile);
-            if (File.Exists(outputFilePath))
+            var outputFilePath = Path.Combine(builder.Parameters.RootedOutputDirectory, outputPath);
+            if (!IsOutputUsed(outputPath) && File.Exists(outputFilePath))
             {
-                builder.Logger.Log("Deleting: " + outputFile);
+                builder.Logger.Log("Deleting: " + outputPath);
                 File.Delete(outputFilePath);
             }
         }
 
-        _unusedDependencies.Clear();
         _unusedOutputs.Clear();
+    }
+
+    private bool IsOutputUsed(string outputPathToCheck)
+    {
+        foreach (var (mainOutput, fileCache) in _cache)
+        {
+            if (mainOutput == outputPathToCheck)
+            {
+                return true;
+            }
+
+            foreach (var (outputPath, _) in fileCache.Outputs)
+            {
+                if (outputPath == outputPathToCheck)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentCollection.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentCollection.cs
@@ -15,9 +15,28 @@ namespace MonoGame.Framework.Content.Pipeline.Builder;
 /// </summary>
 public class ContentCollection : IContentCollection
 {
-    private readonly Dictionary<string, ContentInfo?> _imputFiles = [];
-    private readonly List<(ContentRule rule, ContentInfo? info)> _rules = [];
-    private string _contentRoot = "Content";
+    private const string DEFAULT_CONTENT_ROOT = "Content";
+
+    private string _contentRoot = DEFAULT_CONTENT_ROOT;
+    private readonly Dictionary<string, ContentCollectionRoot> _content = new()
+    {
+        [DEFAULT_CONTENT_ROOT] = new ContentCollectionRoot(DEFAULT_CONTENT_ROOT)
+    };
+
+    private ContentCollectionRoot CurrentContent
+    {
+        get
+        {
+            if (_content.TryGetValue(_contentRoot, out ContentCollectionRoot? val))
+            {
+                return val;
+            }
+
+            var collection = new ContentCollectionRoot(_contentRoot);
+            _content[_contentRoot] = collection;
+            return collection;
+        }
+    }
 
     /// <summary>
     /// Sets the content root path that will be used when generating the output paths during include methods.
@@ -30,8 +49,7 @@ public class ContentCollection : IContentCollection
     /// </summary>
     /// <param name="inputPath">Relative path to the content file.</param>
     /// <param name="outputPath">Relative path for the copy, if its not specified, the inputPath will be used.</param>
-    public void IncludeCopy(string inputPath, string? outputPath)
-        => _imputFiles[inputPath] = new(_contentRoot, false, null, null, string.IsNullOrWhiteSpace(outputPath) ? ContentInfo.GetDefaultOutputPath : s => outputPath);
+    public void IncludeCopy(string inputPath, string? outputPath) => CurrentContent.IncludeCopy(inputPath, outputPath);
 
     /// <summary>
     /// Marks the file at inputPath to be built with specified settings.
@@ -46,7 +64,7 @@ public class ContentCollection : IContentCollection
     /// the system will use reflection to try to figure out an apropriate processor.
     /// </param>
     public void Include(string inputPath, IContentImporter? contentImporter = null, IContentProcessor? contentProcessor = null)
-        => _imputFiles[inputPath] = new(_contentRoot, true, contentImporter, contentProcessor);
+        => CurrentContent.Include(inputPath, contentImporter, contentProcessor);
 
     /// <summary>
     /// Marks the file at inputPath to be built with specified settings.
@@ -62,14 +80,13 @@ public class ContentCollection : IContentCollection
     /// the system will use reflection to try to figure out an apropriate processor.
     /// </param>
     public void Include(string inputPath, string outputPath, IContentImporter? contentImporter = null, IContentProcessor? contentProcessor = null)
-        => _imputFiles[inputPath] = new(_contentRoot, true, contentImporter, contentProcessor, (s) => outputPath);
+        => CurrentContent.Include(inputPath, outputPath, contentImporter, contentProcessor);
 
     /// <summary>
     /// Marks the file at excludePath to be excluded from the content handling.
     /// </summary>
     /// <param name="excludePath">Relative path to the content file.</param>
-    public void Exclude(string excludePath)
-        => _imputFiles[excludePath] = null;
+    public void Exclude(string excludePath) => CurrentContent.Exclude(excludePath);
 
     /// <summary>
     /// Marks the files that match the includePattern to be copied to the output directory.
@@ -81,13 +98,8 @@ public class ContentCollection : IContentCollection
     /// </typeparam>
     /// <param name="includePattern">A pattern to use for building of content files.</param>
     /// <param name="outputPath">Relative path for the output content, if its not specified, the relative filePath will be used with .xnb extension.</param>
-    public void IncludeCopy<T>(string includePattern, Func<string, string>? outputPath = null)
-        where T : ContentRule, new()
-    {
-        var rule = new T { Pattern = includePattern };
-        RemoveFilesByRule(rule);
-        _rules.Add((rule, new(_contentRoot, false, null, null, outputPath)));
-    }
+    public void IncludeCopy<T>(string includePattern, Func<string, string>? outputPath = null) where T : ContentRule, new()
+        => CurrentContent.IncludeCopy<T>(includePattern, outputPath);
 
     /// <summary>
     /// Marks the files that match the includePattern to be built with the specified settings.
@@ -108,11 +120,7 @@ public class ContentCollection : IContentCollection
     /// </param>
     public void Include<T>(string includePattern, IContentImporter? contentImporter = null, IContentProcessor? contentProcessor = null)
         where T : ContentRule, new()
-    {
-        var rule = new T { Pattern = includePattern };
-        RemoveFilesByRule(rule);
-        _rules.Add((rule, new(_contentRoot, true, contentImporter, contentProcessor)));
-    }
+        => CurrentContent.Include<T>(includePattern, contentImporter, contentProcessor);
 
     /// <summary>
     /// Marks the files that match the includePattern to be built with the specified settings.
@@ -132,13 +140,9 @@ public class ContentCollection : IContentCollection
     /// An <see cref="IContentProcessor"/> to be used for the building, if its not specified, 
     /// the system will use reflection to try to figure out an apropriate processor.
     /// </param>
-    public void Include<T>(string includePattern, Func<string, string> outputPath, IContentImporter? contentImporter = null, IContentProcessor? contentProcessor = null)
-        where T : ContentRule, new()
-    {
-        var rule = new T { Pattern = includePattern };
-        RemoveFilesByRule(rule);
-        _rules.Add((rule, new(_contentRoot, true, contentImporter, contentProcessor, outputPath)));
-    }
+    public void Include<T>(string includePattern, Func<string, string> outputPath, IContentImporter? contentImporter = null,
+        IContentProcessor? contentProcessor = null) where T : ContentRule, new()
+         => CurrentContent.Include<T>(includePattern, outputPath, contentImporter, contentProcessor);
 
     /// <summary>
     /// Marks the files that match the excludePattern to be excluded from the content handling.
@@ -149,59 +153,31 @@ public class ContentCollection : IContentCollection
     /// <para><see cref="RegexRule"/> - specifies that input pattern should be a regex.</para>
     /// </typeparam>
     /// <param name="excludePattern">A pattern to use for exclusion of content files.</param>
-    public void Exclude<T>(string excludePattern)
-        where T : ContentRule, new()
-    {
-        var rule = new T { Pattern = excludePattern };
-        RemoveFilesByRule(rule);
-        _rules.Add((rule, null));
-    }
+    public void Exclude<T>(string excludePattern) where T : ContentRule, new() => CurrentContent.Exclude<T>(excludePattern);
 
     /// <summary>
     /// Gets information about how the ocntent should be handled for the passed relative filepath.
     /// </summary>
     /// <param name="filePath">Relative path to the content file.</param>
-    /// <param name="contentInfo"><see cref="ContentInfo"/> describing the desired content handling.</param>
+    /// <param name="contentInfos">A list of <see cref="ContentInfo"/> describing the desired content handling.</param>
     /// <returns><c>true</c> if the content should be handled, <c>false</c> otherwise.</returns>
-    public bool GetContentInfo(string filePath, ref ContentInfo? contentInfo)
+    public bool GetContentInfo(string filePath, out List<ContentInfo> contentInfos)
     {
-        if (_imputFiles.TryGetValue(filePath, out var info))
-        {
-            if (info == null)
-                return false;
+        contentInfos = [];
 
-            contentInfo = info;
-            return true;
-        }
-
-        for (int i = _rules.Count - 1; i >= 0; i--)
+        foreach (var pair in _content)
         {
-            (ContentRule rule, ContentInfo? info) rule = _rules[i];
-            if (rule.rule.IsMatch(filePath))
+            if (!pair.Value.GetContentInfo(filePath, out List<ContentInfo> currentContent))
             {
-                contentInfo = rule.info;
-                return rule.info != null;
+                continue;
+            }
+
+            foreach (var info in currentContent)
+            {
+                contentInfos.Add(info);
             }
         }
 
-        return false;
-    }
-
-    private void RemoveFilesByRule(ContentRule rule)
-    {
-        List<string> elementsToRemove = [];
-
-        foreach (var pair in _imputFiles)
-        {
-            if (rule.IsMatch(pair.Key))
-            {
-                elementsToRemove.Add(pair.Key);
-            }
-        }
-
-        foreach (var element in elementsToRemove)
-        {
-            _imputFiles.Remove(element);
-        }
+        return contentInfos.Count > 0;
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentCollectionRoot.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentCollectionRoot.cs
@@ -1,0 +1,145 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+ 
+using Microsoft.Xna.Framework.Content.Pipeline;
+
+namespace MonoGame.Framework.Content.Pipeline.Builder;
+
+class ContentCollectionRoot(string contentRoot)
+{
+    private readonly string _contentRoot = contentRoot;
+    private readonly Dictionary<string, ContentInfo?> _imputFiles = [];
+    private readonly List<(ContentRule rule, ContentInfo? info)> _rules = [];
+
+    public void IncludeCopy(string inputPath, string? outputPath)
+        => _imputFiles[inputPath] = new(_contentRoot, false, null, null, string.IsNullOrWhiteSpace(outputPath) ? (s => s) : (_ => outputPath));
+
+    public void Include(string inputPath, IContentImporter? contentImporter, IContentProcessor? contentProcessor)
+        => _imputFiles[inputPath] = new(_contentRoot, true, contentImporter, contentProcessor);
+
+    public void Include(string inputPath, string outputPath, IContentImporter? contentImporter, IContentProcessor? contentProcessor )
+        => _imputFiles[inputPath] = new(_contentRoot, true, contentImporter, contentProcessor, _ => outputPath);
+
+    public void Exclude(string excludePath) => _imputFiles[excludePath] = null;
+
+    public void IncludeCopy<T>(string includePattern, Func<string, string>? outputPath)
+        where T : ContentRule, new()
+    {
+        var rule = new T { Pattern = includePattern };
+        RemoveFilesByRule(rule, false, outputPath ?? (s => s));
+        _rules.Add((rule, new(_contentRoot, false, null, null, outputPath)));
+    }
+
+    public void Include<T>(string includePattern, IContentImporter? contentImporter, IContentProcessor? contentProcessor)
+        where T : ContentRule, new()
+    {
+        var rule = new T { Pattern = includePattern };
+        RemoveFilesByRule(rule, true, s => s);
+        _rules.Add((rule, new(_contentRoot, true, contentImporter, contentProcessor)));
+    }
+
+    public void Include<T>(string includePattern, Func<string, string> outputPath, IContentImporter? contentImporter, IContentProcessor? contentProcessor)
+        where T : ContentRule, new()
+    {
+        var rule = new T { Pattern = includePattern };
+        RemoveFilesByRule(rule, true, outputPath);
+        _rules.Add((rule, new(_contentRoot, true, contentImporter, contentProcessor, outputPath)));
+    }
+
+    public void Exclude<T>(string excludePattern)
+        where T : ContentRule, new()
+    {
+        var rule = new T { Pattern = excludePattern };
+        RemoveFilesByRule(rule, true, null);
+        _rules.Add((rule, null));
+    }
+
+    public bool GetContentInfo(string filePath, out List<ContentInfo> contentInfos)
+    {
+        HashSet<string> usedOutputs = [];
+        contentInfos = [];
+
+        bool inputFiles = _imputFiles.TryGetValue(filePath, out ContentInfo? inputFilesInfo);
+        bool? shouldBuild = null;
+
+        if (inputFilesInfo != null)
+        {
+            usedOutputs.Add(filePath.GetDestinationPath(inputFilesInfo.ShouldBuild, inputFilesInfo.GetOutputPath));
+            shouldBuild = inputFilesInfo.ShouldBuild;
+        }
+        else if (inputFiles)
+        {
+            usedOutputs.Add(filePath.GetDestinationPath(true));
+            usedOutputs.Add(filePath.GetDestinationPath(false));
+        }
+
+        for (int i = _rules.Count - 1; i >= 0; i--)
+        {
+            (ContentRule rule, ContentInfo? info) rule = _rules[i];
+            if (rule.rule.IsMatch(filePath))
+            {
+                if (rule.info == null)
+                {
+                    // Everything before this got discarded, we can exit here.
+                    break;
+                }
+
+                var outputPath = filePath.GetDestinationPath(rule.info.ShouldBuild, rule.info.GetOutputPath);
+                if (usedOutputs.Contains(outputPath))
+                {
+                    // Output already got used up later in list, nothing for us to do here.
+                    continue;
+                }
+
+                if (shouldBuild != null && shouldBuild != rule.info.ShouldBuild)
+                {
+                    continue;
+                }
+
+                usedOutputs.Add(outputPath);
+                contentInfos.Add(rule.info); // TODO: check for build action
+                shouldBuild = rule.info?.ShouldBuild;
+            }
+        }
+
+        if (inputFilesInfo != null)
+        {
+            contentInfos.Add(inputFilesInfo);
+        }
+
+        return contentInfos.Count > 0;
+    }
+
+    private void RemoveFilesByRule(ContentRule rule, bool build, Func<string, string>? outputPathRes)
+    {
+        List<string> elementsToRemove = [];
+
+        foreach (var pair in _imputFiles)
+        {
+            if (!rule.IsMatch(pair.Key))
+            {
+                continue;
+            }
+
+            // we want to check the output path, but only when the build action does not change
+            if (outputPathRes != null && pair.Value?.ShouldBuild == build)
+            {
+                var ruleOutput = pair.Key.GetDestinationPath(build, outputPathRes);
+                var inputFilesOutput = pair.Key.GetDestinationPath(build, pair.Value.GetOutputPath);
+
+                if (ruleOutput != inputFilesOutput)
+                {
+                    continue;
+                }
+            }
+
+            elementsToRemove.Add(pair.Key);
+        }
+
+        foreach (var element in elementsToRemove)
+        {
+            _imputFiles.Remove(element);
+        }
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentFileCache.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentFileCache.cs
@@ -7,57 +7,24 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Framework.Content.Pipeline.Builder;
 
-/// <summary>
-/// Contains cached information about a single source content file.
-/// </summary>
-public record ContentFileCache
+record ContentFileCache : IContentFileCache
 {
-    /// <summary>
-    /// The ContentRoot that was used for the building of the content file,
-    /// </summary>
     public string ContentRoot { get; init; } = "";
 
-    /// <summary>
-    /// <c>true</c> if the content was built, <c>false</c> if the content was copied.
-    /// </summary>
     public bool ShouldBuild { get; init; } = false;
 
-    /// <summary>
-    /// An <see cref="IContentImporter"/> that was used for the building of the content file,
-    /// </summary>
     public IContentImporter? Importer { get; init; } = null;
 
-    /// <summary>
-    /// An <see cref="IContentProcessor"/> that was used for the building of the content file,
-    /// </summary>
     public IContentProcessor? Processor { get; init; } = null;
 
-    /// <summary>
-    /// Indicates if the content was compressed.
-    /// </summary>
     public bool CompressContent { get; init; } = false;
 
-    /// <summary>
-    /// Indicates the <see cref="GraphicsProfile"/> that was used when the content was built.
-    /// </summary>
     public GraphicsProfile GraphicsProfile { get; init; } = GraphicsProfile.HiDef;
 
-    /// <summary>
-    /// A dictionary of keys of dependency files that either the <see cref="IContentImporter"/> or <see cref="IContentProcessor"/> included
-    /// and values of the last modified times for those files.
-    /// </summary>
     public Dictionary<string, DateTime> Dependencies { get; init; } = [];
 
-    /// <summary>
-    /// A hashset of output files that the <see cref="IContentProcessor"/> included.
-    /// </summary>
-    public HashSet<string> Outputs { get; init; } = [];
+    public Dictionary<string, DateTime> Outputs { get; init; } = [];
 
-    /// <summary>
-    /// Adds the specified file as a dependency related to the current content file.
-    /// </summary>
-    /// <param name="builder">A <see cref="ContentBuilder"/> the added depedency is related to.</param>
-    /// <param name="dependencyPath">A relative or absolute path to the dependency file.</param>
     public void AddDependency(ContentBuilder builder, string dependencyPath)
     {
         string fullDependencyPath;
@@ -80,14 +47,9 @@ public record ContentFileCache
         }
 
         var lastModifiedTime = File.GetLastWriteTimeUtc(fullDependencyPath);
-        Dependencies[relativeDependencyPath] = lastModifiedTime;
+        Dependencies[relativeDependencyPath.Sanitize()] = lastModifiedTime;
     }
 
-    /// <summary>
-    /// Removes the specified file as a dependency related to the current content file.
-    /// </summary>
-    /// <param name="builder">A <see cref="ContentBuilder"/> the added depedency is related to.</param>
-    /// <param name="dependencyPath">A relative or absolute path to the dependency file.</param>
     public void RemoveDependency(ContentBuilder builder, string dependencyPath)
     {
         string relativeDependencyPath = Path.IsPathRooted(dependencyPath) ?
@@ -96,29 +58,76 @@ public record ContentFileCache
         Dependencies.Remove(relativeDependencyPath);
     }
 
-    /// <summary>
-    /// Adds the specified file as an output file related to the current content file.
-    /// </summary>
-    /// <param name="builder">A <see cref="ContentBuilder"/> the output file is related to.</param>
-    /// <param name="outputPath">A relative or absolute path to the output file.</param>
     public void AddOutputFile(ContentBuilder builder, string outputPath)
     {
-        var relativeOutputFile = Path.IsPathRooted(outputPath) ?
-            Path.GetRelativePath(builder.Parameters.RootedOutputDirectory, outputPath) :
-            outputPath;
-        Outputs.Add(relativeOutputFile);
+        string fullOutputPath;
+        string relativeOutputPath;
+
+        if (Path.IsPathRooted(outputPath))
+        {
+            fullOutputPath = outputPath;
+            relativeOutputPath = Path.GetRelativePath(builder.Parameters.RootedOutputDirectory, outputPath);
+        }
+        else
+        {
+            fullOutputPath = Path.Combine(builder.Parameters.RootedOutputDirectory, outputPath);
+            relativeOutputPath = outputPath;
+        }
+
+        if (!File.Exists(fullOutputPath))
+        {
+            return;
+        }
+
+        var lastModifiedTime = File.GetLastWriteTimeUtc(fullOutputPath);
+        Outputs[relativeOutputPath.Sanitize()] = lastModifiedTime;
     }
 
-    /// <summary>
-    /// Removes the specified file as an output related to the current content file.
-    /// </summary>
-    /// <param name="builder">A <see cref="ContentBuilder"/> the output file is related to.</param>
-    /// <param name="outputPath">A relative or absolute path to the output file.</param>
     public void RemoveOutputFile(ContentBuilder builder, string outputPath)
     {
         var relativeOutputFile = Path.IsPathRooted(outputPath) ?
             Path.GetRelativePath(builder.Parameters.RootedOutputDirectory, outputPath) :
             outputPath;
         Outputs.Remove(relativeOutputFile);
+    }
+
+    public bool IsValid(ContentBuilder builder, ContentInfo info)
+    {
+        if (info.ShouldBuild || ShouldBuild)
+        {
+            if (builder.Parameters.GraphicsProfile != GraphicsProfile ||
+                builder.Parameters.CompressContent != CompressContent ||
+                info.ContentRoot != ContentRoot ||
+                info.ShouldBuild != ShouldBuild ||
+                !ContentBuilderHelper.ArePropsEqual(Importer, info.Importer) ||
+                !ContentBuilderHelper.ArePropsEqual(Processor, info.Processor))
+            {
+                return false;
+            }
+        }
+
+        foreach (var (dependencyFile, cachedModifiedTime) in Dependencies)
+        {
+            var dependencyFilePath = Path.Combine(builder.Parameters.RootedSourceDirectory, dependencyFile);
+            var modifiedTime = File.GetLastWriteTimeUtc(dependencyFilePath);
+
+            if (modifiedTime != cachedModifiedTime)
+            {
+                return false;
+            }
+        }
+
+        foreach (var (outputPath, cachedModifiedTime) in Outputs)
+        {
+            var outputFilePath = Path.Combine(builder.Parameters.RootedOutputDirectory, outputPath);
+            var modifiedTime = File.GetLastWriteTimeUtc(outputFilePath);
+
+            if (modifiedTime != cachedModifiedTime)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentInfo.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentInfo.cs
@@ -16,7 +16,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder;
 /// <param name="outputPath">The desired output path to be setup based on the input path to the content.</param>
 public class ContentInfo(string contentRoot = "", bool shouldBuild = true, IContentImporter? importer = null, IContentProcessor? processor = null, Func<string, string>? outputPath = null)
 {
-    private readonly Func<string, string> _outputPath = outputPath ?? (shouldBuild ? GetDefaultOutputPath : GetDefaultCopyPath);
+    private readonly Func<string, string> _outputPath = outputPath ?? (s => s);
 
     /// <summary>
     /// A relative path to be used as a prefix to the output path.
@@ -43,30 +43,7 @@ public class ContentInfo(string contentRoot = "", bool shouldBuild = true, ICont
     /// <summary>
     /// Gets the desired output path for the current <see cref="ShouldBuild"/> operation.
     /// </summary>
-    /// <param name="filePath">A relative path to the content file.</param>
+    /// <param name="filePath">A relative path to the content file (without extension in case of build action).</param>
     /// <returns>Desired relative path for the output content.</returns>
     public string GetOutputPath(string filePath) => _outputPath(filePath);
-
-    /// <summary>
-    /// Gets the default relative output filepath when building content. By default only the extension gets replaced with .xnb extension.
-    /// </summary>
-    /// <param name="filePath">A relative path to the content file.</param>
-    /// <returns>Desired relative path for the built content.</returns>
-    public static string GetDefaultOutputPath(string filePath)
-    {
-        var extLength = Path.GetExtension(filePath).Length;
-        if (extLength > 0)
-        {
-            filePath = filePath[..^extLength];
-        }
-
-        return filePath + ".xnb";
-    }
-
-    /// <summary>
-    /// Gets the default relative output filepath when copying content. By default input and output relative paths match.
-    /// </summary>
-    /// <param name="filePath">A relative path to the content file.</param>
-    /// <returns>Desired relative path for the coppied content.</returns>
-    public static string GetDefaultCopyPath(string filePath) => filePath;
 }

--- a/MonoGame.Framework.Content.Pipeline/Builder/IContentCache.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/IContentCache.cs
@@ -2,8 +2,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using Microsoft.Xna.Framework.Content.Pipeline;
-
 namespace MonoGame.Framework.Content.Pipeline.Builder;
 
 /// <summary>
@@ -18,16 +16,26 @@ public interface IContentCache
     void LoadCache(ContentBuilder builder);
 
     /// <summary>
+    /// Saves any pending content cache information to disk for the specified builder.
+    /// </summary>
+    /// <param name="builder">A <see cref="ContentBuilder"/> that the cache file is related to.</param>
+    void FlushCache(ContentBuilder builder);
+
+    /// <summary>
+    /// Creates a new insteance of <see cref="IContentFileCache" /> that the current implementation of <see cref="IContentCache"/> uses.
+    /// </summary>
+    /// <param name="builder">A <see cref="ContentBuilder"/> that the cache file is related to.</param>
+    /// <param name="info">A <see cref="ContentInfo"/> for which to create the <see cref="IContentFileCache"/> for.</param>
+    /// <returns></returns>
+    IContentFileCache CreateContentFileCache(ContentBuilder builder, ContentInfo info);
+
+    /// <summary>
     /// Reads (from memory or disk) cached information about the content file and returns it if its valid.
     /// </summary>
     /// <param name="builder">A <see cref="ContentBuilder"/> that the cache file is related to.</param>
-    /// <param name="relativePath">A relative path to the content file.</param>
-    /// <param name="contentRoot">A relative path that is added as prefix to the output.</param>
-    /// <param name="shouldBuild">If the content file will be built or copied.</param>
-    /// <param name="importer">An <see cref="IContentImporter"/> the content file will be passed through.</param>
-    /// <param name="processor">An <see cref="IContentProcessor"/> the content file will be passed through.</param>
-    /// <returns>An instance of <see cref="ContentFileCache"/> if valid cached information about the content is found, <c>null</c> otherwise.</returns>
-    ContentFileCache? ReadContentFileCache(ContentBuilder builder, string relativePath, string contentRoot, bool shouldBuild = false, IContentImporter? importer = null, IContentProcessor? processor = null);
+    /// <param name="relativeDstPath">A relative path to the content file.</param>
+    /// <returns>An instance of <see cref="ContentFileCache"/> if cached information about the content is found, <c>null</c> otherwise.</returns>
+    IContentFileCache? ReadContentFileCache(ContentBuilder builder, string relativeDstPath);
 
     /// <summary>
     /// Writes down (to memory or disk) information about the content file.
@@ -35,18 +43,19 @@ public interface IContentCache
     /// Do note that <see cref="FlushCache"/> will always be called before exiting the content builder.
     /// </summary>
     /// <param name="builder">A <see cref="ContentBuilder"/> that the cache file is related to.</param>
-    /// <param name="relativePath">A relative path to the content file.</param>
-    /// <param name="fileCache">A <see cref="ContentFileCache"/> containing the information about the source file and compiled content.</param>
-    void WriteContentFileCache(ContentBuilder builder, string relativePath, ContentFileCache fileCache);
+    /// <param name="relativeDstPath">A relative path to the content file.</param>
+    /// <param name="fileCache">An insteance of <see cref="IContentFileCache"/> that contains information about the built content.</param>
+    void WriteContentFileCache(ContentBuilder builder, string relativeDstPath, IContentFileCache? fileCache);
 
     /// <summary>
-    /// Saves any pending content cache information to disk for the specified builder.
+    /// Marks the specified <see cref="IContentFileCache"/> as being used by the <see cref="ContentBuilder" /> and
+    /// that is should not get cleaned up by the <see cref="CleanCache"/>
     /// </summary>
-    /// <param name="builder">A <see cref="ContentBuilder"/> that the cache file is related to.</param>
-    void FlushCache(ContentBuilder builder);
+    /// <param name="fileCache">An insteance of <see cref="IContentFileCache"/> that contains information about the built content.</param>
+    void MarkUsed(IContentFileCache fileCache);
 
     /// <summary>
-    /// Clears out any unused content files from the cache and the disk.
+    /// Clears out any unused content files from the cache and the disk that were not marked by <see cref="MarkUsed" />.
     /// </summary>
     /// <param name="builder">A <see cref="ContentBuilder"/> that the cache file is related to.</param>
     void CleanCache(ContentBuilder builder);

--- a/MonoGame.Framework.Content.Pipeline/Builder/IContentCollection.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/IContentCollection.cs
@@ -13,7 +13,7 @@ public interface IContentCollection
     /// Gets information about how the ocntent should be handled for the passed relative filepath.
     /// </summary>
     /// <param name="filePath">Relative path to the content file.</param>
-    /// <param name="contentInfo"><see cref="ContentInfo"/> describing the desired content handling.</param>
+    /// <param name="contentInfos">A list of <see cref="ContentInfo"/> describing the desired content handling.</param>
     /// <returns><c>true</c> if the content should be handled, <c>false</c> otherwise.</returns>
-    bool GetContentInfo(string filePath, ref ContentInfo? contentInfo);
+    bool GetContentInfo(string filePath, out List<ContentInfo> contentInfos);
 }

--- a/MonoGame.Framework.Content.Pipeline/Builder/IContentFIleCache.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/IContentFIleCache.cs
@@ -1,0 +1,33 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace MonoGame.Framework.Content.Pipeline.Builder;
+
+/// <summary>
+/// An interface for storing information about the compiled content.
+/// </summary>
+public interface IContentFileCache
+{
+    /// <summary>
+    /// Adds the specified file as a dependency related to the current content file.
+    /// </summary>
+    /// <param name="builder">A <see cref="ContentBuilder"/> the added depedency is related to.</param>
+    /// <param name="dependencyPath">A relative or absolute path to the dependency file.</param>
+    void AddDependency(ContentBuilder builder, string dependencyPath);
+
+    /// <summary>
+    /// Adds the specified file as an output file related to the current content file.
+    /// </summary>
+    /// <param name="builder">A <see cref="ContentBuilder"/> the output file is related to.</param>
+    /// <param name="outputPath">A relative or absolute path to the output file.</param>
+    void AddOutputFile(ContentBuilder builder, string outputPath);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="builder">A <see cref="ContentBuilder"/> the added depedency is related to.</param>
+    /// <param name="info">A <see cref="ContentInfo"/> for which to use to check the validity of the cached asset.</param>
+    /// <returns><c>true</c> if the file cache is still valid, <c>false</c> otherwise.</returns>
+    bool IsValid(ContentBuilder builder, ContentInfo info);
+}


### PR DESCRIPTION
- ContentCollection: Add ability for specifying multiple outputs for the same asset input
- ContentCollection: Make include / exclude only do operations on current content root
- ContentCollection: Modify outputPath function to expect a path without extension in case of build action
- Parameters: Make Parameters a class so they can both be read from CLI and afterwards modified in code more easily
- Parameters: Add ability to rebuild content
- Cache: Make content cache track content based on produced outputs instead of inputs
- Cache: Mark ContentFileCache as internal and make an IContentFileCache that the IContentCache is working with
- Cache: Track output file times in case of external modifications
- Cache: Sanitize filepaths
- Builder: Add ability for multiple dependencies of the same asset to have separate properties (more refactoring on this is coming so that we don't waste space)
- Builder: Sanitize passed pathing to ContentCollection
- Builder: Automatically append .xnb to output path in case of build action
- Builder: Remove GetDefaultOutputPath and GetDefaultCopyPath as they now no longer do any modifications