### PR TITLE
Update DesktopGL to SDL 2.32.10

### DIFF
--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoGame.Library.SDL" Version="2.32.2.1" />
+    <PackageReference Include="MonoGame.Library.SDL" Version="2.32.10.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updating SDL to the newly released 2.32.10 for DesktopGL.

---

DesktopVK and WindowsDX12 presently use 2.28.4, this PR doesn't change that.

I'm currently investigating issues with them and SDL and will address that independently.




