### PR TITLE
Fix texture importer error message

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
@@ -164,13 +164,13 @@ public abstract class ContentBuilder
 
         if (!ContentBuilderHelper.GetImporter(relativePath, contentInfo.Importer, out IContentImporter importer))
         {
-            Logger.Log(LogLevel.Warning, "Importer: Not found :(");
+            Logger.Log(LogLevel.Warning, "Importer: Not found");
             return null;
         }
         Logger.Log($"Imposter: {importer.GetType().Name}");
         if (!ContentBuilderHelper.GetProcessor(importer, contentInfo.Processor, out IContentProcessor processor))
         {
-            Logger.Log(LogLevel.Warning, "Processor: Not found :(");
+            Logger.Log(LogLevel.Warning, "Processor: Not found");
             return null;
         }
         Logger.Log($"Processor: {processor.GetType().Name}");

--- a/native/pipeline/mgcp_texture.cpp
+++ b/native/pipeline/mgcp_texture.cpp
@@ -15,7 +15,8 @@ void* MP_ImportBitmap(const char* importPath, MGCP_Bitmap& bitmap)
     void* data = nullptr;
 
     f = stbi__fopen(importPath, "rb");
-    if (!f) goto err;
+    if (!f)
+        return (void*)"The file was not found.";
 
     if (stbi_is_hdr_from_file(f))
     {


### PR DESCRIPTION
When the source texture is not found we need to return an appropriate error message.

