### PR TITLE
Fix backslashes in content builder paths

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
@@ -82,7 +82,7 @@ public abstract class ContentBuilder
         }
         catch (Exception ex)
         {
-            Logger.Log(LogLevel.Error, $"Countent failed to build:\n{ex}");
+            Logger.Log(LogLevel.Error, $"Content failed to build:\n{ex}");
             FailedToBuild++;
         }
         Logger.PopFile();
@@ -107,7 +107,7 @@ public abstract class ContentBuilder
         }
         catch (Exception ex)
         {
-            Logger.Log(LogLevel.Error, $"Countent failed to build:\n{ex}");
+            Logger.Log(LogLevel.Error, $"Content failed to build:\n{ex}");
             FailedToBuild++;
         }
         Logger.PopFile();

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
@@ -87,7 +87,7 @@ public abstract class ContentBuilder
             FailedToBuild++;
             if (ex is not SkipLogException)
             {
-                Logger.Log(LogLevel.Error, $"Countent failed to build: {ex}");
+                Logger.Log(LogLevel.Error, $"Content failed to build: {ex}");
             }
             if (parentContext != null)
             {
@@ -122,7 +122,7 @@ public abstract class ContentBuilder
             FailedToBuild++;
             if (ex is not SkipLogException)
             {
-                Logger.Log(LogLevel.Error, $"Countent failed to build: {ex}");
+                Logger.Log(LogLevel.Error, $"Content failed to build: {ex}");
             }
             if (parentContext != null)
             {

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
@@ -117,8 +117,8 @@ public abstract class ContentBuilder
     private object? ProcessContent(string relativePath, ContentInfo contentInfo, bool writeToDisk, string? relativeOutputPath, ContentProcessorContext? parentContext)
     {
         var filePath = Path.Combine(Parameters.RootedSourceDirectory, relativePath);
-        var relativeDestPath = Path.Combine(contentInfo.ContentRoot, string.IsNullOrEmpty(relativeOutputPath) ? relativePath.GetDestinationPath(contentInfo.ShouldBuild, contentInfo.GetOutputPath) : relativeOutputPath);
-        var outputPath = Path.Combine(Parameters.RootedOutputDirectory, relativeDestPath);
+        var relativeDestPath = Path.Combine(contentInfo.ContentRoot, string.IsNullOrEmpty(relativeOutputPath) ? relativePath.GetDestinationPath(contentInfo.ShouldBuild, contentInfo.GetOutputPath) : relativeOutputPath).Sanitize();
+        var outputPath = Path.Combine(Parameters.RootedOutputDirectory, relativeDestPath).Sanitize();
         var outputDir = Path.GetDirectoryName(outputPath);
 
         if (string.IsNullOrWhiteSpace(outputDir))

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentCollectionRoot.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentCollectionRoot.cs
@@ -13,15 +13,15 @@ class ContentCollectionRoot(string contentRoot)
     private readonly List<(ContentRule rule, ContentInfo? info)> _rules = [];
 
     public void IncludeCopy(string inputPath, string? outputPath)
-        => _imputFiles[inputPath] = new(_contentRoot, false, null, null, string.IsNullOrWhiteSpace(outputPath) ? (s => s) : (_ => outputPath));
+        => _imputFiles[inputPath.Sanitize()] = new(_contentRoot, false, null, null, string.IsNullOrWhiteSpace(outputPath) ? (s => s) : (_ => outputPath));
 
     public void Include(string inputPath, IContentImporter? contentImporter, IContentProcessor? contentProcessor)
-        => _imputFiles[inputPath] = new(_contentRoot, true, contentImporter, contentProcessor);
+        => _imputFiles[inputPath.Sanitize()] = new(_contentRoot, true, contentImporter, contentProcessor);
 
     public void Include(string inputPath, string outputPath, IContentImporter? contentImporter, IContentProcessor? contentProcessor )
-        => _imputFiles[inputPath] = new(_contentRoot, true, contentImporter, contentProcessor, _ => outputPath);
+        => _imputFiles[inputPath.Sanitize()] = new(_contentRoot, true, contentImporter, contentProcessor, _ => outputPath);
 
-    public void Exclude(string excludePath) => _imputFiles[excludePath] = null;
+    public void Exclude(string excludePath) => _imputFiles[excludePath.Sanitize()] = null;
 
     public void IncludeCopy<T>(string includePattern, Func<string, string>? outputPath)
         where T : ContentRule, new()
@@ -60,7 +60,7 @@ class ContentCollectionRoot(string contentRoot)
         HashSet<string> usedOutputs = [];
         contentInfos = [];
 
-        bool inputFiles = _imputFiles.TryGetValue(filePath, out ContentInfo? inputFilesInfo);
+        bool inputFiles = _imputFiles.TryGetValue(filePath.Sanitize(), out ContentInfo? inputFilesInfo);
         bool? shouldBuild = null;
 
         if (inputFilesInfo != null)

--- a/MonoGame.Framework.Content.Pipeline/Builder/WildcardRule.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/WildcardRule.cs
@@ -17,5 +17,5 @@ public class WildcardRule : ContentRule
     /// </summary>
     /// <param name="filePath">Relative path to the content file.</param>
     /// <returns>Returns true if filePath matches the Wildcard <see cref="ContentRule.Pattern"/>.</returns>
-    public override bool IsMatch(string filePath) => LikeOperator.LikeString(filePath, Pattern, CompareMethod.Binary);
+    public override bool IsMatch(string filePath) => LikeOperator.LikeString(filePath, Pattern.Sanitize(), CompareMethod.Binary);
 }

--- a/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
@@ -175,7 +175,7 @@ public class ContentBuildLogger
     public virtual void PushFile(string filename)
     {
         filename = filename.Sanitize();
-        Log(filename.Sanitize());
+        Log(filename);
         _filenames.Push(filename);
     }
 

--- a/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System.Diagnostics;
+using MonoGame.Framework.Content.Pipeline.Builder;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline;
 
@@ -173,7 +174,8 @@ public class ContentBuildLogger
     /// <param name="filename">Name of the file containing future messages.</param>
     public virtual void PushFile(string filename)
     {
-        Log(filename);
+        filename = filename.Sanitize();
+        Log(filename.Sanitize());
         _filenames.Push(filename);
     }
 


### PR DESCRIPTION
This PR corrects incoming backslashes to forward slashes on any paths passed in by the developer from a public API.

This is important because most Windows devs will use backslashes `\` because that is what they are used to.  This however is wrong for cross platform use.  While we recommend people use forward slashes, people will either not notice or not care.  

In particular the wildcard input of `**\*.png`  won't work on any platform but `**/*.png` will.

These changes ensures things "just work" and reduces support requests.

Also fixed a spelling mistake.
 