### PR TITLE
DesktopVK fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ _*
 /native/**/*.vcxproj.filters
 /native/**/*.make
 /native/**/Makefile
+/native/**/*.mgfxo.h

--- a/MonoGame.Framework/Platform/Native/GameWindow.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GameWindow.Native.cs
@@ -162,7 +162,13 @@ internal class NativeGameWindow : GameWindow
             MGP.Window_ExitFullScreen(_handle);
         }
 
-        ClientResize(pp.BackBufferWidth, pp.BackBufferHeight);
+        if (_width == pp.BackBufferWidth && _height == pp.BackBufferHeight)
+            return;
+
+        _width = pp.BackBufferWidth;
+        _height = pp.BackBufferHeight;
+
+        MGP.Window_SetClientSize(_handle, pp.BackBufferWidth, pp.BackBufferHeight);
     }
 
     public unsafe void ClientResize(int width, int height)
@@ -170,38 +176,12 @@ internal class NativeGameWindow : GameWindow
         if (_width == width && _height == height)
             return;
 
-        if (!IsFullScreen)
-            MGP.Window_SetClientSize(_handle, width, height);
-
-        UpdateBackBufferSize(width, height);
-
-        OnClientSizeChanged();
-    }
-
-    private void UpdateBackBufferSize(int width, int height)
-    {
         _width = width;
         _height = height;
 
-        // TODO: Implement sperate swap change logic for
-        // non-primary windows.
+        MGP.Window_SetClientSize(_handle, width, height);
 
-        // TODO: We should expose a feature to allow
-        // for either the swapchain to resize to match
-        // the window size or remain fixed size and stretch.
-
-        // Only the primary window will resize the
-        // default back buffer.
-        if (!_primaryWindow)
-            return;
-
-        var manager = _platform.Game.graphicsDeviceManager;
-        if (manager.GraphicsDevice == null)
-            return;
-
-        manager.PreferredBackBufferWidth = _width;
-        manager.PreferredBackBufferHeight = _height;
-        manager.ApplyChanges();
+        OnClientSizeChanged();
     }
 
     protected override unsafe void SetTitle(string title)

--- a/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
@@ -193,7 +193,8 @@ internal static unsafe partial class MGG
         int width,
         int height,
         SurfaceFormat color,
-        DepthFormat depth);
+        DepthFormat depth,
+        int syncInterval);
 
     [DllImport(MGP.MonoGameNativeDLL, EntryPoint = "MGG_GraphicsDevice_BeginFrame", ExactSpelling = true)]
     public static extern int GraphicsDevice_BeginFrame(MGG_GraphicsDevice* device);

--- a/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
@@ -56,7 +56,8 @@ public partial class GraphicsDevice
                 PresentationParameters.BackBufferWidth,
                 PresentationParameters.BackBufferHeight,
                 PresentationParameters.BackBufferFormat,
-                PresentationParameters.DepthStencilFormat);
+                PresentationParameters.DepthStencilFormat,
+                PresentationParameters.PresentationInterval.GetSyncInterval());
 
         // Setup the default texture.
         DefaultTexture = new Texture2D(this, 2, 2);
@@ -83,7 +84,8 @@ public partial class GraphicsDevice
             PresentationParameters.BackBufferWidth,
             PresentationParameters.BackBufferHeight,
             PresentationParameters.BackBufferFormat,
-            PresentationParameters.DepthStencilFormat);
+            PresentationParameters.DepthStencilFormat,
+            PresentationParameters.PresentationInterval.GetSyncInterval());
 
         _viewport = new Viewport(
             0,

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -429,7 +429,8 @@ void MGG_GraphicsDevice_ResizeSwapchain(
 	mgint width,
 	mgint height,
 	MGSurfaceFormat color,
-	MGDepthFormat depth)
+	MGDepthFormat depth,
+	mgint syncInterval)
 {
 #if !defined(_GAMING_XBOX)
 

--- a/native/monogame/include/api_MGG.h
+++ b/native/monogame/include/api_MGG.h
@@ -33,7 +33,7 @@ MG_EXPORT void MGG_GraphicsAdapter_GetInfo(MGG_GraphicsAdapter* adapter, MGG_Gra
 MG_EXPORT MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_GraphicsAdapter* adapter);
 MG_EXPORT void MGG_GraphicsDevice_Destroy(MGG_GraphicsDevice* device);
 MG_EXPORT void MGG_GraphicsDevice_GetCaps(MGG_GraphicsDevice* device, MGG_GraphicsDevice_Caps& caps);
-MG_EXPORT void MGG_GraphicsDevice_ResizeSwapchain(MGG_GraphicsDevice* device, void* nativeWindowHandle, mgint width, mgint height, MGSurfaceFormat color, MGDepthFormat depth);
+MG_EXPORT void MGG_GraphicsDevice_ResizeSwapchain(MGG_GraphicsDevice* device, void* nativeWindowHandle, mgint width, mgint height, MGSurfaceFormat color, MGDepthFormat depth, mgint syncInterval);
 MG_EXPORT mgint MGG_GraphicsDevice_BeginFrame(MGG_GraphicsDevice* device);
 MG_EXPORT void MGG_GraphicsDevice_Clear(MGG_GraphicsDevice* device, MGClearOptions options, Vector4& color, mgfloat depth, mgint stencil);
 MG_EXPORT void MGG_GraphicsDevice_Present(MGG_GraphicsDevice* device, mgint currentFrame, mgint syncInterval);

--- a/native/monogame/sdl/MGP_sdl.cpp
+++ b/native/monogame/sdl/MGP_sdl.cpp
@@ -831,7 +831,30 @@ void MGP_Window_SetPosition(MGP_Window* window, mgint x, mgint y)
 void MGP_Window_SetClientSize(MGP_Window* window, mgint width, mgint height)
 {
     assert(window != nullptr);
-    SDL_SetWindowSize(window->window, width, height);
+
+    // Resizing with SDL depends on the fullscreen mode.
+    // If we're in exclusive-fullscreen, SDL_SetWindowDisplayMode()
+    // is needed to be called with the closest requested size.
+    // If windowed-fullscreen or just windowed, only
+    // SDL_SetWindowSize() is needed.
+
+    auto flags = SDL_GetWindowFlags(window->window);
+
+    if ((flags & SDL_WINDOW_FULLSCREEN) != 0)
+    {
+        SDL_DisplayMode closest{ 0, 0, 0, 0, nullptr };
+        const SDL_DisplayMode desired{ 0, width, height, 60, nullptr };
+        if (SDL_GetClosestDisplayMode(0, &desired, &closest))
+        {
+            SDL_SetWindowDisplayMode(window->window, &closest);
+            // We need to call SDL_SetWindowSize() as well otherwise
+            // SDL won't send resize proper resize events to our
+            // event queue for the Viewport to update properly.
+            SDL_SetWindowSize(window->window, closest.w, closest.h);
+        }
+    }
+    else
+        SDL_SetWindowSize(window->window, width, height);
 }
 
 void MGP_Window_SetCursor(MGP_Window* window, MGP_Cursor* cursor)

--- a/native/monogame/sdl/MGP_sdl.cpp
+++ b/native/monogame/sdl/MGP_sdl.cpp
@@ -679,6 +679,19 @@ mgbyte MGP_Platform_BeforeUpdate(MGP_Platform* platform)
 mgbyte MGP_Platform_BeforeDraw(MGP_Platform* platform)
 {
 	assert(platform != nullptr);
+
+    // TO DO: Vulkan wants that we stop rendering if the window is minimized on Windows (because surface extent is 0x0 when this happens, which will crash Vulkan).
+    // This code assume that we only have one primary window. If we ever implement multi-window support, this will need to be changed.
+    for (auto window : platform->windows)
+    {
+        if (window != nullptr)
+        {
+            auto flags = SDL_GetWindowFlags(window->window);
+            if ((flags & SDL_WINDOW_MINIMIZED) != 0)
+                return false;
+        }
+    }
+
 	return true;
 }
 

--- a/native/monogame/sdl/MGP_sdl.cpp
+++ b/native/monogame/sdl/MGP_sdl.cpp
@@ -479,8 +479,6 @@ mgbyte MGP_Platform_PollEvent(MGP_Platform* platform, MGP_Event& event_)
                 // (This maps the range of values to -32767:32767 instead of SDL's -32768:32767)
                 event_.Controller.Value = (event_.Controller.Value == -32768 ? 32767 : ~event_.Controller.Value + 1);
             }
-            else
-
             return true;
             break;
 

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -276,8 +276,6 @@ struct MGG_GraphicsDevice
 	MGVK_TargetSet targets;
 	std::map<uint32_t, MGVK_TargetSetCache*> targetCache;
 
-	// Extension support flags
-	bool customBorderColorSupported = false;
 
 	//
 	bool pipelineStateDirty = false;
@@ -1126,26 +1124,6 @@ static void MGVK_ExecuteAndFreeCommandBuffer(MGG_GraphicsDevice* device, VkComma
 	vkFreeCommandBuffers(device->device, device->cmdPool, 1, &commandBuffer);
 }
 
-static bool MGVK_CheckExtensionSupport(VkPhysicalDevice physicalDevice, const char* extensionName)
-{
-	uint32_t extensionCount;
-	vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extensionCount, nullptr);
-
-	if (extensionCount == 0)
-		return false;
-
-	std::vector<VkExtensionProperties> availableExtensions(extensionCount);
-	vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extensionCount, availableExtensions.data());
-
-	for (const auto& extensionProperties : availableExtensions) {
-		if (strcmp(extensionName, extensionProperties.extensionName) == 0) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_GraphicsAdapter* adapter)
 {
 	assert(system != nullptr);
@@ -1218,58 +1196,15 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 	deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 	deviceFeatures2.features = enabledFeatures;
 
-	// Check for custom border color extension support
-	device->customBorderColorSupported = false;
-	VkPhysicalDeviceCustomBorderColorFeaturesEXT customBorderColorFeatures = {};
-	
 #if defined(__APPLE__)
-	// Apple/MoltenVK doesn't support custom border colors
 	deviceFeatures2.pNext = nullptr;
 #else
-	// Check if the device supports the custom border color extension
-	if (MGVK_CheckExtensionSupport(device->physicalDevice, VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME))
-	{
-		// Check if the physical device supports the required features
-		VkPhysicalDeviceCustomBorderColorFeaturesEXT availableFeatures = {};
-		availableFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT;
-		
-		VkPhysicalDeviceFeatures2 queryFeatures = {};
-		queryFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-		queryFeatures.pNext = &availableFeatures;
-		
-		vkGetPhysicalDeviceFeatures2(device->physicalDevice, &queryFeatures);
-		
-		// Only enable if both customBorderColors and customBorderColorWithoutFormat are supported
-		if (availableFeatures.customBorderColors && availableFeatures.customBorderColorWithoutFormat)
-		{
-			extensions.push_back(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
-			customBorderColorFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT;
-			customBorderColorFeatures.customBorderColors = VK_TRUE;
-			customBorderColorFeatures.customBorderColorWithoutFormat = VK_TRUE;
-			deviceFeatures2.pNext = &customBorderColorFeatures;
-			device->customBorderColorSupported = true;
-			
-#if defined(DEBUG)
-			printf("VK_EXT_custom_border_color extension enabled\n");
-#endif
-		}
-		else
-		{
-			deviceFeatures2.pNext = nullptr;
-			
-#if defined(DEBUG)
-			printf("VK_EXT_custom_border_color extension available but features not supported\n");
-#endif
-		}
-	}
-	else
-	{
-		deviceFeatures2.pNext = nullptr;
-		
-#if defined(DEBUG)
-		printf("VK_EXT_custom_border_color extension not available, using fallback border colors\n");
-#endif
-	}
+	extensions.push_back(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
+	VkPhysicalDeviceCustomBorderColorFeaturesEXT customBorderColorFeatures = {};
+	customBorderColorFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT;
+	customBorderColorFeatures.customBorderColors = VK_TRUE;
+	customBorderColorFeatures.customBorderColorWithoutFormat = VK_TRUE;
+	deviceFeatures2.pNext = &customBorderColorFeatures;
 #endif
 
 	VkDeviceCreateInfo deviceCreateInfo = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
@@ -4014,26 +3949,21 @@ MGG_SamplerState* MGG_SamplerState_Create(MGG_GraphicsDevice* device, MGG_Sample
 		samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
 	else
 	{
-		// Check if custom border color extension is supported
-		if (device->customBorderColorSupported)
-		{
-			samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
-			bcolor.sType = VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT;
+#if defined(__APPLE__)
+		samplerInfo.borderColor = VK_BORDER_COLOR_INT_TRANSPARENT_BLACK;
+#else
+		samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
+		bcolor.sType = VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT;
 
-			// RGBA
-			bcolor.format = VK_FORMAT_UNDEFINED;
-			bcolor.customBorderColor.float32[0] = ((info->BorderColor >> 0) & 0xFF) / 255.0f;
-			bcolor.customBorderColor.float32[1] = ((info->BorderColor >> 8) & 0xFF) / 255.0f;
-			bcolor.customBorderColor.float32[2] = ((info->BorderColor >> 16) & 0xFF) / 255.0f;
-			bcolor.customBorderColor.float32[3] = ((info->BorderColor >> 24) & 0xFF) / 255.0f;
+		// RGBA
+		bcolor.format = VK_FORMAT_UNDEFINED;
+		bcolor.customBorderColor.float32[0] = ((info->BorderColor >> 0) & 0xFF) / 255.0f;
+		bcolor.customBorderColor.float32[1] = ((info->BorderColor >> 8) & 0xFF) / 255.0f;
+		bcolor.customBorderColor.float32[2] = ((info->BorderColor >> 16) & 0xFF) / 255.0f;
+		bcolor.customBorderColor.float32[3] = ((info->BorderColor >> 24) & 0xFF) / 255.0f;
 
-			samplerInfo.pNext = &bcolor;
-		}
-		else
-		{
-			// Fallback to closest standard border color when custom border colors are not supported
-			samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
-		}
+		samplerInfo.pNext = &bcolor;
+#endif
 	}
 
 	switch (info->Filter)

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -213,6 +213,7 @@ struct MGG_GraphicsDevice
 	VkPhysicalDeviceProperties deviceProperties;
 	VkPhysicalDeviceFeatures deviceFeatures;
 	VkPhysicalDeviceMemoryProperties deviceMemoryProperties;
+	bool customBorderColorSupported = false;
 
 	VkDevice device = VK_NULL_HANDLE;
 	VkQueue queue = VK_NULL_HANDLE;
@@ -705,7 +706,7 @@ static VkImageAspectFlags DetermineAspectMask(VkFormat format)
 	return result;
 }
 
-uint64_t CheckValidationLayerSupport(const std::vector<const char*>& validationLayers)
+bool AreValidationLayersSupported()
 {
 	uint32_t layerCount;
 	vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
@@ -713,24 +714,26 @@ uint64_t CheckValidationLayerSupport(const std::vector<const char*>& validationL
 	std::vector<VkLayerProperties> availableLayers(layerCount);
 	vkEnumerateInstanceLayerProperties(&layerCount, availableLayers.data());
 
-	uint64_t found = 0;
-
-	for (int i = 0; i < validationLayers.size(); i++)
+	for (const auto& layerProperties : availableLayers)
 	{
-		const char* layerName = validationLayers[i];
-
-		for (const auto& layerProperties : availableLayers)
-		{
-			if (strcmp(layerName, layerProperties.layerName) == 0)
-			{
-				found |= ((uint64_t)1) << i;
-				break;
-			}
-		}
+		if (strcmp("VK_LAYER_KHRONOS_validation", layerProperties.layerName) == 0)
+			return true;
 	}
 
-	return found;
+	return false;
 }
+
+static bool HasExtension(const std::vector<const char*>& extensions, const char* extension)
+{
+	for (const auto& ext : extensions)
+	{
+		if (strcmp(ext, extension) == 0)
+			return true;
+	}
+
+	return false;
+}
+
 MGG_GraphicsSystem* MGG_GraphicsSystem_Create()
 {
 #ifndef __APPLE__
@@ -764,19 +767,52 @@ MGG_GraphicsSystem* MGG_GraphicsSystem_Create()
 		SDL_Vulkan_GetInstanceExtensions(nullptr, &count, instanceExtensions.data());
 	}
 #else
-#error Not Implemented!
+	{
+		uint32_t count;
+		vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr);
+		instanceExtensions.resize(count);
+
+		vkEnumerateInstanceExtensionProperties(nullptr, &count, instanceExtensions.data());
+	}
 #endif
-	instanceExtensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+
+	// Check instance-level extensions support or if they are core in this instance
+	uint32_t version;
+	err = vkEnumerateInstanceVersion(&version);
+	if (err != VK_SUCCESS)
+	{
+		printf("Failed to retrieve Vulkan instance version!");
+		return nullptr;
+	}
+
+	printf("Vulkan instance version: %d.%d.%d\n", VK_API_VERSION_MAJOR(version), VK_API_VERSION_MINOR(version), VK_API_VERSION_PATCH(version));
+
+	// This extension should be widely supported (~89% of systems according to https://vulkan.gpuinfo.org/listinstanceextensions.php?platform=all)
+	// This extension is used to initialize the VK_EXT_custom_border_color (which therefore won't be supported)
+	if (!(VK_API_VERSION_MAJOR(version) > 1 || VK_API_VERSION_MINOR(version) >= 1) && // This extension is core in 1.1 SDK.
+		!HasExtension(instanceExtensions, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
+	{
+		printf("%s is not supported by this SDK!\n", VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+		// This is a critical failure.
+		return nullptr;
+	}
 
 	std::vector<const char*> enabledLayers;
 
 #ifdef DEBUG
-	instanceExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 
-#ifndef __APPLE__
-	enabledLayers.push_back("VK_LAYER_KHRONOS_validation");
-	CheckValidationLayerSupport(enabledLayers);
-#endif
+	// This extension has a very poor support on Android (less than 25%). Chances are that DEBUG builds won't work on Android.
+	if (!HasExtension(instanceExtensions, VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) // This exention is not core in any SDK and might be unsupported.
+		printf("%s is not supported by this SDK. Labeling Vulkan object will not be possible.\n", VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+	if (AreValidationLayersSupported())
+	{
+		enabledLayers.push_back("VK_LAYER_KHRONOS_validation");
+		printf("Validation layers are enabled (performances will be drastically impacted). To run without validation layers, please use a RELEASE build or uninstall the Vulkan SDK.\n");
+	}
+	else
+		printf("Validation layers aren't supported (you might want to install the Vulkan SDK to support them).\n");
+
 #endif
 
 	VkInstanceCreateInfo instance_create_info = { VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO };
@@ -809,15 +845,16 @@ MGG_GraphicsSystem* MGG_GraphicsSystem_Create()
 		VkResult res = vkEnumeratePhysicalDevices(system->instance, &count, NULL);
 		if (res == VK_SUCCESS)
 		{
-			VkPhysicalDevice* gpus = (VkPhysicalDevice*)calloc(count, sizeof(*gpus));
+			std::vector<VkPhysicalDevice> gpus;
+			gpus.resize(count);
 
-			res = vkEnumeratePhysicalDevices(system->instance, &count, gpus);
+			res = vkEnumeratePhysicalDevices(system->instance, &count, gpus.data());
 			if (res == VK_SUCCESS)
 			{
-				for (uint32_t i = 0; i < count; ++i)
+				for (const auto& gpu : gpus)
 				{
 					auto adapter = new MGG_GraphicsAdapter();
-					adapter->device = gpus[i];
+					adapter->device = gpu;
 
 					vkGetPhysicalDeviceProperties(adapter->device, &adapter->properties);
 					vkGetPhysicalDeviceFeatures(adapter->device, &adapter->features);
@@ -826,8 +863,6 @@ MGG_GraphicsSystem* MGG_GraphicsSystem_Create()
 					system->adapters.push_back(adapter);
 				}
 			}
-
-			free((void*)gpus);
 		}
 	}
 
@@ -1138,6 +1173,9 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 	vkGetPhysicalDeviceFeatures(device->physicalDevice, &device->deviceFeatures);
 	vkGetPhysicalDeviceProperties(device->physicalDevice, &device->deviceProperties);
 
+	printf("Selected GPU: %s\n", device->deviceProperties.deviceName);
+	printf("Supported Vulkan API version: %d.%d.%d\n", VK_API_VERSION_MAJOR(device->deviceProperties.apiVersion), VK_API_VERSION_MINOR(device->deviceProperties.apiVersion), VK_API_VERSION_PATCH(device->deviceProperties.apiVersion));
+
 	// Capture some needed limits.
 	device->minUniformBufferOffsetAlignment = adapter->properties.limits.minUniformBufferOffsetAlignment;
 
@@ -1180,6 +1218,34 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 	}
 	assert(queueFamilyCount == queueCreateInfoCount);
 
+	// Check if VK_KHR_swapchain and VK_EXT_custom_border_color are supported
+	std::vector<VkExtensionProperties> deviceExtensions;
+	{
+		uint32_t count;
+		vkEnumerateDeviceExtensionProperties(device->physicalDevice, nullptr, &count, nullptr);
+		deviceExtensions.resize(count);
+
+		vkEnumerateDeviceExtensionProperties(device->physicalDevice, nullptr, &count, deviceExtensions.data());
+	}
+
+	bool swapChainSupported = false;
+	for (const auto& extension : deviceExtensions)
+	{
+		if (strcmp(extension.extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0)
+			swapChainSupported = true;
+		if (strcmp(extension.extensionName, VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME) == 0)
+			device->customBorderColorSupported = true;
+	}
+
+	if (!swapChainSupported)
+	{
+		printf("%s is not supported by this driver!\n", VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+		// This is a critical failure.
+		return nullptr;
+	}
+	if (!device->customBorderColorSupported) // We can live without this extention.
+		printf("%s is not supported by this driver!\n", VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
+
 	std::vector<const char*> extensions;
 	extensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 
@@ -1197,16 +1263,19 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 	deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 	deviceFeatures2.features = enabledFeatures;
 
-#if defined(__APPLE__)
-	deviceFeatures2.pNext = nullptr;
-#else
-	extensions.push_back(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
-	VkPhysicalDeviceCustomBorderColorFeaturesEXT customBorderColorFeatures = {};
-	customBorderColorFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT;
-	customBorderColorFeatures.customBorderColors = VK_TRUE;
-	customBorderColorFeatures.customBorderColorWithoutFormat = VK_TRUE;
-	deviceFeatures2.pNext = &customBorderColorFeatures;
-#endif
+	if (!device->customBorderColorSupported)
+	{
+		deviceFeatures2.pNext = nullptr;
+	}
+	else
+	{
+		extensions.push_back(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
+		VkPhysicalDeviceCustomBorderColorFeaturesEXT customBorderColorFeatures = {};
+		customBorderColorFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT;
+		customBorderColorFeatures.customBorderColors = VK_TRUE;
+		customBorderColorFeatures.customBorderColorWithoutFormat = VK_TRUE;
+		deviceFeatures2.pNext = &customBorderColorFeatures;
+	}
 
 	VkDeviceCreateInfo deviceCreateInfo = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
 	deviceCreateInfo.queueCreateInfoCount = queueCreateInfoCount;
@@ -4000,21 +4069,24 @@ MGG_SamplerState* MGG_SamplerState_Create(MGG_GraphicsDevice* device, MGG_Sample
 		samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
 	else
 	{
-#if defined(__APPLE__)
-		samplerInfo.borderColor = VK_BORDER_COLOR_INT_TRANSPARENT_BLACK;
-#else
-		samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
-		bcolor.sType = VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT;
+		if (!device->customBorderColorSupported)
+		{
+			samplerInfo.borderColor = VK_BORDER_COLOR_INT_TRANSPARENT_BLACK;
+		}
+		else
+		{
+			samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
+			bcolor.sType = VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT;
 
-		// RGBA
-		bcolor.format = VK_FORMAT_UNDEFINED;
-		bcolor.customBorderColor.float32[0] = ((info->BorderColor >> 0) & 0xFF) / 255.0f;
-		bcolor.customBorderColor.float32[1] = ((info->BorderColor >> 8) & 0xFF) / 255.0f;
-		bcolor.customBorderColor.float32[2] = ((info->BorderColor >> 16) & 0xFF) / 255.0f;
-		bcolor.customBorderColor.float32[3] = ((info->BorderColor >> 24) & 0xFF) / 255.0f;
+			// RGBA
+			bcolor.format = VK_FORMAT_UNDEFINED;
+			bcolor.customBorderColor.float32[0] = ((info->BorderColor >> 0) & 0xFF) / 255.0f;
+			bcolor.customBorderColor.float32[1] = ((info->BorderColor >> 8) & 0xFF) / 255.0f;
+			bcolor.customBorderColor.float32[2] = ((info->BorderColor >> 16) & 0xFF) / 255.0f;
+			bcolor.customBorderColor.float32[3] = ((info->BorderColor >> 24) & 0xFF) / 255.0f;
 
-		samplerInfo.pNext = &bcolor;
-#endif
+			samplerInfo.pNext = &bcolor;
+		}
 	}
 
 	switch (info->Filter)

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -454,6 +454,7 @@ struct MGG_OcclusionQuery
 struct MGG_GraphicsSystem
 {
 	VkInstance instance;
+	mgbool supportsPhysicalDeviceProperties2EXT;
 
 	std::vector<MGG_GraphicsAdapter*> adapters;
 };
@@ -723,11 +724,11 @@ bool AreValidationLayersSupported()
 	return false;
 }
 
-static bool HasExtension(const std::vector<const char*>& extensions, const char* extension)
+static bool SupportsExtension(const std::vector<VkExtensionProperties>& supportedExtensions, const char* extensionName)
 {
-	for (const auto& ext : extensions)
+	for (const auto& extension : supportedExtensions)
 	{
-		if (strcmp(ext, extension) == 0)
+		if (strcmp(extension.extensionName, extensionName) == 0)
 			return true;
 	}
 
@@ -740,7 +741,7 @@ MGG_GraphicsSystem* MGG_GraphicsSystem_Create()
 	auto err = volkInitialize();
 	if (err != VK_SUCCESS)
 	{
-		printf("Failed to initialize volk!");
+		printf("Failed to initialize volk!\n");
 		return nullptr;
 	}
 #else
@@ -757,6 +758,15 @@ MGG_GraphicsSystem* MGG_GraphicsSystem_Create()
 	app_info.pApplicationName = "Unknown";
 	app_info.pEngineName = "MonoGame";
 
+	std::vector<VkExtensionProperties> supportedInstanceExtensions;
+	{
+		uint32_t count;
+		vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr);
+		supportedInstanceExtensions.resize(count);
+
+		vkEnumerateInstanceExtensionProperties(nullptr, &count, supportedInstanceExtensions.data());
+	}
+
 	std::vector<const char*> instanceExtensions;
 #if defined(MG_SDL2)
 	{
@@ -764,15 +774,8 @@ MGG_GraphicsSystem* MGG_GraphicsSystem_Create()
 		SDL_Vulkan_GetInstanceExtensions(nullptr, &count, nullptr);
 		instanceExtensions.resize(count);
 
+		// This call returns the extensions that SDL needs for the created instance.
 		SDL_Vulkan_GetInstanceExtensions(nullptr, &count, instanceExtensions.data());
-	}
-#else
-	{
-		uint32_t count;
-		vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr);
-		instanceExtensions.resize(count);
-
-		vkEnumerateInstanceExtensionProperties(nullptr, &count, instanceExtensions.data());
 	}
 #endif
 
@@ -781,20 +784,23 @@ MGG_GraphicsSystem* MGG_GraphicsSystem_Create()
 	err = vkEnumerateInstanceVersion(&version);
 	if (err != VK_SUCCESS)
 	{
-		printf("Failed to retrieve Vulkan instance version!");
+		printf("Failed to retrieve Vulkan instance version!\n");
 		return nullptr;
 	}
 
 	printf("Vulkan instance version: %d.%d.%d\n", VK_API_VERSION_MAJOR(version), VK_API_VERSION_MINOR(version), VK_API_VERSION_PATCH(version));
 
 	// This extension should be widely supported (~89% of systems according to https://vulkan.gpuinfo.org/listinstanceextensions.php?platform=all)
-	// This extension is used to initialize the VK_EXT_custom_border_color (which therefore won't be supported)
-	if (!(VK_API_VERSION_MAJOR(version) > 1 || VK_API_VERSION_MINOR(version) >= 1) && // This extension is core in 1.1 SDK.
-		!HasExtension(instanceExtensions, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
+	// This extension is used to initialize the VK_EXT_custom_border_color (which therefore won't be supported if absent)
+	bool supportsProperties2EXT = false;
+	if (SupportsExtension(supportedInstanceExtensions, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
 	{
-		printf("%s is not supported by this SDK!\n", VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-		// This is a critical failure.
-		return nullptr;
+		supportsProperties2EXT = true;
+		instanceExtensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+	}
+	else
+	{
+		printf("%s is not supported by this instance! VK_EXT_custom_border_color will not be supported either.\n", VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	}
 
 	std::vector<const char*> enabledLayers;
@@ -802,8 +808,14 @@ MGG_GraphicsSystem* MGG_GraphicsSystem_Create()
 #ifdef DEBUG
 
 	// This extension has a very poor support on Android (less than 25%). Chances are that DEBUG builds won't work on Android.
-	if (!HasExtension(instanceExtensions, VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) // This exention is not core in any SDK and might be unsupported.
-		printf("%s is not supported by this SDK. Labeling Vulkan object will not be possible.\n", VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+	if (SupportsExtension(supportedInstanceExtensions, VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
+	{
+		instanceExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+	}
+	else
+	{
+		printf("%s is not supported by this instance. Labeling Vulkan object will not be possible.\n", VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+	}
 
 	if (AreValidationLayersSupported())
 	{
@@ -828,7 +840,7 @@ MGG_GraphicsSystem* MGG_GraphicsSystem_Create()
 	err = vkCreateInstance(&instance_create_info, nullptr, &instance);
 	if (err != VK_SUCCESS)
 	{
-		printf("Failed to create Vulkan instance!");
+		printf("Failed to create Vulkan instance!\n");
 		return nullptr;
 	}
 
@@ -838,6 +850,7 @@ MGG_GraphicsSystem* MGG_GraphicsSystem_Create()
 
 	auto system = new MGG_GraphicsSystem();
 	system->instance = instance;
+	system->supportsPhysicalDeviceProperties2EXT = supportsProperties2EXT;
 
 	// Gather the physical devices.
 	{
@@ -1234,7 +1247,7 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 		if (strcmp(extension.extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0)
 			swapChainSupported = true;
 		if (strcmp(extension.extensionName, VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME) == 0)
-			device->customBorderColorSupported = true;
+			device->customBorderColorSupported = system->supportsPhysicalDeviceProperties2EXT;
 	}
 
 	if (!swapChainSupported)
@@ -1259,13 +1272,14 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 		enabledFeatures.occlusionQueryPrecise = VK_TRUE;
 	}
 
-	VkPhysicalDeviceFeatures2 deviceFeatures2 = {};
-	deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-	deviceFeatures2.features = enabledFeatures;
-
+	VkDeviceCreateInfo deviceCreateInfo = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
+	deviceCreateInfo.queueCreateInfoCount = queueCreateInfoCount;
+	deviceCreateInfo.pQueueCreateInfos = queueCreateInfos;
+	
 	if (!device->customBorderColorSupported)
 	{
-		deviceFeatures2.pNext = nullptr;
+		deviceCreateInfo.pEnabledFeatures = &enabledFeatures;
+		deviceCreateInfo.pNext = nullptr;
 	}
 	else
 	{
@@ -1274,16 +1288,18 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 		customBorderColorFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT;
 		customBorderColorFeatures.customBorderColors = VK_TRUE;
 		customBorderColorFeatures.customBorderColorWithoutFormat = VK_TRUE;
+
+		VkPhysicalDeviceFeatures2 deviceFeatures2 = {};
+		deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+		deviceFeatures2.features = enabledFeatures;
 		deviceFeatures2.pNext = &customBorderColorFeatures;
+
+		deviceCreateInfo.pEnabledFeatures = nullptr;
+		deviceCreateInfo.pNext = &deviceFeatures2;
 	}
 
-	VkDeviceCreateInfo deviceCreateInfo = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
-	deviceCreateInfo.queueCreateInfoCount = queueCreateInfoCount;
-	deviceCreateInfo.pQueueCreateInfos = queueCreateInfos;
 	deviceCreateInfo.enabledExtensionCount = extensions.size();
 	deviceCreateInfo.ppEnabledExtensionNames = extensions.data();
-	deviceCreateInfo.pEnabledFeatures = nullptr;
-	deviceCreateInfo.pNext = &deviceFeatures2;
 
 	auto res = vkCreateDevice(device->physicalDevice, &deviceCreateInfo, NULL, &device->device);
 	VK_CHECK_RESULT(res);
@@ -1576,22 +1592,32 @@ void MGVK_RecreateSwapChain(
 	device->depthFormat = vkDepth;
 
 	{
+		// Check if the requested color format is supported, and fallback to another one otherwise.
 		VkFormat surface_format = VK_FORMAT_UNDEFINED;
 		uint32_t format_count = 0;
 		res = vkGetPhysicalDeviceSurfaceFormatsKHR(device->physicalDevice, device->surface, &format_count, nullptr);
 		VK_CHECK_RESULT(res);
 
-		VkSurfaceFormatKHR* surfFormats = new VkSurfaceFormatKHR[format_count];
-		res = vkGetPhysicalDeviceSurfaceFormatsKHR(device->physicalDevice, device->surface, &format_count, surfFormats);
+		std::vector<VkSurfaceFormatKHR> surfFormats(format_count);
+		res = vkGetPhysicalDeviceSurfaceFormatsKHR(device->physicalDevice, device->surface, &format_count, surfFormats.data());
 		VK_CHECK_RESULT(res);
 
-		surface_format = surfFormats[0].format;
-		if ((1 == format_count) && (VK_FORMAT_UNDEFINED == surfFormats[0].format))
-			surface_format = VK_FORMAT_B8G8R8A8_UNORM;
+		for (const auto& surfFormat : surfFormats)
+		{
+			if (surfFormat.format == vkColor &&
+				surfFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+			{
+				// The expected format is supported
+				surface_format = surfFormat.format;
+				break;
+			}
+		}
 
-		device->colorFormat = surface_format;
-
-		delete[] surfFormats;
+		if (surface_format == VK_FORMAT_UNDEFINED)
+		{
+			// Format is unsupported, what should we do?
+			return;
+		}
 	}
 
 	// Requested swapchain extent will be clamped based on the surface's min/max extent.
@@ -1612,7 +1638,7 @@ void MGVK_RecreateSwapChain(
 	create_info.surface = device->surface;
 	create_info.minImageCount = kConcurrentFrameCount;
 	create_info.imageFormat = device->colorFormat;
-	create_info.imageColorSpace = VK_COLORSPACE_SRGB_NONLINEAR_KHR;
+	create_info.imageColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 	create_info.imageExtent = extent;
 	create_info.imageArrayLayers = 1;
 	create_info.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
@@ -1625,16 +1651,16 @@ void MGVK_RecreateSwapChain(
 	res = vkGetPhysicalDeviceSurfacePresentModesKHR(device->physicalDevice, device->surface, &presentModeCount, nullptr);
 	VK_CHECK_RESULT(res);
 	
-	VkPresentModeKHR* presentModes = new VkPresentModeKHR[presentModeCount];
-	res = vkGetPhysicalDeviceSurfacePresentModesKHR(device->physicalDevice, device->surface, &presentModeCount, presentModes);
+	std::vector<VkPresentModeKHR> presentModes(presentModeCount);
+	res = vkGetPhysicalDeviceSurfacePresentModesKHR(device->physicalDevice, device->surface, &presentModeCount, presentModes.data());
 	VK_CHECK_RESULT(res);
 	
 	// Prefer MAILBOX -> IMMEDIATE -> FIFO (FIFO is always supported)
 	device->syncInterval = syncInterval; // 0 is IMMEDIATE, 1 is either MAILBOX or FIFO, 2 is half-Vsync and we currently don't support that on Vulkan.
 	VkPresentModeKHR selectedPresentMode = VK_PRESENT_MODE_FIFO_KHR; // Default, guaranteed to be supported by Vulkan specs.
-	for (uint32_t i = 0; i < presentModeCount; i++)
+	for (const auto& presentMode : presentModes)
 	{
-		// We used to upgrade FIFO to MAILBOX when supported because should be preferred,
+		// We used to upgrade FIFO to MAILBOX when supported because it should be preferred,
 		// but driver support seems to be broken sometimes. Some drivers report MAILBOX
 		// as supported but will actually behave like IMMEDIATE instead.
 		/*
@@ -1648,16 +1674,15 @@ void MGVK_RecreateSwapChain(
 		*/
 		// Vsync is disabled, set IMMEDIATE if supported
 		if (device->syncInterval == 0 &&
-			presentModes[i] == VK_PRESENT_MODE_IMMEDIATE_KHR)
+			presentMode == VK_PRESENT_MODE_IMMEDIATE_KHR)
 		{
 			selectedPresentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
 			break;
 		}
 	}
-	delete[] presentModes;
 	
 	create_info.presentMode = selectedPresentMode;
-	create_info.clipped = true;
+	create_info.clipped = VK_TRUE;
 	//create_info.pNext = &scalingCreateInfo;
 	res = vkCreateSwapchainKHR(device->device, &create_info, nullptr, &device->swapchain);
 	VK_CHECK_RESULT(res);

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -243,6 +243,7 @@ struct MGG_GraphicsDevice
 	VkSurfaceKHR surface = VK_NULL_HANDLE;
 	VkSwapchainKHR swapchain = VK_NULL_HANDLE;
 	uint32_t swapchain_image_index = 0;
+	int syncInterval = 0;
 
 	uint64_t vertexBuffersDirty = 0xFFFFFFFF;
 	MGG_Buffer* vertexBuffers[8] = { 0 };
@@ -1451,7 +1452,8 @@ void MGVK_RecreateSwapChain(
 	mguint width,
 	mguint height,
 	VkFormat vkColor,
-	VkFormat vkDepth)
+	VkFormat vkDepth,
+	mgint syncInterval)
 {
 	assert(device != nullptr);
 	assert(nativeWindowHandle != nullptr);
@@ -1558,20 +1560,30 @@ void MGVK_RecreateSwapChain(
 	VK_CHECK_RESULT(res);
 	
 	// Prefer MAILBOX -> IMMEDIATE -> FIFO (FIFO is always supported)
-	VkPresentModeKHR selectedPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+	device->syncInterval = syncInterval; // 0 is IMMEDIATE, 1 is either MAILBOX or FIFO, 2 is half-Vsync and we currently don't support that on Vulkan.
+	VkPresentModeKHR selectedPresentMode = VK_PRESENT_MODE_FIFO_KHR; // Default, guaranteed to be supported by Vulkan specs.
 	for (uint32_t i = 0; i < presentModeCount; i++)
 	{
-		if (presentModes[i] == VK_PRESENT_MODE_MAILBOX_KHR)
+		// We used to upgrade FIFO to MAILBOX when supported because should be preferred,
+		// but driver support seems to be broken sometimes. Some drivers report MAILBOX
+		// as supported but will actually behave like IMMEDIATE instead.
+		/*
+		if (device->syncInterval > 0 &&
+			presentModes[i] == VK_PRESENT_MODE_MAILBOX_KHR)
 		{
 			selectedPresentMode = VK_PRESENT_MODE_MAILBOX_KHR;
+			fprintf(stderr, "Vsync is upgraded.\n");
 			break;
 		}
-		else if (presentModes[i] == VK_PRESENT_MODE_IMMEDIATE_KHR)
+		*/
+		// Vsync is disabled, set IMMEDIATE if supported
+		if (device->syncInterval == 0 &&
+			presentModes[i] == VK_PRESENT_MODE_IMMEDIATE_KHR)
 		{
 			selectedPresentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
+			break;
 		}
 	}
-	
 	delete[] presentModes;
 	
 	create_info.presentMode = selectedPresentMode;
@@ -1641,7 +1653,8 @@ void MGVK_RecreateSwapChain(MGG_GraphicsDevice* device)
 		device->swapchainWidth,
 		device->swapchainHeight,
 		device->colorFormat,
-		device->depthFormat);
+		device->depthFormat,
+		device->syncInterval);
 
     MGG_GraphicsDevice_SetRenderTargets(device, nullptr, nullptr, 0);
 }
@@ -1652,12 +1665,13 @@ void MGG_GraphicsDevice_ResizeSwapchain(
 	mgint width,
 	mgint height,
 	MGSurfaceFormat color,
-	MGDepthFormat depth)
+	MGDepthFormat depth,
+	mgint syncInterval)
 {
 	auto vkColor = ToVkFormat(color);
 	auto vkDepth = ToVkFormat(depth);
 
-	MGVK_RecreateSwapChain(device, nativeWindowHandle, width, height, vkColor, vkDepth);
+	MGVK_RecreateSwapChain(device, nativeWindowHandle, width, height, vkColor, vkDepth, syncInterval);
 }
 
 

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -116,7 +116,7 @@ struct MGVK_Program;
 
 typedef uint32_t FrameCounter;
 
-const FrameCounter kFreeFrames = 2;
+const FrameCounter kFreeFrames = 3;
 const FrameCounter kConcurrentFrameCount = 2;
 
 
@@ -2688,6 +2688,27 @@ static void MGVK_UpdateRenderPass(MGG_GraphicsDevice* device, FrameCounter curre
 	device->deferredOcclusionQueries.clear();
 }
 
+static const int DefaultPoolSize = 1024;
+
+static void MGVK_FillDescriptorSetCache(MGG_GraphicsDevice* device, MGG_Shader* shader)
+{
+	// Pre-fill the free descriptor sets now.
+	VkDescriptorSetAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
+	alloc_info.descriptorPool = shader->pool;
+	alloc_info.descriptorSetCount = 1;
+	alloc_info.pSetLayouts = &shader->setLayout;
+	for (int i = 0; i < DefaultPoolSize; i++)
+	{
+		MGVK_DescriptorInfo* info = new MGVK_DescriptorInfo;
+		info->frame = 0;
+		shader->freeSets.push(info);
+
+		VkResult res = vkAllocateDescriptorSets(device->device, &alloc_info, &info->set);
+		VK_CHECK_RESULT(res);
+		VK_SET_OBJECT_NAME(device->device, info->set, VK_OBJECT_TYPE_DESCRIPTOR_SET, "MGVK_DescriptorInfo.set (Shader id: %u, index: %d)", shader->id, i);
+	}
+}
+
 static void MGVK_UpdateDescriptors(MGG_GraphicsDevice* device, FrameCounter currentFrame, MGG_Shader* shader, VkDescriptorSet* current, uint32_t* dynamicOffset)
 {
 	// If nothing is dirty then skip the update.
@@ -2729,7 +2750,15 @@ static void MGVK_UpdateDescriptors(MGG_GraphicsDevice* device, FrameCounter curr
 		if (!dirty)
 			break;
 	}
-	//hash = MG_ComputeHash(frame_index);
+	// We hash the frameIndex because each frame in the swap chain has its
+	// own uniforms buffer (device->frames[frameIndex].uniforms) that gets
+	// bound to the descriptor set. If we don't, some frame will use the
+	// wrong buffer if the descriptor is retrieved from the cache (and will
+	// result in flickers/broken rendering).
+	// 
+	// TO DO: refactor the descriptor cache and uniforms buffer handling so
+	// that we don't create twice as much descriptor due to this.
+	hash = MG_ComputeHash(frameIndex, hash);
 
 	// Do we have this same descriptor cached?
 	info = shader->usedSets[hash];
@@ -2737,16 +2766,16 @@ static void MGVK_UpdateDescriptors(MGG_GraphicsDevice* device, FrameCounter curr
 	{
 		// The descriptor wasn't cached... so we need to
 		// create a new one from the free sets.
-		if (shader->freeSets.size() > 0)
+		if (shader->freeSets.size() == 0)
 		{
-			info = shader->freeSets.front();
-			shader->freeSets.pop();
+			// Allocate more cache if empty.
+			MGVK_FillDescriptorSetCache(device, shader);
 		}
-		else
-		{
-			// TODO: We're out of free sets... allocate more?
-			assert(0);
-		}
+
+		assert(shader->freeSets.size() > 0);
+		
+		info = shader->freeSets.front();
+		shader->freeSets.pop();
 
 		// Cache the new or recycled set for later use.
 		shader->usedSets[hash] = info;
@@ -4739,8 +4768,6 @@ void MGG_InputLayout_Destroy(MGG_GraphicsDevice* device, MGG_InputLayout* layout
 	delete layout;
 }
 
-static const int DefaultPoolSize = 1024;
-
 MGG_Shader* MGG_Shader_Create(MGG_GraphicsDevice* device, MGShaderStage stage, mgbyte* bytecode, mgint sizeInBytes)
 {
 	assert(device != nullptr);
@@ -4825,20 +4852,7 @@ MGG_Shader* MGG_Shader_Create(MGG_GraphicsDevice* device, MGShaderStage stage, m
 	}
 
 	// Pre-fill the free descriptor sets now.
-	VkDescriptorSetAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
-	alloc_info.descriptorPool = shader->pool;
-	alloc_info.descriptorSetCount = 1;
-	alloc_info.pSetLayouts = &shader->setLayout;
-	for (int i = 0; i < DefaultPoolSize; i++)
-	{
-		MGVK_DescriptorInfo* info = new MGVK_DescriptorInfo;
-		info->frame = 0;
-		shader->freeSets.push(info);
-
-		res = vkAllocateDescriptorSets(device->device, &alloc_info, &info->set);
-		VK_CHECK_RESULT(res);
-		VK_SET_OBJECT_NAME(device->device, info->set, VK_OBJECT_TYPE_DESCRIPTOR_SET, "MGVK_DescriptorInfo.set (Shader id: %u, index: %d)", shader->id, i);
-	}
+	MGVK_FillDescriptorSetCache(device, shader);
 
 	// Prepare the write descriptor set for updates at runtime.
 	VkWriteDescriptorSet* write = shader->writes = new VkWriteDescriptorSet[layoutBindings.size()];

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1211,25 +1211,12 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 		}
 	}
 
-	int queueCreateInfoCount = 0;
-	VkDeviceQueueCreateInfo* queueCreateInfos = new VkDeviceQueueCreateInfo[queueFamilyCount];
-	memset(queueCreateInfos, 0, sizeof(VkDeviceQueueCreateInfo) * queueFamilyCount);
-
-	for (int i = 0; i < queueFamilyCount; i++)
-	{
-		const VkQueueFamilyProperties* properties = queueFamilyProps + i;
-		float* queuePriorities = new float[properties->queueCount];
-
-		for (int j = 0; j < properties->queueCount; ++j)
-			queuePriorities[j] = 1.0f;
-
-		queueCreateInfos[i].sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-		queueCreateInfos[i].queueFamilyIndex = i;
-		queueCreateInfos[i].queueCount = 1;
-		queueCreateInfos[i].pQueuePriorities = queuePriorities;
-		++queueCreateInfoCount;
-	}
-	assert(queueFamilyCount == queueCreateInfoCount);
+	VkDeviceQueueCreateInfo queueCreateInfo {};
+	queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+	queueCreateInfo.queueFamilyIndex = queueFamilyIndex;
+	queueCreateInfo.queueCount = 1;
+	float priority = 1.0f;
+	queueCreateInfo.pQueuePriorities = &priority;
 
 	// Check if VK_KHR_swapchain and VK_EXT_custom_border_color are supported
 	std::vector<VkExtensionProperties> deviceExtensions;
@@ -1273,8 +1260,8 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 	}
 
 	VkDeviceCreateInfo deviceCreateInfo = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
-	deviceCreateInfo.queueCreateInfoCount = queueCreateInfoCount;
-	deviceCreateInfo.pQueueCreateInfos = queueCreateInfos;
+	deviceCreateInfo.queueCreateInfoCount = 1;
+	deviceCreateInfo.pQueueCreateInfos = &queueCreateInfo;
 	
 	if (!device->customBorderColorSupported)
 	{

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1555,6 +1555,7 @@ void MGVK_RecreateSwapChain(
 		height == device->swapchainHeight &&
 		vkColor == device->colorFormat &&
 		vkDepth == device->depthFormat &&
+		syncInterval == device->syncInterval &&
 		device->swapchain != VK_NULL_HANDLE)
 		return;
 
@@ -1737,6 +1738,15 @@ void MGG_GraphicsDevice_ResizeSwapchain(
 	MGDepthFormat depth,
 	mgint syncInterval)
 {
+	assert(device);
+
+	// Swapchain resize should not happen manually in Vulkan, we should leave this work to
+	// vkQueuePresentKHR() and vkAcquireNextImageKHR() which will react to surface changes.
+	// We should only let this through if the swapchain needs to be created or if syncInterval has changed.
+	if (device->swapchain != VK_NULL_HANDLE &&
+		device->syncInterval == syncInterval)
+		return;
+
 	auto vkColor = ToVkFormat(color);
 	auto vkDepth = ToVkFormat(depth);
 
@@ -1800,7 +1810,10 @@ mgint MGG_GraphicsDevice_BeginFrame(MGG_GraphicsDevice* device)
 
 	// If the swapchain is null, it probably means that the window is minimized and we must attempt to check if it has been restored.
 	if (device->swapchain == VK_NULL_HANDLE)
+	{
+		printf("Swapchain was null before acquiring a frame. This shouldn't happen.\n");
 		MGVK_RecreateSwapChain(device);
+	}
 
 	VkResult res;
 
@@ -2108,8 +2121,15 @@ void MGG_GraphicsDevice_Present(MGG_GraphicsDevice* device, mgint currentFrame, 
 	presentInfo.pImageIndices = &device->swapchain_image_index;
 
 	res = vkQueuePresentKHR(device->queue, &presentInfo);
-	if (res == VK_ERROR_OUT_OF_DATE_KHR) // This will happen if the window is minimized.
+	if (res == VK_ERROR_OUT_OF_DATE_KHR || // This will happen if the window is minimized.
+		res == VK_SUBOPTIMAL_KHR)
+	{
+		if (res == VK_SUBOPTIMAL_KHR)
+			printf("Swapchain suboptimal. Recreating swapchain...\n");
+		else
+			printf("Swapchain out of date. Recreating swapchain...\n");
 		MGVK_RecreateSwapChain(device);
+	}
 	else
 	{
 		VK_CHECK_RESULT(res);

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1559,8 +1559,8 @@ void MGVK_RecreateSwapChain(
 	device->colorFormat = vkColor;
 	device->depthFormat = vkDepth;
 
-	VkSurfaceCapabilitiesKHR surface_capabilities;
 	{
+		VkSurfaceCapabilitiesKHR surface_capabilities;
 		res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device->physicalDevice, device->surface, &surface_capabilities);
 		VK_CHECK_RESULT(res);
 
@@ -1602,12 +1602,7 @@ void MGVK_RecreateSwapChain(
 
 	VkSwapchainCreateInfoKHR create_info = { VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR };
 	create_info.surface = device->surface;
-	// Use the maximum of our desired count and the surface's minimum requirement
-	create_info.minImageCount = (surface_capabilities.minImageCount > kConcurrentFrameCount) ? 
-								surface_capabilities.minImageCount : kConcurrentFrameCount;
-	// Cap at maxImageCount if it's not zero (zero means no limit)
-	if (surface_capabilities.maxImageCount > 0 && create_info.minImageCount > surface_capabilities.maxImageCount)
-		create_info.minImageCount = surface_capabilities.maxImageCount;
+	create_info.minImageCount = kConcurrentFrameCount;
 	create_info.imageFormat = device->colorFormat;
 	create_info.imageColorSpace = VK_COLORSPACE_SRGB_NONLINEAR_KHR;
 	create_info.imageExtent = extent;
@@ -1658,10 +1653,7 @@ void MGVK_RecreateSwapChain(
 	res = vkGetSwapchainImagesKHR(device->device, device->swapchain, &swapchainCount, swapchainImages);
 	VK_CHECK_RESULT(res);
 
-	// Store swapchain images, but only create frame textures for the ones we'll use
-	uint32_t framesToCreate = (swapchainCount < kConcurrentFrameCount) ? swapchainCount : kConcurrentFrameCount;
-
-	for (uint32_t i = 0; i < framesToCreate; ++i)
+	for (uint32_t i = 0; i < swapchainCount; ++i)
 	{
 		VkImageCreateInfo image_create_info = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
 		image_create_info.imageType = VK_IMAGE_TYPE_2D;

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1448,8 +1448,8 @@ void MGG_GraphicsDevice_GetCaps(MGG_GraphicsDevice* device, MGG_GraphicsDevice_C
 void MGVK_RecreateSwapChain(
 	MGG_GraphicsDevice* device,
 	void* nativeWindowHandle,
-	mgint width,
-	mgint height,
+	mguint width,
+	mguint height,
 	VkFormat vkColor,
 	VkFormat vkDepth)
 {
@@ -1489,16 +1489,21 @@ void MGVK_RecreateSwapChain(
 
 	cleanupSwapChain(device);
 
-	device->swapchainWidth = width;
-	device->swapchainHeight = height;
+	VkSurfaceCapabilitiesKHR surface_capabilities;
+	res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device->physicalDevice, device->surface, &surface_capabilities);
+	VK_CHECK_RESULT(res);
+
+	// If max extent is zero'd, it means the window is minimized, and we should leave the swapchain to VK_NULL_HANDLE and stop rendering (this is done in MGP_Platform_BeforeDraw()).
+	if (surface_capabilities.maxImageExtent.width == 0 || surface_capabilities.maxImageExtent.height == 0)
+		return;
+
+	// We apply the extent range to the entire swapchain size to avoid surface scaling and errors.
+	device->swapchainWidth = std::clamp(width, surface_capabilities.minImageExtent.width, surface_capabilities.maxImageExtent.width);
+	device->swapchainHeight = std::clamp(height, surface_capabilities.minImageExtent.height, surface_capabilities.maxImageExtent.height);
 	device->colorFormat = vkColor;
 	device->depthFormat = vkDepth;
 
 	{
-		VkSurfaceCapabilitiesKHR surface_capabilities;
-		res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device->physicalDevice, device->surface, &surface_capabilities);
-		VK_CHECK_RESULT(res);
-
 		VkFormat surface_format = VK_FORMAT_UNDEFINED;
 		uint32_t format_count = 0;
 		res = vkGetPhysicalDeviceSurfaceFormatsKHR(device->physicalDevice, device->surface, &format_count, nullptr);
@@ -1511,10 +1516,6 @@ void MGVK_RecreateSwapChain(
 		surface_format = surfFormats[0].format;
 		if ((1 == format_count) && (VK_FORMAT_UNDEFINED == surfFormats[0].format))
 			surface_format = VK_FORMAT_B8G8R8A8_UNORM;
-
-		VkSurfaceCapabilitiesKHR surface_caps;
-		res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device->physicalDevice, device->surface, &surface_caps);
-		VK_CHECK_RESULT(res);
 
 		device->colorFormat = surface_format;
 
@@ -1714,6 +1715,10 @@ mgint MGG_GraphicsDevice_BeginFrame(MGG_GraphicsDevice* device)
 {
 	assert(device != nullptr);
 
+	// If the swapchain is null, it probably means that the window is minimized and we must attempt to check if it has been restored.
+	if (device->swapchain == VK_NULL_HANDLE)
+		MGVK_RecreateSwapChain(device);
+
 	VkResult res;
 
 	const FrameCounter currentFrame = device->frame;
@@ -1728,10 +1733,13 @@ mgint MGG_GraphicsDevice_BeginFrame(MGG_GraphicsDevice* device)
 	res = vkResetFences(device->device, 1, &cmd.completedFence);
 	VK_CHECK_RESULT(res);
 
-	device->swapchain_image_index = 0;
-	res = vkAcquireNextImageKHR(device->device, device->swapchain, UINT64_MAX,
-		cmd.imageAcquiredSemaphore, VK_NULL_HANDLE, &device->swapchain_image_index);
-	VK_CHECK_RESULT(res);
+	if (device->swapchain != VK_NULL_HANDLE)
+	{
+		device->swapchain_image_index = 0;
+		res = vkAcquireNextImageKHR(device->device, device->swapchain, UINT64_MAX,
+			cmd.imageAcquiredSemaphore, VK_NULL_HANDLE, &device->swapchain_image_index);
+		VK_CHECK_RESULT(res);
+	}
 
 	frame.uniformOffset = 0;
 	if (frame.uniforms == NULL)
@@ -2017,7 +2025,7 @@ void MGG_GraphicsDevice_Present(MGG_GraphicsDevice* device, mgint currentFrame, 
 	presentInfo.pImageIndices = &device->swapchain_image_index;
 
 	res = vkQueuePresentKHR(device->queue, &presentInfo);
-	if (res == VK_ERROR_OUT_OF_DATE_KHR)
+	if (res == VK_ERROR_OUT_OF_DATE_KHR) // This will happen if the window is minimized.
 		MGVK_RecreateSwapChain(device);
 	else
 	{


### PR DESCRIPTION
This PR has several fixes to DesktopVK:
- fixes rendering glitches related to the descriptor cache not working
- fixes possible issues with gamepad stick events
- fixes Vsync support (I've also disabled ```MAILBOX``` mode promotion, as I found that some drivers give false-positives about this mode: they tell you that it's supported, but won't work)
- fixes a crash when minimizing the window on Windows
- fixes exclusive-fullscreen support, changing resolution while in exclusive-fullscreen, restoring window size when going out of exclusive-fullscreen, and a unit test about resizing events
- fixes/better extension compatibility
- reverted ```minImageCount``` as it didn't fix the issue properly, see #9000 
- upgraded SDL to 2.32.10
- some light clean up and compatibility tweaks



