### PR TITLE
Add basic FAudio support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "external/CppNet"]
 	path = external/CppNet
 	url = https://github.com/MonoGame/CppNet.git
+[submodule "native/monogame/external/faudio"]
+	path = native/monogame/external/faudio
+	url = https://github.com/FNA-XNA/FAudio.git

--- a/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
+++ b/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
@@ -1,4 +1,3 @@
-
 namespace BuildScripts;
 
 [TaskName("Build Native Dependencies")]
@@ -6,108 +5,108 @@ public sealed class BuildNativeDependenciesTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
     {
+        BuildSDL2(context);
+        BuildFAudio(context);
+    }
+
+    private void BuildSDL2(BuildContext context)
+    {
         var sdlSourceDir = "native/monogame/external/sdl2/sdl";
         var sdlBuildDir = System.IO.Path.Combine(sdlSourceDir, "build");
 
-        if (context.DirectoryExists(sdlBuildDir))
-        {
-            context.DeleteDirectory(sdlBuildDir, new DeleteDirectorySettings { Recursive = true });
-        }
-        context.CreateDirectory(sdlBuildDir);
+        RecreateDirectory(context, sdlBuildDir);
 
-        var configureSettings = new ProcessSettings { WorkingDirectory = sdlBuildDir };
-        var configureArgs = new ProcessArgumentBuilder();
-        // Add the relative path to the source directory.
-        configureArgs.Append("../");
-        configureArgs.Append("-DSDL_STATIC=ON -DSDL_TEST=OFF");
+        var configureArgs = new ProcessArgumentBuilder()
+            .Append("-S").AppendQuoted(context.MakeAbsolute(new DirectoryPath(sdlSourceDir)).FullPath)
+            .Append("-B").AppendQuoted(context.MakeAbsolute(new DirectoryPath(sdlBuildDir)).FullPath)
+            .Append("-DSDL_STATIC=ON")
+            .Append("-DSDL_TEST=OFF");
 
-        // Append platform-specific CMake arguments.
-        switch (context.Environment.Platform.Family)
-        {
-            case PlatformFamily.Windows:
-                configureArgs.Append("-A x64");
-                configureArgs.Append("-D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded");
-                break;
-            case PlatformFamily.Linux:
-                configureArgs.Append("-D CMAKE_POSITION_INDEPENDENT_CODE=ON");
-                break;
-            case PlatformFamily.OSX:
-                configureArgs.Append("-D CMAKE_OSX_ARCHITECTURES=\"x86_64;arm64\"");
-                configureArgs.Append("-D CMAKE_OSX_DEPLOYMENT_TARGET=10.15");
-                break;
-        }
+        AppendPlatformCMakeArgs(configureArgs, context, isSDL: true);
 
-        configureSettings.Arguments = configureArgs;
+        RunCMake(context, configureArgs, "SDL2 CMake configuration failed!");
 
-        if (context.StartProcess("cmake", configureSettings) != 0)
-        {
-            throw new Exception("SDL2 CMake configuration failed!");
-        }
+        RunCMakeBuild(context, sdlBuildDir, "Release", "SDL2 build failed!");
+    }
 
-        var buildSettings = new ProcessSettings { WorkingDirectory = sdlBuildDir };
-        var buildArgs = new ProcessArgumentBuilder();
-        buildArgs.Append("--build .");
-        buildArgs.Append("--config Release");
-        buildArgs.Append("--parallel");
-
-        buildSettings.Arguments = buildArgs;
-
-        if (context.StartProcess("cmake", buildSettings) != 0)
-        {
-            throw new Exception("SDL2 build failed!");
-        }
-
-
+    private void BuildFAudio(BuildContext context)
+    {
         var faudioSourceDir = "native/monogame/external/faudio";
         var faudioBuildDir = System.IO.Path.Combine(faudioSourceDir, "build");
-        if (context.DirectoryExists(faudioBuildDir))
-        {
-            context.DeleteDirectory(faudioBuildDir, new DeleteDirectorySettings { Recursive = true });
-        }
 
+        RecreateDirectory(context, faudioBuildDir);
 
-        DirectoryPath sdlIncludeDir = System.IO.Path.Combine(sdlSourceDir, "include");
+        var sdlIncludeDir = System.IO.Path.Combine("native/monogame/external/sdl2/sdl", "include");
 
-        context.CreateDirectory(faudioBuildDir);
-        var faudioConfigureSettings = new ProcessSettings { WorkingDirectory = faudioBuildDir };
-        var faudioConfigureArgs = new ProcessArgumentBuilder();
-        faudioConfigureArgs.Append("../");
-        faudioConfigureArgs.Append("-DBUILD_SHARED_LIBS=OFF");
-        faudioConfigureArgs.Append($"-DCMAKE_C_FLAGS=\"/I{context.MakeAbsolute(sdlIncludeDir)}\"");
-        faudioConfigureArgs.Append($"-DCMAKE_CXX_FLAGS=\"/I{context.MakeAbsolute(sdlIncludeDir)}\"");
-        faudioConfigureArgs.Append("-DBUILD_SDL3=OFF");
+        var configureArgs = new ProcessArgumentBuilder()
+            .Append("-S").AppendQuoted(context.MakeAbsolute(new DirectoryPath(faudioSourceDir)).FullPath)
+            .Append("-B").AppendQuoted(context.MakeAbsolute(new DirectoryPath(faudioBuildDir)).FullPath)
+            .Append("-DBUILD_SHARED_LIBS=OFF")
+            .Append($"-DCMAKE_C_STANDARD_INCLUDE_DIRECTORIES={context.MakeAbsolute(new DirectoryPath(sdlIncludeDir))}")
+            .Append($"-DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES={context.MakeAbsolute(new DirectoryPath(sdlIncludeDir))}")
+            .Append("-DBUILD_SDL3=OFF");
 
-        // Append platform-specific CMake arguments.
+        AppendPlatformCMakeArgs(configureArgs, context, isSDL: false);
+
+        RunCMake(context, configureArgs, "FAudio CMake configuration failed!");
+
+        RunCMakeBuild(context, faudioBuildDir, "Release", "FAudio build failed!");
+    }
+
+    private void AppendPlatformCMakeArgs(ProcessArgumentBuilder args, BuildContext context, bool isSDL)
+    {
         switch (context.Environment.Platform.Family)
         {
             case PlatformFamily.Windows:
-                faudioConfigureArgs.Append("-A x64");
-                faudioConfigureArgs.Append("-D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded");
+                args.Append("-A").Append("x64");
+                if (isSDL)
+                {
+                    args.Append("-DSDL_FORCE_STATIC_VCRT=ON");
+                }
+                else
+                {
+                    args.Append("-DCMAKE_C_FLAGS_DEBUG=\"/MTd /Zi /Ob0 /Od /RTC1\"");
+                    args.Append("-DCMAKE_C_FLAGS_RELEASE=\"/MT /O2 /Ob2 /DNDEBUG\"");
+                }
                 break;
+
             case PlatformFamily.Linux:
-                faudioConfigureArgs.Append("-D CMAKE_POSITION_INDEPENDENT_CODE=ON");
+                args.Append("-DCMAKE_POSITION_INDEPENDENT_CODE=ON");
                 break;
+
             case PlatformFamily.OSX:
-                faudioConfigureArgs.Append("-D CMAKE_OSX_ARCHITECTURES=\"x86_64;arm64\"");
-                faudioConfigureArgs.Append("-D CMAKE_OSX_DEPLOYMENT_TARGET=10.15");
+                args.Append("-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64");
+                args.Append("-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15");
                 break;
         }
-        faudioConfigureSettings.Arguments = faudioConfigureArgs;
+    }
 
-        if (context.StartProcess("cmake", faudioConfigureSettings) != 0)
+    private void RunCMake(BuildContext context, ProcessArgumentBuilder args, string errorMessage)
+    {
+        var settings = new ProcessSettings { Arguments = args };
+        if (context.StartProcess("cmake", settings) != 0)
         {
-            throw new Exception("FAudio CMake configuration failed!");
+            throw new Exception(errorMessage);
         }
-        var faudioBuildSettings = new ProcessSettings { WorkingDirectory = faudioBuildDir };
-        var faudioBuildArgs = new ProcessArgumentBuilder();
-        faudioBuildArgs.Append("--build .");
-        faudioBuildArgs.Append("--config Release");
-        faudioBuildArgs.Append("--parallel");
-        faudioBuildSettings.Arguments = faudioBuildArgs;
+    }
 
-        if (context.StartProcess("cmake", faudioBuildSettings) != 0)
+    private void RunCMakeBuild(BuildContext context, string buildDir, string config, string errorMessage)
+    {
+        var buildArgs = new ProcessArgumentBuilder()
+            .Append("--build")
+            .AppendQuoted(context.MakeAbsolute(new DirectoryPath(buildDir)).FullPath)
+            .Append("--config").Append(config)
+            .Append("--parallel");
+
+        RunCMake(context, buildArgs, errorMessage);
+    }
+
+    private void RecreateDirectory(BuildContext context, string dir)
+    {
+        if (context.DirectoryExists(dir))
         {
-            throw new Exception("FAudio build failed!");
+            context.DeleteDirectory(dir, new DeleteDirectorySettings { Recursive = true });
         }
+        context.CreateDirectory(dir);
     }
 }

--- a/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
+++ b/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
@@ -38,7 +38,7 @@ public sealed class BuildNativeDependenciesTask : FrostingTask<BuildContext>
         }
 
         configureSettings.Arguments = configureArgs;
-        
+
         if (context.StartProcess("cmake", configureSettings) != 0)
         {
             throw new Exception("SDL2 CMake configuration failed!");
@@ -51,10 +51,63 @@ public sealed class BuildNativeDependenciesTask : FrostingTask<BuildContext>
         buildArgs.Append("--parallel");
 
         buildSettings.Arguments = buildArgs;
-        
+
         if (context.StartProcess("cmake", buildSettings) != 0)
         {
             throw new Exception("SDL2 build failed!");
+        }
+
+
+        var faudioSourceDir = "native/monogame/external/faudio";
+        var faudioBuildDir = System.IO.Path.Combine(faudioSourceDir, "build");
+        if (context.DirectoryExists(faudioBuildDir))
+        {
+            context.DeleteDirectory(faudioBuildDir, new DeleteDirectorySettings { Recursive = true });
+        }
+
+
+        DirectoryPath sdlIncludeDir = System.IO.Path.Combine(sdlSourceDir, "include");
+
+        context.CreateDirectory(faudioBuildDir);
+        var faudioConfigureSettings = new ProcessSettings { WorkingDirectory = faudioBuildDir };
+        var faudioConfigureArgs = new ProcessArgumentBuilder();
+        faudioConfigureArgs.Append("../");
+        faudioConfigureArgs.Append("-DBUILD_SHARED_LIBS=OFF");
+        faudioConfigureArgs.Append($"-DCMAKE_C_FLAGS=\"/I{context.MakeAbsolute(sdlIncludeDir)}\"");
+        faudioConfigureArgs.Append($"-DCMAKE_CXX_FLAGS=\"/I{context.MakeAbsolute(sdlIncludeDir)}\"");
+        faudioConfigureArgs.Append("-DBUILD_SDL3=OFF");
+
+        // Append platform-specific CMake arguments.
+        switch (context.Environment.Platform.Family)
+        {
+            case PlatformFamily.Windows:
+                faudioConfigureArgs.Append("-A x64");
+                faudioConfigureArgs.Append("-D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded");
+                break;
+            case PlatformFamily.Linux:
+                faudioConfigureArgs.Append("-D CMAKE_POSITION_INDEPENDENT_CODE=ON");
+                break;
+            case PlatformFamily.OSX:
+                faudioConfigureArgs.Append("-D CMAKE_OSX_ARCHITECTURES=\"x86_64;arm64\"");
+                faudioConfigureArgs.Append("-D CMAKE_OSX_DEPLOYMENT_TARGET=10.15");
+                break;
+        }
+        faudioConfigureSettings.Arguments = faudioConfigureArgs;
+
+        if (context.StartProcess("cmake", faudioConfigureSettings) != 0)
+        {
+            throw new Exception("FAudio CMake configuration failed!");
+        }
+        var faudioBuildSettings = new ProcessSettings { WorkingDirectory = faudioBuildDir };
+        var faudioBuildArgs = new ProcessArgumentBuilder();
+        faudioBuildArgs.Append("--build .");
+        faudioBuildArgs.Append("--config Release");
+        faudioBuildArgs.Append("--parallel");
+        faudioBuildSettings.Arguments = faudioBuildArgs;
+
+        if (context.StartProcess("cmake", faudioBuildSettings) != 0)
+        {
+            throw new Exception("FAudio build failed!");
         }
     }
 }

--- a/native/monogame/common/mg_audio.cpp
+++ b/native/monogame/common/mg_audio.cpp
@@ -1,0 +1,31 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+float* MGA_Voice_CalculatePanMatrix(float pan, float scale, float* matrix, int srcChannels)
+{
+	if (srcChannels == 1)
+	{
+		matrix[0] = (pan >= 0 ? (1.f - pan) : 1.f) * scale; // Left
+		matrix[1] = (pan <= 0 ? (-pan - 1.f) : 1.f) * scale; // Right
+	}
+	else if (srcChannels == 2)
+	{
+		if (-1.0f <= pan && pan <= 0.0f)
+		{
+			matrix[0] = (0.5f * pan + 1.0f) * scale;	// .5 when pan is -1, 1 when pan is 0
+			matrix[1] = (0.5f * -pan) * scale;			// .5 when pan is -1, 0 when pan is 0
+			matrix[2] = 0.0f;							//  0 when pan is -1, 0 when pan is 0
+			matrix[3] = (pan + 1.0f) * scale;			//  0 when pan is -1, 1 when pan is 0
+		}
+		else
+		{
+			matrix[0] = (-pan + 1.0f) * scale;			//  1 when pan is 0,   0 when pan is 1
+			matrix[1] = 0.0f;							//  0 when pan is 0,   0 when pan is 1
+			matrix[2] = (0.5f * pan) * scale;			//  0 when pan is 0, .5f when pan is 1
+			matrix[3] = (0.5f * -pan + 1.0f) * scale;	//  1 when pan is 0. .5f when pan is 1
+		}
+	}
+
+	return matrix;
+}

--- a/native/monogame/faudio/MGA_faudio.cpp
+++ b/native/monogame/faudio/MGA_faudio.cpp
@@ -72,7 +72,7 @@ MGA_System* MGA_System_Create()
 	}
 
 	// Create reverb effect
-	uint32_t result2 = FAudioCreateReverb(&system->reverbEffect, 0);
+	result = FAudioCreateReverb(&system->reverbEffect, 0);
 	if (result != 0)
 	{
 		FAudioVoice_DestroyVoice(system->masteringVoice);
@@ -214,11 +214,18 @@ void MGA_Buffer_InitializeFormat(MGA_Buffer* buffer, mgbyte* waveHeader, mgbyte*
 	assert(waveData != nullptr);
 	assert(length > 0);
 
-	// !TODO: Parse wave header and initialize format
-	// For now, copy the data
+	auto wformat = (FAudioWaveFormatEx*)waveHeader;
+
+	// Copy format
+	buffer->format = *wformat;
+
+	// Copy audio data
 	buffer->data = new mgbyte[length];
 	memcpy(buffer->data, waveData, length);
 	buffer->size = length;
+
+	// Calculate duration
+	buffer->duration = (mgulong)((length * 1000) / buffer->format.nAvgBytesPerSec);
 }
 
 void MGA_Buffer_InitializePCM(MGA_Buffer* buffer, mgbyte* waveData, mgint offset, mgint length, mgint sampleBits, mgint sampleRate, mgint channels, mgint loopStart, mgint loopLength)

--- a/native/monogame/faudio/MGA_faudio.cpp
+++ b/native/monogame/faudio/MGA_faudio.cpp
@@ -7,24 +7,71 @@
 #include "mg_common.h"
 
 
-// TODO: Implement against the C++ API for FAudio.
+#include "FAudio.h"
+#include "FAudioFX.h"
+#include "F3DAudio.h"
 
 struct MGA_System
 {
+	FAudio* faudio = nullptr;
+	FAudioMasteringVoice* masteringVoice = nullptr;
+	FAudioSubmixVoice* reverbVoice = nullptr;
+	F3DAUDIO_HANDLE f3daudio;
 };
 
 struct MGA_Buffer
 {
+	FAudioWaveFormatEx format;
+	mgbyte* data = nullptr;
+	mguint size = 0;
+	mgulong duration = 0;
 };
 
 struct MGA_Voice
 {
+	FAudioSourceVoice* sourceVoice;
+	MGA_System* system;
+	MGSoundState state = MGSoundState::Stopped;
+	mgfloat volume = 1.0f;
+	mgfloat pitch = 0.0f;
+	mgfloat pan = 0.0f;
+	mgfloat reverbMix = 0.0f;
 };
 
 
 MGA_System* MGA_System_Create()
 {
+	// Create FAudio instance
 	auto system = new MGA_System();
+	uint32_t result = FAudioCreate(&system->faudio, 0, FAUDIO_DEFAULT_PROCESSOR);
+	if (result != 0)
+	{
+		delete system;
+		return nullptr;
+	}
+
+	// Create mastering voice
+	result = FAudio_CreateMasteringVoice(
+		system->faudio,
+		&system->masteringVoice,
+		FAUDIO_DEFAULT_CHANNELS,
+		FAUDIO_DEFAULT_SAMPLERATE,
+		0,
+		0,
+		nullptr
+	);
+	if (result != 0)
+	{
+		FAudio_Release(system->faudio);
+		delete system;
+		return nullptr;
+	}
+
+	// !TODO : Create reverb effect and submix voice
+
+	// Initialize F3DAudio
+	F3DAudioInitialize(SPEAKER_STEREO, 343.0f, system->f3daudio);
+
 	return system;
 }
 
@@ -32,9 +79,16 @@ void MGA_System_Destroy(MGA_System* system)
 {
 	assert(system != nullptr);
 
-	// TODO: We're assuming here the C# side is cleaning up
-	// buffers/voices, but if we want this to be a good C++
-	// API as well, we likely should cleanup ourselves too.
+	// !TODO : Destroy reverb effect and submix voice
+
+	if (system->masteringVoice)
+	{
+		FAudioVoice_DestroyVoice(system->masteringVoice);
+	}
+	if (system->faudio)
+	{
+		FAudio_Release(system->faudio);
+	}
 
 	delete system;
 }
@@ -59,6 +113,10 @@ MGA_Buffer* MGA_Buffer_Create(MGA_System* system)
 void MGA_Buffer_Destroy(MGA_Buffer* buffer)
 {
 	assert(buffer != nullptr);
+	if (buffer->data)
+	{
+		delete[] buffer->data;
+	}
 	delete buffer;
 }
 
@@ -68,6 +126,12 @@ void MGA_Buffer_InitializeFormat(MGA_Buffer* buffer, mgbyte* waveHeader, mgbyte*
 	assert(waveHeader != nullptr);
 	assert(waveData != nullptr);
 	assert(length > 0);
+
+	// !TODO: Parse wave header and initialize format
+	// For now, copy the data
+	buffer->data = new mgbyte[length];
+	memcpy(buffer->data, waveData, length);
+	buffer->size = length;
 }
 
 void MGA_Buffer_InitializePCM(MGA_Buffer* buffer, mgbyte* waveData, mgint offset, mgint length, mgint sampleBits, mgint sampleRate, mgint channels, mgint loopStart, mgint loopLength)
@@ -76,6 +140,23 @@ void MGA_Buffer_InitializePCM(MGA_Buffer* buffer, mgbyte* waveData, mgint offset
 	assert(waveData != nullptr);
 	assert(offset >=0);
 	assert(length > 0);
+
+	// Initialize PCM format
+	buffer->format.wFormatTag = 1; // WAVE_FORMAT_PCM
+	buffer->format.nChannels = channels;
+	buffer->format.nSamplesPerSec = sampleRate;
+	buffer->format.nAvgBytesPerSec = sampleRate * channels * (sampleBits / 8);
+	buffer->format.nBlockAlign = channels * (sampleBits / 8);
+	buffer->format.wBitsPerSample = sampleBits;
+	buffer->format.cbSize = 0;
+
+	// Copy audio data
+	buffer->data = new mgbyte[length];
+	memcpy(buffer->data, waveData + offset, length);
+	buffer->size = length;
+
+	// Calculate duration
+	buffer->duration = (mgulong)((length * 1000) / buffer->format.nAvgBytesPerSec);
 }
 
 void MGA_Buffer_InitializeXact(MGA_Buffer* buffer, mguint codec, mgbyte* waveData, mgint length, mgint sampleRate, mgint blockAlignment, mgint channels, mgint loopStart, mgint loopLength)
@@ -83,31 +164,88 @@ void MGA_Buffer_InitializeXact(MGA_Buffer* buffer, mguint codec, mgbyte* waveDat
 	assert(buffer != nullptr);
 	assert(waveData != nullptr);
 	assert(length > 0);
+
+	// Initialize XACT format
+	buffer->format.wFormatTag = codec;
+	buffer->format.nChannels = channels;
+	buffer->format.nSamplesPerSec = sampleRate;
+	buffer->format.nAvgBytesPerSec = sampleRate * blockAlignment;
+	buffer->format.nBlockAlign = blockAlignment;
+	buffer->format.wBitsPerSample = 0; // Variable for compressed formats
+	buffer->format.cbSize = 0;
+
+	// Copy audio data
+	buffer->data = new mgbyte[length];
+	memcpy(buffer->data, waveData, length);
+	buffer->size = length;
+
+	// Calculate duration (approximate for compressed formats)
+	if (codec == 0x166) // WMA
+	{
+		buffer->duration = (mgulong)((length * 1000) / (sampleRate * channels * 2));
+	}
+	else
+	{
+		buffer->duration = (mgulong)((length * 1000) / buffer->format.nAvgBytesPerSec);
+	}
 }
 
 mgulong MGA_Buffer_GetDuration(MGA_Buffer* buffer)
 {
 	assert(buffer != nullptr);
-	return 0;
+	return buffer->duration;
 }
 
 MGA_Voice* MGA_Voice_Create(MGA_System* system, mgint sampleRate, mgint channels)
 {
 	assert(system != nullptr);
 	auto voice = new MGA_Voice();
+
+	voice->system = system;
+	// Create source voice
+	FAudioWaveFormatEx format;
+	format.wFormatTag = 1; // WAVE_FORMAT_PCM
+	format.nChannels = channels;
+	format.nSamplesPerSec = sampleRate;
+	format.nAvgBytesPerSec = sampleRate * channels * 2; // 16-bit
+	format.nBlockAlign = channels * 2;
+	format.wBitsPerSample = 16;
+	format.cbSize = 0;
+	uint32_t result = FAudio_CreateSourceVoice(
+		system->faudio,
+		&voice->sourceVoice,
+		&format,
+		0,
+		FAUDIO_DEFAULT_FREQ_RATIO,
+		nullptr,
+		nullptr,
+		nullptr
+	);
+	if (result != 0)
+	{
+		delete voice;
+		return nullptr;
+	}
+
 	return voice;
 }
 
 void MGA_Voice_Destroy(MGA_Voice* voice)
 {
 	assert(voice != nullptr);
+	if (voice->sourceVoice)
+	{
+		FAudioVoice_DestroyVoice(voice->sourceVoice);
+	}
 	delete voice;
 }
 
 mgint MGA_Voice_GetBufferCount(MGA_Voice* voice)
 {
 	assert(voice != nullptr);
-	return 0;
+	FAudioVoiceState state;
+	FAudioSourceVoice_GetState(voice->sourceVoice, &state, 0);
+	return state.BuffersQueued;
 }
 
 void MGA_Voice_SetBuffer(MGA_Voice* voice, MGA_Buffer* buffer)
@@ -115,11 +253,22 @@ void MGA_Voice_SetBuffer(MGA_Voice* voice, MGA_Buffer* buffer)
 	assert(voice != nullptr);
 
 	// Stop and remove any pending buffers first.
+	FAudioSourceVoice_Stop(voice->sourceVoice, 0, FAUDIO_COMMIT_NOW);
+	FAudioSourceVoice_FlushSourceBuffers(voice->sourceVoice);
 
 	// Append a buffer if we got one.
 	if (buffer)
 	{
-
+		FAudioBuffer audioBuffer = {};
+		audioBuffer.AudioBytes = buffer->size;
+		audioBuffer.pAudioData = buffer->data;
+		audioBuffer.PlayBegin = 0;
+		audioBuffer.PlayLength = 0;
+		audioBuffer.LoopBegin = 0;
+		audioBuffer.LoopLength = 0;
+		audioBuffer.LoopCount = 0;
+		audioBuffer.pContext = nullptr;
+		FAudioSourceVoice_SubmitSourceBuffer(voice->sourceVoice, &audioBuffer, nullptr);
 	}
 }
 
@@ -134,72 +283,272 @@ void MGA_Voice_AppendBuffer(MGA_Voice* voice, mgbyte* buffer, mguint size)
 		
 	// Allocate a dynamic buffer that can be reused later.	
 	// Append the buffer.
+	FAudioBuffer audioBuffer = {};
+	audioBuffer.AudioBytes = size;
+	audioBuffer.pAudioData = buffer;
+	audioBuffer.PlayBegin = 0;
+	audioBuffer.PlayLength = 0;
+	audioBuffer.LoopBegin = 0;
+	audioBuffer.LoopLength = 0;
+	audioBuffer.LoopCount = 0;
+	audioBuffer.pContext = nullptr;
+	FAudioSourceVoice_SubmitSourceBuffer(voice->sourceVoice, &audioBuffer, nullptr);
 }
 
 void MGA_Voice_Play(MGA_Voice* voice, mgbyte looped)
 {
 	assert(voice != nullptr);
+
+	FAudioSourceVoice_Start(voice->sourceVoice, 0, FAUDIO_COMMIT_NOW);
+	voice->state = MGSoundState::Playing;
 }
 
 void MGA_Voice_Pause(MGA_Voice* voice)
 {
 	assert(voice != nullptr);
+
+	FAudioSourceVoice_Stop(voice->sourceVoice, 0, FAUDIO_COMMIT_NOW);
+	voice->state = MGSoundState::Paused;
 }
 
 void MGA_Voice_Resume(MGA_Voice* voice)
 {
 	assert(voice != nullptr);
+
+	FAudioSourceVoice_Start(voice->sourceVoice, 0, FAUDIO_COMMIT_NOW);
+	voice->state = MGSoundState::Playing;
 }
 
 void MGA_Voice_Stop(MGA_Voice* voice, mgbyte immediate)
 {
 	assert(voice != nullptr);
+
+	FAudioSourceVoice_Stop(voice->sourceVoice, immediate ? FAUDIO_PLAY_TAILS : 0, FAUDIO_COMMIT_NOW);
+	FAudioSourceVoice_FlushSourceBuffers(voice->sourceVoice);
+	voice->state = MGSoundState::Stopped;
 }
 
 MGSoundState MGA_Voice_GetState(MGA_Voice* voice)
 {
 	assert(voice != nullptr);
-	return MGSoundState::Stopped;
+	return voice->state;
 }
 
 mgulong MGA_Voice_GetPosition(MGA_Voice* voice)
 {
 	assert(voice != nullptr);
-	return 0;
+
+	FAudioVoiceState state;
+	FAudioSourceVoice_GetState(voice->sourceVoice, &state, 0);
+	return state.SamplesPlayed;
 }
 
 void MGA_Voice_SetPan(MGA_Voice* voice, mgfloat pan)
 {
 	assert(voice != nullptr);
+	// !TODO: Implement output matrix update
 }
 
 void MGA_Voice_SetPitch(MGA_Voice* voice, mgfloat pitch)
 {
 	assert(voice != nullptr);
+
+	voice->pitch = pitch;
+	FAudioSourceVoice_SetFrequencyRatio(voice->sourceVoice, powf(2.0f, pitch), FAUDIO_COMMIT_NOW);
 }
 
 void MGA_Voice_SetVolume(MGA_Voice* voice, mgfloat volume)
 {
 	assert(voice != nullptr);
+
+	voice->volume = volume;
+	FAudioVoice_SetVolume(voice->sourceVoice, volume, FAUDIO_COMMIT_NOW);
 }
 
 void MGA_Voice_SetReverbMix(MGA_Voice* voice, mgfloat mix)
 {
 	assert(voice != nullptr);
+
+	if (mix < 0)
+		voice->reverbMix = 0.0f;
+	else if (mix > 2.0f)
+		voice->reverbMix = 2.0f;
+	else
+		voice->reverbMix = mix;
+	if (voice->reverbMix > 0.0f)
+	{
+		FAudioSendDescriptor desc[2];
+		desc[0].pOutputVoice = voice->system->reverbVoice;
+		desc[0].Flags = 0;
+		desc[1].pOutputVoice = voice->system->masteringVoice;
+		desc[1].Flags = 0;
+		FAudioVoiceSends sends;
+		sends.SendCount = 2;
+		sends.pSends = desc;
+		FAudioVoice_SetOutputVoices(voice->sourceVoice, &sends);
+		// Update output matrix for both sends
+		FAudioVoiceDetails details;
+		FAudioVoice_GetVoiceDetails(voice->sourceVoice, &details);
+		int srcChannels = details.InputChannels;
+		FAudioVoice_GetVoiceDetails(voice->system->reverbVoice, &details);
+		int reverbChannels = details.InputChannels;
+		FAudioVoice_GetVoiceDetails(voice->system->masteringVoice, &details);
+		int masterChannels = details.InputChannels;
+		// Set reverb send matrix
+		float reverbMatrix[16] = { 0 };
+		for (int i = 0; i < srcChannels * reverbChannels; i++)
+		{
+			reverbMatrix[i] = voice->reverbMix;
+		}
+		FAudioVoice_SetOutputMatrix(
+			voice->sourceVoice,
+			voice->system->reverbVoice,
+			srcChannels,
+			reverbChannels,
+			reverbMatrix,
+			FAUDIO_COMMIT_NOW
+		);
+		// Set master send matrix
+		float masterMatrix[16] = { 0 };
+		for (int i = 0; i < srcChannels* masterChannels; i++)
+		{
+			masterMatrix[i] = 1.0f - (voice->reverbMix > 1.0f ? 1.0f : voice->reverbMix);
+		}
+		FAudioVoice_SetOutputMatrix(
+			voice->sourceVoice,
+			voice->system->masteringVoice,
+			srcChannels,
+			masterChannels,
+			masterMatrix,
+			FAUDIO_COMMIT_NOW
+		);
+	}
+	else
+	{
+		FAudioSendDescriptor desc[1];
+		desc[0].pOutputVoice = voice->system->masteringVoice;
+		desc[0].Flags = 0;
+		FAudioVoiceSends sends;
+		sends.SendCount = 1;
+		sends.pSends = desc;
+		FAudioVoice_SetOutputVoices(voice->sourceVoice, &sends);
+		// Reset output matrix
+		FAudioVoiceDetails details;
+		FAudioVoice_GetVoiceDetails(voice->sourceVoice, &details);
+		int srcChannels = details.InputChannels;
+		FAudioVoice_GetVoiceDetails(voice->system->masteringVoice, &details);
+		int masterChannels = details.InputChannels;
+		float masterMatrix[16] = { 0 };
+		for (int i = 0; i < srcChannels * masterChannels; i++)
+		{
+			masterMatrix[i] = 1.0f;
+		}
+		FAudioVoice_SetOutputMatrix(
+			voice->sourceVoice,
+			voice->system->masteringVoice,
+			srcChannels,
+			masterChannels,
+			masterMatrix,
+			FAUDIO_COMMIT_NOW
+		);
+	}
 }
 
 void MGA_Voice_SetFilterMode(MGA_Voice* voice, MGFilterMode mode, mgfloat filterQ, mgfloat frequency)
 {
 	assert(voice != nullptr);
+
+	FAudioVoiceDetails details;
+	FAudioVoice_GetVoiceDetails(voice->sourceVoice, &details);
+	if (filterQ > 0.0f)
+	{
+		filterQ = 1.0f / filterQ;
+		if (filterQ > FAUDIO_MAX_FILTER_ONEOVERQ)
+			filterQ = FAUDIO_MAX_FILTER_ONEOVERQ;
+	}
+	else
+	{
+		filterQ = 1.0f;
+	}
+	FAudioFilterParameters params;
+	params.Type = (FAudioFilterType)mode;
+	params.Frequency = frequency;
+	params.OneOverQ = filterQ;
+	FAudioVoice_SetFilterParameters(voice->sourceVoice, &params, FAUDIO_COMMIT_NOW);
 }
 
 void MGA_Voice_ClearFilterMode(MGA_Voice* voice)
 {
 	assert(voice != nullptr);
+
+	FAudioFilterParameters params;
+	params.Type = FAudioLowPassFilter;
+	params.Frequency = FAUDIO_MAX_FILTER_FREQUENCY;
+	params.OneOverQ = 1.0f;
+	FAudioVoice_SetFilterParameters(voice->sourceVoice, &params, FAUDIO_COMMIT_NOW);
 }
 
 void MGA_Voice_Apply3D(MGA_Voice* voice, Listener& listener, Emitter& emitter, mgfloat distanceScale)
 {
 	assert(voice != nullptr);
+
+	F3DAUDIO_LISTENER f3dListener;
+	f3dListener.OrientFront.x = listener.Forward.X;
+	f3dListener.OrientFront.y = listener.Forward.Y;
+	f3dListener.OrientFront.z = listener.Forward.Z;
+	f3dListener.OrientTop.x = listener.Up.X;
+	f3dListener.OrientTop.y = listener.Up.Y;
+	f3dListener.OrientTop.z = listener.Up.Z;
+	f3dListener.Position.x = listener.Position.X;
+	f3dListener.Position.y = listener.Position.Y;
+	f3dListener.Position.z = listener.Position.Z;
+	f3dListener.Velocity.x = listener.Velocity.X;
+	f3dListener.Velocity.y = listener.Velocity.Y;
+	f3dListener.Velocity.z = listener.Velocity.Z;
+	f3dListener.pCone = nullptr;
+	FAudioVoiceDetails details;
+	FAudioVoice_GetVoiceDetails(voice->sourceVoice, &details);
+	int srcChannelCount = details.InputChannels;
+
+	FAudioVoice_GetVoiceDetails(voice->system->masteringVoice, &details);
+	int dstChannelCount = details.InputChannels;
+
+	static float azimuths[4] = { 0, 0, 0, 0 };
+	F3DAUDIO_EMITTER f3dEmitter;
+	memset(&f3dEmitter, 0, sizeof(f3dEmitter));
+	f3dEmitter.OrientFront.x = emitter.Forward.X;
+	f3dEmitter.OrientFront.y = emitter.Forward.Y;
+	f3dEmitter.OrientFront.z = emitter.Forward.Z;
+	f3dEmitter.OrientTop.x = emitter.Up.X;
+	f3dEmitter.OrientTop.y = emitter.Up.Y;
+	f3dEmitter.OrientTop.z = emitter.Up.Z;
+	f3dEmitter.Position.x = emitter.Position.X;
+	f3dEmitter.Position.y = emitter.Position.Y;
+	f3dEmitter.Position.z = emitter.Position.Z;
+	f3dEmitter.Velocity.x = emitter.Velocity.X;
+	f3dEmitter.Velocity.y = emitter.Velocity.Y;
+	f3dEmitter.Velocity.z = emitter.Velocity.Z;
+	f3dEmitter.DopplerScaler = emitter.DopplerScale;
+	f3dEmitter.ChannelCount = srcChannelCount;
+	f3dEmitter.pChannelAzimuths = azimuths;
+	f3dEmitter.CurveDistanceScaler = 1.0f;
+	static float DspMatrix[FAUDIO_MAX_AUDIO_CHANNELS * 8];
+	F3DAUDIO_DSP_SETTINGS dsp;
+	memset(&dsp, 0, sizeof(dsp));
+	dsp.pMatrixCoefficients = DspMatrix;
+	dsp.SrcChannelCount = srcChannelCount;
+	dsp.DstChannelCount = dstChannelCount;
+
+	uint32_t flags = F3DAUDIO_CALCULATE_MATRIX | F3DAUDIO_CALCULATE_DOPPLER;
+	F3DAudioCalculate(voice->system->f3daudio, &f3dListener, &f3dEmitter, flags, &dsp);
+	FAudioVoice_SetOutputMatrix(
+		voice->sourceVoice,
+		voice->system->masteringVoice,
+		srcChannelCount,
+		dstChannelCount,
+		dsp.pMatrixCoefficients,
+		FAUDIO_COMMIT_NOW
+	);
+	FAudioSourceVoice_SetFrequencyRatio(voice->sourceVoice, dsp.DopplerFactor, FAUDIO_COMMIT_NOW);
 }
 

--- a/native/monogame/faudio/MGA_faudio.cpp
+++ b/native/monogame/faudio/MGA_faudio.cpp
@@ -8,6 +8,7 @@
 
 
 #include "FAudio.h"
+#include "FAPO.h"
 #include "FAudioFX.h"
 #include "F3DAudio.h"
 
@@ -16,6 +17,9 @@ struct MGA_System
 	FAudio* faudio = nullptr;
 	FAudioMasteringVoice* masteringVoice = nullptr;
 	FAudioSubmixVoice* reverbVoice = nullptr;
+	FAPO* reverbEffect = nullptr;
+	FAudioEffectDescriptor reverbEffectDesc;
+	FAudioEffectChain reverbEffectChain;
 	F3DAUDIO_HANDLE f3daudio;
 };
 
@@ -67,7 +71,47 @@ MGA_System* MGA_System_Create()
 		return nullptr;
 	}
 
-	// !TODO : Create reverb effect and submix voice
+	// Create reverb effect
+	uint32_t result2 = FAudioCreateReverb(&system->reverbEffect, 0);
+	if (result != 0)
+	{
+		FAudioVoice_DestroyVoice(system->masteringVoice);
+		FAudio_Release(system->faudio);
+		delete system;
+		return nullptr;
+	}
+
+	// Get mastering voice details
+	FAudioVoiceDetails details;
+	FAudioVoice_GetVoiceDetails(system->masteringVoice, &details);
+
+	// Create effect descriptor
+	system->reverbEffectDesc.InitialState = true;
+	system->reverbEffectDesc.OutputChannels = details.InputChannels;
+	system->reverbEffectDesc.pEffect = system->reverbEffect;
+
+	// Create effect chain
+	system->reverbEffectChain.EffectCount = 1;
+	system->reverbEffectChain.pEffectDescriptors = &system->reverbEffectDesc;
+
+	// Create submix voice with reverb effect
+	result = FAudio_CreateSubmixVoice(
+		system->faudio,
+		&system->reverbVoice,
+		details.InputChannels,
+		details.InputSampleRate,
+		0,
+		0,
+		nullptr,
+		&system->reverbEffectChain
+	);
+	if (result != 0)
+	{
+		FAudioVoice_DestroyVoice(system->masteringVoice);
+		FAudio_Release(system->faudio);
+		delete system;
+		return nullptr;
+	}
 
 	// Initialize F3DAudio
 	F3DAudioInitialize(SPEAKER_STEREO, 343.0f, system->f3daudio);
@@ -79,7 +123,15 @@ void MGA_System_Destroy(MGA_System* system)
 {
 	assert(system != nullptr);
 
-	// !TODO : Destroy reverb effect and submix voice
+	// Destroy reverb effect and submix voice
+	if (system->reverbVoice)
+	{
+		FAudioVoice_DestroyVoice(system->reverbVoice);
+	}
+	if (system->reverbEffect)
+	{
+		system->reverbEffect->Release(system->reverbEffect);
+	}
 
 	if (system->masteringVoice)
 	{
@@ -101,6 +153,41 @@ mgint MGA_System_GetMaxInstances()
 void MGA_System_SetReverbSettings(MGA_System* system, ReverbSettings& settings)
 {
 	assert(system != nullptr);
+
+	// Get reverb voice details
+	FAudioVoiceDetails details;
+	FAudioVoice_GetVoiceDetails(system->reverbVoice, &details);
+
+	// All parameters related to sampling rate or time are relative to a 48kHz
+	// voice and must be scaled for use with other sampling rates.
+	float timeScale = 48000.0f / details.InputSampleRate;
+
+	FAudioFXReverbParameters params;
+	params.WetDryMix = settings.WetDryMixPct;
+	params.ReflectionsDelay = (uint32_t)(settings.ReflectionsDelayMs * timeScale);
+	params.ReverbDelay = (uint8_t)(settings.ReverbDelayMs * timeScale);
+	params.RearDelay = (uint8_t)(settings.RearDelayMs * timeScale);
+	params.PositionLeft = (uint8_t)settings.PositionLeft;
+	params.PositionRight = (uint8_t)settings.PositionRight;
+	params.PositionMatrixLeft = (uint8_t)settings.PositionLeftMatrix;
+	params.PositionMatrixRight = (uint8_t)settings.PositionRightMatrix;
+	params.EarlyDiffusion = (uint8_t)settings.EarlyDiffusion;
+	params.LateDiffusion = (uint8_t)settings.LateDiffusion;
+	params.LowEQGain = (uint8_t)settings.LowEqGain;
+	params.LowEQCutoff = (uint8_t)settings.LowEqCutoff;
+	params.HighEQGain = (uint8_t)settings.HighEqGain;
+	params.HighEQCutoff = (uint8_t)settings.HighEqCutoff;
+	params.RoomFilterFreq = settings.RoomFilterFrequencyHz * timeScale;
+	params.RoomFilterMain = settings.RoomFilterMainDb;
+	params.RoomFilterHF = settings.RoomFilterHighFrequencyDb;
+	params.ReflectionsGain = settings.ReflectionsGainDb;
+	params.ReverbGain = settings.ReverbGainDb;
+	params.DecayTime = settings.DecayTimeSec;
+	params.Density = settings.DensityPct;
+	params.RoomSize = settings.RoomSizeFeet;
+
+	uint32_t result = FAudioVoice_SetEffectParameters(system->reverbVoice, 0, &params, sizeof(params), FAUDIO_COMMIT_NOW);
+	assert(result == 0);
 }
 
 MGA_Buffer* MGA_Buffer_Create(MGA_System* system)
@@ -343,10 +430,36 @@ mgulong MGA_Voice_GetPosition(MGA_Voice* voice)
 	return state.SamplesPlayed;
 }
 
+static void MGA_Voice_UpdateOutputMatrix(MGA_Voice* voice)
+{
+	FAudioVoiceDetails details;
+	FAudioVoice_GetVoiceDetails(voice->sourceVoice, &details);
+	int srcChannelCount = details.InputChannels;
+	FAudioVoice_GetVoiceDetails(voice->system->masteringVoice, &details);
+	int dstChannelCount = details.InputChannels;
+
+	// Default to zero volume on all channels.
+	float panMatrix[16];
+	memset(panMatrix, 0, sizeof(panMatrix));
+
+	// Set the pan on the correct channels based on the reverb mix.
+	if (!(voice->reverbMix > 0.0f))
+		FAudioVoice_SetOutputMatrix(voice->sourceVoice, nullptr, srcChannelCount, dstChannelCount,
+			MGA_Voice_CalculatePanMatrix(voice->pan, 1.0f, panMatrix, srcChannelCount), FAUDIO_COMMIT_NOW);
+	else
+	{
+		FAudioVoice_SetOutputMatrix(voice->sourceVoice, voice->system->reverbVoice, srcChannelCount, dstChannelCount,
+			MGA_Voice_CalculatePanMatrix(voice->pan, voice->reverbMix, panMatrix, srcChannelCount), FAUDIO_COMMIT_NOW);
+		FAudioVoice_SetOutputMatrix(voice->sourceVoice, voice->system->masteringVoice, srcChannelCount, dstChannelCount,
+			MGA_Voice_CalculatePanMatrix(voice->pan, 1.0f - (voice->reverbMix > 1.0f ? 1.0f : voice->reverbMix), panMatrix, srcChannelCount), FAUDIO_COMMIT_NOW);
+	}
+}
+
 void MGA_Voice_SetPan(MGA_Voice* voice, mgfloat pan)
 {
 	assert(voice != nullptr);
-	// !TODO: Implement output matrix update
+	voice->pan = pan;
+	MGA_Voice_UpdateOutputMatrix(voice);
 }
 
 void MGA_Voice_SetPitch(MGA_Voice* voice, mgfloat pitch)
@@ -375,6 +488,7 @@ void MGA_Voice_SetReverbMix(MGA_Voice* voice, mgfloat mix)
 		voice->reverbMix = 2.0f;
 	else
 		voice->reverbMix = mix;
+
 	if (voice->reverbMix > 0.0f)
 	{
 		FAudioSendDescriptor desc[2];
@@ -386,42 +500,6 @@ void MGA_Voice_SetReverbMix(MGA_Voice* voice, mgfloat mix)
 		sends.SendCount = 2;
 		sends.pSends = desc;
 		FAudioVoice_SetOutputVoices(voice->sourceVoice, &sends);
-		// Update output matrix for both sends
-		FAudioVoiceDetails details;
-		FAudioVoice_GetVoiceDetails(voice->sourceVoice, &details);
-		int srcChannels = details.InputChannels;
-		FAudioVoice_GetVoiceDetails(voice->system->reverbVoice, &details);
-		int reverbChannels = details.InputChannels;
-		FAudioVoice_GetVoiceDetails(voice->system->masteringVoice, &details);
-		int masterChannels = details.InputChannels;
-		// Set reverb send matrix
-		float reverbMatrix[16] = { 0 };
-		for (int i = 0; i < srcChannels * reverbChannels; i++)
-		{
-			reverbMatrix[i] = voice->reverbMix;
-		}
-		FAudioVoice_SetOutputMatrix(
-			voice->sourceVoice,
-			voice->system->reverbVoice,
-			srcChannels,
-			reverbChannels,
-			reverbMatrix,
-			FAUDIO_COMMIT_NOW
-		);
-		// Set master send matrix
-		float masterMatrix[16] = { 0 };
-		for (int i = 0; i < srcChannels* masterChannels; i++)
-		{
-			masterMatrix[i] = 1.0f - (voice->reverbMix > 1.0f ? 1.0f : voice->reverbMix);
-		}
-		FAudioVoice_SetOutputMatrix(
-			voice->sourceVoice,
-			voice->system->masteringVoice,
-			srcChannels,
-			masterChannels,
-			masterMatrix,
-			FAUDIO_COMMIT_NOW
-		);
 	}
 	else
 	{
@@ -432,26 +510,9 @@ void MGA_Voice_SetReverbMix(MGA_Voice* voice, mgfloat mix)
 		sends.SendCount = 1;
 		sends.pSends = desc;
 		FAudioVoice_SetOutputVoices(voice->sourceVoice, &sends);
-		// Reset output matrix
-		FAudioVoiceDetails details;
-		FAudioVoice_GetVoiceDetails(voice->sourceVoice, &details);
-		int srcChannels = details.InputChannels;
-		FAudioVoice_GetVoiceDetails(voice->system->masteringVoice, &details);
-		int masterChannels = details.InputChannels;
-		float masterMatrix[16] = { 0 };
-		for (int i = 0; i < srcChannels * masterChannels; i++)
-		{
-			masterMatrix[i] = 1.0f;
-		}
-		FAudioVoice_SetOutputMatrix(
-			voice->sourceVoice,
-			voice->system->masteringVoice,
-			srcChannels,
-			masterChannels,
-			masterMatrix,
-			FAUDIO_COMMIT_NOW
-		);
 	}
+
+	MGA_Voice_UpdateOutputMatrix(voice);
 }
 
 void MGA_Voice_SetFilterMode(MGA_Voice* voice, MGFilterMode mode, mgfloat filterQ, mgfloat frequency)

--- a/native/monogame/faudio/MGA_faudio.cpp
+++ b/native/monogame/faudio/MGA_faudio.cpp
@@ -6,7 +6,7 @@
 
 #include "mg_common.h"
 
-
+#include <cmath>
 #include "FAudio.h"
 #include "FAPO.h"
 #include "FAudioFX.h"

--- a/native/monogame/include/mg_common.h
+++ b/native/monogame/include/mg_common.h
@@ -65,6 +65,8 @@ mguint MG_ComputeHash(const mgbyte* value, mgint length);
 mguint MG_ComputeHash(mguint value, mguint result = 0x811c9dc5);
 mguint MG_ComputeHash(const mgbyte* value, mgint length, mguint result);
 
+float* MGA_Voice_CalculatePanMatrix(float pan, float scale, float* matrix, int srcChannels);
+
 // Removes the element preserving order.
 template <class T>
 void mg_remove(std::vector<T>& vector, const T& element)

--- a/native/monogame/premake5.lua
+++ b/native/monogame/premake5.lua
@@ -115,8 +115,12 @@ function configs()
     defines {"NDEBUG"}
     optimize "On"
 
+    filter {"system:windows"}
+    staticruntime "On"
+    filter {"system:windows", "configurations:Debug"}
+    runtime "Debug"
     filter {"system:windows", "configurations:Release"}
-    buildoptions {"/MT"}
+    runtime "Release"
 
     filter "system:macosx"
     buildoptions {"-arch x86_64", "-arch arm64"}

--- a/native/monogame/premake5.lua
+++ b/native/monogame/premake5.lua
@@ -83,6 +83,20 @@ function faudio()
     defines {"MG_FAUDIO"}
 
     files {"faudio/**.h", "faudio/**.cpp"}
+
+    includedirs {"external/faudio/include"}
+    
+    filter {"system:windows"}
+    libdirs {"external/faudio/build/Release"}
+    links {"FAudio.lib"}
+    
+    filter {"system:macosx"}
+    libdirs {"external/faudio/build"}
+    linkoptions {"-Wl,-force_load,external/faudio/build/libFAudio.a"}
+    
+    filter {"system:linux"}
+    linkoptions {"external/faudio/build/libFAudio.a"}
+    filter {}
 end
 
 -- Xaudio is supported on Windows and Xbox.

--- a/native/monogame/premake5.lua
+++ b/native/monogame/premake5.lua
@@ -92,7 +92,10 @@ function faudio()
     
     filter {"system:macosx"}
     libdirs {"external/faudio/build"}
-    linkoptions {"-Wl,-force_load,external/faudio/build/libFAudio.a"}
+    linkoptions {
+        "-Wl,-force_load,external/faudio/build/libFAudio.a",
+        "-Wl,-ld_classic"
+    }
     
     filter {"system:linux"}
     linkoptions {"external/faudio/build/libFAudio.a"}

--- a/native/monogame/xaudio/MGA_xaudio2.cpp
+++ b/native/monogame/xaudio/MGA_xaudio2.cpp
@@ -553,34 +553,6 @@ mgulong MGA_Voice_GetPosition(MGA_Voice* voice)
 	return 0;
 }
 
-static float* MGA_Voice_CalculatePanMatrix(float pan, float scale, float* matrix, int srcChannels)
-{
-	if (srcChannels == 1)
-	{
-		matrix[0] = (pan >= 0 ? (1.f - pan) : 1.f) * scale; // Left
-		matrix[1] = (pan <= 0 ? (-pan - 1.f) : 1.f) * scale; // Right
-	}
-	else if (srcChannels == 2)
-	{
-		if (-1.0f <= pan && pan <= 0.0f)
-		{
-			matrix[0] = (0.5f * pan + 1.0f) * scale;	// .5 when pan is -1, 1 when pan is 0
-			matrix[1] = (0.5f * -pan) * scale;			// .5 when pan is -1, 0 when pan is 0
-			matrix[2] = 0.0f;							//  0 when pan is -1, 0 when pan is 0
-			matrix[3] = (pan + 1.0f) * scale;			//  0 when pan is -1, 1 when pan is 0
-		}
-		else
-		{
-			matrix[0] = (-pan + 1.0f) * scale;			//  1 when pan is 0,   0 when pan is 1
-			matrix[1] = 0.0f;							//  0 when pan is 0,   0 when pan is 1
-			matrix[2] = (0.5f * pan) * scale;			//  0 when pan is 0, .5f when pan is 1
-			matrix[3] = (0.5f * -pan + 1.0f) * scale;	//  1 when pan is 0. .5f when pan is 1
-		}
-	}
-
-	return matrix;
-}
-
 static void MGA_Voice_UpdateOutputMatrix(MGA_Voice* voice)
 {
 	XAUDIO2_VOICE_DETAILS details;


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes https://github.com/MonoGame/MonoGame/issues/9007

<!--
Please ensure there is an existing issue describing the problem this PR addresses, especially for complex changes.
Include steps to reproduce in that issue if possible.
-->

### Description of Change

This pull request integrates the **FAudio** library into MonoGame's native audio backend, providing a robust, cross-platform, low-level audio foundation.  
FAudio brings advanced capabilities for buffer management, voice control, audio effects, and 3D spatial audio.

#### **FAudio Integration**
- Added `FAudio` as a Git submodule under `native/monogame/external/faudio` for consistent source management.  
- Extended `BuildNativeDependenciesTask.cs` to clone, configure, and build FAudio with platform-specific **CMake** settings.  
- Updated `premake5.lua` to include FAudio headers and link the built library across Windows, macOS, and Linux targets.

#### **Native Audio System Implementation**
- Implemented `MGA_faudio.cpp` to provide a complete audio pipeline using **FAudio APIs**:
  - Audio device and mastering voice creation/destruction
  - Buffer creation, format initialization, and memory lifecycle management
  - Voice and buffer queue management

#### **Playback & Voice Control**
- Added playback API support for play, pause, resume, stop, and seek.
- Volume, pitch, pan, reverb, and filter effects implemented natively.
- Exposed audio state querying for fine-grained control.

#### **Advanced Audio Features**
- Integrated **FAudioFX** and **F3DAudio** for:
  - Reverb and environmental effects
  - 3D audio spatialization and positioning
