### PR TITLE
Update DllImport attributes to use AL.LibraryName

### DIFF
--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -562,21 +562,21 @@ namespace MonoGame.OpenAL
         }
 
 #if IOS
-        [DllImport("_Internal", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(AL.LibraryName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alcSuspendContext(IntPtr context);
         internal static void SuspendContext(IntPtr context) => alcSuspendContext(context);
 
-        [DllImport("_Internal", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(AL.LibraryName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alcProcessContext(IntPtr context);
         internal static void ProcessContext(IntPtr context) => alcProcessContext(context);
 #endif
 
 #if ANDROID
-        [DllImport("openal", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(AL.LibraryName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alcDevicePauseSOFT(IntPtr device);
         internal static void DevicePause(IntPtr device) => alcDevicePauseSOFT(device);
 
-        [DllImport("openal", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(AL.LibraryName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alcDeviceResumeSOFT(IntPtr device);
         internal static void DeviceResume(IntPtr device) => alcDeviceResumeSOFT(device);
 #endif


### PR DESCRIPTION
Fixes Issue reported via https://github.com/MonoGame/MonoGame/issues/8885.

We were using `_Internal` rather than `__Internal` for the iOS specific API's . This has been replaced with the `AL.LibraryName` so that we are consistent with other declarations.
