### PR TITLE
[Native] WindowsDX12 fixes

### DIFF
--- a/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
+++ b/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
@@ -25,7 +25,6 @@ public sealed class BuildNativeDependenciesTask : FrostingTask<BuildContext>
         switch (context.Environment.Platform.Family)
         {
             case PlatformFamily.Windows:
-                configureArgs.Append("-A x64");
                 configureArgs.Append("-D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded");
                 break;
             case PlatformFamily.Linux:

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -423,6 +423,12 @@ void MGG_GraphicsDevice_GetCaps(MGG_GraphicsDevice* device, MGG_GraphicsDevice_C
 #endif
 }
 
+void MGG_GraphicsDevice_ResolveRenderTargets(MGG_GraphicsDevice* device)
+{
+	assert(device != nullptr);
+	// This is a no-op for Direct3D 12.
+}
+
 void MGG_GraphicsDevice_ResizeSwapchain(
 	MGG_GraphicsDevice* device,
 	void* nativeWindowHandle,
@@ -633,7 +639,7 @@ void MGG_GraphicsDevice_SetScissorRectangle(MGG_GraphicsDevice* device, mgint x,
 	device->scissorDirty = true;
 }
 
-void MGG_GraphicsDevice_SetRenderTargets(MGG_GraphicsDevice* device, MGG_Texture** targets, mgint count)
+void MGG_GraphicsDevice_SetRenderTargets(MGG_GraphicsDevice* device, MGG_Texture** targets, mgint* arraySlices, mgint count)
 {
 	assert(device != nullptr);
 
@@ -650,6 +656,16 @@ void MGG_GraphicsDevice_SetRenderTargets(MGG_GraphicsDevice* device, MGG_Texture
 		var renderTarget = (IRenderTarget)_currentRenderTargetBindings[0].RenderTarget;
 		*/
 	}
+}
+
+void MGG_GraphicsDevice_GetBackBufferData(MGG_GraphicsDevice* device, mgint x, mgint y, mgint width, mgint height, void* data, mgint count, mgint dataBytes)
+{
+	assert(device != nullptr);
+	assert(data != nullptr);
+	assert(count > 0);
+	assert(dataBytes > 0);
+
+	// !TODO, need to implement
 }
 
 void MGG_GraphicsDevice_SetConstantBuffer(MGG_GraphicsDevice* device, MGShaderStage stage, mgint slot, MGG_Buffer* buffer)


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes #9018 #9022 

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

* Added `MGG_GraphicsDevice_ResolveRenderTargets` as a no-op for Direct3D 12.
* Extended `MGG_GraphicsDevice_SetRenderTargets` to accept an `arraySlices` parameter.
* Added `MGG_GraphicsDevice_GetBackBufferData`, a stub.

### Build configuration update

* Removed the `-A x64` argument from the CMake configuration for Windows, allowing to build with VS 2026.



