### PR TITLE
Use HashSet to track GraphicsDevice resources

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Globalization;
 using MonoGame.Framework.Utilities;
 using System.Runtime.InteropServices;
+using System.Linq;
 
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -672,9 +673,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     // Dispose of all remaining graphics resources before disposing of the graphics device
                     lock (_resourcesLock)
                     {
-                        var allResources = new WeakReference[_resources.Count];
-                        _resources.CopyTo(allResources);
-                        foreach (var resource in allResources)
+                        foreach (var resource in _resources.ToArray())
                         {
                             var target = resource.Target as IDisposable;
                             if (target != null)

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Xna.Framework.Graphics
         // Use WeakReference for the global resources list as we do not know when a resource
         // may be disposed and collected. We do not want to prevent a resource from being
         // collected by holding a strong reference to it in this list.
-        private readonly List<WeakReference> _resources = new List<WeakReference>();
+        private readonly HashSet<WeakReference> _resources = new HashSet<WeakReference>();
 
         // TODO Graphics Device events need implementing
         /// <summary>
@@ -672,7 +672,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     // Dispose of all remaining graphics resources before disposing of the graphics device
                     lock (_resourcesLock)
                     {
-                        foreach (var resource in _resources.ToArray())
+                        var allResources = new WeakReference[_resources.Count];
+                        _resources.CopyTo(allResources);
+                        foreach (var resource in allResources)
                         {
                             var target = resource.Target as IDisposable;
                             if (target != null)
@@ -804,7 +806,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 // Remove references to resources that have been garbage collected.
-                _resources.RemoveAll(wr => !wr.IsAlive);
+                _resources.RemoveWhere(wr => !wr.IsAlive);
             }
         }
 

--- a/Tests/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceTest.cs
@@ -852,5 +852,32 @@ namespace MonoGame.Tests.Graphics
 
             CheckFrames();
         }
+
+        [Test]
+        [RunOnUI]
+        public void DisposeReferencedResources()
+        {
+            var rt = new RenderTarget2D(gdm.GraphicsDevice, 5, 5);
+            var vb = new DynamicVertexBuffer(gd, VertexPositionColor.VertexDeclaration, 1, BufferUsage.None);
+
+            var middleIb = new DynamicIndexBuffer(gd, IndexElementSize.SixteenBits, 1, BufferUsage.None);
+
+            var ib = new DynamicIndexBuffer(gd, IndexElementSize.SixteenBits, 1, BufferUsage.None);
+            var rtc = new RenderTargetCube(gd, 1, false, SurfaceFormat.Color, DepthFormat.Depth16);
+
+            middleIb.Dispose();
+            Assert.IsTrue(middleIb.IsDisposed);
+
+            // Remaining referenced resources should be disposed.
+            gd.Dispose();
+
+            Assert.IsTrue(rt.IsDisposed);
+
+            Assert.IsTrue(vb.IsDisposed);
+
+            Assert.IsTrue(ib.IsDisposed);
+
+            Assert.IsTrue(rtc.IsDisposed);
+        }
     }
 }


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Improves performance of `GraphicsDevice.RemoveResourceReference` (and by extension `GraphicsResource.Dispose`) when there are a lot of resources. 

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

`List<T>.Remove(T item)` needs to iterate every item of the list to find the one to remove, then shift items when removing from the middle. HashSet<T> has much faster deletion, at the cost of a slightly slower insert.

My specific example had over 30000 resources, and triggered large stutters when clearing a cache with around 4000 recently allocated items. It was iterating approximately 120000000 resources removing these entries, since they would be at the end of the list.

My test case was a little extreme since I was scrolling a map with a huge number of unique models that stream in+out, but it's an easy improvement to make.

<!-- 
Enter description of the fix in this section.
Please be as descriptive as possible, future contributors will need to know *why* these changes are being made.
For inspiration review the commit/PR history in the MonoGame repository.
-->