### PR TITLE
[Native] WindowsDX12 fixes #2

### DIFF
--- a/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
+++ b/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
@@ -25,6 +25,7 @@ public sealed class BuildNativeDependenciesTask : FrostingTask<BuildContext>
         switch (context.Environment.Platform.Family)
         {
             case PlatformFamily.Windows:
+                configureArgs.Append("-A x64");
                 configureArgs.Append("-D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded");
                 break;
             case PlatformFamily.Linux:
@@ -37,7 +38,7 @@ public sealed class BuildNativeDependenciesTask : FrostingTask<BuildContext>
         }
 
         configureSettings.Arguments = configureArgs;
-        
+
         if (context.StartProcess("cmake", configureSettings) != 0)
         {
             throw new Exception("SDL2 CMake configuration failed!");
@@ -50,7 +51,7 @@ public sealed class BuildNativeDependenciesTask : FrostingTask<BuildContext>
         buildArgs.Append("--parallel");
 
         buildSettings.Arguments = buildArgs;
-        
+
         if (context.StartProcess("cmake", buildSettings) != 0)
         {
             throw new Exception("SDL2 build failed!");

--- a/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
+++ b/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
@@ -25,7 +25,6 @@ public sealed class BuildNativeDependenciesTask : FrostingTask<BuildContext>
         switch (context.Environment.Platform.Family)
         {
             case PlatformFamily.Windows:
-                configureArgs.Append("-A x64");
                 configureArgs.Append("-D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded");
                 break;
             case PlatformFamily.Linux:

--- a/native/monogame/directx12/CommandContext.cpp
+++ b/native/monogame/directx12/CommandContext.cpp
@@ -273,6 +273,8 @@ void CommandContext::SetPSODeviceParameters(D3D12_GRAPHICS_PIPELINE_STATE_DESC& 
     psoDesc.NumRenderTargets = m_currentRT.size();
     for (int i = 0; i < m_currentRT.size(); i++)
         psoDesc.RTVFormats[i] = m_currentRT[i]->GetFormat();
+    for (int i = m_currentRT.size(); i < D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT; i++)
+        psoDesc.RTVFormats[i] = DXGI_FORMAT_UNKNOWN;
     psoDesc.DSVFormat = m_currentDepthStencil ? m_currentDepthStencil->GetFormat() : DXGI_FORMAT_UNKNOWN;
 }
 

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -1249,8 +1249,6 @@ void MGG_Buffer_Destroy(MGG_GraphicsDevice* device, MGG_Buffer* buffer)
 
 void MGG_Buffer_SetData(MGG_GraphicsDevice* device, MGG_Buffer*& buffer, mgint offset, mgbyte* data, mgint elementCount, mgint vertexStride, mgint elementSizeInBytes, mgbool discard)
 {
-//void MGG_Buffer_SetData(MGG_GraphicsDevice* device, MGG_Buffer*& buffer, mgint offset, mgbyte* data, mgint length, mgbyte discard)
-//{
 	assert(device != nullptr);
 	assert(buffer != nullptr);
 	assert(data != nullptr);
@@ -1425,8 +1423,6 @@ MGG_Texture* MGG_RenderTarget_Create(
 	if (depthFormat != MGDepthFormat::None)
 	{
 		texture->depthTexture = new Texture(width, height, depthFormat);
-		//if (multiSampleCount > 1)
-			//DepthTexture.SetMSAA(sampleCount);
 		texture->depthTexture->Create(device->resources);
 	}
 

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -1155,7 +1155,8 @@ static MGG_Buffer* MGDX_BufferDiscard(MGG_GraphicsDevice* device, MGG_Buffer* bu
 
 	// Search for the best fit from the free list.		
 	MGG_Buffer* best = nullptr;
-	for (int i=0; i < device->free.size(); i++)
+	auto bestIndex = -1;
+	for (int i = 0; i < device->free.size(); i++)
 	{
 		auto curr = device->free[i];
 
@@ -1169,19 +1170,22 @@ static MGG_Buffer* MGDX_BufferDiscard(MGG_GraphicsDevice* device, MGG_Buffer* bu
 		if (best == nullptr || best->actualSize > currSize)
 		{
 			best = curr;
+			bestIndex = i;
 
 			if (currSize == dataSize)
-			{
-				device->free[i] = device->free.back();
-				device->free.pop_back();
 				break;
-			}
 		}
 	}
 
 	// We didn't find a match, so allocate a new one.
 	if (best == nullptr)
 		best = MGG_Buffer_Create(device, type, dataSize);
+
+	else
+	{
+		device->free[bestIndex] = device->free.back();
+		device->free.pop_back();
+	}
 
 	best->dataSize = dataSize;
 

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -123,6 +123,8 @@ struct MGG_Texture
 
 	MGSurfaceFormat format;
 	Texture* texture = nullptr;
+
+	Texture* depthTexture = nullptr;
 };
 
 struct MGG_InputLayout
@@ -537,7 +539,14 @@ static void MGDX_DestroyFrameResources(MGG_GraphicsDevice* device, mgint current
 
 			device->destroyTextures.pop();
 
-			delete texture->texture;
+			if (texture->texture) {
+				texture->texture->FreeDescriptors(device->resources);
+				delete texture->texture;
+			}
+			if (texture->depthTexture) {
+				texture->depthTexture->FreeDescriptors(device->resources);
+				delete texture->depthTexture;
+			}
 			delete texture;
 		}
 	}
@@ -649,12 +658,13 @@ void MGG_GraphicsDevice_SetRenderTargets(MGG_GraphicsDevice* device, MGG_Texture
 	}
 	else
 	{
-		/*
-		device->context->SetRenderTarget(
-		DxCommandContext.SetRenderTarget(rtHandle.AddrOfPinnedObject(), (uint)_currentRenderTargetCount, (_currentRenderTargetBindings[0].RenderTarget as RenderTarget2D).DxDepthTexture);
-		rtHandle.Free();
-		var renderTarget = (IRenderTarget)_currentRenderTargetBindings[0].RenderTarget;
-		*/
+		std::vector<Texture*> colorTargets;
+		colorTargets.reserve(count);
+		for (size_t i = 0; i < count; i++) {
+			colorTargets.push_back(targets[i]->texture);
+		}
+
+		device->context->SetRenderTarget(static_cast<void*>(colorTargets.data()), count, targets[0]->depthTexture);
 	}
 }
 
@@ -1237,11 +1247,17 @@ void MGG_Buffer_Destroy(MGG_GraphicsDevice* device, MGG_Buffer* buffer)
 	device->destroyBuffers.push(buffer);
 }
 
-void MGG_Buffer_SetData(MGG_GraphicsDevice* device, MGG_Buffer*& buffer, mgint offset, mgbyte* data, mgint length, mgbyte discard)
+void MGG_Buffer_SetData(MGG_GraphicsDevice* device, MGG_Buffer*& buffer, mgint offset, mgbyte* data, mgint elementCount, mgint vertexStride, mgint elementSizeInBytes, mgbool discard)
 {
+//void MGG_Buffer_SetData(MGG_GraphicsDevice* device, MGG_Buffer*& buffer, mgint offset, mgbyte* data, mgint length, mgbyte discard)
+//{
 	assert(device != nullptr);
 	assert(buffer != nullptr);
 	assert(data != nullptr);
+	assert(offset >= 0);
+	assert(elementCount > 0);
+	assert(vertexStride > 0);
+	assert(elementSizeInBytes > 0);
 
 	// TODO: Force discard here if we find we're
 	// copying over data still in use.  See NX.
@@ -1288,6 +1304,9 @@ void MGG_Buffer_SetData(MGG_GraphicsDevice* device, MGG_Buffer*& buffer, mgint o
 			break;
 		}
 	}
+
+	// Temp fix for now
+	auto length = elementCount * elementSizeInBytes;
 
 	// Copy the data.
 	UINT8* pVertexDataBegin;
@@ -1398,7 +1417,18 @@ MGG_Texture* MGG_RenderTarget_Create(
 	assert(type != MGTextureType::Cube || (slices % 6) == 0);
 
 	auto texture = new MGG_Texture();
+
 	texture->format = format;
+	texture->texture = new Texture(SurfaceType::RenderTarget, TextureDimension::Texture2D, width, height, mipmaps, format);
+	texture->texture->Create(device->resources);
+
+	if (depthFormat != MGDepthFormat::None)
+	{
+		texture->depthTexture = new Texture(width, height, depthFormat);
+		//if (multiSampleCount > 1)
+			//DepthTexture.SetMSAA(sampleCount);
+		texture->depthTexture->Create(device->resources);
+	}
 
 	return texture;
 }

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -423,6 +423,12 @@ void MGG_GraphicsDevice_GetCaps(MGG_GraphicsDevice* device, MGG_GraphicsDevice_C
 #endif
 }
 
+void MGG_GraphicsDevice_ResolveRenderTargets(MGG_GraphicsDevice* device)
+{
+	assert(device != nullptr);
+	// This is a no-op for Direct3D 12.
+}
+
 void MGG_GraphicsDevice_ResizeSwapchain(
 	MGG_GraphicsDevice* device,
 	void* nativeWindowHandle,
@@ -633,7 +639,7 @@ void MGG_GraphicsDevice_SetScissorRectangle(MGG_GraphicsDevice* device, mgint x,
 	device->scissorDirty = true;
 }
 
-void MGG_GraphicsDevice_SetRenderTargets(MGG_GraphicsDevice* device, MGG_Texture** targets, mgint count)
+void MGG_GraphicsDevice_SetRenderTargets(MGG_GraphicsDevice* device, MGG_Texture** targets, mgint* arraySlices, mgint count)
 {
 	assert(device != nullptr);
 
@@ -650,6 +656,16 @@ void MGG_GraphicsDevice_SetRenderTargets(MGG_GraphicsDevice* device, MGG_Texture
 		var renderTarget = (IRenderTarget)_currentRenderTargetBindings[0].RenderTarget;
 		*/
 	}
+}
+
+void MGG_GraphicsDevice_GetBackBufferData(MGG_GraphicsDevice* device, mgint x, mgint y, mgint width, mgint height, void* data, mgint count, mgint dataBytes)
+{
+	assert(device != nullptr);
+	assert(data != nullptr);
+	assert(count > 0);
+	assert(dataBytes > 0);
+
+	// !TODO, need to implement
 }
 
 void MGG_GraphicsDevice_SetConstantBuffer(MGG_GraphicsDevice* device, MGShaderStage stage, mgint slot, MGG_Buffer* buffer)

--- a/native/monogame/directx12/Texture.cpp
+++ b/native/monogame/directx12/Texture.cpp
@@ -94,6 +94,10 @@ Texture::Texture(DeviceResources* device, IDXGISwapChain3* swapchain, int buffer
 #endif
 
 Texture::~Texture() {
+    assert(impl->m_srvHandle.ptr == 0);
+    assert(impl->m_uavHandles.empty());
+    assert(impl->m_rtvHandle.ptr == 0);
+    assert(impl->m_dsvHandle.ptr == 0);
     delete impl;
 }
 

--- a/native/monogame/directx12/Texture.cpp
+++ b/native/monogame/directx12/Texture.cpp
@@ -94,10 +94,6 @@ Texture::Texture(DeviceResources* device, IDXGISwapChain3* swapchain, int buffer
 #endif
 
 Texture::~Texture() {
-    assert(impl->m_srvHandle.ptr == 0);
-    assert(impl->m_uavHandles.empty());
-    assert(impl->m_rtvHandle.ptr == 0);
-    assert(impl->m_dsvHandle.ptr == 0);
     delete impl;
 }
 


### PR DESCRIPTION
Several fixes for getting WindowsDX working.

This is working off PR #9023

1. Fixed a bug where switching from multiple render targets back to a single render target wasn't properly handled. https://github.com/MonoGame/MonoGame/pull/9031/commits/6027892d7f73a12cd54822c28e2f5d5491f1e18b
2. Creating/setting a custom render target was never fully implemented. Custom render target is now created along with it's depth texture. Fixes #9021 https://github.com/MonoGame/MonoGame/pull/9031/commits/6027892d7f73a12cd54822c28e2f5d5491f1e18b
4. Disposing of textures was not calling `FreeDescriptors` resulting in an eventual crash. https://github.com/MonoGame/MonoGame/pull/9031/commits/6027892d7f73a12cd54822c28e2f5d5491f1e18b
5. `MGG_Buffer_SetData` was not using the correct signature. Going to need more work. https://github.com/MonoGame/MonoGame/pull/9031/commits/6027892d7f73a12cd54822c28e2f5d5491f1e18b
6. Fixed bug where a buffer remains on the free list when it doesn't match the exact size. a04b28103b6d207ee0fe9e4813606c38b38f98a1

