### PR TITLE
Add Support for Texture3D on OpenGL

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/Texture3D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture3D.OpenGL.cs
@@ -75,8 +75,69 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformGetData<T>(int level, int left, int top, int right, int bottom, int front, int back, T[] data, int startIndex, int elementCount)
              where T : struct
         {
+#if GLES
+            throw new NotSupportedException("OpenGL ES 2.0 doesn't support 3D textures.");
+#else
+            var width = right - left;
+            var height = bottom - top;
+            var depth = back - front;
 
-            throw new NotImplementedException();
+            Threading.BlockOnUIThread(() =>
+            {
+                GL.BindTexture(glTarget, glTexture);
+                GraphicsExtensions.CheckGLError();
+
+                // If we're getting a subset of the texture, we need to read the entire level and copy the relevant portion
+                if (left != 0 || top != 0 || front != 0 || width != Width || height != Height || depth != Depth)
+                {
+                    var elementSizeInByte = Marshal.SizeOf<T>();
+                    var levelWidth = Math.Max(Width >> level, 1);
+                    var levelHeight = Math.Max(Height >> level, 1);
+                    var levelDepth = Math.Max(Depth >> level, 1);
+                    var levelSize = levelWidth * levelHeight * levelDepth * Format.GetSize();
+                    var tempData = new byte[levelSize];
+
+                    var tempHandle = GCHandle.Alloc(tempData, GCHandleType.Pinned);
+                    try
+                    {
+                        GL.GetTexImage(glTarget, level, glFormat, glType, tempData);
+                        GraphicsExtensions.CheckGLError();
+
+                        // Copy the subset to the output array
+                        var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+                        try
+                        {
+                            var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startIndex * elementSizeInByte);
+                            var formatSize = Format.GetSize();
+
+                            for (int z = 0; z < depth; z++)
+                            {
+                                for (int y = 0; y < height; y++)
+                                {
+                                    var sourceIndex = ((front + z) * levelHeight * levelWidth + (top + y) * levelWidth + left) * formatSize;
+                                    var destIndex = (z * height * width + y * width) * formatSize;
+                                    Marshal.Copy(tempData, sourceIndex, dataPtr + destIndex, width * formatSize);
+                                }
+                            }
+                        }
+                        finally
+                        {
+                            dataHandle.Free();
+                        }
+                    }
+                    finally
+                    {
+                        tempHandle.Free();
+                    }
+                }
+                else
+                {
+                    // Get the entire texture level - we can read directly into the data array
+                    GL.GetTexImage(glTarget, level, glFormat, glType, data);
+                    GraphicsExtensions.CheckGLError();
+                }
+            });
+#endif
         }
     }
 }

--- a/Tests/Framework/Graphics/GraphicsDeviceTestFixtureBase.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceTestFixtureBase.cs
@@ -18,6 +18,7 @@ using NUnit.Framework.Internal;
 
 namespace MonoGame.Tests.Graphics
 {
+    [RunOnUI] 
     internal class GraphicsDeviceTestFixtureBase
     {
         protected TestGameBase game;
@@ -51,6 +52,7 @@ namespace MonoGame.Tests.Graphics
         #region SetUp and TearDown
 
         [SetUp]
+        [RunOnUI]
         public virtual void SetUp()
         {
             game = new TestGameBase();
@@ -79,6 +81,7 @@ namespace MonoGame.Tests.Graphics
         }
 
         [TearDown]
+        [RunOnUI]
         public virtual void TearDown()
         {
             game.Dispose();

--- a/Tests/Framework/Graphics/SpriteBatchTest.cs
+++ b/Tests/Framework/Graphics/SpriteBatchTest.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics {
     [TestFixture]
     [NonParallelizable]
+    [RunOnUI]
 	class SpriteBatchTest : GraphicsDeviceTestFixtureBase {
 		private SpriteBatch _spriteBatch;
 		private Texture2D _texture;

--- a/Tests/Framework/Graphics/SpriteFontTest.cs
+++ b/Tests/Framework/Graphics/SpriteFontTest.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 namespace MonoGame.Tests.Graphics {
 	[TestFixture]
     [NonParallelizable]
+    [RunOnUI]
 	class SpriteFontTest : GraphicsDeviceTestFixtureBase {
 
 		private SpriteBatch _spriteBatch;

--- a/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
+++ b/Tests/Framework/Graphics/Texture2DNonVisualTest.cs
@@ -14,6 +14,7 @@ namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
     [NonParallelizable]
+    [RunOnUI]
     internal class Texture2DNonVisualTest : GraphicsDeviceTestFixtureBase
     {
         Texture2D _texture;

--- a/Tests/Framework/Graphics/Texture2DTest.cs
+++ b/Tests/Framework/Graphics/Texture2DTest.cs
@@ -10,6 +10,7 @@ namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
     [NonParallelizable]
+    [RunOnUI]
     class Texture2DTest : GraphicsDeviceTestFixtureBase
     {
         [Test]

--- a/Tests/Framework/Graphics/Texture3DNonVisualTest.cs
+++ b/Tests/Framework/Graphics/Texture3DNonVisualTest.cs
@@ -11,15 +11,25 @@ namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
     [NonParallelizable]
+    [RunOnUI]
     internal class Texture3DNonVisualTest : GraphicsDeviceTestFixtureBase
     {
         Texture3D t;
         Color[] reference;
         const int w=50, h=50, d=50, a = w * d * h;
 
-        [OneTimeSetUp]
-        public void TestFixtureSetUp()
+        [TearDown]
+        public override void TearDown()
         {
+            t.Dispose();
+            base.TearDown();
+        }
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
             reference = new Color[a];
 
             t = new Texture3D(game.GraphicsDevice, w, h, d, false, SurfaceFormat.Color);
@@ -30,17 +40,6 @@ namespace MonoGame.Tests.Graphics
                     reference[layer * w * h + i] = new Color(layer * 5, layer * 5, layer * 5, layer * 5);
                 }
             }
-        }
-
-        [OneTimeTearDown]
-        public void TestFixtureTearDown()
-        {
-            t.Dispose();
-        }
-
-        [SetUp]
-        public void TestSetUp()
-        {
             t.SetData(reference);
         }
 

--- a/Tests/Framework/Graphics/Texture3DNonVisualTest.cs
+++ b/Tests/Framework/Graphics/Texture3DNonVisualTest.cs
@@ -11,23 +11,18 @@ namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
     [NonParallelizable]
-    public class Texture3DNonVisualTest
+    internal class Texture3DNonVisualTest : GraphicsDeviceTestFixtureBase
     {
         Texture3D t;
         Color[] reference;
         const int w=50, h=50, d=50, a = w * d * h;
-        private Game _game;
 
         [OneTimeSetUp]
         public void TestFixtureSetUp()
         {
             reference = new Color[a];
-            _game = new Game();
-            var graphicsDeviceManager = new GraphicsDeviceManager(_game);
-            graphicsDeviceManager.GraphicsProfile = GraphicsProfile.HiDef;
-            graphicsDeviceManager.ApplyChanges();
 
-            t = new Texture3D(_game.GraphicsDevice, w, h, d, false, SurfaceFormat.Color);
+            t = new Texture3D(game.GraphicsDevice, w, h, d, false, SurfaceFormat.Color);
             for (int layer = 0; layer < d; layer++)
             {
                 for (int i = 0; i < w * h; i++)
@@ -40,7 +35,6 @@ namespace MonoGame.Tests.Graphics
         [OneTimeTearDown]
         public void TestFixtureTearDown()
         {
-            _game.Dispose();
             t.Dispose();
         }
 
@@ -55,7 +49,7 @@ namespace MonoGame.Tests.Graphics
         public void ZeroSizeShouldFailTest()
         {
             Texture3D texture;
-            var gd = _game.GraphicsDevice;
+            var gd = game.GraphicsDevice;
             Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture3D(gd, 0, 1, 1, false, SurfaceFormat.Color));
             Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture3D(gd, 1, 0, 1, false, SurfaceFormat.Color));
             Assert.Throws<ArgumentOutOfRangeException>(() => texture = new Texture3D(gd, 1, 1, 0, false, SurfaceFormat.Color));

--- a/Tests/Framework/Graphics/Texture3DNonVisualTest.cs
+++ b/Tests/Framework/Graphics/Texture3DNonVisualTest.cs
@@ -9,9 +9,6 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Tests.Graphics
 {
-#if DESKTOPGL
-    [Ignore("Texture3D is not implemented for the OpenGL backend.")]
-#endif
     [TestFixture]
     [NonParallelizable]
     public class Texture3DNonVisualTest

--- a/Tests/Framework/Graphics/Texture3DTest.cs
+++ b/Tests/Framework/Graphics/Texture3DTest.cs
@@ -7,9 +7,6 @@ using NUnit.Framework;
 
 namespace MonoGame.Tests.Graphics
 {
-#if DESKTOPGL
-    [Ignore("Texture3D is not implemented for the OpenGL backend.")]
-#endif
     [TestFixture]
     [NonParallelizable]
     class Texture3DTest : GraphicsDeviceTestFixtureBase

--- a/Tests/Framework/Graphics/Texture3DTest.cs
+++ b/Tests/Framework/Graphics/Texture3DTest.cs
@@ -9,6 +9,7 @@ namespace MonoGame.Tests.Graphics
 {
     [TestFixture]
     [NonParallelizable]
+    [RunOnUI]
     class Texture3DTest : GraphicsDeviceTestFixtureBase
     {
         [Test]

--- a/Tests/Framework/Visual/VisualTestFixtureBase.cs
+++ b/Tests/Framework/Visual/VisualTestFixtureBase.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 using MonoGame.Tests.Components;
 
 namespace MonoGame.Tests.Visual {
+	[RunOnUI]
 	class VisualTestFixtureBase {
 		private VisualTestGame _game;
 		protected VisualTestGame Game { get { return _game; } }

--- a/Tests/Runner/Program.cs
+++ b/Tests/Runner/Program.cs
@@ -29,32 +29,56 @@ namespace MonoGame.Tests
     {
         static Thread mainThread = Thread.CurrentThread;
         static MainThreadSynchronizationContext mainThreadSynchronizationContext;
-        public static TestResult Invoke (Func<TestResult> func, TestResult result)
+        public static TestResult Invoke(Func<TestResult> func, TestResult result)
         {
-            if (Thread.CurrentThread != mainThread) {
+            if (Thread.CurrentThread != mainThread)
+            {
                 TestResult r = result;
-                mainThreadSynchronizationContext.Send (state => {
-                    try {
-                    r = func();
-                    } catch (Exception ex) {
-                        r.RecordException (ex);
+                mainThreadSynchronizationContext.Send(state =>
+                {
+                    try
+                    {
+                        r = func();
+                    }
+                    catch (Exception ex)
+                    {
+                        r.RecordException(ex);
                     }
                 }, null);
                 return r;
-            } else {
+            }
+            else
+            {
                 return func();
             }
         }
-        static async Task<int> Main(string [] args)
+        
+        [STAThread]
+        static async Task<int> Main(string[] args)
         {
             mainThread = Thread.CurrentThread;
             mainThreadSynchronizationContext = new MainThreadSynchronizationContext(mainThread);
-            SynchronizationContext.SetSynchronizationContext (mainThreadSynchronizationContext);
+            SynchronizationContext.SetSynchronizationContext(mainThreadSynchronizationContext);
+            
             int result = 0;
-            var task = Task.Run (() => result = new AutoRun().Execute(args)).ContinueWith ((t) => {
-                mainThreadSynchronizationContext.End ();
-            }, continuationOptions: TaskContinuationOptions.ExecuteSynchronously);
-            mainThreadSynchronizationContext.ExecuteQueuedCallbacks ();
+            bool testsComplete = false;
+            
+            var task = Task.Run(() =>
+            {
+                try
+                {
+                    result = new AutoRun().Execute(args);
+                }
+                finally
+                {
+                    testsComplete = true;
+                    mainThreadSynchronizationContext.End();
+                }
+            });
+            
+            // Process callbacks on the main thread while tests run
+            mainThreadSynchronizationContext.ExecuteQueuedCallbacks();
+            
             await task;
             return result;
         }


### PR DESCRIPTION
Fixes #9040

* Implement 3D Texture support for DesktopGL.
* Fixed Texture3DNonVisualTest to use RunOnIU Attribute so it works on MacOS
* Fixed Texture3DTest to use RunOnUI Attribute so it works on MacOS
* Fixed a bug in the Test Program.Main where the Continuation would not fire if we hit an exception. 







