### PR TITLE
Reveal amount of textures in TextureCollection

### DIFF
--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Xna.Framework.Graphics
         private ShaderStage _stage;
         private int _dirty;
 
+        /// <summary>
+        /// Amount of textures
+        /// </summary>
+        public int Count => _textures.Length;
+
         internal TextureCollection(GraphicsDevice graphicsDevice, int maxTextures, ShaderStage stage)
         {
             _graphicsDevice = graphicsDevice;

--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -19,7 +19,13 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Amount of textures
         /// </summary>
-        public int Count => _textures.Length;
+        public int Count
+        {
+            get
+            {
+                return _textures.Length;
+            }
+        }
 
         internal TextureCollection(GraphicsDevice graphicsDevice, int maxTextures, ShaderStage stage)
         {

--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             get
             {
-                return _textures.Length;
+                return Math.Min(_textures.Length, 16);
             }
         }
 


### PR DESCRIPTION
### Description of Change

Reveals amount of textures in the TextureCollection.
Example usage:
```c#
  // Reset the graphics device textures
for(var i = 0; i < GraphicsDevice.Textures.Count; ++i) 
{
  GraphicsDevice.Textures[i] = null;
}
```

The maximum returned amount of textures is limited by 16 for two purposes:
* Make sure the logic with modifying `_dirty` field won't be broken
* Doubtful anyone would need more than 16 textures anyway



