### PR TITLE
Updated template checkout for Development

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,15 +124,17 @@ jobs:
         shell: bash
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: |
+            9.0.x
+            8.0.x
         env:
           DotnetVersion: 9.0.305
 
       - name: Test generated Nuget packages
         if: runner.os != 'Linux'
-        run: dotnet run --project build/Build.csproj -- --target=TestNuGet
+        run: dotnet run --project build/Build.csproj -- --target=TestNuGet --framework net9.0
         env:
           DotnetVersion: 9.0.305
           ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,12 +126,15 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'        
+          dotnet-version: '9.0.x'
+        env:
+          DotnetVersion: 9.0.305
 
       - name: Test generated Nuget packages
         if: runner.os != 'Linux'
         run: dotnet run --project build/Build.csproj -- --target=TestNuGet
         env:
+          DotnetVersion: 9.0.305
           ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}
           ACTIONS_RUNTIME_URL: "${{ env.ACTIONS_RUNTIME_URL }}"           
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,6 +123,11 @@ jobs:
           CI: true
         shell: bash
 
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'        
+
       - name: Test generated Nuget packages
         if: runner.os != 'Linux'
         run: dotnet run --project build/Build.csproj -- --target=TestNuGet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-15, ubuntu-24.04]
+        os: [windows-latest, macos-26, ubuntu-24.04]
       fail-fast: false
     steps:
       - name: Clone repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > global.json
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '${{ env.DotnetVersion }}'
           
@@ -123,20 +123,20 @@ jobs:
           CI: true
         shell: bash
 
+      - name: Generate global.json
+        run: |
+          echo '{ "sdk": { "version": "9.0.x" } }' > global.json
+
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             9.0.x
-            8.0.x
-        env:
-          DotnetVersion: 9.0.305
 
       - name: Test generated Nuget packages
         if: runner.os != 'Linux'
         run: dotnet run --project build/Build.csproj -- --target=TestNuGet --framework net9.0
         env:
-          DotnetVersion: 9.0.305
           ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}
           ACTIONS_RUNTIME_URL: "${{ env.ACTIONS_RUNTIME_URL }}"           
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,6 +133,11 @@ jobs:
           dotnet-version: |
             9.0.x
 
+      - name: Setup DotNet on MacOS for DotNet 9
+        if: runner.environment == 'github-hosted' && runner.os == 'macos'
+        run: |
+          dotnet workload install android macos ios
+
       - name: Test generated Nuget packages
         if: runner.os != 'Linux'
         run: dotnet run --project build/Build.csproj -- --target=TestNuGet --framework net9.0


### PR DESCRIPTION
# Summary

Updating the tempalte checkout for the recent changes:

- Update templates to default to dotnet 9
- Updating Android TargetFramework - Google 16kbfix
- Updating iOS min version
- Updating the Content Builder Project template to latest
- Updated automation to handle the DotNet 9 templates from the `3.8.4.1` release.