### PR TITLE
Remove Android workload from MacOS to prevent building Android on Macos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup DotNet on MacOS
         if: runner.environment == 'github-hosted' && runner.os == 'macos'
         run: |
-          dotnet workload install android macos ios
+          dotnet workload install macos ios
 
       - name: Add msbuild to PATH
         if: runner.os == 'Windows'


### PR DESCRIPTION
# Summary

Removes the `android` workflow from the MacOS dotnet setup, to prevent the `BuildAndroid` task running on MacOS due to recent image issues.

Android is still built on Linux/Windows for validation and is still operational.