### PR TITLE
Update dotnet setup to exclude android workload for MacOS

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -9,6 +9,7 @@
 # liberapay: # Replace with a single Liberapay username
 # issuehunt: # Replace with a single IssueHunt username
 # otechie: # Replace with a single Otechie username
+
 patreon: MonoGame
 github: MonoGame
 [![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=K3K9QACYMZMUE)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Setup DotNet on MacOS for DotNet 9
         if: runner.environment == 'github-hosted' && runner.os == 'macos'
         run: |
-          dotnet workload install android macos ios
+          dotnet workload install macos ios
 
       - name: Test generated Nuget packages
         if: runner.os != 'Linux'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup DotNet on MacOS
         if: runner.environment == 'github-hosted' && runner.os == 'macos'
         run: |
-          dotnet workload install android macos ios
+          dotnet workload install macos ios
 
       - name: Add msbuild to PATH
         if: runner.os == 'Windows'

--- a/build/TestNuGetsTasks/Test2dstartkitTask.cs
+++ b/build/TestNuGetsTasks/Test2dstartkitTask.cs
@@ -3,7 +3,7 @@ namespace BuildScripts;
 [TaskName("TestFull2DStarterKit")]
 public sealed class TestFull2DStarterKitTask : TestMonoGameTemplateTaskBase
 {
-    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows, PlatformFamily.Linux, PlatformFamily.OSX };
+    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows, PlatformFamily.Linux };
     
     protected override string TemplateName => "Full 2D Starter Kit";
     protected override string ProjectFolderName => "mgtwodstartkit";

--- a/build/TestNuGetsTasks/TestAndroidTask.cs
+++ b/build/TestNuGetsTasks/TestAndroidTask.cs
@@ -3,7 +3,7 @@ namespace BuildScripts;
 [TaskName("TestAndroid")]
 public sealed class TestAndroidTask : TestMonoGameTemplateTaskBase
 {
-    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows, PlatformFamily.Linux, PlatformFamily.OSX };
+    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows, PlatformFamily.Linux };
     
     protected override string TemplateName => "Android";
     protected override string ProjectFolderName => "android";

--- a/build/TestNuGetsTasks/Testblank2dstartkitTask.cs
+++ b/build/TestNuGetsTasks/Testblank2dstartkitTask.cs
@@ -3,7 +3,7 @@ namespace BuildScripts;
 [TaskName("TestBlank2DStarterKit")]
 public sealed class TestBlank2DStarterKitTask : TestMonoGameTemplateTaskBase
 {
-    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows, PlatformFamily.Linux, PlatformFamily.OSX};
+    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows, PlatformFamily.Linux};
     
     protected override string TemplateName => "Blank 2D Starter Kit";
     protected override string ProjectFolderName => "blank2dstartkit";


### PR DESCRIPTION
# Summary

Removes the `android` workflow from the MacOS dotnet setup, to prevent the `BuildAndroid` task running on MacOS due to recent image issues.

Android is still built on Linux/Windows for validation and is still operational.