### PR TITLE
Remove Android building/testing on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,11 +40,6 @@ jobs:
         run: |
           dotnet workload install android ios
 
-      - name: Setup DotNet on linux
-        if: runner.environment == 'github-hosted' && runner.os == 'Linux'
-        run: |
-          dotnet workload install android
-
       - name: Setup DotNet on MacOS
         if: runner.environment == 'github-hosted' && runner.os == 'macos'
         run: |

--- a/build/TestNuGetsTasks/Test2dstartkitTask.cs
+++ b/build/TestNuGetsTasks/Test2dstartkitTask.cs
@@ -3,7 +3,7 @@ namespace BuildScripts;
 [TaskName("TestFull2DStarterKit")]
 public sealed class TestFull2DStarterKitTask : TestMonoGameTemplateTaskBase
 {
-    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows, PlatformFamily.Linux };
+    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows };
     
     protected override string TemplateName => "Full 2D Starter Kit";
     protected override string ProjectFolderName => "mgtwodstartkit";

--- a/build/TestNuGetsTasks/TestAndroidTask.cs
+++ b/build/TestNuGetsTasks/TestAndroidTask.cs
@@ -3,7 +3,7 @@ namespace BuildScripts;
 [TaskName("TestAndroid")]
 public sealed class TestAndroidTask : TestMonoGameTemplateTaskBase
 {
-    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows, PlatformFamily.Linux };
+    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows };
     
     protected override string TemplateName => "Android";
     protected override string ProjectFolderName => "android";

--- a/build/TestNuGetsTasks/Testblank2dstartkitTask.cs
+++ b/build/TestNuGetsTasks/Testblank2dstartkitTask.cs
@@ -3,7 +3,7 @@ namespace BuildScripts;
 [TaskName("TestBlank2DStarterKit")]
 public sealed class TestBlank2DStarterKitTask : TestMonoGameTemplateTaskBase
 {
-    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows, PlatformFamily.Linux};
+    private static readonly PlatformFamily[] _supportedPlatforms = { PlatformFamily.Windows};
     
     protected override string TemplateName => "Blank 2D Starter Kit";
     protected override string ProjectFolderName => "blank2dstartkit";


### PR DESCRIPTION
# Summary

Even with the entire pipeline FORCED to use DotNet 9, for some reason Android is using DotNet 10 on Linux and is breaking the build.

Force removing it for now to enable PR's to pass testing

Windows is now the only platform to handle Android