### PR TITLE
WindowsDX12: Mark scissor as dirty if viewport changed and no custom scissor test.

### DIFF
--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -778,6 +778,9 @@ void MGDX_ApplyState(MGG_GraphicsDevice* device)
 	{
 		cl->RSSetViewports(1, &device->viewport);
 		device->viewportDirty = false;
+
+		if (!device->scissorTestEnable)
+			device->scissorDirty = true;
 	}
 
 	if (device->scissorDirty)


### PR DESCRIPTION
There is a bug where the Scissor Rectangle is not being updated to match the Viewport when the Scissor Test is disabled.

This fixes it so when the Viewport is marked as dirty it ensures the Scissor Rectangle is updated as well (if scissor test is disabled).






