### PR TITLE
Patch tests workflow for Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -326,12 +326,12 @@ jobs:
       #     CI: true
       #   working-directory: tests-windowsdx
         
-      - name: Run DirectX All Tests Except Audio
-        if: runner.os == 'Windows' && runner.environment != 'github-hosted'
-        run: dotnet test --filter Category!=Audio MonoGame.Tests.dll  
-        env:
-          CI: true
-        working-directory: tests-windowsdx
+      # - name: Run DirectX All Tests Except Audio
+      #   if: runner.os == 'Windows' && runner.environment != 'github-hosted'
+      #   run: dotnet test --filter Category!=Audio MonoGame.Tests.dll  
+      #   env:
+      #     CI: true
+      #   working-directory: tests-windowsdx
 
       # Run the DesktopGL tests on all platforms using NUnitLite runner not dotnet test
       # We have to run this is bits because the tests crash if too many are run in one go?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-26, ubuntu-24.04]
+        include:
+          - os: windows-latest
+            platform: windows
+            shell: pwsh
+          - os: macos-26
+            platform: macos
+            shell: bash
+          - os: ubuntu-24.04
+            platform: linux
+            shell: bash      
       fail-fast: false
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v5
@@ -241,7 +253,7 @@ jobs:
         include:
           - os: windows${{ needs.choose-runner.outputs.runner }}latest
             platform: windows
-            shell: cmd
+            shell: pwsh
           - os: macos${{ needs.choose-runner.outputs.runner }}15
             platform: macos
             shell: bash
@@ -249,8 +261,6 @@ jobs:
             platform: linux
             shell: bash
             filter: --where="Category != Audio"
-          # - os: linux
-          #   platform: linux
       fail-fast: false
     defaults:
       run:
@@ -319,19 +329,19 @@ jobs:
 
       # Run the DirectX tests in two steps: first the audio, then the rest.
       # This is because the audio tests has some incompatibilities within the runner with ContentManagerTests.
-      # - name: Run DirectX Audio Tests
-      #   if: runner.os == 'Windows' && runner.environment != 'github-hosted'
-      #   run: dotnet test --filter Category=Audio MonoGame.Tests.dll 
-      #   env:
-      #     CI: true
-      #   working-directory: tests-windowsdx
+      - name: Run DirectX Audio Tests
+        if: runner.os == 'Windows' && runner.environment != 'github-hosted'
+        run: dotnet test --filter Category=Audio MonoGame.Tests.dll 
+        env:
+          CI: true
+        working-directory: tests-windowsdx
         
-      # - name: Run DirectX All Tests Except Audio
-      #   if: runner.os == 'Windows' && runner.environment != 'github-hosted'
-      #   run: dotnet test --filter Category!=Audio MonoGame.Tests.dll  
-      #   env:
-      #     CI: true
-      #   working-directory: tests-windowsdx
+      - name: Run DirectX All Tests Except Audio
+        if: runner.os == 'Windows' && runner.environment != 'github-hosted'
+        run: dotnet test --filter Category!=Audio MonoGame.Tests.dll  
+        env:
+          CI: true
+        working-directory: tests-windowsdx
 
       # Run the DesktopGL tests on all platforms using NUnitLite runner not dotnet test
       # We have to run this is bits because the tests crash if too many are run in one go?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -324,6 +324,7 @@ jobs:
           path: tests-windowsdx
 
       - name: Set global.json for tests-windowsdx
+        if: runner.os == 'Windows' && runner.environment != 'github-hosted'
         run: |
           echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > tests-windowsdx/global.json
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,6 +236,8 @@ jobs:
     name: tests-${{ matrix.os }}
     needs: [ build, choose-runner ]
     runs-on: ${{ matrix.os }}
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1 
     strategy:
       matrix:
         include:
@@ -312,7 +314,6 @@ jobs:
 
       - name: Set global.json for tests-desktopgl
         run: |
-          set DOTNET_CLI_TELEMETRY_OPTOUT=1
           echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > tests-desktopgl/global.json
 
       - name: Download tests-windowsdx-${{ matrix.platform }}
@@ -324,7 +325,6 @@ jobs:
 
       - name: Set global.json for tests-windowsdx
         run: |
-          set DOTNET_CLI_TELEMETRY_OPTOUT=1
           echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > tests-windowsdx/global.json
 
       # Run the DirectX tests in two steps: first the audio, then the rest.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Generate global.json
         run: |
+          echo "DotNetVersion=${{ env.DotnetVersion }}"
           echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > global.json
 
       - name: Setup .NET Core SDK
@@ -158,6 +159,7 @@ jobs:
 
         - name: Generate global.json
           run: |
+            echo "DotNetVersion=${{ env.DotnetVersion }}"
             echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > global.json
 
         - name: Setup .NET Core SDK
@@ -192,6 +194,7 @@ jobs:
 
         - name: Generate global.json
           run: |
+            echo "DotNetVersion=${{ env.DotnetVersion }}"
             echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > global.json
 
         - name: Setup .NET Core SDK
@@ -269,6 +272,7 @@ jobs:
 
       - name: Generate global.json
         run: |
+          echo "DotNetVersion=${{ env.DotnetVersion }}"
           echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > global.json
 
       - name: Setup .NET Core SDK
@@ -327,14 +331,14 @@ jobs:
       # This is because the audio tests has some incompatibilities within the runner with ContentManagerTests.
       - name: Run DirectX Audio Tests
         if: runner.os == 'Windows' && runner.environment != 'github-hosted'
-        run: dotnet vstest MonoGame.Tests.dll --TestCaseFilter:Category=Audio
+        run: dotnet vstest ..\Tests\MonoGame.Tests.WindowsDX.csproj --TestCaseFilter:Category=Audio
         env:
           CI: true
         working-directory: tests-windowsdx
         
       - name: Run DirectX All Tests Except Audio
         if: runner.os == 'Windows' && runner.environment != 'github-hosted'
-        run: dotnet vstest MonoGame.Tests.dll --TestCaseFilter:"Category!=Audio" 
+        run: dotnet vstest ..\Tests\MonoGame.Tests.WindowsDX.csproj --TestCaseFilter:"Category!=Audio" 
         env:
           CI: true
         working-directory: tests-windowsdx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -309,13 +309,23 @@ jobs:
         with:
           name: tests-desktopgl-${{ matrix.platform }}
           path: tests-desktopgl
-          
+
+      - name: Set global.json for tests-desktopgl
+        run: |
+          set DOTNET_CLI_TELEMETRY_OPTOUT=1
+          echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > tests-desktopgl/global.json
+
       - name: Download tests-windowsdx-${{ matrix.platform }}
         if: runner.os == 'Windows' && runner.environment != 'github-hosted'
         uses: actions/download-artifact@v4
         with:
           name: tests-windowsdx-${{ matrix.platform }}
           path: tests-windowsdx
+
+      - name: Set global.json for tests-windowsdx
+        run: |
+          set DOTNET_CLI_TELEMETRY_OPTOUT=1
+          echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > tests-windowsdx/global.json
 
       # Run the DirectX tests in two steps: first the audio, then the rest.
       # This is because the audio tests has some incompatibilities within the runner with ContentManagerTests.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,13 +5,14 @@ on: [push, pull_request]
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
- 
+
+env:
+  DotnetVersion: 9.0.307
+  
 jobs:
   build:
     name: build-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    env:
-      DotnetVersion: 9.0.307
     strategy:
       matrix:
         os: [windows-latest, macos-26, ubuntu-24.04]
@@ -24,7 +25,6 @@ jobs:
 
       - name: Generate global.json
         run: |
-          echo "DotNetVersion=${{ env.DotnetVersion }}"
           echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > global.json
 
       - name: Setup .NET Core SDK
@@ -149,8 +149,6 @@ jobs:
     name: PackageBinaries
     needs: [ build, tests ]
     runs-on: ubuntu-latest
-    env:
-      DotnetVersion: 9.0.307
     steps:
         - name: Clone Repository
           uses: actions/checkout@v5
@@ -159,7 +157,6 @@ jobs:
 
         - name: Generate global.json
           run: |
-            echo "DotNetVersion=${{ env.DotnetVersion }}"
             echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > global.json
 
         - name: Setup .NET Core SDK
@@ -180,8 +177,6 @@ jobs:
     name: Deploy
     needs: [ build, tests ]
     runs-on: ubuntu-latest
-    env:
-      DotnetVersion: 9.0.307
     if: ${{ github.event_name == 'push' }}
     permissions:
         packages: write
@@ -194,7 +189,6 @@ jobs:
 
         - name: Generate global.json
           run: |
-            echo "DotNetVersion=${{ env.DotnetVersion }}"
             echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > global.json
 
         - name: Setup .NET Core SDK
@@ -242,9 +236,6 @@ jobs:
     name: tests-${{ matrix.os }}
     needs: [ build, choose-runner ]
     runs-on: ${{ matrix.os }}
-    env:
-      DotnetVersion: 8.0.404
-      DOTNET_CLI_TELEMETRY_OPTOUT: 1 
     strategy:
       matrix:
         include:
@@ -272,7 +263,6 @@ jobs:
 
       - name: Generate global.json
         run: |
-          echo "DotNetVersion=${{ env.DotnetVersion }}"
           echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > global.json
 
       - name: Setup .NET Core SDK
@@ -319,7 +309,7 @@ jobs:
         with:
           name: tests-desktopgl-${{ matrix.platform }}
           path: tests-desktopgl
-
+          
       - name: Download tests-windowsdx-${{ matrix.platform }}
         if: runner.os == 'Windows' && runner.environment != 'github-hosted'
         uses: actions/download-artifact@v4
@@ -329,16 +319,16 @@ jobs:
 
       # Run the DirectX tests in two steps: first the audio, then the rest.
       # This is because the audio tests has some incompatibilities within the runner with ContentManagerTests.
-      - name: Run DirectX Audio Tests
-        if: runner.os == 'Windows' && runner.environment != 'github-hosted'
-        run: dotnet vstest ..\Tests\MonoGame.Tests.WindowsDX.csproj --TestCaseFilter:Category=Audio
-        env:
-          CI: true
-        working-directory: tests-windowsdx
+      # - name: Run DirectX Audio Tests
+      #   if: runner.os == 'Windows' && runner.environment != 'github-hosted'
+      #   run: dotnet test --filter Category=Audio MonoGame.Tests.dll 
+      #   env:
+      #     CI: true
+      #   working-directory: tests-windowsdx
         
       - name: Run DirectX All Tests Except Audio
         if: runner.os == 'Windows' && runner.environment != 'github-hosted'
-        run: dotnet vstest ..\Tests\MonoGame.Tests.WindowsDX.csproj --TestCaseFilter:"Category!=Audio" 
+        run: dotnet test --filter Category!=Audio MonoGame.Tests.dll  
         env:
           CI: true
         working-directory: tests-windowsdx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,14 +5,13 @@ on: [push, pull_request]
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
-env:
-  DotnetVersion: 9.0.307
-  
+ 
 jobs:
   build:
     name: build-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      DotnetVersion: 9.0.307
     strategy:
       matrix:
         os: [windows-latest, macos-26, ubuntu-24.04]
@@ -149,6 +148,8 @@ jobs:
     name: PackageBinaries
     needs: [ build, tests ]
     runs-on: ubuntu-latest
+    env:
+      DotnetVersion: 9.0.307
     steps:
         - name: Clone Repository
           uses: actions/checkout@v5
@@ -177,6 +178,8 @@ jobs:
     name: Deploy
     needs: [ build, tests ]
     runs-on: ubuntu-latest
+    env:
+      DotnetVersion: 9.0.307
     if: ${{ github.event_name == 'push' }}
     permissions:
         packages: write
@@ -237,6 +240,7 @@ jobs:
     needs: [ build, choose-runner ]
     runs-on: ${{ matrix.os }}
     env:
+      DotnetVersion: 8.0.404
       DOTNET_CLI_TELEMETRY_OPTOUT: 1 
     strategy:
       matrix:
@@ -312,21 +316,12 @@ jobs:
           name: tests-desktopgl-${{ matrix.platform }}
           path: tests-desktopgl
 
-      - name: Set global.json for tests-desktopgl
-        run: |
-          echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > tests-desktopgl/global.json
-
       - name: Download tests-windowsdx-${{ matrix.platform }}
         if: runner.os == 'Windows' && runner.environment != 'github-hosted'
         uses: actions/download-artifact@v4
         with:
           name: tests-windowsdx-${{ matrix.platform }}
           path: tests-windowsdx
-
-      - name: Set global.json for tests-windowsdx
-        if: runner.os == 'Windows' && runner.environment != 'github-hosted'
-        run: |
-          echo '{ "sdk": { "version": "${{ env.DotnetVersion }}" } }' > tests-windowsdx/global.json
 
       # Run the DirectX tests in two steps: first the audio, then the rest.
       # This is because the audio tests has some incompatibilities within the runner with ContentManagerTests.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -332,14 +332,14 @@ jobs:
       # This is because the audio tests has some incompatibilities within the runner with ContentManagerTests.
       - name: Run DirectX Audio Tests
         if: runner.os == 'Windows' && runner.environment != 'github-hosted'
-        run: dotnet test --filter Category=Audio MonoGame.Tests.dll 
+        run: dotnet vstest MonoGame.Tests.dll --TestCaseFilter:Category=Audio
         env:
           CI: true
         working-directory: tests-windowsdx
         
       - name: Run DirectX All Tests Except Audio
         if: runner.os == 'Windows' && runner.environment != 'github-hosted'
-        run: dotnet test --filter Category!=Audio MonoGame.Tests.dll 
+        run: dotnet vstest MonoGame.Tests.dll --TestCaseFilter:"Category!=Audio" 
         env:
           CI: true
         working-directory: tests-windowsdx


### PR DESCRIPTION
# Summary

After applying environment and dotnet fixes for automation, windows tests are now failing.

These fixes are forcing dotnet 9 and disabling parsing