### PR TITLE
Feature Opengl Native

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Premake5
         uses: abel0b/setup-premake@v2.4
         with:
-          version: "5.0.0-beta2"
+          version: "5.0.0-beta6"
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -101,7 +101,16 @@ jobs:
 
       - name: Install Fonts
         uses: monogame/monogame-actions/install-fonts@v1
-        
+
+      - name: Setup Emsdk
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: '3.1.56'
+      
+      - name: List Emscripten Version
+        run: |
+          emcc --version
+
       - name: Install SDL2 deps on Linux
         if: runner.os == 'Linux'
         run: |
@@ -111,6 +120,20 @@ jobs:
             libwayland-dev libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
             libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev \
             libpipewire-0.3-dev libdecor-0-dev
+
+      - name: Clean Up Disk Space
+        if: runner.os == 'Linux'
+        run: |
+          # Space usage before cleanup
+          df -h /
+      
+          # Remove unused tool caches (comment any required ones with #)
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      
+          # Verify gains
+          df -h /
 
       - name: Dotnet Restore Templates
         if: runner.environment == 'github-hosted' && runner.os == 'Windows'

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Xna.Framework
                 // We only have a precision timer on Windows, so other platforms may still overshoot
 #if WINDOWS && !DESKTOPGL
                 MonoGame.Framework.Utilities.TimerHelper.SleepForNoMoreThan(sleepTime);
-#elif DESKTOPGL || ANDROID || IOS
+#elif DESKTOPGL || ANDROID || IOS || NATIVE
                 if (sleepTime >= 2.0)
                     System.Threading.Thread.Sleep(1);
 #endif

--- a/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using MonoGame.Interop;
 using System.Threading;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework;
 
@@ -28,6 +29,22 @@ class NativeGamePlatform : GamePlatform
     private readonly List<string> _dropList = new List<string>(64);
 
     private int _isExiting;
+
+    private static Game _emscriptenGame;
+    private delegate void em_callback_func();
+
+    [DllImport("*", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void emscripten_set_main_loop(em_callback_func func, int fps, bool simulateInfiniteLoop);
+
+    [DllImport("*", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void emscripten_cancel_main_loop();
+
+    [ObjCRuntime.MonoPInvokeCallback(typeof(em_callback_func))]
+    private static unsafe void RunEmscriptenMainLoop()
+    {
+        _emscriptenGame.Tick();
+    }
+
 
     public unsafe NativeGamePlatform(Game game) : base(game)
     {
@@ -271,7 +288,15 @@ class NativeGamePlatform : GamePlatform
 
     public override unsafe void StartRunLoop()
     {
-        MGP.Platform_StartRunLoop(Handle);
+        if (PlatformInfo.MonoGamePlatform == MonoGamePlatform.WebGL)
+        {
+            _emscriptenGame = this.Game;
+            emscripten_set_main_loop(RunEmscriptenMainLoop, fps: 0, simulateInfiniteLoop: false);
+        }
+        else
+        {
+            MGP.Platform_StartRunLoop(Handle);
+        }
     }
 
     public override unsafe void BeforeInitialize()

--- a/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Drawing;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 

--- a/MonoGame.Framework/Platform/Native/ObjCRuntime.cs
+++ b/MonoGame.Framework/Platform/Native/ObjCRuntime.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ObjCRuntime;
+
+[AttributeUsage(AttributeTargets.Method)]
+class MonoPInvokeCallbackAttribute : Attribute
+{
+    public MonoPInvokeCallbackAttribute(Type t)
+    {
+
+    }
+}

--- a/MonoGame.Framework/Platform/Native/VertexElement.Native.cs
+++ b/MonoGame.Framework/Platform/Native/VertexElement.Native.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Runtime.InteropServices;
 using MonoGame.Interop;
 
 namespace Microsoft.Xna.Framework.Graphics;

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -28,7 +28,7 @@ public class BuildContext : FrostingContext
     public BuildContext(ICakeContext context) : base(context)
     {
         var repositoryUrl = context.Argument("build-repository", DefaultRepositoryUrl);
-        var buildConfiguration = context.Argument("build-configuration", "Release");
+        BuildConfiguration = context.Argument("build-configuration", "Release");
         BuildOutput = context.Argument("build-output", "Artifacts");
         NuGetsDirectory = $"{BuildOutput}/NuGet/";
         BinariesDirectory = $"{BuildOutput}/Binaries/";
@@ -43,7 +43,7 @@ public class BuildContext : FrostingContext
         {
             MSBuildSettings = DotNetMSBuildSettings,
             Verbosity = DotNetVerbosity.Minimal,
-            Configuration = buildConfiguration,
+            Configuration = BuildConfiguration,
             WorkingDirectory = this.ShellWorkingDir
         };
 
@@ -52,14 +52,14 @@ public class BuildContext : FrostingContext
             MSBuildSettings = DotNetMSBuildSettings,
             Verbosity = DotNetVerbosity.Minimal,
             OutputDirectory = NuGetsDirectory,
-            Configuration = buildConfiguration,
+            Configuration = BuildConfiguration,
             WorkingDirectory = this.ShellWorkingDir
         };
 
         MSBuildSettings = new MSBuildSettings
         {
             Verbosity = Verbosity.Minimal,
-            Configuration = buildConfiguration
+            Configuration = BuildConfiguration
         };
         MSBuildSettings.WithProperty(nameof(Version), Version);
         MSBuildSettings.WithProperty(nameof(repositoryUrl), repositoryUrl);
@@ -67,7 +67,7 @@ public class BuildContext : FrostingContext
         MSPackSettings = new MSBuildSettings
         {
             Verbosity = Verbosity.Minimal,
-            Configuration = buildConfiguration,
+            Configuration = BuildConfiguration,
             Restore = true
         };
         MSPackSettings.WithProperty(nameof(Version), Version);
@@ -79,7 +79,7 @@ public class BuildContext : FrostingContext
         {
             MSBuildSettings = DotNetMSBuildSettings,
             Verbosity = DotNetVerbosity.Minimal,
-            Configuration = buildConfiguration,
+            Configuration = BuildConfiguration,
             SelfContained = false,
             WorkingDirectory = this.ShellWorkingDir
         };
@@ -88,7 +88,7 @@ public class BuildContext : FrostingContext
         {
             MSBuildSettings = DotNetMSBuildSettings,
             Verbosity = DotNetVerbosity.Minimal,
-            Configuration = buildConfiguration,
+            Configuration = BuildConfiguration,
             WorkingDirectory = this.ShellWorkingDir
         };
 
@@ -103,14 +103,14 @@ public class BuildContext : FrostingContext
         {
             MSBuildSettings = DotNetMSBuildSettings,
             Verbosity = DotNetVerbosity.Minimal,
-            Configuration = buildConfiguration,
+            Configuration = BuildConfiguration,
             OutputDirectory = BinariesDirectory,
             WorkingDirectory = this.ShellWorkingDir
         };
 
         Console.WriteLine($"Version: {Version}");
         Console.WriteLine($"RepositoryUrl: {repositoryUrl}");
-        Console.WriteLine($"BuildConfiguration: {buildConfiguration}");
+        Console.WriteLine($"BuildConfiguration: {BuildConfiguration}");
 
         if (context.IsRunningOnWindows())
         {
@@ -155,6 +155,8 @@ public class BuildContext : FrostingContext
     public MSBuildSettings MSPackSettings { get; }
 
     public string ShellWorkingDir { get; set; } = Directory.GetCurrentDirectory();
+
+    public string BuildConfiguration { get;}
 
     public string GetProjectPath(ProjectType type, string id = "") => type switch
     {

--- a/build/BuildFrameworksTasks/BuildEmscriptenTask.cs
+++ b/build/BuildFrameworksTasks/BuildEmscriptenTask.cs
@@ -1,0 +1,15 @@
+﻿
+namespace BuildScripts;
+
+[TaskName("Build Emscripten")]
+[IsDependentOn(typeof(BuildNativeDependenciesTask))]
+public sealed class BuildEmscriptenTask : FrostingTask<BuildContext>
+{
+    public override bool ShouldRun(BuildContext context) => !context.IsRunningOnWindows();
+    public override void Run(BuildContext context)
+    {
+        var buildPremake = new BuildPremake();
+        buildPremake.Run(context, "Emscripten", "native/monogame", "monogame.sln", "emscripten");
+
+    }
+}

--- a/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
+++ b/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
@@ -7,6 +7,10 @@ public sealed class BuildNativeDependenciesTask : FrostingTask<BuildContext>
     {
         BuildSDL2(context);
         BuildFAudio(context);
+        if (context.IsRunningOnWindows())
+            return;
+        BuildSDL2ForEmscripten(context);
+        BuildFAudioForEmscripten(context);
     }
 
     private void BuildSDL2(BuildContext context)
@@ -51,6 +55,145 @@ public sealed class BuildNativeDependenciesTask : FrostingTask<BuildContext>
         RunCMake(context, configureArgs, "FAudio CMake configuration failed!");
 
         RunCMakeBuild(context, faudioBuildDir, "Release", "FAudio build failed!");
+    }
+
+    void BuildSDL2ForEmscripten(BuildContext context)
+    {
+        var sdlSourceDir = "native/monogame/external/sdl2/sdl";
+        var sdlBuildDir = System.IO.Path.Combine(sdlSourceDir, "build_emscripten");
+        
+        RecreateDirectory(context, sdlBuildDir);
+
+        var configureSettings = new ProcessSettings { WorkingDirectory = sdlBuildDir };
+        SetupEmscriptenEnvironment(context, configureSettings);
+        var configureArgs = new ProcessArgumentBuilder();
+        // Add the relative path to the source directory.
+        configureArgs.Append("cmake");
+        configureArgs.Append("../");
+        configureArgs.Append("-DSDL_STATIC=ON -DSDL_TEST=OFF");
+        configureArgs.Append($"-D CMAKE_BUILD_TYPE=Release");
+
+        configureSettings.Arguments = configureArgs;
+
+        var emcmake = context.IsRunningOnWindows() ? "emcmake.bat" : "emcmake";
+
+        if (context.StartProcess(emcmake, configureSettings) != 0)
+        {
+            throw new Exception("SDL2 Emscripten CMake configuration failed!");
+        }
+
+        var buildSettings = new ProcessSettings { WorkingDirectory = sdlBuildDir };
+        SetupEmscriptenEnvironment(context, buildSettings);
+            
+        var buildArgs = new ProcessArgumentBuilder();
+        buildArgs.Append("make");
+
+        buildSettings.Arguments = buildArgs;
+
+        var emmake = context.IsRunningOnWindows() ? "emmake.bat" : "emmake";
+
+        if (context.StartProcess(emmake, buildSettings) != 0)
+        {
+            throw new Exception("SDL2 Emscripten build failed!");
+        }
+
+        var sourcePath = context.GetOutputPath($"Artifacts/monogame.native/emscripten/wasm/{context.BuildConfiguration}");
+
+        if (!context.DirectoryExists(sourcePath))
+        {
+            context.CreateDirectory(sourcePath);
+        }
+
+        context.CopyFile(
+            System.IO.Path.Combine(sdlBuildDir, "libSDL2.a"),
+            System.IO.Path.Combine(sourcePath, "libSDL2.a"));
+    }
+
+    void BuildFAudioForEmscripten(BuildContext context)
+    {
+        var faudioSourceDir = "native/monogame/external/faudio";
+        var faudioBuildDir = System.IO.Path.Combine(faudioSourceDir, "build_emscripten");
+
+        RecreateDirectory(context, faudioBuildDir);
+
+        var sdlIncludeDir = System.IO.Path.Combine("native/monogame/external/sdl2/sdl", "include");
+        var sdlBuildDir = System.IO.Path.Combine("native/monogame/external/sdl2/sdl", "build_emscripten");
+        var sdlLibPath = System.IO.Path.Combine(sdlBuildDir, "libSDL2.a");
+
+        var configureSettings = new ProcessSettings { WorkingDirectory = faudioBuildDir };
+        SetupEmscriptenEnvironment(context, configureSettings);
+        var configureArgs = new ProcessArgumentBuilder();
+        // Add the relative path to the source directory.
+        configureArgs.Append("cmake");
+        configureArgs.Append("../");
+        configureArgs.Append("-DBUILD_SHARED_LIBS=OFF");
+        configureArgs.Append($"-DSDL2_INCLUDE_DIRS={context.MakeAbsolute(new DirectoryPath(sdlIncludeDir))}");
+        configureArgs.Append($"-DSDL2_LIBRARIES={context.MakeAbsolute(new FilePath(sdlLibPath))}");
+        configureArgs.Append($"-DCMAKE_C_STANDARD_INCLUDE_DIRECTORIES={context.MakeAbsolute(new DirectoryPath(sdlIncludeDir))}");
+        configureArgs.Append($"-DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES={context.MakeAbsolute(new DirectoryPath(sdlIncludeDir))}");
+        configureArgs.Append("-DBUILD_SDL3=OFF");
+        configureArgs.Append($"-D CMAKE_BUILD_TYPE=Release");
+
+        configureSettings.Arguments = configureArgs;
+
+        var emcmake = context.IsRunningOnWindows() ? "emcmake.bat" : "emcmake";
+
+        if (context.StartProcess(emcmake, configureSettings) != 0)
+        {
+            throw new Exception("FAudio Emscripten CMake configuration failed!");
+        }
+
+        var buildSettings = new ProcessSettings { WorkingDirectory = faudioBuildDir };
+        SetupEmscriptenEnvironment(context, buildSettings);
+        var buildArgs = new ProcessArgumentBuilder();
+        buildArgs.Append("make");
+
+        buildSettings.Arguments = buildArgs;
+
+        var emmake = context.IsRunningOnWindows() ? "emmake.bat" : "emmake";
+        
+        if (context.StartProcess(emmake, buildSettings) != 0)
+        {
+            throw new Exception("FAudio Emscripten build failed!");
+        }
+
+        var sourcePath = context.GetOutputPath($"Artifacts/monogame.native/emscripten/wasm/{context.BuildConfiguration}");
+
+        if (!context.DirectoryExists(sourcePath))
+        {
+            context.CreateDirectory(sourcePath);
+        }
+
+        context.CopyFile(
+            System.IO.Path.Combine(faudioBuildDir, "libFAudio.a"),
+            System.IO.Path.Combine(sourcePath, "libFAudio.a"));
+    }
+
+    private void SetupEmscriptenEnvironment(BuildContext context, ProcessSettings settings)
+    {
+        var emSdkDir = System.Environment.GetEnvironmentVariable("EMSDK") ?? string.Empty;
+        var emscriptenDir = System.IO.Path.Combine(emSdkDir, "upstream", "emscripten");
+        var nodeDir =  System.Environment.GetEnvironmentVariable("EMSDK_NODE") ?? string.Empty;
+        var pythonDir = System.Environment.GetEnvironmentVariable("EMSDK_PYTHON") ?? string.Empty;
+        var llvmBin =   System.IO.Path.Combine(emSdkDir, "upstream", "bin");
+        settings.EnvironmentVariables = new Dictionary<string, string>()
+        {
+            { "EMSDK", emSdkDir },
+            { "EMSDK_NODE", nodeDir },
+            { "EMSDK_PYTHON", pythonDir },
+            { "EMSCRIPTEN", emscriptenDir },
+            { "PATH", $"{emSdkDir};{emscriptenDir};{llvmBin};{nodeDir};{pythonDir};{System.Environment.GetEnvironmentVariable("PATH")}" }
+        };
+        if (!context.IsRunningOnWindows())
+        {
+            settings.EnvironmentVariables["PATH"] = $"{emSdkDir}:{emscriptenDir}:{llvmBin}:{nodeDir}:{pythonDir}:{System.Environment.GetEnvironmentVariable("PATH")}";
+        }
+
+        context.Information("Emscripten Environment Variables:");
+        foreach (var kvp in settings.EnvironmentVariables)
+        {
+            context.Information($"{kvp.Key}={kvp.Value}");
+        }
     }
 
     private void AppendPlatformCMakeArgs(ProcessArgumentBuilder args, BuildContext context, bool isSDL)

--- a/build/DeployTasks/UploadArtifactsTask.cs
+++ b/build/DeployTasks/UploadArtifactsTask.cs
@@ -51,6 +51,7 @@ public sealed class UploadArtifactsTask : AsyncFrostingTask<BuildContext>
                 break;
             case PlatformFamily.Linux:
                 await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/native/mgpipeline/linux/Release/"), $"mgpipeline-{os}.{context.Version}");
+                await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/emscripten/wasm/Release/"), $"mgnative-wasm-{os}.{context.Version}");
                 //await context.GitHubActions().Commands.UploadArtifact(new DirectoryPath("Artifacts/monogame.native/linux/"), $"mgnative-{os}.{context.Version}");
                 break;
             case PlatformFamily.OSX:

--- a/build/Tasks.cs
+++ b/build/Tasks.cs
@@ -10,6 +10,7 @@ public sealed class BuildShadersTask : FrostingTask<BuildContext> { }
 
 [TaskName("Build Frameworks")]
 [IsDependentOn(typeof(BuildNativeTask))]
+[IsDependentOn(typeof(BuildEmscriptenTask))]
 [IsDependentOn(typeof(BuildDesktopGLTask))]
 [IsDependentOn(typeof(BuildWindowsDXTask))]
 [IsDependentOn(typeof(BuildAndroidTask))]

--- a/build/Utils/BuildPremake.cs
+++ b/build/Utils/BuildPremake.cs
@@ -3,7 +3,7 @@ namespace BuildScripts;
 
 public sealed class BuildPremake
 {
-    public void Run(BuildContext context, string name, string workingDirectory, string solutionFile)
+    public void Run(BuildContext context, string name, string workingDirectory, string solutionFile, string os = "")
     {
         int exit;
         exit = context.StartProcess("premake5", new ProcessSettings { WorkingDirectory = workingDirectory, Arguments = "clean" });
@@ -22,6 +22,9 @@ public sealed class BuildPremake
             default:
                 throw new NotSupportedException($"Platform {context.Environment.Platform.Family} is not supported for building the {name}.");
         }
+
+        if (!string.IsNullOrEmpty(os))
+            premakeArguments += $" --os={os}";
 
         exit = context.StartProcess("premake5", new ProcessSettings { WorkingDirectory = workingDirectory, Arguments = premakeArguments });
         if (exit != 0)

--- a/native/monogame/include/mg_effect.h
+++ b/native/monogame/include/mg_effect.h
@@ -9,6 +9,8 @@
 #define MG_BUILTIN_EFFECT_SYMBOL(name) name##_dx12_mgfxo
 #elif defined(MG_VULKAN)
 #define MG_BUILTIN_EFFECT_SYMBOL(name) name##_vk_mgfxo
+#elif defined(MG_OPENGL)
+#define MG_BUILTIN_EFFECT_SYMBOL(name) name##_ogl_mgfxo
 #else
 #error "Unsupported graphics backend, this header is intended for native builtin effects embedding only."
 #endif

--- a/native/monogame/opengl/MGG_OpenGL.cpp
+++ b/native/monogame/opengl/MGG_OpenGL.cpp
@@ -1,0 +1,880 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#include "api_MGG.h"
+#include "mg_common.h"
+
+// Effect includes for OpenGL
+// #include "AlphaTestEffect.ogl.mgfxo.h"
+// #include "BasicEffect.ogl.mgfxo.h"
+// #include "DualTextureEffect.ogl.mgfxo.h"
+// #include "EnvironmentMapEffect.ogl.mgfxo.h"
+// #include "SkinnedEffect.ogl.mgfxo.h"
+// #include "SpriteEffect.ogl.mgfxo.h"
+//#include "mg_effect.h"
+
+// Include required headers for OpenGL/Emscripten
+#if defined(MG_EMSCRIPTEN)
+#include <emscripten.h>
+#include <emscripten/html5.h>
+// Include OpenGLES 3.0 headers
+#include <GLES3/gl3.h>
+#else
+// #if defined(__APPLE__)
+// #include <OpenGL/gl.h>
+// #include <OpenGL/glext.h>
+// #else
+// #include <GL/gl.h>
+// #include <GL/glext.h>
+// #endif
+#endif
+
+#if defined(MG_SDL2)
+#define GL_GLEXT_PROTOTYPES 1
+#include <SDL.h>
+#include <SDL_opengl.h>
+#include <SDL_opengl_glext.h>
+#endif
+
+#include <vector>
+#include <string>
+#include <cstring>
+
+// Debug macros
+#ifdef DEBUG
+void GL_CHECK_ERROR() { \
+    GLenum err = glGetError(); \
+    if (err != GL_NO_ERROR) { \
+        fprintf(stderr, "OpenGL error %d at %s:%d\n", err, __FILE__, __LINE__); \
+    } \
+}
+#else
+#define GL_CHECK_ERROR() ((void)0)
+#endif
+// Structures for OpenGL graphics system
+
+struct MGG_GraphicsAdapter {
+    // OpenGL specific adapter info
+    char name[128] = { 0 };
+    char vendor[128] = { 0 };
+    char version[128] = { 0 };
+};
+
+struct MGG_GraphicsSystem {
+    std::vector<MGG_GraphicsAdapter*> adapters;
+};
+
+struct MGG_GraphicsDevice
+{
+    MGG_GraphicsSystem* system = nullptr;
+    MGG_GraphicsAdapter* adapter = nullptr;
+    
+#if defined(MG_EMSCRIPTEN)
+    EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = 0;
+#else
+    SDL_GLContext context = nullptr;
+    SDL_Window* window = nullptr;
+#endif
+
+    // Viewport
+    int viewportX = 0;
+    int viewportY = 0;
+    int viewportWidth = 0;
+    int viewportHeight = 0;
+    float viewportMinDepth = 0.0f;
+    float viewportMaxDepth = 1.0f;
+    
+    // Scissor rect
+    int scissorX = 0;
+    int scissorY = 0;
+    int scissorWidth = 0;
+    int scissorHeight = 0;
+};
+
+struct MGG_Buffer {
+    MGBufferType type;
+    int sizeInBytes;
+    std::string name;  // Optional name
+};
+
+struct MGG_Texture {
+    MGTextureType type;
+    MGSurfaceFormat format;
+    int width;
+    int height;
+    int depth;
+    int mipmaps;
+    int slices;
+    bool isRenderTarget;
+    MGDepthFormat depthFormat;
+    GLuint texture;
+};
+
+struct MGG_SamplerState {
+    MGG_SamplerState_Info info;
+    GLuint sampler;
+};
+
+struct MGG_BlendState {
+    MGG_BlendState_Info info;
+    GLuint state;
+};
+
+struct MGG_DepthStencilState {
+    MGG_DepthStencilState_Info info;
+    GLuint state;
+};
+
+struct MGG_RasterizerState {
+    MGG_RasterizerState_Info info;
+    GLuint state;
+};
+
+struct MGG_Shader {
+    MGShaderStage stage;
+    std::vector<uint8_t> bytecode;
+    GLuint shader;
+};
+
+struct MGG_InputLayout {
+    std::vector<MGG_InputElement> elements;
+    std::vector<int> strides;
+};
+
+struct MGG_OcclusionQuery {
+    bool isActive;
+};
+
+// Implementation of API functions
+
+MGG_GraphicsSystem* MGG_GraphicsSystem_Create() {
+    printf("Creating OpenGL graphics system\n");
+    MGG_GraphicsSystem* system = new MGG_GraphicsSystem();
+    
+#if defined(MG_EMSCRIPTEN)
+    // Create a default adapter
+    MGG_GraphicsAdapter* adapter = new MGG_GraphicsAdapter();
+    system->adapters.push_back(adapter);
+#else
+    // Non-Emscripten build - create a dummy adapter for testing
+    MGG_GraphicsAdapter* adapter = new MGG_GraphicsAdapter();
+    system->adapters.push_back(adapter);
+#endif
+    return system;
+}
+
+void MGG_GraphicsSystem_Destroy(MGG_GraphicsSystem* system) {
+    printf("Destroying OpenGL graphics system\n");
+    for (auto adapter : system->adapters) {
+        delete adapter;
+    }
+    delete system;
+}
+
+MGG_GraphicsAdapter* MGG_GraphicsAdapter_Get(MGG_GraphicsSystem* system, mgint index) {
+    printf("Getting OpenGL graphics adapter at index %d\n", index);
+    if (!system) return nullptr;
+    if (index >= 0 && index < static_cast<mgint>(system->adapters.size())) {
+        return system->adapters[index];
+    }
+    return nullptr;
+}
+
+void MGG_GraphicsAdapter_GetInfo(MGG_GraphicsAdapter* adapter, MGG_GraphicsAdaptor_Info& info) {
+    assert(adapter);
+    printf("Getting info for OpenGL graphics adapter: %s\n", adapter->name);
+    // Set adapter properties based on OpenGL capabilities
+    // The actual implementation would query these from the OpenGL context
+    info.DeviceName = adapter->name;
+    info.Description = adapter->vendor;
+    info.DeviceId = 0;
+    info.Revision = 0;
+    info.VendorId = 0;
+    info.SubSystemId = 0;
+    info.MonitorHandle = nullptr;
+    info.DisplayModes = nullptr;
+    info.DisplayModeCount = 0;
+    // Initialize CurrentDisplayMode with zeros
+    info.CurrentDisplayMode = { MGSurfaceFormat::Color, 0, 0 };
+}
+
+MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_GraphicsAdapter* adapter) {
+    printf("Creating OpenGL graphics device\n");
+    MGG_GraphicsDevice* device = new MGG_GraphicsDevice();
+    device->system = system;
+    device->adapter = adapter;
+printf("Creating OpenGL graphics device\n");
+#if defined(MG_EMSCRIPTEN)
+    // Set up OpenGL context attributes
+    EmscriptenWebGLContextAttributes attrs;
+    emscripten_webgl_init_context_attributes(&attrs);
+    attrs.majorVersion = 2; // OpenGL 2.0 maps to OpenGLES 3.0
+    attrs.minorVersion = 0;
+    attrs.enableExtensionsByDefault = 1;
+    attrs.alpha = 1;
+    attrs.depth = 1;
+    attrs.stencil = 1;
+    attrs.antialias = 1;
+    attrs.premultipliedAlpha = 1;
+    attrs.preserveDrawingBuffer = 0;
+    attrs.powerPreference = EM_WEBGL_POWER_PREFERENCE_DEFAULT;
+    attrs.failIfMajorPerformanceCaveat = 0;
+    printf("Getting canvas\n");
+    
+    // Get the canvas element - assuming the default "#canvas" selector
+    device->context = emscripten_webgl_create_context("#canvas", &attrs);
+    printf("Got canvas %lu\n", device->context);
+    if (device->context <= 0) {
+        fprintf(stderr, "Failed to create OpenGL context: %lu\n", device->context);
+        delete device;
+        return nullptr;
+    }
+     printf("making current\n");
+    // Make the context current
+    EMSCRIPTEN_RESULT result = emscripten_webgl_make_context_current(device->context);
+    if (result != EMSCRIPTEN_RESULT_SUCCESS) {
+        fprintf(stderr, "Failed to make OpenGL context current: %d\n", result);
+        emscripten_webgl_destroy_context(device->context);
+        delete device;
+        return nullptr;
+    }
+#else
+    // Set OpenGL attributes for SDL
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+
+    // GLES compatibility
+    // SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    // SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+    // SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+    // dont use this for max compatibility
+    //SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+    SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+    
+    // Try to get the current window first
+    device->window = SDL_GetWindowFromID(1);
+
+    // Create OpenGL context
+    device->context = SDL_GL_CreateContext(device->window);
+    // If 4.3 fails, try 4.1 (for macOS)
+    if (!device->context) {
+        printf("OpenGL 4.3 not available, trying 4.1...\n");
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+        device->context = SDL_GL_CreateContext(device->window);
+    }
+    
+    if (!device->context) {
+        fprintf(stderr, "Failed to create OpenGL context: %s\n", SDL_GetError());
+        delete device;
+        return nullptr;
+    }
+    
+    // Make the context current
+    if (SDL_GL_MakeCurrent(device->window, device->context) < 0) {
+        fprintf(stderr, "Failed to make OpenGL context current: %s\n", SDL_GetError());
+        SDL_GL_DeleteContext(device->context);
+        delete device;
+        return nullptr;
+    }
+#endif
+    // Print OpenGL version information
+    const GLubyte* version = glGetString(GL_VERSION);
+    const GLubyte* vendor = glGetString(GL_VENDOR);
+    const GLubyte* renderer = glGetString(GL_RENDERER);
+    const GLubyte* glslVersion = glGetString(GL_SHADING_LANGUAGE_VERSION);
+    
+    printf("=== OpenGL Context Information ===\n");
+    printf("OpenGL Version: %s\n", version ? (const char*)version : "Unknown");
+    printf("OpenGL Vendor: %s\n", vendor ? (const char*)vendor : "Unknown");
+    printf("OpenGL Renderer: %s\n", renderer ? (const char*)renderer : "Unknown");
+    printf("GLSL Version: %s\n", glslVersion ? (const char*)glslVersion : "Unknown");
+    printf("==================================\n");
+
+    // Initialize default viewport state
+    device->viewportX = 0;
+    device->viewportY = 0;
+    device->viewportWidth = 800;  // Default size
+    device->viewportHeight = 600; // Default size
+    device->viewportMinDepth = 0.0f;
+    device->viewportMaxDepth = 1.0f;
+    
+    // Initialize default scissor state
+    device->scissorX = 0;
+    device->scissorY = 0;
+    device->scissorWidth = 800;  // Default size
+    device->scissorHeight = 600; // Default size
+    printf("Created OpenGL graphics device: %lu\n", device->context);
+    return device;
+}
+
+void MGG_GraphicsDevice_Destroy(MGG_GraphicsDevice* device) {
+    if (!device) return;
+    printf("Destroying OpenGL graphics device: %zu\n", (size_t)device->context);
+#if defined(MG_EMSCRIPTEN)
+    // Destroy the OpenGL context
+    if (device->context > 0) {
+        emscripten_webgl_destroy_context(device->context);
+        device->context = 0;
+    }
+#else
+    if (!device->context) {
+        // Dummy context - nothing to destroy
+        SDL_GL_DeleteContext(device->context);
+        device->context = nullptr;
+    }
+#endif
+}
+
+void MGG_GraphicsDevice_GetCaps(MGG_GraphicsDevice* device, MGG_GraphicsDevice_Caps& caps) {
+    // Set device capabilities based on OpenGL capabilities
+    printf("Getting capabilities for OpenGL graphics device: %zu\n", (size_t)device->context);
+#if defined(MG_EMSCRIPTEN)
+    caps.MaxTextureSlots = 16;
+    caps.MaxVertexBufferSlots = 8;
+    caps.MaxVertexTextureSlots = 8;
+#else
+    glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &caps.MaxTextureSlots);
+    GL_CHECK_ERROR();
+    glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, &caps.MaxVertexTextureSlots);
+    GL_CHECK_ERROR();
+    glGetIntegerv(GL_MAX_VERTEX_ATTRIBS, &caps.MaxVertexBufferSlots);
+    GL_CHECK_ERROR();
+#endif
+    caps.ShaderProfile = 0; // OpenGL MonoGame Shader Profile
+    printf("Device capabilities: MaxTextureSlots=%d, MaxVertexBufferSlots=%d, MaxVertexTextureSlots=%d\n",
+           caps.MaxTextureSlots, caps.MaxVertexBufferSlots, caps.MaxVertexTextureSlots);
+}
+
+void MGG_GraphicsDevice_ResizeSwapchain(MGG_GraphicsDevice* device, void* nativeWindowHandle, mgint width, mgint height, MGSurfaceFormat color, MGDepthFormat depth, mgint syncInterval) {
+    if (!device) return;
+    printf("Resizing OpenGL graphics device: %zu (width=%d, height=%d)\n", (size_t)device->context, width, height);
+#if defined(MG_EMSCRIPTEN)
+    // In WebGL, we don't need to explicitly resize the swapchain
+    // The browser handles canvas resizing
+    
+    // We can use emscripten_set_canvas_element_size to resize the canvas if needed
+    if (width > 0 && height > 0) {
+        emscripten_set_canvas_element_size("#canvas", width, height);
+    }
+#else
+    // For desktop OpenGL, we need to recreate the framebuffer
+    switch (depth)
+    {
+        case MGDepthFormat::None:
+            // No depth buffer needed
+            SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0);
+            SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 0);
+            SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+            break;
+        case MGDepthFormat::Depth16:
+            SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 16);
+            SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 0);
+            SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+            break;
+        case MGDepthFormat::Depth24:
+            SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+            SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 0);
+            SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+            break;
+        case MGDepthFormat::Depth24Stencil8:
+            SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+            SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
+            SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+            break;
+        default:
+            fprintf(stderr, "Unsupported depth format for OpenGL: %d\n", (int)depth);
+            break;
+    }
+    if (device->context) {
+        SDL_GL_DeleteContext(device->context);
+        device->context = nullptr;
+    }
+    device->context = SDL_GL_CreateContext(device->window);
+    if (!device->context) {
+        fprintf(stderr, "Failed to create OpenGL context: %s\n", SDL_GetError());
+        delete device;
+        return;
+    }
+    // all the tetures will be gone now, so we need to recreate them
+    
+    // Make the context current
+    if (SDL_GL_MakeCurrent(device->window, device->context) < 0) {
+        fprintf(stderr, "Failed to make OpenGL context current: %s\n", SDL_GetError());
+        SDL_GL_DeleteContext(device->context);
+        delete device;
+        return;
+    }
+    // For SDL, we can set the window size
+    if (device->window) {
+        SDL_SetWindowSize(device->window, width, height);
+    }
+#endif
+    
+    // Update viewport to match new size
+    device->viewportWidth = width;
+    device->viewportHeight = height;
+    glViewport(device->viewportX, device->viewportY, width, height);
+    GL_CHECK_ERROR();
+    
+    // Update scissor rectangle to match new size
+    device->scissorWidth = width;
+    device->scissorHeight = height;
+    glScissor(device->scissorX, device->scissorY, width, height);
+    GL_CHECK_ERROR();
+    printf("Resized OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+mgint MGG_GraphicsDevice_BeginFrame(MGG_GraphicsDevice* device) {
+    printf("Beginning frame for OpenGL graphics device\n");
+    if (!device) return 0;
+    
+#if defined(MG_EMSCRIPTEN)
+    // Make sure our context is current
+    EMSCRIPTEN_RESULT result = emscripten_webgl_make_context_current(device->context);
+    if (result != EMSCRIPTEN_RESULT_SUCCESS) {
+        fprintf(stderr, "Failed to make OpenGL context current: %d\n", result);
+        return 0;
+    }
+#else
+    SDL_GL_MakeCurrent(device->window, device->context);
+#endif
+    printf("Ending frame for OpenGL graphics device: %zu\n", (size_t)device->context);
+
+    return 1; // Frame index - OpenGL doesn't use multiple frames like Vulkan
+}
+
+void MGG_GraphicsDevice_Clear(MGG_GraphicsDevice* device, MGClearOptions options, Vector4& color, mgfloat depth, mgint stencil) {
+    printf("Clearing OpenGL graphics device\n");
+    if (!device) return;
+    
+    // Check which framebuffer is currently bound
+    GLint currentFramebuffer = 0;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &currentFramebuffer);
+    printf("Current framebuffer: %d\n", currentFramebuffer);
+    
+    GLbitfield clearMask = 0;
+    
+    // Set clear color if color buffer is being cleared
+    if (static_cast<mgint>(options) & static_cast<mgint>(MGClearOptions::Target)) {
+        glClearColor(color.X, color.Y, color.Z, color.W);
+        GL_CHECK_ERROR();
+        clearMask |= GL_COLOR_BUFFER_BIT;
+        printf("Clear color: (%f, %f, %f, %f)\n", color.X, color.Y, color.Z, color.W);
+    }
+    
+    // Set clear depth if depth buffer is being cleared
+    if (static_cast<mgint>(options) & static_cast<mgint>(MGClearOptions::DepthBuffer)) {
+#if defined(MG_EMSCRIPTEN)
+        // WebGL/OpenGL ES uses glClearDepthf
+        glClearDepthf(depth);
+#else
+        // Desktop OpenGL uses glClearDepth with double parameters
+        glClearDepth((double)depth);
+#endif
+        GL_CHECK_ERROR();
+        clearMask |= GL_DEPTH_BUFFER_BIT;
+        printf("Clear depth: %f\n", depth);
+    }
+    
+    // Set clear stencil if stencil buffer is being cleared
+    if (static_cast<mgint>(options) & static_cast<mgint>(MGClearOptions::Stencil)) {
+        glClearStencil(stencil);
+        GL_CHECK_ERROR();
+        clearMask |= GL_STENCIL_BUFFER_BIT;
+        printf("Clear stencil: %d\n", stencil);
+    }
+    
+    // Perform the clear operation
+    if (clearMask != 0) {
+        printf("Calling glClear with mask: 0x%x\n", clearMask);
+        glClear(clearMask);
+        GL_CHECK_ERROR();
+    }
+    
+    GL_CHECK_ERROR();
+
+    printf("Cleared OpenGL graphics device\n");
+}
+
+void MGG_GraphicsDevice_Present(MGG_GraphicsDevice* device, mgint currentFrame, mgint syncInterval) {
+    if (!device) return;
+    printf("Presenting OpenGL graphics device: %zu (syncInterval=%d)\n", (size_t)device->context, syncInterval);
+   
+#if defined(MG_EMSCRIPTEN)
+    // In WebGL, the browser handles buffer swapping with requestAnimationFrame
+    // We don't need to do anything special here, as opposed to other APIs
+    
+    // We could potentially use emscripten_set_main_loop_timing to control frame rate
+    // But typically the browser's requestAnimationFrame handles this well
+#else
+    // Ensure we're swapping the correct window
+    SDL_Window* currentWindow = SDL_GL_GetCurrentWindow();
+    printf("Current SDL window: %p, device window: %p\n", currentWindow, device->window);
+    
+    if (currentWindow != device->window) {
+        fprintf(stderr, "Warning: Current window doesn't match device window!\n");
+    }
+    
+    printf("Calling SDL_GL_SwapWindow...\n");
+    SDL_GL_SwapWindow(device->window);
+    printf("SDL_GL_SwapWindow completed\n");
+#endif
+    
+    GL_CHECK_ERROR();
+    printf("Present completed\n");
+}
+
+void MGG_GraphicsDevice_SetBlendState(MGG_GraphicsDevice* device, MGG_BlendState* state, mgfloat factorR, mgfloat factorG, mgfloat factorB, mgfloat factorA) {
+    printf("Setting blend state for OpenGL graphics device\n");
+    if (!device || !state) return;
+    printf("End Set blend state for OpenGL graphics device\n");
+}
+
+void MGG_GraphicsDevice_SetDepthStencilState(MGG_GraphicsDevice* device, MGG_DepthStencilState* state) {
+    printf("Setting depth stencil state for OpenGL graphics device\n");
+    if (!device || !state) return;
+    printf("End Set depth stencil state for OpenGL graphics device\n");
+}
+
+void MGG_GraphicsDevice_SetRasterizerState(MGG_GraphicsDevice* device, MGG_RasterizerState* state) {
+    printf("Setting rasterizer state for OpenGL graphics device\n");
+    if (!device || !state) return;
+    printf("End Set rasterizer state for OpenGL graphics device\n");
+}
+
+void MGG_GraphicsDevice_GetTitleSafeArea(mgint& x, mgint& y, mgint& width, mgint& height) {
+    printf("Getting title safe area for OpenGL graphics device\n");
+#if defined(MG_EMSCRIPTEN)
+    // In WebGL, the entire canvas is considered safe
+    // So we'll just return default values
+    double cssWidth, cssHeight;
+    emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
+    
+    x = 0;
+    y = 0;
+    width = static_cast<mgint>(cssWidth);
+    height = static_cast<mgint>(cssHeight);
+#else
+    // Default values
+    x = 0;
+    y = 0;
+    width = 0; 
+    height = 0;
+#endif
+    printf("Got title safe area for OpenGL graphics device: (%d, %d, %d, %d)\n", x, y, width, height);
+}
+
+void MGG_GraphicsDevice_SetViewport(MGG_GraphicsDevice* device, mgint x, mgint y, mgint width, mgint height, mgfloat minDepth, mgfloat maxDepth) {
+    printf("Setting viewport for OpenGL graphics device: %zu (%d, %d, %d, %d)\n", (size_t)device->context, x, y, width, height);
+    if (!device) return;
+    
+    // Store viewport values
+    device->viewportX = x;
+    device->viewportY = y;
+    device->viewportWidth = width;
+    device->viewportHeight = height;
+    device->viewportMinDepth = minDepth;
+    device->viewportMaxDepth = maxDepth;
+    
+    // Set the viewport in OpenGLES
+    glViewport(x, y, width, height);
+    GL_CHECK_ERROR();
+    
+    // Note: OpenGL depth range is [0,1], but Direct3D is [-1,1]
+    // minDepth and maxDepth are in the Direct3D range, so we need to map them
+#if defined(MG_EMSCRIPTEN)
+    // WebGL/OpenGL ES uses glDepthRangef
+    glDepthRangef(minDepth, maxDepth);
+#else
+    // Desktop OpenGL uses glDepthRange with double parameters
+    glDepthRange((double)minDepth, (double)maxDepth);
+#endif
+    GL_CHECK_ERROR();
+}
+
+void MGG_GraphicsDevice_SetScissorRectangle(MGG_GraphicsDevice* device, mgint x, mgint y, mgint width, mgint height) {
+    if (!device) return;
+    printf("Setting scissor rectangle for OpenGL graphics device: %zu (%d, %d, %d, %d)\n", (size_t)device->context, x, y, width, height);
+    // Store scissor values
+    device->scissorX = x;
+    device->scissorY = y;
+    device->scissorWidth = width;
+    device->scissorHeight = height;
+    
+    // Enable scissor test
+    glEnable(GL_SCISSOR_TEST);
+    GL_CHECK_ERROR();
+    
+    // Set scissor rectangle
+    // Note: OpenGL has (0,0) at bottom-left, need to flip Y coordinate
+    int flippedY = device->viewportHeight - (y + height);
+    glScissor(x, flippedY, width, height);
+    
+    GL_CHECK_ERROR();
+}
+
+void MGG_GraphicsDevice_SetRenderTargets(MGG_GraphicsDevice* device, MGG_Texture** targets, mgint* arraySlices, mgint count) {
+    if (!device) return;
+    printf("Setting render targets for OpenGL graphics device: %zu (count=%d)\n", (size_t)device->context, count);
+    printf("Ending SetRenderTargets for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_SetConstantBuffer(MGG_GraphicsDevice* device, MGShaderStage stage, mgint slot, MGG_Buffer* buffer) {
+    if (!device) return;
+    printf("Setting constant buffer for OpenGL graphics device: %zu (stage=%d, slot=%d)\n", (size_t)device->context, stage, slot);
+    printf("Ending SetConstantBuffer for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_SetTexture(MGG_GraphicsDevice* device, MGShaderStage stage, mgint slot, MGG_Texture* texture) {
+    if (!device) return;
+    printf("Setting texture for OpenGL graphics device: %zu (stage=%d, slot=%d)\n", (size_t)device->context, stage, slot);
+    printf("Ending SetTexture for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_SetSamplerState(MGG_GraphicsDevice* device, MGShaderStage stage, mgint slot, MGG_SamplerState* state) {
+    if (!device) return;
+    printf("Setting sampler state for OpenGL graphics device: %zu (stage=%d, slot=%d)\n", (size_t)device->context, stage, slot);
+    
+    if (!state) return;
+    printf("Ending SetSamplerState for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_SetIndexBuffer(MGG_GraphicsDevice* device, MGIndexElementSize size, MGG_Buffer* buffer) {
+    if (!device || !buffer) return;
+    printf("Setting index buffer for OpenGL graphics device: %zu (size=%d)\n", (size_t)device->context, size);
+    printf("Ending SetIndexBuffer for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_SetVertexBuffer(MGG_GraphicsDevice* device, mgint slot, MGG_Buffer* buffer, mgint vertexOffset) {
+    if (!device || !buffer) return;
+    printf("Setting vertex buffer for OpenGL graphics device: %zu (slot=%d, offset=%d)\n", (size_t)device->context, slot, vertexOffset);
+    printf("Ending SetVertexBuffer for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_SetShader(MGG_GraphicsDevice* device, MGShaderStage stage, MGG_Shader* shader) {
+    assert(device != nullptr);
+	assert(shader != nullptr);
+	assert(shader->stage == stage);
+
+    printf("Start Set shader for OpenGL graphics device: %zu (stage=%d)\n", (size_t)device->context, stage);
+    printf("End Set shader for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_SetInputLayout(MGG_GraphicsDevice* device, MGG_InputLayout* layout) {
+    if (!device) return;
+    printf("Setting input layout for OpenGL graphics device: %zu\n", (size_t)device->context);
+    printf("Ending SetInputLayout for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_Draw(MGG_GraphicsDevice* device, MGPrimitiveType primitiveType, mgint vertexStart, mgint vertexCount) {
+    if (!device || vertexCount <= 0) return;
+    printf("Drawing OpenGL graphics device: %zu (primitiveType=%d, vertexStart=%d, vertexCount=%d)\n", (size_t)device->context, primitiveType, vertexStart, vertexCount);
+    printf("Ending Draw for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_DrawIndexed(MGG_GraphicsDevice* device, MGPrimitiveType primitiveType, mgint primitiveCount, mgint indexStart, mgint vertexStart) {
+    if (!device || primitiveCount <= 0) return;
+    printf("Drawing indexed OpenGL graphics device: %zu (primitiveType=%d, primitiveCount=%d, indexStart=%d, vertexStart=%d)\n", (size_t)device->context, primitiveType, primitiveCount, indexStart, vertexStart);
+    printf("Ending DrawIndexed for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_DrawIndexedInstanced(MGG_GraphicsDevice* device, MGPrimitiveType primitiveType, mgint primitiveCount, mgint indexStart, mgint vertexStart, mgint instanceCount) {
+    if (!device || primitiveCount <= 0 || instanceCount <= 0) return;
+    printf("Drawing instanced indexed OpenGL graphics device: %zu (primitiveType=%d, primitiveCount=%d, indexStart=%d, vertexStart=%d, instanceCount=%d)\n", (size_t)device->context, primitiveType, primitiveCount, indexStart, vertexStart, instanceCount);
+    printf("Ending DrawIndexedInstanced for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_ResolveRenderTargets(MGG_GraphicsDevice* device) {
+    if (!device) return;
+    printf("Resolving render targets for OpenGL graphics device: %zu\n", (size_t)device->context);
+    printf("Ending ResolveRenderTargets for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_GraphicsDevice_GetBackBufferData(MGG_GraphicsDevice* device, mgint x, mgint y, mgint width, mgint height, void* data, mgint count, mgint dataBytes) {
+    if (!device || !data) return;
+    printf("Getting back buffer data for OpenGL graphics device: %zu (x=%d, y=%d, width=%d, height=%d, count=%d, dataBytes=%d)\n", (size_t)device->context, x, y, width, height, count, dataBytes);
+    printf("Ending GetBackBufferData for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+MGG_BlendState* MGG_BlendState_Create(MGG_GraphicsDevice* device, MGG_BlendState_Info* info) {
+    printf("Creating blend state for OpenGL graphics device: %zu\n", (size_t)device->context);
+    MGG_BlendState* state = new MGG_BlendState();
+    state->info = *info;
+    
+    // OpenGL doesn't have explicit state objects like Direct3D
+    // Instead, we just store the state information and apply it when needed
+    state->state = 0; // Not used in WebGL
+    
+    return state;
+}
+
+void MGG_BlendState_Destroy(MGG_GraphicsDevice* device, MGG_BlendState* state) {
+    delete state;
+}
+
+MGG_DepthStencilState* MGG_DepthStencilState_Create(MGG_GraphicsDevice* device, MGG_DepthStencilState_Info* info) {
+    MGG_DepthStencilState* state = new MGG_DepthStencilState();
+    state->info = *info;
+    state->state = 0; // Not used in WebGL
+    return state;
+}
+
+void MGG_DepthStencilState_Destroy(MGG_GraphicsDevice* device, MGG_DepthStencilState* state) {
+    // No OpenGL resources to clean up
+    delete state;
+}
+
+MGG_RasterizerState* MGG_RasterizerState_Create(MGG_GraphicsDevice* device, MGG_RasterizerState_Info* info) {
+    MGG_RasterizerState* state = new MGG_RasterizerState();
+    state->info = *info;
+    state->state = 0; // Not used in WebGL
+    return state;
+}
+
+void MGG_RasterizerState_Destroy(MGG_GraphicsDevice* device, MGG_RasterizerState* state) {
+    // No OpenGL resources to clean up
+    delete state;
+}
+
+MGG_SamplerState* MGG_SamplerState_Create(MGG_GraphicsDevice* device, MGG_SamplerState_Info* info) {
+    MGG_SamplerState* state = new MGG_SamplerState();
+    state->info = *info;
+    state->sampler = 0; // Not used in WebGL
+    return state;
+}
+
+void MGG_SamplerState_Destroy(MGG_GraphicsDevice* device, MGG_SamplerState* state) {
+    // No OpenGL resources to clean up
+    delete state;
+}
+
+MGG_Buffer* MGG_Buffer_Create(MGG_GraphicsDevice* device, MGBufferType type, mgint sizeInBytes) {
+    printf("Creating buffer for OpenGL graphics device: %zu (type=%d, size=%d)\n", (size_t)device->context, type, sizeInBytes);
+    if (!device || sizeInBytes <= 0) return nullptr;
+    
+    MGG_Buffer* buffer = new MGG_Buffer();
+    printf("Created buffer for OpenGL graphics device: %zu (type=%d, size=%d)\n", (size_t)device->context, type, sizeInBytes);
+    return buffer;
+}
+
+void MGG_Buffer_Destroy(MGG_GraphicsDevice* device, MGG_Buffer* buffer) {
+    printf("Destroying buffer for OpenGL graphics device: %zu\n", (size_t)device->context);
+    if (!device || !buffer) return;
+    delete buffer;
+}
+
+void MGG_Buffer_SetData(MGG_GraphicsDevice* device, MGG_Buffer*& buffer, mgint offset, mgbyte* data, mgint elementCount, mgint vertexStride, mgint elementSizeInBytes, mgbool discard) {
+    printf("Setting buffer data for OpenGL graphics device: %zu\n", (size_t)device->context);
+    if (!device || !buffer || !data) return;
+    printf("Ended Set buffer data for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_Buffer_GetData(MGG_GraphicsDevice* device, MGG_Buffer* buffer, mgint offset, mgbyte* data, mgint dataCount, mgint dataBytes, mgint dataStride) {
+    if (!device || !buffer || !data) return;
+    printf("Getting buffer data for OpenGL graphics device: %zu\n", (size_t)device->context);
+    printf("Ended Get buffer data for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+MGG_Texture* MGG_Texture_Create(MGG_GraphicsDevice* device, MGTextureType type, MGSurfaceFormat format, mgint width, mgint height, mgint depth, mgint mipmaps, mgint slices) {
+    if (!device || width <= 0 || height <= 0) return nullptr;
+    printf("Creating texture: %d x %d x %d\n", width, height, depth);
+
+    MGG_Texture* texture = new MGG_Texture();
+    printf("Created texture for OpenGL graphics device: %zu\n", (size_t)device->context);
+    return texture;
+}
+
+MGG_Texture* MGG_RenderTarget_Create(MGG_GraphicsDevice* device, MGTextureType type, MGSurfaceFormat format, mgint width, mgint height, mgint depth, mgint mipmaps, mgint slices, MGDepthFormat depthFormat, mgint multiSampleCount, MGRenderTargetUsage usage) {
+    if (!device || width <= 0 || height <= 0) return nullptr;
+    printf("Creating render target: %d x %d x %d\n", width, height, depth);
+    MGG_Texture* texture = new MGG_Texture();
+    printf("Created render target for OpenGL graphics device: %zu\n", (size_t)device->context);
+    return texture;
+}
+
+void MGG_Texture_Destroy(MGG_GraphicsDevice* device, MGG_Texture* texture) {
+    printf("Destroying texture for OpenGL graphics device: %zu\n", (size_t)device->context);
+    if (!device || !texture) return;
+    delete texture;
+}
+
+void MGG_Texture_SetData(MGG_GraphicsDevice* device, MGG_Texture* texture, mgint level, mgint slice, mgint x, mgint y, mgint z, mgint width, mgint height, mgint depth, mgbyte* data, mgint dataBytes) {
+    printf("Setting texture data: %zu, %u, %d, %d, %d, %d, %d, %d\n", (size_t)device->context, texture->texture, x, y, z, width, height, depth);
+    if (!device || !texture || !data) return;
+    printf("Setting texture data: %d x %d x %d\n", width, height, depth);
+    printf("Ended Set texture data for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_Texture_GetData(MGG_GraphicsDevice* device, MGG_Texture* texture, mgint level, mgint slice, mgint x, mgint y, mgint z, mgint width, mgint height, mgint depth, mgbyte* data, mgint dataBytes) {
+    if (!device || !texture || !data) return;
+    printf("Getting texture data: %zu, %u, %d, %d, %d, %d, %d, %d\n", (size_t)device->context, texture->texture, x, y, z, width, height, depth);
+    printf("Ended Get texture data for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+MGG_InputLayout* MGG_InputLayout_Create(MGG_GraphicsDevice* device, MGG_Shader* vertexShader, mgint* strides, mgint streamCount, MGG_InputElement* elements, mgint elementCount) {
+    printf("Creating input layout for OpenGL graphics device: %zu\n", (size_t)device->context);
+    if (!device || !vertexShader || elementCount <= 0) return nullptr;
+    
+    MGG_InputLayout* layout = new MGG_InputLayout();
+    printf("Created input layout for OpenGL graphics device: %zu\n", (size_t)device->context);
+    return layout;
+}
+
+void MGG_InputLayout_Destroy(MGG_GraphicsDevice* device, MGG_InputLayout* layout) {
+    if (!device || !layout) return;
+    printf("Destroying input layout for OpenGL graphics device: %zu\n", (size_t)device->context);
+    delete layout;
+}
+
+MGG_Shader* MGG_Shader_Create(MGG_GraphicsDevice* device, MGShaderStage stage, mgbyte* bytecode, mgint sizeInBytes) {
+    printf("Creating shader for OpenGL graphics device: %zu (stage=%d, size=%d)\n", (size_t)device->context, stage, sizeInBytes);
+    if (!device || !bytecode || sizeInBytes <= 0) return nullptr;
+    
+    MGG_Shader* shader = new MGG_Shader();
+    printf("Created shader for OpenGL graphics device: %zu\n", (size_t)device->context);
+    return shader;
+}
+
+void MGG_Shader_Destroy(MGG_GraphicsDevice* device, MGG_Shader* shader) {
+    if (!device || !shader) return;
+    printf("Destroying shader for OpenGL graphics device: %zu\n", (size_t)device->context);
+    delete shader;
+}
+
+MGG_OcclusionQuery* MGG_OcclusionQuery_Create(MGG_GraphicsDevice* device) {
+    if (!device) return nullptr;
+    printf("Creating occlusion query for OpenGL graphics device: %zu\n", (size_t)device->context);
+    MGG_OcclusionQuery* query = new MGG_OcclusionQuery();
+    printf("Created occlusion query for OpenGL graphics device: %zu\n", (size_t)device->context);
+    return query;
+}
+
+void MGG_OcclusionQuery_Destroy(MGG_GraphicsDevice* device, MGG_OcclusionQuery* query) {
+    if (!device || !query) return;
+    printf("Destroying occlusion query for OpenGL graphics device: %zu\n", (size_t)device->context);
+    delete query;
+}
+
+void MGG_OcclusionQuery_Begin(MGG_GraphicsDevice* device, MGG_OcclusionQuery* query) {
+    if (!device || !query) return;
+    printf("Beginning occlusion query for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+void MGG_OcclusionQuery_End(MGG_GraphicsDevice* device, MGG_OcclusionQuery* query) {
+    if (!device || !query || !query->isActive) return;
+    printf("Ending occlusion query for OpenGL graphics device: %zu\n", (size_t)device->context);
+}
+
+mgbyte MGG_OcclusionQuery_GetResult(MGG_GraphicsDevice* device, MGG_OcclusionQuery* query, mgint& pixelCount) {
+    if (!device || !query) {
+        pixelCount = 0;
+        return false;
+    }    
+    return true;
+}

--- a/native/monogame/premake5.lua
+++ b/native/monogame/premake5.lua
@@ -18,6 +18,10 @@ function common(project_name)
     filter "system:linux"
     pic "On"
     filter {}
+    if os.target() == "emscripten" then
+        kind "StaticLib"
+        targetprefix "" -- remove lib prefix
+    end
     defines {"DLL_EXPORT"}
     targetdir(platform_target_path)
     targetname "mgruntime"
@@ -35,21 +39,27 @@ function sdl2()
 
     includedirs {"external/sdl2/sdl/include"}
 
-    filter {"system:windows"}
-    links {"external/sdl2/sdl/build/Release/SDL2-static.lib", "winmm", "imm32", "user32", "gdi32", "advapi32",
-           "setupapi", "ole32", "oleaut32", "version", "shell32"}
-    filter {"system:macosx"}
-    libdirs {"external/sdl2/sdl/build"}
-    linkoptions {"-Wl,-force_load,external/sdl2/sdl/build/libSDL2.a"}
-    links {"SDL2"}
-    links {"Cocoa.framework", "IOKit.framework", "ForceFeedback.framework", "CoreAudio.framework",
-        "AudioToolbox.framework", "CoreGraphics.framework", "CoreFoundation.framework", "Metal.framework",
-        "CoreVideo.framework", "GameController.framework", "CoreHaptics.framework", "Carbon.framework", "iconv"}
+    if os.target() ~= "emscripten" then
+        filter {"system:windows"}
+        links {"external/sdl2/sdl/build/Release/SDL2-static.lib", "winmm", "imm32", "user32", "gdi32", "advapi32",
+            "setupapi", "ole32", "oleaut32", "version", "shell32"}
+        filter {"system:macosx"}
+        libdirs {"external/sdl2/sdl/build"}
+        linkoptions {"-Wl,-force_load,external/sdl2/sdl/build/libSDL2.a"}
+        links {"SDL2"}
+        links {"Cocoa.framework", "IOKit.framework", "ForceFeedback.framework", "CoreAudio.framework",
+            "AudioToolbox.framework", "CoreGraphics.framework", "CoreFoundation.framework", "Metal.framework",
+            "CoreVideo.framework", "GameController.framework", "CoreHaptics.framework", "Carbon.framework", "iconv"}
 
-    filter {"system:linux"}
-    linkoptions {"external/sdl2/sdl/build/libSDL2.a"}
-    links {"dl", "pthread", "m", "rt"}
-    filter {}
+        filter {"system:linux"}
+        linkoptions {"external/sdl2/sdl/build/libSDL2.a"}
+        links {"dl", "pthread", "m", "rt"}
+        filter {}
+    end
+
+    if os.target() == "emscripten" then
+        linkoptions {"external/sdl2/sdl/build_emscripten/libSDL2.a"}
+    end
 end
 
 -- Vulkan is supported for all desktop platforms.
@@ -78,28 +88,56 @@ function directx12()
     filter {}
 end
 
--- FAudio is supported for all desktop platforms.
+-- Add Emscripten/WASM support
+function opengl()
+    defines {"MG_OPENGL"}
+    if os.target() == "emscripten" then
+        defines {"MG_EMSCRIPTEN"}
+        defines {"MG_WEBGL"}
+    end
+
+    -- Add your Emscripten-specific files
+    files {"opengl/**.h", "opengl/**.cpp"}
+
+    if os.target() ~= "emscripten" then
+        filter {"system:macosx"}
+        links {"OpenGL.framework"}
+        filter {"system:windows"}
+        links {"opengl32"}
+        filter {}
+    end
+end
+
+-- FAudio is supported for all desktop/web platforms.
 function faudio()
     defines {"MG_FAUDIO"}
 
     files {"faudio/**.h", "faudio/**.cpp"}
 
     includedirs {"external/faudio/include"}
+
+    if os.target() ~= "emscripten" then
     
-    filter {"system:windows"}
-    libdirs {"external/faudio/build/Release"}
-    links {"FAudio.lib"}
-    
-    filter {"system:macosx"}
-    libdirs {"external/faudio/build"}
-    linkoptions {
-        "-Wl,-force_load,external/faudio/build/libFAudio.a",
-        "-Wl,-ld_classic"
-    }
-    
-    filter {"system:linux"}
-    linkoptions {"external/faudio/build/libFAudio.a"}
-    filter {}
+        filter {"system:windows"}
+        libdirs {"external/faudio/build/Release"}
+        links {"FAudio.lib"}
+        
+        filter {"system:macosx"}
+        libdirs {"external/faudio/build"}
+        linkoptions {
+            "-Wl,-force_load,external/faudio/build/libFAudio.a",
+            "-Wl,-ld_classic"
+        }
+        
+        filter {"system:linux"}
+        linkoptions {"external/faudio/build/libFAudio.a"}
+        filter {}
+
+    end
+
+    if os.target() == "emscripten" then
+        linkoptions {"external/faudio/build_emscripten/libFAudio.a"}
+    end
 end
 
 -- Xaudio is supported on Windows and Xbox.
@@ -128,18 +166,37 @@ function configs()
     filter "system:macosx"
     buildoptions {"-arch x86_64", "-arch arm64"}
     linkoptions {"-arch x86_64", "-arch arm64"}
+
+    filter {"system:macosx", "configurations:Debug"}
+    buildoptions {"-g", "-O0", "-fno-omit-frame-pointer"}
+    linkoptions {"-g"}
+
+    if os.target() == "emscripten" then
+        -- Change to StaticLib for Emscripten builds to output .a files
+        kind "StaticLib"
+    end
+    
     filter {}
 end
 
 workspace "monogame"
 configurations {"Debug", "Release"}
 
-project "desktopvk"
-common("desktopvk")
-sdl2()
-vulkan()
-faudio()
-configs()
+if os.target() ~= "emscripten" then
+    project "desktopvk"
+    common("desktopvk")
+    sdl2()
+    vulkan()
+    faudio()
+    configs()
+
+    project "desktopgl"
+    common("desktopgl")
+    sdl2()
+    opengl()
+    faudio()
+    configs()
+end
 
 if os.target() == "windows" then
     project "windowsdx"
@@ -147,5 +204,15 @@ if os.target() == "windows" then
     sdl2()
     directx12()
     xaudio()
+    configs()
+end
+
+-- Add this to your project section
+if os.target() == "emscripten" then
+    project "wasm"
+    common("wasm")
+    sdl2()
+    opengl()
+    faudio()
     configs()
 end

--- a/native/monogame/sdl/MGP_sdl.cpp
+++ b/native/monogame/sdl/MGP_sdl.cpp
@@ -12,6 +12,10 @@
 #include <combaseapi.h>
 #endif
 
+#if MG_EMSCRIPTEN
+#include <emscripten.h>
+#endif
+
 
 struct MGP_Platform
 {
@@ -199,12 +203,18 @@ MGP_Platform* MGP_Platform_Create(MGGameRunBehavior& behavior)
 			SDL_INIT_HAPTIC);
 	}
 
+#ifndef MG_EMSCRIPTEN
 	SDL_DisableScreenSaver();
+#endif
 
 	SDL_SetHint("SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS", "0");
 	SDL_SetHint("SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "1");
 
-	behavior = MGGameRunBehavior::Synchronous;
+#if MG_EMSCRIPTEN
+    behavior = MGGameRunBehavior::Asynchronous;
+#else
+    behavior = MGGameRunBehavior::Synchronous;
+#endif
 
 	auto platform = new MGP_Platform();
 	return platform;
@@ -261,6 +271,10 @@ MGMonoGamePlatform MGP_Platform_GetPlatform()
     return MGMonoGamePlatform::DesktopVK;
 #elif MG_DIRECTX12
     return MGMonoGamePlatform::WindowsDX12;
+#elif MG_EMSCRIPTEN
+    return MGMonoGamePlatform::WebGL;
+#elif MG_OPENGL
+    return MGMonoGamePlatform::DesktopGL;
 #else
     assert(false);
     return (MGMonoGamePlatform)-1;
@@ -273,6 +287,8 @@ MGGraphicsBackend MGP_Platform_GetGraphicsBackend()
     return MGGraphicsBackend::Vulkan;
 #elif MG_DIRECTX12
     return MGGraphicsBackend::DirectX12;
+#elif MG_EMSCRIPTEN || MG_OPENGL
+    return MGGraphicsBackend::OpenGL;
 #else
     assert(false);
     return (MGGraphicsBackend)-1;
@@ -664,6 +680,11 @@ mgbyte MGP_Platform_PollEvent(MGP_Platform* platform, MGP_Event& event_)
     return false;
 }
 
+void MGP_Platform_StartRunLoop(MGP_Platform* platform)
+{
+    assert(platform != nullptr);
+}
+
 mgbyte MGP_Platform_BeforeRun(MGP_Platform* platform)
 {
 	assert(platform != nullptr);
@@ -715,6 +736,8 @@ MGP_Window* MGP_Window_Create(
 
 #if defined(MG_VULKAN) || defined(MG_DIRECTX12)
 	flags |= SDL_WINDOW_VULKAN;
+#elif defined(MG_OPENGL) || defined(MG_EMSCRIPTEN)
+    flags |= SDL_WINDOW_OPENGL;
 #else
 	#error Not implemented
 #endif


### PR DESCRIPTION
A work in progress, an implementation of OpenGL for the new native backend. 

- Currently only supports Clearing the screen. 
- Mostly about setting up the infrastructure to build it using Emscripten.
- Only supports WebGL at this point, not tested on Deskop

the plan is for this backend to ONLY support modern OpenGL 4.1+ or WebGL 2.0

Example csproj for WebGL

```xml
<Project>
  <Sdk Name="Microsoft.NET.Sdk.WebAssembly" />
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net9.0</TargetFramework>
    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
    <MonoGamePlatform>Web</MonoGamePlatform>
    <DefineConstants>$(DefineConstants);MONOGAME;MG_$(MonoGamePlatform)</DefineConstants>
    <!-- This is to basically disable globalization to exclude icudt.dat (1.5MB) and reduce size of dotnet.wasm -->
    <InvariantGlobalization>true</InvariantGlobalization>
    <WasmBuildNative>true</WasmBuildNative>
    <WasmAllowUndefinedSymbols>true</WasmAllowUndefinedSymbols>
    <EmccExtraLDFlags>-sFULL_ES3</EmccExtraLDFlags>
    <WasmEmitSymbolMap>true</WasmEmitSymbolMap>
    <EmccFlags>-sVERBOSE=1 -Wbad-function-cast -Wcast-function-type -O2 -g3 -sINITIAL_MEMORY=128MB -sMAXIMUM_MEMORY=2048MB -sALLOW_MEMORY_GROWTH=1</EmccFlags>
  </PropertyGroup>

  <ItemGroup>
    <ProjectReference Include="..\MonoGame.Framework\MonoGame.Framework.Native.csproj" />
  </ItemGroup>

  <ItemGroup>
    <LinkerArg Include="-s USE_WEBGL2=1 -s FULL_ES3=1 -s TOTAL_STACK=5242880" />
    <WasmShellExtraEmccFlags Include="--preload-file $(MSBuildThisFileDirectory)..\Content@/Content" />
    <NativeFileReference Include="..\Artifacts\monogame.native\emscripten\desktopwasm\$(Configuration)\monogame.native.a" CopyToOutputDirectory="PreserveNewest" />
    <NativeFileReference Include="..\Artifacts\monogame.native\emscripten\desktopwasm\$(Configuration)\SDL2.a" CopyToOutputDirectory="PreserveNewest" />
  </ItemGroup>

</Project>
```

Example Program.cs, WebGL is Asynchronous so we need a way to pause the dotnet runtime after `Run` returns. Otherwise the app will just exit. This is because calling `emscripten_set_main_loop` with a `true` for `simulateInfiniteLoop` results in a deadlock. 

```csharp
public static class Program
{
    [STAThread]
    static async Task Main()
    {
        TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
        using (var game = new Game1())
        {
            game.Run();
            await tcs.Task;
        }
    }
}
```

<img width="727" height="400" alt="image" src="https://github.com/user-attachments/assets/907cc086-bef8-4bcb-ac25-4358e86fc1b6" />

<img width="590" height="271" alt="image" src="https://github.com/user-attachments/assets/2b428f6d-0ebd-44bb-ae58-399a91b787ff" />



