### PR TITLE
Add gamepad profile validation for iOS/tvOS

### DIFF
--- a/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.iOS.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Xna.Framework.Input
             };
             if (controller.ExtendedGamepad != null)
             {
+                capabilities.IsConnected = true;
                 capabilities.HasAButton = true;
                 capabilities.HasBButton = true;
                 capabilities.HasXButton = true;
@@ -87,6 +88,7 @@ namespace Microsoft.Xna.Framework.Input
             }
             else if (controller.Gamepad != null)
             {
+                capabilities.IsConnected = true;
                 capabilities.HasAButton = true;
                 capabilities.HasBButton = true;
                 capabilities.HasXButton = true;
@@ -128,6 +130,10 @@ namespace Microsoft.Xna.Framework.Input
                     continue;
 
                 if (controller.PlayerIndex != ind)
+                    continue;
+
+                // validate controller has a valid input profile before reporting as connected
+                if (controller.ExtendedGamepad == null && controller.Gamepad == null)
                     continue;
 
                 connected = true;

--- a/MonoGame.Framework/Platform/Input/GamePad.tvOS.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.tvOS.cs
@@ -85,6 +85,10 @@ namespace Microsoft.Xna.Framework.Input
                 if (controller.PlayerIndex != (int)ind)
                     continue;
 
+                // validate controller has a valid input profile before reporting as connected
+                if (controller.ExtendedGamepad == null && controller.Gamepad == null && controller.MicroGamepad == null)
+                    continue;
+
                 connected = true;
                 if (MenuPressed)
                 {
@@ -174,6 +178,7 @@ namespace Microsoft.Xna.Framework.Input
                 };
             if (controller.ExtendedGamepad != null)
             {
+                capabilities.IsConnected = true;
                 capabilities.HasAButton = true;
                 capabilities.HasBButton = true;
                 capabilities.HasXButton = true;
@@ -194,6 +199,7 @@ namespace Microsoft.Xna.Framework.Input
             }
             else if (controller.Gamepad != null)
             {
+                capabilities.IsConnected = true;
                 capabilities.HasAButton = true;
                 capabilities.HasBButton = true;
                 capabilities.HasXButton = true;
@@ -208,6 +214,7 @@ namespace Microsoft.Xna.Framework.Input
             }
             else if (controller.MicroGamepad != null)
             {
+                capabilities.IsConnected = true;
                 capabilities.HasAButton = true;
                 capabilities.HasXButton = true;
                 capabilities.HasBackButton = true;


### PR DESCRIPTION
- Validate controllers have valid gamepad profiles before reporting as connected
- Fix GetCapabilities() to set IsConnected = true when profiles exist
- Applies to both iOS and tvOS implementations

Addresses #9099

### Description of Change

Adds defensive validation to iOS/tvOS gamepad detection in response to reports of phantom controllers appearing in iOS 18.

## Changes Made

1. **Profile validation in `PlatformGetState()`**: Before reporting a controller as connected, verify it has a valid gamepad profile (ExtendedGamepad, Gamepad, or MicroGamepad for tvOS).

2. **`GetCapabilities()`**: Now sets `IsConnected = true` when a controller has a valid profile.

## Rationale

Users report phantom gamepads appearing on iOS 18, even when no gamepad is connected. Disabling Bluetooth or unpairing devices resolves it, suggesting Apple's `GCController.Controllers` array may include paired-but-disconnected controllers or misclassified Bluetooth devices.

This validation ensures only controllers with actual gamepad input profiles are reported as connected by adding a defensive layer without breaking legitimate controller support.

## Testing Notes

- Non-breaking change—legitimate controllers with valid profiles continue to work
- Filters devices without gamepad profiles (keyboards, mice, disconnected controllers)
