### PR TITLE
Add OpenGL ES 3.x support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -409,6 +409,11 @@ jobs:
         with:
           xcode-version: '${{ env.XCodeVersion }}'
 
+      - name: Download Nuget
+        uses: actions/download-artifact@v4
+        with:
+          path: Artifacts/NuGet
+
       - name: Download tests-desktopgl-${{ matrix.platform }}
         uses: actions/download-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,33 @@
-﻿# Changelog
+# Changelog
+
+## Upcoming Release
+
+#### Added support for OpenGL ES 3.0 on Mobile Platforms
+
+MonoGame now support **OpenGL ES 3.0** on iOS and Android.
+Support for OpenGL ES 1.x and 2.0 will be deprecated in the coming months.
+
+**What this means:**
+- **iOS**: Requires iPhone 5S or later (2013+), iOS 7.0+
+- **Android**: Requires Android 4.3+ with OpenGL ES 3.0 compatible GPU
+- **Impact**: Less than 2% of active devices (as of 2024)
+
+**New features enabled:**
+- `VertexBuffer.GetData()` now works on mobile platforms
+- `IndexBuffer.GetData()` now works on mobile platforms
+- `Texture3D` creation and `SetData()` now work on mobile platforms
+- Modern texture formats (ETC2, float textures) enabled by default
+- Better performance through more efficient OpenGL ES 3.0 API
+
+**Migration:**
+- Games will throw `NoSuitableGraphicsDeviceException` on devices without OpenGL ES 3.0
+- Update your minimum OS requirements in app store listings
+- See [MIGRATION_GLES3.md](MIGRATION_GLES3.md) for detailed migration guide
+
+**Technical details:**
+- Implemented `glMapBufferRange` with read access for buffer data retrieval
+- Removed OpenGL ES 2.0 workarounds and capability checks
+- Simplified graphics capability detection
 
 ## 3.8.4 Release - April 2nd - 2025
 

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -120,5 +120,7 @@ namespace Microsoft.Xna.Framework.Graphics
         internal bool SupportsBaseIndexInstancing { get; private set; }
 
         internal bool SupportsSeparateBlendStates { get; private set; }
+
+        internal bool SupportsMapBuffer { get; private set; }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -804,7 +804,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #endif // OPENGL
 
-                    public static int GetSyncInterval(this PresentInterval interval)
+        public static int GetSyncInterval(this PresentInterval interval)
         {
             switch (interval)
             {
@@ -1060,7 +1060,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 #endif
-            }
+    }
 
     internal class MonoGameGLException : Exception
     {

--- a/MonoGame.Framework/Graphics/SurfaceFormat.cs
+++ b/MonoGame.Framework/Graphics/SurfaceFormat.cs
@@ -160,27 +160,27 @@ namespace Microsoft.Xna.Framework.Graphics
         RgbaAtcInterpolatedAlpha = 81,
 
 		/// <summary>
-        /// Etc2 RGB8 (Android/iOS withh OpenglES 3.0)
+        /// Etc2 RGB8 (Android/iOS with OpenglES 3.0)
 		/// </summary>
         Rgb8Etc2 = 90,
 		/// <summary>
-        /// Etc2 SRGB8 (Android/iOS withh OpenglES 3.0)
+        /// Etc2 SRGB8 (Android/iOS with OpenglES 3.0)
 		/// </summary>
         Srgb8Etc2 = 91,
 		/// <summary>
-        /// Etc2 RGB8A1 (Android/iOS withh OpenglES 3.0)
+        /// Etc2 RGB8A1 (Android/iOS with OpenglES 3.0)
 		/// </summary>
         Rgb8A1Etc2 = 92,
 		/// <summary>
-        /// Etc2 SRGB8A1 (Android/iOS withh OpenglES 3.0)
+        /// Etc2 SRGB8A1 (Android/iOS with OpenglES 3.0)
 		/// </summary>
         Srgb8A1Etc2 = 93,
 		/// <summary>
-        /// Etc2 RGBA8 EAC (Android/iOS withh OpenglES 3.0)
+        /// Etc2 RGBA8 EAC (Android/iOS with OpenglES 3.0)
 		/// </summary>
         Rgba8Etc2 = 94,
 		/// <summary>
-        /// Etc2 SRGB8A8 EAC (Android/iOS withh OpenglES 3.0)
+        /// Etc2 SRGB8A8 EAC (Android/iOS with OpenglES 3.0)
 		/// </summary>
         SRgb8A8Etc2 = 95,
         /// <summary>

--- a/MonoGame.Framework/Platform/Graphics/GraphicsCapabilities.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsCapabilities.OpenGL.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Xna.Framework.Graphics
             // Framebuffer objects
 #if GLES
             SupportsFramebufferObjectARB = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 2 || GL.HasExtension("GL_ARB_framebuffer_object")); // always supported on GLES 2.0+
-            SupportsFramebufferObjectEXT = GL.HasExtension("GL_EXT_framebuffer_object");;
+            SupportsFramebufferObjectEXT = GL.HasExtension("GL_EXT_framebuffer_object");
             SupportsFramebufferObjectIMG = GL.HasExtension("GL_IMG_multisampled_render_to_texture") |
                                                  GL.HasExtension("GL_APPLE_framebuffer_multisample") |
                                                  GL.HasExtension("GL_EXT_multisampled_render_to_texture") |
@@ -95,8 +95,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             MaxTextureAnisotropy = anisotropy;
 
-            // sRGB
+            // sRGB and texture formats
 #if GLES
+            // sRGB, float textures, and half-float textures are core in OpenGL ES 3.0+
             SupportsSRgb = GL.HasExtension("GL_EXT_sRGB");
             SupportsFloatTextures = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 || GL.HasExtension("GL_EXT_color_buffer_float"));
             SupportsHalfFloatTextures = GL.BoundApi == GL.RenderApi.ES && (device.glMajorVersion >= 3 || GL.HasExtension("GL_EXT_color_buffer_half_float"));
@@ -104,8 +105,8 @@ namespace Microsoft.Xna.Framework.Graphics
 #else
             SupportsSRgb = GL.HasExtension("GL_EXT_texture_sRGB") && GL.HasExtension("GL_EXT_framebuffer_sRGB");
             SupportsFloatTextures = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.HasExtension("GL_ARB_texture_float"));
-            SupportsHalfFloatTextures = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.HasExtension("GL_ARB_half_float_pixel"));;
-            SupportsNormalized = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.HasExtension("GL_EXT_texture_norm16"));;
+            SupportsHalfFloatTextures = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.HasExtension("GL_ARB_half_float_pixel"));
+            SupportsNormalized = GL.BoundApi == GL.RenderApi.GL && (device.glMajorVersion >= 3 || GL.HasExtension("GL_EXT_texture_norm16"));
 #endif
 
             // TODO: Implement OpenGL support for texture arrays
@@ -122,8 +123,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #if GLES
             SupportsSeparateBlendStates = false;
+            SupportsMapBuffer = GL.BoundApi == GL.RenderApi.ES && device.glMajorVersion >= 3;
 #else
             SupportsSeparateBlendStates = device.glMajorVersion >= 4 || GL.HasExtension("GL_ARB_draw_buffers_blend");
+            SupportsMapBuffer = device.glMajorVersion >= 3 || GL.HasExtension("GL_ARB_map_buffer_range");
 #endif
         }
 

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         (IntPtr)(offset.ToInt64() + element.Offset));
 
                     // only set the divisor if instancing is supported
-                    if (GraphicsCapabilities.SupportsInstancing) 
+                    if (GraphicsCapabilities.SupportsInstancing)
                         GL.VertexAttribDivisor(element.AttributeLocation, vertexBufferBinding.InstanceFrequency);
 
                     GraphicsExtensions.CheckGLError();
@@ -297,12 +297,12 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             catch (FormatException)
             {
-                //if it fails we default to 1.1 context
-                glMajorVersion = 1;
-                glMinorVersion = 1;
+                // Unable to parse version - assume unsupported
+                throw new NoSuitableGraphicsDeviceException(
+                    "Unable to determine OpenGL ES version. MonoGame requires OpenGL ES 2.0 or higher.");
             }
 #else
-                try
+            try
             {
                 string version = GL.GetString(StringName.Version);
 
@@ -321,13 +321,13 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
 
 #if !GLES
-			// Initialize draw buffer attachment array
-			int maxDrawBuffers;
+            // Initialize draw buffer attachment array
+            int maxDrawBuffers;
             GL.GetInteger(GetPName.MaxDrawBuffers, out maxDrawBuffers);
-            GraphicsExtensions.CheckGLError ();
-			_drawBuffers = new DrawBuffersEnum[maxDrawBuffers];
-			for (int i = 0; i < maxDrawBuffers; i++)
-				_drawBuffers[i] = (DrawBuffersEnum)(FramebufferAttachment.ColorAttachment0Ext + i);
+            GraphicsExtensions.CheckGLError();
+            _drawBuffers = new DrawBuffersEnum[maxDrawBuffers];
+            for (int i = 0; i < maxDrawBuffers; i++)
+                _drawBuffers[i] = (DrawBuffersEnum)(FramebufferAttachment.ColorAttachment0Ext + i);
 #endif
         }
 
@@ -361,7 +361,7 @@ namespace Microsoft.Xna.Framework.Graphics
             for (int i = 0; i < _bufferBindingInfos.Length; i++)
                 _bufferBindingInfos[i] = new BufferBindingInfo(null, IntPtr.Zero, 0, -1);
         }
-        
+
         private DepthStencilState clearDepthStencilState = new DepthStencilState { StencilEnable = true };
 
         private void PlatformClear(ClearOptions options, Vector4 color, float depth, int stencil)
@@ -380,15 +380,15 @@ namespace Microsoft.Xna.Framework.Graphics
             // So overwrite these states with what is needed to perform
             // the clear correctly and restore it afterwards.
             //
-		    var prevScissorRect = ScissorRectangle;
-		    var prevDepthStencilState = DepthStencilState;
+            var prevScissorRect = ScissorRectangle;
+            var prevDepthStencilState = DepthStencilState;
             var prevBlendState = BlendState;
             ScissorRectangle = _viewport.Bounds;
             // DepthStencilState.Default has the Stencil Test disabled; 
             // make sure stencil test is enabled before we clear since
             // some drivers won't clear with stencil test disabled
             DepthStencilState = this.clearDepthStencilState;
-		    BlendState = BlendState.Opaque;
+            BlendState = BlendState.Opaque;
             ApplyState(false);
 
             ClearBufferMask bufferMask = 0;
@@ -402,18 +402,18 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
                 bufferMask = bufferMask | ClearBufferMask.ColorBufferBit;
             }
-			if ((options & ClearOptions.Stencil) == ClearOptions.Stencil)
+            if ((options & ClearOptions.Stencil) == ClearOptions.Stencil)
             {
                 if (stencil != _lastClearStencil)
                 {
-				    GL.ClearStencil(stencil);
+                    GL.ClearStencil(stencil);
                     GraphicsExtensions.CheckGLError();
                     _lastClearStencil = stencil;
                 }
                 bufferMask = bufferMask | ClearBufferMask.StencilBufferBit;
-			}
+            }
 
-			if ((options & ClearOptions.DepthBuffer) == ClearOptions.DepthBuffer) 
+            if ((options & ClearOptions.DepthBuffer) == ClearOptions.DepthBuffer)
             {
                 if (depth != _lastClearDepth)
                 {
@@ -421,23 +421,23 @@ namespace Microsoft.Xna.Framework.Graphics
                     GraphicsExtensions.CheckGLError();
                     _lastClearDepth = depth;
                 }
-				bufferMask = bufferMask | ClearBufferMask.DepthBufferBit;
-			}
+                bufferMask = bufferMask | ClearBufferMask.DepthBufferBit;
+            }
 
 #if MONOMAC || IOS
             if (GL.CheckFramebufferStatus(FramebufferTarget.FramebufferExt) == FramebufferErrorCode.FramebufferComplete)
             {
 #endif
-                GL.Clear(bufferMask);
-                GraphicsExtensions.CheckGLError();
+            GL.Clear(bufferMask);
+            GraphicsExtensions.CheckGLError();
 #if MONOMAC || IOS
             }
 #endif
-           		
+
             // Restore the previous render state.
-		    ScissorRectangle = prevScissorRect;
-		    DepthStencilState = prevDepthStencilState;
-		    BlendState = prevBlendState;
+            ScissorRectangle = prevScissorRect;
+            DepthStencilState = prevDepthStencilState;
+            BlendState = prevBlendState;
         }
 
         private void PlatformDispose()
@@ -570,7 +570,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             GL.DepthRange(value.MinDepth, value.MaxDepth);
             GraphicsExtensions.LogGLError("GraphicsDevice.Viewport_set() GL.DepthRange");
-                
+
             // In OpenGL we have to re-apply the special "posFixup"
             // vertex shader uniform if the viewport changes.
             _vertexShaderDirty = true;
@@ -643,7 +643,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var color = 0;
             var depth = 0;
             var stencil = 0;
-            
+
             var sampleCount = GetClampedMultisampleCount(preferredFormat, preferredMultiSampleCount);
             if (sampleCount > 0 && preferredDepthFormat != DepthFormat.None)
             {
@@ -651,7 +651,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
                 sampleCount = Math.Min(sampleCount, maxDepthMultiSampleCount);
             }
-            
+
             if (sampleCount > 0 && this.framebufferHelper.SupportsBlitFramebuffer)
             {
                 this.framebufferHelper.GenRenderbuffer(out color);
@@ -665,7 +665,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 var stencilInternalFormat = (RenderbufferStorage)0;
                 switch (preferredDepthFormat)
                 {
-                    case DepthFormat.Depth16: 
+                    case DepthFormat.Depth16:
                         depthInternalFormat = RenderbufferStorage.DepthComponent16;
                         break;
 #if GLES
@@ -719,7 +719,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
                 }
             }
-            
+
             renderTarget.GLColorBuffer = color;
             renderTarget.GLDepthBuffer = depth;
             renderTarget.GLStencilBuffer = stencil;
@@ -793,7 +793,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     for (var i = 0; i < this._currentRenderTargetCount; ++i)
                     {
                         var rt = this._currentRenderTargetBindings[i].RenderTarget as IRenderTarget;
-                        this.framebufferHelper.FramebufferTexture2D((int)(FramebufferAttachment.ColorAttachment0 + i), (int) rt.GetFramebufferTarget(renderTargetBinding), rt.GLTexture);
+                        this.framebufferHelper.FramebufferTexture2D((int)(FramebufferAttachment.ColorAttachment0 + i), (int)rt.GetFramebufferTarget(renderTargetBinding), rt.GLTexture);
                     }
                     this.glResolveFramebuffers.Add((RenderTargetBinding[])this._currentRenderTargetBindings.Clone(), glResolveFramebuffer);
                 }
@@ -953,8 +953,8 @@ namespace Microsoft.Xna.Framework.Graphics
             _posFixup[1] = 1.0f;
             if (UseHalfPixelOffset)
             {
-                _posFixup[2] = (63.0f/64.0f)/Viewport.Width;
-                _posFixup[3] = -(63.0f/64.0f)/Viewport.Height;
+                _posFixup[2] = (63.0f / 64.0f) / Viewport.Width;
+                _posFixup[3] = -(63.0f / 64.0f) / Viewport.Height;
             }
             else
             {
@@ -993,10 +993,10 @@ namespace Microsoft.Xna.Framework.Graphics
             if (force || BlendFactor != _lastBlendState.BlendFactor)
             {
                 GL.BlendColor(
-                    this.BlendFactor.R/255.0f,
-                    this.BlendFactor.G/255.0f,
-                    this.BlendFactor.B/255.0f,
-                    this.BlendFactor.A/255.0f);
+                    this.BlendFactor.R / 255.0f,
+                    this.BlendFactor.G / 255.0f,
+                    this.BlendFactor.B / 255.0f,
+                    this.BlendFactor.A / 255.0f);
                 GraphicsExtensions.CheckGLError();
                 _lastBlendState.BlendFactor = this.BlendFactor;
             }
@@ -1004,15 +1004,15 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void PlatformApplyState(bool applyShaders)
         {
-            if ( _scissorRectangleDirty )
-	        {
+            if (_scissorRectangleDirty)
+            {
                 var scissorRect = _scissorRectangle;
                 if (!IsRenderTargetBound)
                     scissorRect.Y = PresentationParameters.BackBufferHeight - (scissorRect.Y + scissorRect.Height);
                 GL.Scissor(scissorRect.X, scissorRect.Y, scissorRect.Width, scissorRect.Height);
                 GraphicsExtensions.CheckGLError();
-	            _scissorRectangleDirty = false;
-	        }
+                _scissorRectangleDirty = false;
+            }
 
             // If we're not applying shaders then early out now.
             if (!applyShaders)
@@ -1069,11 +1069,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
             var shortIndices = _indexBuffer.IndexElementSize == IndexElementSize.SixteenBits;
 
-			var indexElementType = shortIndices ? DrawElementsType.UnsignedShort : DrawElementsType.UnsignedInt;
+            var indexElementType = shortIndices ? DrawElementsType.UnsignedShort : DrawElementsType.UnsignedInt;
             var indexElementSize = shortIndices ? 2 : 4;
-			var indexOffsetInBytes = (IntPtr)(startIndex * indexElementSize);
-			var indexElementCount = GetElementCountArray(primitiveType, primitiveCount);
-			var target = PrimitiveTypeGL(primitiveType);
+            var indexOffsetInBytes = (IntPtr)(startIndex * indexElementSize);
+            var indexElementCount = GetElementCountArray(primitiveType, primitiveCount);
+            var target = PrimitiveTypeGL(primitiveType);
 
             ApplyAttribs(_vertexShader, baseVertex);
 
@@ -1120,16 +1120,16 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformDrawPrimitives(PrimitiveType primitiveType, int vertexStart, int vertexCount)
         {
-            ApplyState(true);   
+            ApplyState(true);
 
             ApplyAttribs(_vertexShader, 0);
 
             if (vertexStart < 0)
                 vertexStart = 0;
 
-			GL.DrawArrays(PrimitiveTypeGL(primitiveType),
-			              vertexStart,
-			              vertexCount);
+            GL.DrawArrays(PrimitiveTypeGL(primitiveType),
+                          vertexStart,
+                          vertexCount);
             GraphicsExtensions.CheckGLError();
         }
 
@@ -1259,12 +1259,12 @@ namespace Microsoft.Xna.Framework.Graphics
             GL.ReadPixels(rect.X, flippedY, rect.Width, rect.Height, PixelFormat.Rgba, PixelType.UnsignedByte, data);
 
             // buffer is returned upside down, so we swap the rows around when copying over
-            var rowSize = rect.Width*PresentationParameters.BackBufferFormat.GetSize() / tSize;
+            var rowSize = rect.Width * PresentationParameters.BackBufferFormat.GetSize() / tSize;
             var row = new T[rowSize];
-            for (var dy = 0; dy < rect.Height/2; dy++)
+            for (var dy = 0; dy < rect.Height / 2; dy++)
             {
-                var topRow = startIndex + dy*rowSize;
-                var bottomRow = startIndex + (rect.Height - dy - 1)*rowSize;
+                var topRow = startIndex + dy * rowSize;
+                var bottomRow = startIndex + (rect.Height - dy - 1) * rowSize;
                 // copy the bottom row to buffer
                 Array.Copy(data, bottomRow, row, 0, rowSize);
                 // copy top row to bottom row
@@ -1286,6 +1286,12 @@ namespace Microsoft.Xna.Framework.Graphics
             int maxMultiSampleCount;
             GL.GetInteger(GetPName.MaxSamples, out maxMultiSampleCount);
             return maxMultiSampleCount;
+        }
+
+        internal void PlatformSetMultiSamplingToMaximum(PresentationParameters presentationParameters, out int quality)
+        {
+            presentationParameters.MultiSampleCount = 4;
+            quality = 0;
         }
 
         internal void OnPresentationChanged()

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -21,9 +21,7 @@ namespace Microsoft.Xna.Framework.Graphics
         internal IGraphicsContext Context { get; private set; }
 #endif
 
-#if !GLES
         private DrawBuffersEnum[] _drawBuffers;
-#endif
 
         enum ResourceType
         {
@@ -320,15 +318,17 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 #endif
 
-#if !GLES
             // Initialize draw buffer attachment array
-            int maxDrawBuffers;
-            GL.GetInteger(GetPName.MaxDrawBuffers, out maxDrawBuffers);
-            GraphicsExtensions.CheckGLError();
-            _drawBuffers = new DrawBuffersEnum[maxDrawBuffers];
-            for (int i = 0; i < maxDrawBuffers; i++)
-                _drawBuffers[i] = (DrawBuffersEnum)(FramebufferAttachment.ColorAttachment0Ext + i);
-#endif
+            if ((GL.BoundApi == GL.RenderApi.ES && glMajorVersion >= 3)
+            || (GL.BoundApi == GL.RenderApi.GL))
+            {
+                int maxDrawBuffers;
+                GL.GetInteger(GetPName.MaxDrawBuffers, out maxDrawBuffers);
+                GraphicsExtensions.CheckGLError();
+                _drawBuffers = new DrawBuffersEnum[maxDrawBuffers];
+                for (int i = 0; i < maxDrawBuffers; i++)
+                    _drawBuffers[i] = (DrawBuffersEnum)(FramebufferAttachment.ColorAttachment0Ext + i);
+            }
         }
 
         private void PlatformInitialize()
@@ -869,9 +869,12 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 this.framebufferHelper.BindFramebuffer(glFramebuffer);
             }
-#if !GLES
-            GL.DrawBuffers(this._currentRenderTargetCount, this._drawBuffers);
-#endif
+
+            if ((GL.BoundApi == GL.RenderApi.ES && glMajorVersion >= 3)
+            || (GL.BoundApi == GL.RenderApi.GL))
+            {
+                GL.DrawBuffers(this._currentRenderTargetCount, this._drawBuffers);
+            }
 
             // Reset the raster state because we flip vertices
             // when rendering offscreen and hence the cull direction.

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -547,7 +547,7 @@ namespace MonoGame.OpenGL
 
     internal partial class ColorFormat
     {
-        internal ColorFormat (int r, int g, int b, int a)
+        internal ColorFormat(int r, int g, int b, int a)
         {
             R = r;
             G = g;
@@ -773,7 +773,7 @@ namespace MonoGame.OpenGL
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [UnmanagedFunctionPointer(callingConvention)]
         [MonoNativeFunctionWrapper]
-        internal delegate void DeleteRenderbuffersDelegate(int count, [In] [Out] ref int buffer);
+        internal delegate void DeleteRenderbuffersDelegate(int count, [In][Out] ref int buffer);
         internal static DeleteRenderbuffersDelegate DeleteRenderbuffers;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
@@ -918,7 +918,7 @@ namespace MonoGame.OpenGL
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [UnmanagedFunctionPointer(callingConvention)]
         [MonoNativeFunctionWrapper]
-        internal delegate void DeleteQueriesDelegate(int count, [In] [Out] ref int queryId);
+        internal delegate void DeleteQueriesDelegate(int count, [In][Out] ref int queryId);
         internal static DeleteQueriesDelegate DeleteQueries;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
@@ -1205,6 +1205,43 @@ namespace MonoGame.OpenGL
         internal delegate void UnmapBufferDelegate(BufferTarget target);
         internal static UnmapBufferDelegate UnmapBuffer;
 
+        /// <summary>
+        /// Access mask flags for glMapBufferRange (OpenGL ES 3.0+ / OpenGL 3.0+).
+        /// </summary>
+        internal enum MapBufferAccessMask
+        {
+            /// <summary>
+            /// The mapped buffer range will be read by the client.
+            /// </summary>
+            MapReadBit = 0x0001,
+            /// <summary>
+            /// The mapped buffer range will be written by the client.
+            /// </summary>
+            MapWriteBit = 0x0002,
+            /// <summary>
+            /// The previous contents of the specified range may be discarded.
+            /// </summary>
+            MapInvalidateRangeBit = 0x0004,
+            /// <summary>
+            /// The previous contents of the entire buffer may be discarded.
+            /// </summary>
+            MapInvalidateBufferBit = 0x0008,
+            /// <summary>
+            /// Explicit flushing of modified buffer range will be performed.
+            /// </summary>
+            MapFlushExplicitBit = 0x0010,
+            /// <summary>
+            /// No GL error will be generated if the buffer is accessed while mapped.
+            /// </summary>
+            MapUnsynchronizedBit = 0x0020,
+        }
+
+        [System.Security.SuppressUnmanagedCodeSecurity()]
+        [UnmanagedFunctionPointer(callingConvention)]
+        [MonoNativeFunctionWrapper]
+        internal delegate IntPtr MapBufferRangeDelegate(BufferTarget target, IntPtr offset, IntPtr length, int access);
+        internal static MapBufferRangeDelegate MapBufferRange;
+
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [UnmanagedFunctionPointer(callingConvention)]
         [MonoNativeFunctionWrapper]
@@ -1214,7 +1251,7 @@ namespace MonoGame.OpenGL
         [System.Security.SuppressUnmanagedCodeSecurity()]
         [UnmanagedFunctionPointer(callingConvention)]
         [MonoNativeFunctionWrapper]
-        internal delegate void DeleteBuffersDelegate(int count, [In] [Out] ref int buffer);
+        internal delegate void DeleteBuffersDelegate(int count, [In][Out] ref int buffer);
         internal static DeleteBuffersDelegate DeleteBuffers;
 
         [System.Security.SuppressUnmanagedCodeSecurity()]
@@ -1245,15 +1282,15 @@ namespace MonoGame.OpenGL
         internal static VertexAttribDivisorDelegate VertexAttribDivisor;
 
 #if DEBUG
-        [UnmanagedFunctionPointer (CallingConvention.StdCall)]
-        delegate void DebugMessageCallbackProc (int source, int type, int id, int severity, int length, IntPtr message, IntPtr userParam);
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        delegate void DebugMessageCallbackProc(int source, int type, int id, int severity, int length, IntPtr message, IntPtr userParam);
         static DebugMessageCallbackProc DebugProc;
-        [System.Security.SuppressUnmanagedCodeSecurity ()]
+        [System.Security.SuppressUnmanagedCodeSecurity()]
         [MonoNativeFunctionWrapper]
-        delegate void DebugMessageCallbackDelegate (DebugMessageCallbackProc callback, IntPtr userParam);
+        delegate void DebugMessageCallbackDelegate(DebugMessageCallbackProc callback, IntPtr userParam);
         static DebugMessageCallbackDelegate DebugMessageCallback;
 
-        internal delegate void ErrorDelegate (string message);
+        internal delegate void ErrorDelegate(string message);
         internal static event ErrorDelegate OnError;
 
         static void DebugMessageCallbackHandler(int source, int type, int id, int severity, int length, IntPtr message, IntPtr userParam)
@@ -1267,147 +1304,150 @@ namespace MonoGame.OpenGL
 
         internal static int SwapInterval { get; set; }
 
-        internal static void LoadEntryPoints ()
+        internal static void LoadEntryPoints()
         {
-            LoadPlatformEntryPoints ();
+            LoadPlatformEntryPoints();
 
             if (Viewport == null)
-                Viewport = LoadFunction<ViewportDelegate> ("glViewport");
+                Viewport = LoadFunction<ViewportDelegate>("glViewport");
             if (Scissor == null)
-                Scissor = LoadFunction<ScissorDelegate> ("glScissor");
+                Scissor = LoadFunction<ScissorDelegate>("glScissor");
             if (MakeCurrent == null)
-                MakeCurrent = LoadFunction<MakeCurrentDelegate> ("glMakeCurrent");
+                MakeCurrent = LoadFunction<MakeCurrentDelegate>("glMakeCurrent");
 
-            GetError = LoadFunction<GetErrorDelegate> ("glGetError");
+            GetError = LoadFunction<GetErrorDelegate>("glGetError");
 
-            TexParameterf = LoadFunction<TexParameterFloatDelegate> ("glTexParameterf");
-            TexParameterfv = LoadFunction<TexParameterFloatArrayDelegate> ("glTexParameterfv");
-            TexParameteri = LoadFunction<TexParameterIntDelegate> ("glTexParameteri");
+            TexParameterf = LoadFunction<TexParameterFloatDelegate>("glTexParameterf");
+            TexParameterfv = LoadFunction<TexParameterFloatArrayDelegate>("glTexParameterfv");
+            TexParameteri = LoadFunction<TexParameterIntDelegate>("glTexParameteri");
 
-            EnableVertexAttribArray = LoadFunction<EnableVertexAttribArrayDelegate> ("glEnableVertexAttribArray");
-            DisableVertexAttribArray = LoadFunction<DisableVertexAttribArrayDelegate> ("glDisableVertexAttribArray");
-            GetIntegerv = LoadFunction<GetIntegerDelegate> ("glGetIntegerv");
-            GetStringInternal = LoadFunction<GetStringDelegate> ("glGetString");
-            ClearDepth = LoadFunction<ClearDepthDelegate> ("glClearDepth");
+            EnableVertexAttribArray = LoadFunction<EnableVertexAttribArrayDelegate>("glEnableVertexAttribArray");
+            DisableVertexAttribArray = LoadFunction<DisableVertexAttribArrayDelegate>("glDisableVertexAttribArray");
+            GetIntegerv = LoadFunction<GetIntegerDelegate>("glGetIntegerv");
+            GetStringInternal = LoadFunction<GetStringDelegate>("glGetString");
+            ClearDepth = LoadFunction<ClearDepthDelegate>("glClearDepth");
             if (ClearDepth == null)
-                ClearDepth = LoadFunction<ClearDepthDelegate> ("glClearDepthf");
-            DepthRanged = LoadFunction<DepthRangedDelegate> ("glDepthRange");
-            DepthRangef = LoadFunction<DepthRangefDelegate> ("glDepthRangef");
-            Clear = LoadFunction<ClearDelegate> ("glClear");
-            ClearColor = LoadFunction<ClearColorDelegate> ("glClearColor");
-            ClearStencil = LoadFunction<ClearStencilDelegate> ("glClearStencil");
-            Flush = LoadFunction<FlushDelegate> ("glFlush");
-            GenTextures = LoadFunction<GenTexturesDelegte> ("glGenTextures");
-            BindTexture = LoadFunction<BindTextureDelegate> ("glBindTexture");
+                ClearDepth = LoadFunction<ClearDepthDelegate>("glClearDepthf");
+            DepthRanged = LoadFunction<DepthRangedDelegate>("glDepthRange");
+            DepthRangef = LoadFunction<DepthRangefDelegate>("glDepthRangef");
+            Clear = LoadFunction<ClearDelegate>("glClear");
+            ClearColor = LoadFunction<ClearColorDelegate>("glClearColor");
+            ClearStencil = LoadFunction<ClearStencilDelegate>("glClearStencil");
+            Flush = LoadFunction<FlushDelegate>("glFlush");
+            GenTextures = LoadFunction<GenTexturesDelegte>("glGenTextures");
+            BindTexture = LoadFunction<BindTextureDelegate>("glBindTexture");
 
-            Enable = LoadFunction<EnableDelegate> ("glEnable");
-            Disable = LoadFunction<DisableDelegate> ("glDisable");
-            CullFace = LoadFunction<CullFaceDelegate> ("glCullFace");
-            FrontFace = LoadFunction<FrontFaceDelegate> ("glFrontFace");
-            PolygonMode = LoadFunction<PolygonModeDelegate> ("glPolygonMode");
-            PolygonOffset = LoadFunction<PolygonOffsetDelegate> ("glPolygonOffset");
+            Enable = LoadFunction<EnableDelegate>("glEnable");
+            Disable = LoadFunction<DisableDelegate>("glDisable");
+            CullFace = LoadFunction<CullFaceDelegate>("glCullFace");
+            FrontFace = LoadFunction<FrontFaceDelegate>("glFrontFace");
+            PolygonMode = LoadFunction<PolygonModeDelegate>("glPolygonMode");
+            PolygonOffset = LoadFunction<PolygonOffsetDelegate>("glPolygonOffset");
 
-            BindBuffer = LoadFunction<BindBufferDelegate> ("glBindBuffer");
-            DrawBuffers = LoadFunction<DrawBuffersDelegate> ("glDrawBuffers");
-            DrawElements = LoadFunction<DrawElementsDelegate> ("glDrawElements");
-            DrawArrays = LoadFunction<DrawArraysDelegate> ("glDrawArrays");
-            Uniform1i = LoadFunction<Uniform1iDelegate> ("glUniform1i");
-            Uniform4fv = LoadFunction<Uniform4fvDelegate> ("glUniform4fv");
+            BindBuffer = LoadFunction<BindBufferDelegate>("glBindBuffer");
+            DrawBuffers = LoadFunction<DrawBuffersDelegate>("glDrawBuffers");
+            DrawElements = LoadFunction<DrawElementsDelegate>("glDrawElements");
+            DrawArrays = LoadFunction<DrawArraysDelegate>("glDrawArrays");
+            Uniform1i = LoadFunction<Uniform1iDelegate>("glUniform1i");
+            Uniform4fv = LoadFunction<Uniform4fvDelegate>("glUniform4fv");
             ReadPixelsInternal = LoadFunction<ReadPixelsDelegate>("glReadPixels");
 
-            ReadBuffer = LoadFunction<ReadBufferDelegate> ("glReadBuffer");
-            DrawBuffer = LoadFunction<DrawBufferDelegate> ("glDrawBuffer");
+            ReadBuffer = LoadFunction<ReadBufferDelegate>("glReadBuffer");
+            DrawBuffer = LoadFunction<DrawBufferDelegate>("glDrawBuffer");
 
             // Render Target Support. These might be null if they are not supported
             // see GraphicsDevice.OpenGL.FramebufferHelper.cs for handling other extensions.
-            GenRenderbuffers = LoadFunction<GenRenderbuffersDelegate> ("glGenRenderbuffers");
-            BindRenderbuffer = LoadFunction<BindRenderbufferDelegate> ("glBindRenderbuffer");
-            DeleteRenderbuffers = LoadFunction<DeleteRenderbuffersDelegate> ("glDeleteRenderbuffers");
-            GenFramebuffers = LoadFunction<GenFramebuffersDelegate> ("glGenFramebuffers");
-            BindFramebuffer = LoadFunction<BindFramebufferDelegate> ("glBindFramebuffer");
-            DeleteFramebuffers = LoadFunction<DeleteFramebuffersDelegate> ("glDeleteFramebuffers");
-            FramebufferTexture2D = LoadFunction<FramebufferTexture2DDelegate> ("glFramebufferTexture2D");
-            FramebufferRenderbuffer = LoadFunction<FramebufferRenderbufferDelegate> ("glFramebufferRenderbuffer");
-            RenderbufferStorage = LoadFunction<RenderbufferStorageDelegate> ("glRenderbufferStorage");
-            RenderbufferStorageMultisample = LoadFunction<RenderbufferStorageMultisampleDelegate> ("glRenderbufferStorageMultisample");
-            GenerateMipmap = LoadFunction<GenerateMipmapDelegate> ("glGenerateMipmap");
-            BlitFramebuffer = LoadFunction<BlitFramebufferDelegate> ("glBlitFramebuffer");
-            CheckFramebufferStatus = LoadFunction<CheckFramebufferStatusDelegate> ("glCheckFramebufferStatus");
+            GenRenderbuffers = LoadFunction<GenRenderbuffersDelegate>("glGenRenderbuffers");
+            BindRenderbuffer = LoadFunction<BindRenderbufferDelegate>("glBindRenderbuffer");
+            DeleteRenderbuffers = LoadFunction<DeleteRenderbuffersDelegate>("glDeleteRenderbuffers");
+            GenFramebuffers = LoadFunction<GenFramebuffersDelegate>("glGenFramebuffers");
+            BindFramebuffer = LoadFunction<BindFramebufferDelegate>("glBindFramebuffer");
+            DeleteFramebuffers = LoadFunction<DeleteFramebuffersDelegate>("glDeleteFramebuffers");
+            FramebufferTexture2D = LoadFunction<FramebufferTexture2DDelegate>("glFramebufferTexture2D");
+            FramebufferRenderbuffer = LoadFunction<FramebufferRenderbufferDelegate>("glFramebufferRenderbuffer");
+            RenderbufferStorage = LoadFunction<RenderbufferStorageDelegate>("glRenderbufferStorage");
+            RenderbufferStorageMultisample = LoadFunction<RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisample");
+            GenerateMipmap = LoadFunction<GenerateMipmapDelegate>("glGenerateMipmap");
+            BlitFramebuffer = LoadFunction<BlitFramebufferDelegate>("glBlitFramebuffer");
+            CheckFramebufferStatus = LoadFunction<CheckFramebufferStatusDelegate>("glCheckFramebufferStatus");
 
-            GenQueries = LoadFunction<GenQueriesDelegate> ("glGenQueries");
-            BeginQuery = LoadFunction<BeginQueryDelegate> ("glBeginQuery");
-            EndQuery = LoadFunction<EndQueryDelegate> ("glEndQuery");
+            GenQueries = LoadFunction<GenQueriesDelegate>("glGenQueries");
+            BeginQuery = LoadFunction<BeginQueryDelegate>("glBeginQuery");
+            EndQuery = LoadFunction<EndQueryDelegate>("glEndQuery");
             GetQueryObject = LoadFunction<GetQueryObjectDelegate>("glGetQueryObjectuiv");
             if (GetQueryObject == null)
-                GetQueryObject = LoadFunction<GetQueryObjectDelegate> ("glGetQueryObjectivARB");
+                GetQueryObject = LoadFunction<GetQueryObjectDelegate>("glGetQueryObjectivARB");
             if (GetQueryObject == null)
-                GetQueryObject = LoadFunction<GetQueryObjectDelegate> ("glGetQueryObjectiv");
-            DeleteQueries = LoadFunction<DeleteQueriesDelegate> ("glDeleteQueries");
+                GetQueryObject = LoadFunction<GetQueryObjectDelegate>("glGetQueryObjectiv");
+            DeleteQueries = LoadFunction<DeleteQueriesDelegate>("glDeleteQueries");
 
-            ActiveTexture = LoadFunction<ActiveTextureDelegate> ("glActiveTexture");
-            CreateShader = LoadFunction<CreateShaderDelegate> ("glCreateShader");
-            ShaderSourceInternal = LoadFunction<ShaderSourceDelegate> ("glShaderSource");
-            CompileShader = LoadFunction<CompileShaderDelegate> ("glCompileShader");
-            GetShaderiv = LoadFunction<GetShaderDelegate> ("glGetShaderiv");
-            GetShaderInfoLogInternal = LoadFunction<GetShaderInfoLogDelegate> ("glGetShaderInfoLog");
-            IsShader = LoadFunction<IsShaderDelegate> ("glIsShader");
-            DeleteShader = LoadFunction<DeleteShaderDelegate> ("glDeleteShader");
-            GetAttribLocation = LoadFunction<GetAttribLocationDelegate> ("glGetAttribLocation");
-            GetUniformLocation = LoadFunction<GetUniformLocationDelegate> ("glGetUniformLocation");
+            ActiveTexture = LoadFunction<ActiveTextureDelegate>("glActiveTexture");
+            CreateShader = LoadFunction<CreateShaderDelegate>("glCreateShader");
+            ShaderSourceInternal = LoadFunction<ShaderSourceDelegate>("glShaderSource");
+            CompileShader = LoadFunction<CompileShaderDelegate>("glCompileShader");
+            GetShaderiv = LoadFunction<GetShaderDelegate>("glGetShaderiv");
+            GetShaderInfoLogInternal = LoadFunction<GetShaderInfoLogDelegate>("glGetShaderInfoLog");
+            IsShader = LoadFunction<IsShaderDelegate>("glIsShader");
+            DeleteShader = LoadFunction<DeleteShaderDelegate>("glDeleteShader");
+            GetAttribLocation = LoadFunction<GetAttribLocationDelegate>("glGetAttribLocation");
+            GetUniformLocation = LoadFunction<GetUniformLocationDelegate>("glGetUniformLocation");
 
-            IsProgram = LoadFunction<IsProgramDelegate> ("glIsProgram");
-            DeleteProgram = LoadFunction<DeleteProgramDelegate> ("glDeleteProgram");
-            CreateProgram = LoadFunction<CreateProgramDelegate> ("glCreateProgram");
-            AttachShader = LoadFunction<AttachShaderDelegate> ("glAttachShader");
-            UseProgram = LoadFunction<UseProgramDelegate> ("glUseProgram");
-            LinkProgram = LoadFunction<LinkProgramDelegate> ("glLinkProgram");
-            GetProgramiv = LoadFunction<GetProgramDelegate> ("glGetProgramiv");
-            GetProgramInfoLogInternal = LoadFunction<GetProgramInfoLogDelegate> ("glGetProgramInfoLog");
-            DetachShader = LoadFunction<DetachShaderDelegate> ("glDetachShader");
+            IsProgram = LoadFunction<IsProgramDelegate>("glIsProgram");
+            DeleteProgram = LoadFunction<DeleteProgramDelegate>("glDeleteProgram");
+            CreateProgram = LoadFunction<CreateProgramDelegate>("glCreateProgram");
+            AttachShader = LoadFunction<AttachShaderDelegate>("glAttachShader");
+            UseProgram = LoadFunction<UseProgramDelegate>("glUseProgram");
+            LinkProgram = LoadFunction<LinkProgramDelegate>("glLinkProgram");
+            GetProgramiv = LoadFunction<GetProgramDelegate>("glGetProgramiv");
+            GetProgramInfoLogInternal = LoadFunction<GetProgramInfoLogDelegate>("glGetProgramInfoLog");
+            DetachShader = LoadFunction<DetachShaderDelegate>("glDetachShader");
 
-            BlendColor = LoadFunction<BlendColorDelegate> ("glBlendColor");
-            BlendEquationSeparate = LoadFunction<BlendEquationSeparateDelegate> ("glBlendEquationSeparate");
+            BlendColor = LoadFunction<BlendColorDelegate>("glBlendColor");
+            BlendEquationSeparate = LoadFunction<BlendEquationSeparateDelegate>("glBlendEquationSeparate");
             BlendEquationSeparatei = LoadFunction<BlendEquationSeparateiDelegate>("glBlendEquationSeparatei");
-            BlendFuncSeparate = LoadFunction<BlendFuncSeparateDelegate> ("glBlendFuncSeparate");
+            BlendFuncSeparate = LoadFunction<BlendFuncSeparateDelegate>("glBlendFuncSeparate");
             BlendFuncSeparatei = LoadFunction<BlendFuncSeparateiDelegate>("glBlendFuncSeparatei");
-            ColorMask = LoadFunction<ColorMaskDelegate> ("glColorMask");
-            DepthFunc = LoadFunction<DepthFuncDelegate> ("glDepthFunc");
-            DepthMask = LoadFunction<DepthMaskDelegate> ("glDepthMask");
-            StencilFuncSeparate = LoadFunction<StencilFuncSeparateDelegate> ("glStencilFuncSeparate");
-            StencilOpSeparate = LoadFunction<StencilOpSeparateDelegate> ("glStencilOpSeparate");
-            StencilFunc = LoadFunction<StencilFuncDelegate> ("glStencilFunc");
-            StencilOp = LoadFunction<StencilOpDelegate> ("glStencilOp");
-            StencilMask = LoadFunction<StencilMaskDelegate> ("glStencilMask");
+            ColorMask = LoadFunction<ColorMaskDelegate>("glColorMask");
+            DepthFunc = LoadFunction<DepthFuncDelegate>("glDepthFunc");
+            DepthMask = LoadFunction<DepthMaskDelegate>("glDepthMask");
+            StencilFuncSeparate = LoadFunction<StencilFuncSeparateDelegate>("glStencilFuncSeparate");
+            StencilOpSeparate = LoadFunction<StencilOpSeparateDelegate>("glStencilOpSeparate");
+            StencilFunc = LoadFunction<StencilFuncDelegate>("glStencilFunc");
+            StencilOp = LoadFunction<StencilOpDelegate>("glStencilOp");
+            StencilMask = LoadFunction<StencilMaskDelegate>("glStencilMask");
 
-            CompressedTexImage2D = LoadFunction<CompressedTexImage2DDelegate> ("glCompressedTexImage2D");
-            TexImage2D = LoadFunction<TexImage2DDelegate> ("glTexImage2D");
-            CompressedTexSubImage2D = LoadFunction<CompressedTexSubImage2DDelegate> ("glCompressedTexSubImage2D");
-            TexSubImage2D = LoadFunction<TexSubImage2DDelegate> ("glTexSubImage2D");
-            PixelStore = LoadFunction<PixelStoreDelegate> ("glPixelStorei");
-            Finish = LoadFunction<FinishDelegate> ("glFinish");
-            GetTexImageInternal = LoadFunction<GetTexImageDelegate> ("glGetTexImage");
-            GetCompressedTexImageInternal = LoadFunction<GetCompressedTexImageDelegate> ("glGetCompressedTexImage");
-            TexImage3D = LoadFunction<TexImage3DDelegate> ("glTexImage3D");
-            TexSubImage3D = LoadFunction<TexSubImage3DDelegate> ("glTexSubImage3D");
-            DeleteTextures = LoadFunction<DeleteTexturesDelegate> ("glDeleteTextures");
+            CompressedTexImage2D = LoadFunction<CompressedTexImage2DDelegate>("glCompressedTexImage2D");
+            TexImage2D = LoadFunction<TexImage2DDelegate>("glTexImage2D");
+            CompressedTexSubImage2D = LoadFunction<CompressedTexSubImage2DDelegate>("glCompressedTexSubImage2D");
+            TexSubImage2D = LoadFunction<TexSubImage2DDelegate>("glTexSubImage2D");
+            PixelStore = LoadFunction<PixelStoreDelegate>("glPixelStorei");
+            Finish = LoadFunction<FinishDelegate>("glFinish");
+            GetTexImageInternal = LoadFunction<GetTexImageDelegate>("glGetTexImage");
+            GetCompressedTexImageInternal = LoadFunction<GetCompressedTexImageDelegate>("glGetCompressedTexImage");
+            TexImage3D = LoadFunction<TexImage3DDelegate>("glTexImage3D");
+            TexSubImage3D = LoadFunction<TexSubImage3DDelegate>("glTexSubImage3D");
+            DeleteTextures = LoadFunction<DeleteTexturesDelegate>("glDeleteTextures");
 
-            GenBuffers = LoadFunction<GenBuffersDelegate> ("glGenBuffers");
-            BufferData = LoadFunction<BufferDataDelegate> ("glBufferData");
-            MapBuffer = LoadFunction<MapBufferDelegate> ("glMapBuffer");
-            UnmapBuffer = LoadFunction<UnmapBufferDelegate> ("glUnmapBuffer");
-            BufferSubData = LoadFunction<BufferSubDataDelegate> ("glBufferSubData");
-            DeleteBuffers = LoadFunction<DeleteBuffersDelegate> ("glDeleteBuffers");
+            GenBuffers = LoadFunction<GenBuffersDelegate>("glGenBuffers");
+            BufferData = LoadFunction<BufferDataDelegate>("glBufferData");
+            MapBuffer = LoadFunction<MapBufferDelegate>("glMapBuffer");
+            UnmapBuffer = LoadFunction<UnmapBufferDelegate>("glUnmapBuffer");
+            MapBufferRange = LoadFunction<MapBufferRangeDelegate>("glMapBufferRange");
+            BufferSubData = LoadFunction<BufferSubDataDelegate>("glBufferSubData");
+            DeleteBuffers = LoadFunction<DeleteBuffersDelegate>("glDeleteBuffers");
 
-            VertexAttribPointer = LoadFunction<VertexAttribPointerDelegate> ("glVertexAttribPointer");
+            VertexAttribPointer = LoadFunction<VertexAttribPointerDelegate>("glVertexAttribPointer");
 
             // Instanced drawing requires GL 3.2 or up, if the either of the following entry points can not be loaded
             // this will get flagged by setting SupportsInstancing in GraphicsCapabilities to false.
-            try {
-                DrawElementsInstanced = LoadFunction<DrawElementsInstancedDelegate> ("glDrawElementsInstanced");
-                VertexAttribDivisor = LoadFunction<VertexAttribDivisorDelegate> ("glVertexAttribDivisor");
+            try
+            {
+                DrawElementsInstanced = LoadFunction<DrawElementsInstancedDelegate>("glDrawElementsInstanced");
+                VertexAttribDivisor = LoadFunction<VertexAttribDivisorDelegate>("glVertexAttribDivisor");
                 DrawElementsInstancedBaseInstance = LoadFunction<DrawElementsInstancedBaseInstanceDelegate>("glDrawElementsInstancedBaseInstance");
             }
-            catch (EntryPointNotFoundException) {
+            catch (EntryPointNotFoundException)
+            {
                 // this will be detected in the initialization of GraphicsCapabilities
             }
 
@@ -1428,11 +1468,12 @@ namespace MonoGame.OpenGL
                 // Ignore the debug message callback if the entry point can not be found
             }
 #endif
-            if (BoundApi == RenderApi.ES) {
-                InvalidateFramebuffer = LoadFunction<InvalidateFramebufferDelegate> ("glDiscardFramebufferEXT");
+            if (BoundApi == RenderApi.ES)
+            {
+                InvalidateFramebuffer = LoadFunction<InvalidateFramebufferDelegate>("glDiscardFramebufferEXT");
             }
 
-            LoadExtensions ();
+            LoadExtensions();
         }
 
         internal static List<string> Extensions;
@@ -1475,7 +1516,7 @@ namespace MonoGame.OpenGL
                 GL.LoadFrameBufferObjectEXTEntryPoints();
             }
             if (GL.RenderbufferStorageMultisample == null)
-            {                
+            {
                 if (HasExtension("GL_APPLE_framebuffer_multisample"))
                 {
                     GL.RenderbufferStorageMultisample = LoadFunction<GL.RenderbufferStorageMultisampleDelegate>("glRenderbufferStorageMultisampleAPPLE");
@@ -1542,100 +1583,109 @@ namespace MonoGame.OpenGL
                 DepthRanged(min, max);
         }
 
-        internal static void Uniform1 (int location, int value) {
+        internal static void Uniform1(int location, int value)
+        {
             Uniform1i(location, value);
         }
 
-        internal static unsafe void Uniform4 (int location, int size, float* value) {
+        internal static unsafe void Uniform4(int location, int size, float* value)
+        {
             Uniform4fv(location, size, value);
         }
 
-        internal unsafe static string GetString (StringName name)
+        internal unsafe static string GetString(StringName name)
         {
-            return Marshal.PtrToStringAnsi (GetStringInternal (name));
+            return Marshal.PtrToStringAnsi(GetStringInternal(name));
         }
 
-        protected static IntPtr MarshalStringArrayToPtr (string[] strings)
+        protected static IntPtr MarshalStringArrayToPtr(string[] strings)
         {
             IntPtr intPtr = IntPtr.Zero;
-            if (strings != null && strings.Length != 0) {
-                intPtr = Marshal.AllocHGlobal (strings.Length * IntPtr.Size);
-                if (intPtr == IntPtr.Zero) {
-                    throw new OutOfMemoryException ();
+            if (strings != null && strings.Length != 0)
+            {
+                intPtr = Marshal.AllocHGlobal(strings.Length * IntPtr.Size);
+                if (intPtr == IntPtr.Zero)
+                {
+                    throw new OutOfMemoryException();
                 }
                 int i = 0;
-                try {
-                    for (i = 0; i < strings.Length; i++) {
-                        IntPtr val = MarshalStringToPtr (strings [i]);
-                        Marshal.WriteIntPtr (intPtr, i * IntPtr.Size, val);
+                try
+                {
+                    for (i = 0; i < strings.Length; i++)
+                    {
+                        IntPtr val = MarshalStringToPtr(strings[i]);
+                        Marshal.WriteIntPtr(intPtr, i * IntPtr.Size, val);
                     }
                 }
-                catch (OutOfMemoryException) {
-                    for (i--; i >= 0; i--) {
-                        Marshal.FreeHGlobal (Marshal.ReadIntPtr (intPtr, i * IntPtr.Size));
+                catch (OutOfMemoryException)
+                {
+                    for (i--; i >= 0; i--)
+                    {
+                        Marshal.FreeHGlobal(Marshal.ReadIntPtr(intPtr, i * IntPtr.Size));
                     }
-                    Marshal.FreeHGlobal (intPtr);
+                    Marshal.FreeHGlobal(intPtr);
                     throw;
                 }
             }
             return intPtr;
         }
 
-        protected unsafe static IntPtr MarshalStringToPtr (string str)
+        protected unsafe static IntPtr MarshalStringToPtr(string str)
         {
-            if (string.IsNullOrEmpty (str))
+            if (string.IsNullOrEmpty(str))
             {
                 return IntPtr.Zero;
             }
-            int num = Encoding.ASCII.GetMaxByteCount (str.Length) + 1;
-            IntPtr intPtr = Marshal.AllocHGlobal (num);
+            int num = Encoding.ASCII.GetMaxByteCount(str.Length) + 1;
+            IntPtr intPtr = Marshal.AllocHGlobal(num);
             if (intPtr == IntPtr.Zero)
             {
-                throw new OutOfMemoryException ();
+                throw new OutOfMemoryException();
             }
-            
-            fixed (char* chars = str)
+            fixed (char* chars = str + RuntimeHelpers.OffsetToStringData / 2)
             {
-                int bytes = Encoding.ASCII.GetBytes (chars, str.Length, (byte*)((void*)intPtr), num);
-                Marshal.WriteByte (intPtr, bytes, 0);
+                int bytes = Encoding.ASCII.GetBytes(chars, str.Length, (byte*)((void*)intPtr), num);
+                Marshal.WriteByte(intPtr, bytes, 0);
                 return intPtr;
             }
         }
 
-        protected static void FreeStringArrayPtr (IntPtr ptr, int length)
+        protected static void FreeStringArrayPtr(IntPtr ptr, int length)
         {
-            for (int i = 0; i < length; i++) {
-                Marshal.FreeHGlobal (Marshal.ReadIntPtr (ptr, i * IntPtr.Size));
+            for (int i = 0; i < length; i++)
+            {
+                Marshal.FreeHGlobal(Marshal.ReadIntPtr(ptr, i * IntPtr.Size));
             }
-            Marshal.FreeHGlobal (ptr);
+            Marshal.FreeHGlobal(ptr);
         }
 
-        internal static string GetProgramInfoLog (int programId)
+        internal static string GetProgramInfoLog(int programId)
         {
             int length = 0;
             GetProgram(programId, GetProgramParameterName.LogLength, out length);
             var sb = new StringBuilder(length, length);
-            GetProgramInfoLogInternal (programId, length, IntPtr.Zero, sb);
+            GetProgramInfoLogInternal(programId, length, IntPtr.Zero, sb);
             return sb.ToString();
         }
 
-        internal static string GetShaderInfoLog (int shaderId) {
+        internal static string GetShaderInfoLog(int shaderId)
+        {
             int length = 0;
             GetShader(shaderId, ShaderParameter.LogLength, out length);
             var sb = new StringBuilder(length, length);
-            GetShaderInfoLogInternal (shaderId, length, IntPtr.Zero, sb);
+            GetShaderInfoLogInternal(shaderId, length, IntPtr.Zero, sb);
             return sb.ToString();
         }
 
         internal unsafe static void ShaderSource(int shaderId, string code)
         {
             int length = code.Length;
-            IntPtr intPtr = MarshalStringArrayToPtr (new string[] { code });
+            IntPtr intPtr = MarshalStringArrayToPtr(new string[] { code });
             ShaderSourceInternal(shaderId, 1, intPtr, &length);
             FreeStringArrayPtr(intPtr, 1);
         }
 
-        internal unsafe static void GetShader (int shaderId, ShaderParameter name, out int result)
+        internal unsafe static void GetShader(int shaderId, ShaderParameter name, out int result)
         {
             fixed (int* ptr = &result)
             {
@@ -1651,18 +1701,19 @@ namespace MonoGame.OpenGL
             }
         }
 
-        internal unsafe static void GetInteger (GetPName name, out int value)
-        {
-            fixed (int* ptr = &value) {
-                GetIntegerv ((int)name, ptr);
-            }
-        }
-
-        internal unsafe static void GetInteger (int name, out int value)
+        internal unsafe static void GetInteger(GetPName name, out int value)
         {
             fixed (int* ptr = &value)
             {
-                GetIntegerv (name, ptr);
+                GetIntegerv((int)name, ptr);
+            }
+        }
+
+        internal unsafe static void GetInteger(int name, out int value)
+        {
+            fixed (int* ptr = &value)
+            {
+                GetIntegerv(name, ptr);
             }
         }
 
@@ -1724,4 +1775,3 @@ namespace MonoGame.OpenGL
         }
     }
 }
-

--- a/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Diagnostics;
+using System.Text;
 using MonoGame.OpenGL;
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -38,7 +39,12 @@ namespace Microsoft.Xna.Framework.Graphics
             //
             _shaderHandle = GL.CreateShader(Stage == ShaderStage.Vertex ? ShaderType.VertexShader : ShaderType.FragmentShader);
             GraphicsExtensions.CheckGLError();
-            GL.ShaderSource(_shaderHandle, _glslCode);
+
+            var glslCode = _glslCode;
+            if (GL.BoundApi == GL.RenderApi.ES && GraphicsDevice.glMajorVersion >= 3)
+                glslCode = UpgradeEs2ShaderSourceToEs3(glslCode, Stage);
+
+            GL.ShaderSource(_shaderHandle, glslCode);
             GraphicsExtensions.CheckGLError();
             GL.CompileShader(_shaderHandle);
             GraphicsExtensions.CheckGLError();
@@ -52,10 +58,50 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsDevice.DisposeShader(_shaderHandle);
                 _shaderHandle = -1;
 
-                throw new ShaderCompilerException(SourceFile, Entrypoint, Stage, errorLog, _glslCode);
+                throw new ShaderCompilerException(SourceFile, Entrypoint, Stage, errorLog, glslCode);
             }
 
             return _shaderHandle;
+        }
+
+        private static string UpgradeEs2ShaderSourceToEs3(string glslCode, ShaderStage stage)
+        {
+            // Let's hack the emitted code to be ES 3.x syntax, see what happens.
+            var upgraded = glslCode;
+
+            if (!upgraded.Contains("#version"))
+                upgraded = "#version 300 es\n" + upgraded;
+
+            upgraded = upgraded
+                .Replace("texture2D(", "texture(")
+                .Replace("textureCube(", "texture(")
+                .Replace("texture3D(", "texture(");
+
+            if (stage == ShaderStage.Vertex)
+            {
+                upgraded = upgraded
+                    .Replace("attribute ", "in ")
+                    .Replace("varying ", "out ");
+
+                return upgraded;
+            }
+
+            upgraded = upgraded.Replace("varying ", "in ");
+
+            for (var i = 0; i < 8; i++)
+            {
+                var legacyDefine = $"#define ps_oC{i} gl_FragData[{i}]";
+                if (!upgraded.Contains(legacyDefine))
+                    continue;
+
+                var replacement = new StringBuilder();
+                replacement.AppendLine($"layout(location = {i}) out vec4 _mgColor{i};");
+                replacement.Append($"#define ps_oC{i} _mgColor{i}");
+
+                upgraded = upgraded.Replace(legacyDefine, replacement.ToString());
+            }
+
+            return upgraded;
         }
 
         internal void GetVertexAttributeLocations(int program)

--- a/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
@@ -88,6 +88,22 @@ namespace Microsoft.Xna.Framework.Graphics
 
             upgraded = upgraded.Replace("varying ", "in ");
 
+            if (upgraded.Contains("gl_FragColor"))
+            {
+                upgraded = upgraded.Replace("gl_FragColor", "_mgColor0");
+
+                if (!upgraded.Contains("layout(location = 0) out vec4 _mgColor0;"))
+                {
+                    var marker = "#endif\n";
+                    var decl = "layout(location = 0) out vec4 _mgColor0;\n";
+                    var markerIndex = upgraded.IndexOf(marker, StringComparison.Ordinal);
+                    if (markerIndex >= 0)
+                        upgraded = upgraded.Insert(markerIndex + marker.Length, decl);
+                    else
+                        upgraded = decl + upgraded;
+                }
+            }
+
             for (var i = 0; i < 8; i++)
             {
                 var legacyDefine = $"#define ps_oC{i} gl_FragData[{i}]";

--- a/MonoGame.Framework/Platform/Graphics/Texture3D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture3D.OpenGL.cs
@@ -11,12 +11,14 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class Texture3D : Texture
     {
+        private GraphicsDevice _graphicsDevice;
 
         private void PlatformConstruct(GraphicsDevice graphicsDevice, int width, int height, int depth, bool mipMap, SurfaceFormat format, bool renderTarget)
         {
-#if GLES
-            throw new NotSupportedException("OpenGL ES 2.0 doesn't support 3D textures.");
-#else
+            _graphicsDevice = graphicsDevice;
+            if (!_graphicsDevice.GraphicsCapabilities.SupportsMapBuffer)
+                throw new NotSupportedException("Texture3D is not supported on OpenGL ES versions below 3.0.");
+
             this.glTarget = TextureTarget.Texture3D;
 
             Threading.BlockOnUIThread(() =>
@@ -35,7 +37,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (mipMap)
                 throw new NotImplementedException("Texture3D does not yet support mipmaps.");
-#endif
         }
 
         private void PlatformSetData<T>(
@@ -43,9 +44,9 @@ namespace Microsoft.Xna.Framework.Graphics
             int left, int top, int right, int bottom, int front, int back,
             T[] data, int startIndex, int elementCount)
         {
-#if GLES
-            throw new NotSupportedException("OpenGL ES 2.0 doesn't support 3D textures.");
-#else
+            if (!_graphicsDevice.GraphicsCapabilities.SupportsMapBuffer)
+                throw new NotSupportedException("Texture3D.SetData is not supported on OpenGL ES versions below 3.0.");
+
             var width = right - left;
             var height = bottom - top;
             var depth = back - front;
@@ -69,14 +70,16 @@ namespace Microsoft.Xna.Framework.Graphics
                     dataHandle.Free();
                 }
             });
-#endif
         }
 
         private void PlatformGetData<T>(int level, int left, int top, int right, int bottom, int front, int back, T[] data, int startIndex, int elementCount)
              where T : struct
         {
 #if GLES
-            throw new NotSupportedException("OpenGL ES 2.0 doesn't support 3D textures.");
+                // Note: glGetTexImage is not available in GLES, even in 3.0+
+                // We would need to use framebuffer + glReadPixels as a workaround
+                // For now, this will only work on desktop OpenGL
+                throw new NotSupportedException("Texture3D.GetData is not supported on OpenGL ES.");
 #else
             var width = right - left;
             var height = bottom - top;

--- a/MonoGame.Framework/Platform/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -46,11 +46,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGetData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount) where T : struct
         {
-#if GLES
             // Buffers are write-only on OpenGL ES 1.1 and 2.0.  See the GL_OES_mapbuffer extension for more information.
             // http://www.khronos.org/registry/gles/extensions/OES/OES_mapbuffer.txt
-            throw new NotSupportedException("Index buffers are write-only on OpenGL ES platforms");
-#else
+            if (GraphicsDevice != null && !GraphicsDevice.GraphicsCapabilities.SupportsMapBuffer)
+                throw new NotSupportedException("IndexBuffer.GetData is not supported on OpenGL ES versions below 3.0. Index buffers are write-only on those OpenGL ES platforms");
+
             if (Threading.IsOnUIThread())
             {
                 GetBufferData(offsetInBytes, data, startIndex, elementCount);
@@ -59,38 +59,64 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 Threading.BlockOnUIThread(() => GetBufferData(offsetInBytes, data, startIndex, elementCount));
             }
-#endif
         }
 
-#if !GLES
         private void GetBufferData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount) where T : struct
         {
             GL.BindBuffer(BufferTarget.ElementArrayBuffer, ibo);
             GraphicsExtensions.CheckGLError();
+
             var elementSizeInByte = Marshal.SizeOf<T>();
-            IntPtr ptr = GL.MapBuffer(BufferTarget.ElementArrayBuffer, BufferAccess.ReadOnly);
-            // Pointer to the start of data to read in the index buffer
+            var dataSize = elementCount * elementSizeInByte;
+            IntPtr ptr;
+
+#if GLES
+            if (GraphicsDevice != null && !GraphicsDevice.GraphicsCapabilities.SupportsMapBuffer)
+                throw new NotSupportedException("IndexBuffer.GetBufferData is not supported on OpenGL ES versions below 3.0.");
+
+            ptr = GL.MapBufferRange(
+                BufferTarget.ElementArrayBuffer,
+                (IntPtr)offsetInBytes,
+                (IntPtr)dataSize,
+                (int)GL.MapBufferAccessMask.MapReadBit);
+#else
+            // Desktop OpenGL uses glMapBuffer and adjusts the pointer
+            ptr = GL.MapBuffer(BufferTarget.ElementArrayBuffer, BufferAccess.ReadOnly);
             ptr = new IntPtr(ptr.ToInt64() + offsetInBytes);
-            if (typeof(T) == typeof(byte))
-            {
-                byte[] buffer = data as byte[];
-                // If data is already a byte[] we can skip the temporary buffer
-                // Copy from the index buffer to the destination array
-                Marshal.Copy(ptr, buffer, startIndex * elementSizeInByte, elementCount * elementSizeInByte);
-            }
-            else
-            {
-                // Temporary buffer to store the copied section of data
-                byte[] buffer = new byte[elementCount * elementSizeInByte];
-                // Copy from the index buffer to the temporary buffer
-                Marshal.Copy(ptr, buffer, 0, buffer.Length);
-                // Copy from the temporary buffer to the destination array
-                Buffer.BlockCopy(buffer, 0, data, startIndex * elementSizeInByte, elementCount * elementSizeInByte);
-            }
-            GL.UnmapBuffer(BufferTarget.ElementArrayBuffer);
-            GraphicsExtensions.CheckGLError();
-        }
 #endif
+
+            GraphicsExtensions.CheckGLError();
+
+            if (ptr == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Failed to map index buffer for reading");
+            }
+
+            try
+            {
+                if (typeof(T) == typeof(byte))
+                {
+                    byte[] buffer = data as byte[];
+                    // If data is already a byte[] we can skip the temporary buffer
+                    // Copy from the index buffer to the destination array
+                    Marshal.Copy(ptr, buffer, startIndex * elementSizeInByte, elementCount * elementSizeInByte);
+                }
+                else
+                {
+                    // Temporary buffer to store the copied section of data
+                    byte[] buffer = new byte[elementCount * elementSizeInByte];
+                    // Copy from the index buffer to the temporary buffer
+                    Marshal.Copy(ptr, buffer, 0, buffer.Length);
+                    // Copy from the temporary buffer to the destination array
+                    Buffer.BlockCopy(buffer, 0, data, startIndex * elementSizeInByte, elementCount * elementSizeInByte);
+                }
+            }
+            finally
+            {
+                GL.UnmapBuffer(BufferTarget.ElementArrayBuffer);
+                GraphicsExtensions.CheckGLError();
+            }
+        }
 
         private void PlatformSetData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, SetDataOptions options)
             where T : struct

--- a/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -49,16 +49,13 @@ namespace Microsoft.Xna.Framework.Graphics
         >(int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride)
             where T : struct
         {
-#if GLES
             // Buffers are write-only on OpenGL ES 1.1 and 2.0.  See the GL_OES_mapbuffer extension for more information.
             // http://www.khronos.org/registry/gles/extensions/OES/OES_mapbuffer.txt
-            throw new NotSupportedException("Vertex buffers are write-only on OpenGL ES platforms");
-#else
-            Threading.BlockOnUIThread(() => GetBufferData(offsetInBytes, data, startIndex, elementCount, vertexStride));
-#endif
-        }
+            if (GraphicsDevice != null && !GraphicsDevice.GraphicsCapabilities.SupportsMapBuffer)
+                throw new NotSupportedException("VertexBuffer.GetData is not supported on OpenGL ES versions below 3.0. Vertex buffers are write-only on those OpenGL ES platforms");
 
-#if !GLES
+            Threading.BlockOnUIThread(() => GetBufferData(offsetInBytes, data, startIndex, elementCount, vertexStride));
+        }
 
         private void GetBufferData<
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T
@@ -68,47 +65,69 @@ namespace Microsoft.Xna.Framework.Graphics
             GL.BindBuffer(BufferTarget.ArrayBuffer, vbo);
             GraphicsExtensions.CheckGLError();
 
-            // Pointer to the start of data in the vertex buffer
-            var ptr = GL.MapBuffer(BufferTarget.ArrayBuffer, BufferAccess.ReadOnly);
+            var dataSize = elementCount * vertexStride;
+            IntPtr ptr;
+
+#if GLES
+            if (GraphicsDevice != null && !GraphicsDevice.GraphicsCapabilities.SupportsMapBuffer)
+                throw new NotSupportedException("VertexBuffer.GetBufferData is not supported on OpenGL ES versions below 3.0.");
+
+            ptr = GL.MapBufferRange(
+                BufferTarget.ArrayBuffer,
+                (IntPtr)offsetInBytes,
+                (IntPtr)dataSize,
+                (int)GL.MapBufferAccessMask.MapReadBit);
+#else
+            // Desktop OpenGL uses glMapBuffer and adjusts the pointer
+            ptr = GL.MapBuffer(BufferTarget.ArrayBuffer, BufferAccess.ReadOnly);
+            ptr = (IntPtr)(ptr.ToInt64() + offsetInBytes);
+#endif
+
             GraphicsExtensions.CheckGLError();
 
-            ptr = (IntPtr)(ptr.ToInt64() + offsetInBytes);
-
-            if (typeof(T) == typeof(byte) && vertexStride == 1)
+            if (ptr == IntPtr.Zero)
             {
-                // If data is already a byte[] and stride is 1 we can skip the temporary buffer
-                var buffer = data as byte[];
-                Marshal.Copy(ptr, buffer, startIndex * vertexStride, elementCount * vertexStride);
+                throw new InvalidOperationException("Failed to map vertex buffer for reading");
             }
-            else
-            {
-                // Temporary buffer to store the copied section of data
-                var tmp = new byte[elementCount * vertexStride];
-                // Copy from the vertex buffer to the temporary buffer
-                Marshal.Copy(ptr, tmp, 0, tmp.Length);
 
-                // Copy from the temporary buffer to the destination array
-                var tmpHandle = GCHandle.Alloc(tmp, GCHandleType.Pinned);
-                try
+            try
+            {
+                if (typeof(T) == typeof(byte) && vertexStride == 1)
                 {
-                    var tmpPtr = tmpHandle.AddrOfPinnedObject();
-                    for (var i = 0; i < elementCount; i++)
+                    // If data is already a byte[] and stride is 1 we can skip the temporary buffer
+                    var buffer = data as byte[];
+                    Marshal.Copy(ptr, buffer, startIndex * vertexStride, elementCount * vertexStride);
+                }
+                else
+                {
+                    // Temporary buffer to store the copied section of data
+                    var tmp = new byte[elementCount * vertexStride];
+                    // Copy from the vertex buffer to the temporary buffer
+                    Marshal.Copy(ptr, tmp, 0, tmp.Length);
+
+                    // Copy from the temporary buffer to the destination array
+                    var tmpHandle = GCHandle.Alloc(tmp, GCHandleType.Pinned);
+                    try
                     {
-                        data[startIndex + i] = Marshal.PtrToStructure<T>(tmpPtr);
-                        tmpPtr = (IntPtr)(tmpPtr.ToInt64() + vertexStride);
+                        var tmpPtr = tmpHandle.AddrOfPinnedObject();
+                        for (var i = 0; i < elementCount; i++)
+                        {
+                            data[startIndex + i] = Marshal.PtrToStructure<T>(tmpPtr);
+                            tmpPtr = (IntPtr)(tmpPtr.ToInt64() + vertexStride);
+                        }
+                    }
+                    finally
+                    {
+                        tmpHandle.Free();
                     }
                 }
-                finally
-                {
-                    tmpHandle.Free();
-                }
             }
-
-            GL.UnmapBuffer(BufferTarget.ArrayBuffer);
-            GraphicsExtensions.CheckGLError();
+            finally
+            {
+                GL.UnmapBuffer(BufferTarget.ArrayBuffer);
+                GraphicsExtensions.CheckGLError();
+            }
         }
-
-#endif
 
         private void PlatformSetData<T>(
             int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride, SetDataOptions options, int bufferSize, int elementSizeInBytes)


### PR DESCRIPTION
Add OpenGL ES 3.x support, while we wait for Vulkan to mature and become more optimised on mobile devices.

As mentioned here - https://discord.com/channels/1176986388340686978/1176986388781076582/1450141953227489440 Mobile phones have supported OpenGL ES 3.x since 2013. We're 12 years behind the ball!! Also all the major game dev IDEs (Unity, Unreal Godot etc), all dropped ES 1 & 2. 

This should also close quite a few issues that have been asking for GetData support since 2014 or so.

iOS:
<img width="2064" height="2752" alt="Simulator Screenshot - iPad Pro 13-inch (M5) (16GB) - iOS 26 2 - 2025-12-19 at 23 48 33" src="https://github.com/user-attachments/assets/9be46bc4-ff51-41e1-bc6f-277e6ee5605c" />

Android:
<img width="2340" height="1080" alt="Screenshot_1766160104" src="https://github.com/user-attachments/assets/6af40caf-389f-4a76-a854-9cd0678ad7da" />

Before this change, ShipGame would crash when loading the gameplay screen.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.





