### PR TITLE
Hook up audio device notifications.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -409,6 +409,11 @@ jobs:
         with:
           xcode-version: '${{ env.XCodeVersion }}'
 
+      - name: Download Nuget
+        uses: actions/download-artifact@v4
+        with:
+          path: Artifacts/NuGet
+
       - name: Download tests-desktopgl-${{ matrix.platform }}
         uses: actions/download-artifact@v4
         with:

--- a/MonoGame.Framework/FrameworkDispatcher.cs
+++ b/MonoGame.Framework/FrameworkDispatcher.cs
@@ -36,6 +36,19 @@ namespace Microsoft.Xna.Framework
             DynamicSoundEffectInstanceManager.UpdatePlayingInstances();
             SoundEffectInstancePool.Update();
             Microphone.UpdateMicrophones();
+
+#if DESKTOPGL || ANGLE
+            try
+            {
+                var controller = OpenALSoundController.Instance;
+                controller?.ProcessDeviceChanges();
+            }
+            catch (NoAudioHardwareException)
+            {
+                // Audio system not initialized, skip device change check
+                // Should we log this?
+            }
+#endif
         }
 
         private static void Initialize()
@@ -44,4 +57,3 @@ namespace Microsoft.Xna.Framework
         }
     }
 }
-

--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -121,6 +121,26 @@ namespace MonoGame.OpenAL
     internal enum AlcGetInteger
     {
         CaptureSamples = 0x0312,
+        Connected = 0x0313,
+    }
+
+    internal enum AlcDeviceType
+    {
+        PlaybackDevice = 0x19D4,
+        CaptureDevice = 0x19D5,
+    }
+
+    internal enum AlcEventType
+    {
+        DefaultDeviceChanged = 0x19D6,
+        DeviceAdded = 0x19D7,
+        DeviceRemoved = 0x19D8,
+    }
+
+    internal enum AlcEventSupport
+    {
+        Supported = 0x19D9,
+        NotSupported = 0x19DA,
     }
 
     internal enum EfxFilteri
@@ -579,6 +599,76 @@ namespace MonoGame.OpenAL
         [DllImport(AL.LibraryName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alcDeviceResumeSOFT(IntPtr device);
         internal static void DeviceResume(IntPtr device) => alcDeviceResumeSOFT(device);
+#endif
+
+#if DESKTOPGL || ANGLE
+        // ALC_SOFT_system_events extension - for device change detection
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void AlcEventCallback(int eventType, int deviceType, IntPtr device, int messageLength, string message, IntPtr userParam);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate int AlcEventIsSupportedDelegate(int eventType, int deviceType);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate bool AlcEventControlDelegate(int count, int[] events, bool enable);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void AlcEventCallbackDelegate(AlcEventCallback callback, IntPtr userParam);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate bool AlcReopenDeviceDelegate(IntPtr device, string deviceName, int[] attribs);
+
+        internal static AlcEventIsSupportedDelegate EventIsSupported;
+        internal static AlcEventControlDelegate EventControl;
+        internal static AlcEventCallbackDelegate EventCallback;
+        internal static AlcReopenDeviceDelegate ReopenDevice;
+
+        private static IntPtr GetProcAddress(params string[] functionNames)
+        {
+            foreach (var functionName in functionNames)
+            {
+                var procAddress = AL.alGetProcAddress(functionName);
+                if (procAddress != IntPtr.Zero)
+                    return procAddress;
+            }
+
+            return IntPtr.Zero;
+        }
+
+        internal static bool TryLoadDeviceChangeFunctions()
+        {
+            if (EventIsSupported != null
+                && EventControl != null
+                && EventCallback != null
+                && ReopenDevice != null)
+            {
+                return true;
+            }
+
+            var eventIsSupported = GetProcAddress("alcEventIsSupportedSOFT", "alEventIsSupportedSOFT");
+            var eventControl = GetProcAddress("alcEventControlSOFT", "alEventControlSOFT");
+            var eventCallback = GetProcAddress("alcEventCallbackSOFT", "alEventCallbackSOFT");
+            var reopenDevice = GetProcAddress("alcReopenDeviceSOFT", "alReopenDeviceSOFT");
+
+            if (eventIsSupported == IntPtr.Zero
+                || eventControl == IntPtr.Zero
+                || eventCallback == IntPtr.Zero
+                || reopenDevice == IntPtr.Zero)
+            {
+                EventIsSupported = null;
+                EventControl = null;
+                EventCallback = null;
+                ReopenDevice = null;
+                return false;
+            }
+
+            EventIsSupported = Marshal.GetDelegateForFunctionPointer<AlcEventIsSupportedDelegate>(eventIsSupported);
+            EventControl = Marshal.GetDelegateForFunctionPointer<AlcEventControlDelegate>(eventControl);
+            EventCallback = Marshal.GetDelegateForFunctionPointer<AlcEventCallbackDelegate>(eventCallback);
+            ReopenDevice = Marshal.GetDelegateForFunctionPointer<AlcReopenDeviceDelegate>(reopenDevice);
+
+            return true;
+        }
 #endif
     }
 

--- a/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Xna.Framework.Audio
             {
                 if (args != null && args.Length > 0)
                     message = String.Format(message, args);
-                
+
                 throw new InvalidOperationException(message + " (Reason: " + AL.GetErrorString(error) + ")");
             }
         }
@@ -73,6 +73,14 @@ namespace Microsoft.Xna.Framework.Audio
         IntPtr NullContext = IntPtr.Zero;
         private int[] allSourcesArray;
 #if DESKTOPGL || ANGLE
+        private Alc.AlcEventCallback _eventCallback;
+        private volatile bool _deviceChangeRequested = false;
+        private readonly object _deviceChangeLock = new object();
+        private bool _supportsDisconnectExt;
+        private bool _supportsReopenDeviceExt;
+        private string _lastDefaultPlaybackDevice;
+#endif
+#if DESKTOPGL || ANGLE
 
         // MacOS & Linux shares a limit of 256.
         internal const int MAX_NUMBER_OF_SOURCES = 256;
@@ -101,7 +109,205 @@ namespace Microsoft.Xna.Framework.Audio
         public bool SupportsEfx { get; private set; }
         public bool SupportsIeee { get; private set; }
 
-        public bool SupportsStereoAngles { get; private set;}
+        public bool SupportsStereoAngles { get; private set; }
+
+#if DESKTOPGL || ANGLE
+        /// <summary>
+        /// Event callback for OpenAL device changes. Called on a background thread.
+        /// Cannot make AL/ALC calls directly from this callback.
+        /// </summary>
+        private void OnDeviceEvent(int eventType, int deviceType, IntPtr device, int messageLength, string message, IntPtr userParam)
+        {
+            var evtType = (AlcEventType)eventType;
+            var devType = (AlcDeviceType)deviceType;
+
+            if (devType != AlcDeviceType.PlaybackDevice)
+                return;
+
+            // Only handle default device changes for playback devices
+            if (evtType == AlcEventType.DefaultDeviceChanged
+            || evtType == AlcEventType.DeviceAdded
+            || evtType == AlcEventType.DeviceRemoved)
+            {
+                // Set flag to trigger device reopening on the main thread
+                // We cannot call OpenAL functions from this callback
+                lock (_deviceChangeLock)
+                {
+                    _deviceChangeRequested = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks if a device change was requested and handles it.
+        /// Should be called from a safe context (not from the event callback).
+        /// </summary>
+        public void ProcessDeviceChanges()
+        {
+            bool isChangeRequested = false;
+            lock (_deviceChangeLock)
+            {
+                isChangeRequested = _deviceChangeRequested;
+                _deviceChangeRequested = false;
+            }
+
+            // Check if the current device has been disconnected (unplugged)
+            bool isDefaultChanged = HasDefaultPlaybackDeviceChanged();
+            bool isDisconnected = _supportsDisconnectExt && CheckDeviceDisconnected();
+
+            if (isChangeRequested || isDefaultChanged || isDisconnected)
+            {
+                ReopenDefaultDevice();
+            }
+        }
+
+        private bool HasDefaultPlaybackDeviceChanged()
+        {
+            var currentDeviceName = GetDefaultPlaybackDeviceName();
+            if (string.IsNullOrEmpty(currentDeviceName))
+                return false;
+
+            if (string.IsNullOrEmpty(_lastDefaultPlaybackDevice))
+            {
+                _lastDefaultPlaybackDevice = currentDeviceName;
+                return false;
+            }
+
+            if (!string.Equals(_lastDefaultPlaybackDevice, currentDeviceName, StringComparison.Ordinal))
+            {
+                _lastDefaultPlaybackDevice = currentDeviceName;
+                return true;
+            }
+
+            return false;
+        }
+
+        private string GetDefaultPlaybackDeviceName()
+        {
+            try
+            {
+                // ALC_DEFAULT_DEVICE_SPECIFIER = 0x1004
+                return Alc.GetString(IntPtr.Zero, (AlcGetString)0x1004);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Checks if the current audio device has been disconnected.
+        /// Uses ALC_EXT_disconnect extension to poll device connection status.
+        /// </summary>
+        private bool CheckDeviceDisconnected()
+        {
+            try
+            {
+                int[] connected = new int[1];
+                Alc.GetInteger(_device, AlcGetInteger.Connected, 1, connected);
+
+                // If connected is 0 (ALC_FALSE), the device is disconnected
+                return connected[0] == 0;
+            }
+            catch
+            {
+                // If the extension isn't available or query fails, assume connected
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Reopens the audio device using the current system default.
+        /// </summary>
+        private void ReopenDefaultDevice()
+        {
+            if (!_supportsReopenDeviceExt || _device == IntPtr.Zero)
+                return;
+            
+            try
+            {
+                // Reopen with null to use the new default device
+                // Pass empty attribute array to maintain current settings
+                bool success = Alc.ReopenDevice(_device, null, Array.Empty<int>());
+
+                if (success)
+                {
+                    _lastDefaultPlaybackDevice = GetDefaultPlaybackDeviceName();
+                }
+                else
+                {
+                    // If reopening fails, log but don't crash
+                    // The audio will continue using the old device
+                    System.Diagnostics.Debug.WriteLine("Failed to reopen OpenAL device with new default");
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Exception reopening OpenAL device: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Initializes device change detection using ALC_SOFT_system_events extension.
+        /// </summary>
+        private void InitializeDeviceChangeDetection()
+        {
+            _supportsDisconnectExt = Alc.IsExtensionPresent(_device, "ALC_EXT_disconnect");
+            _supportsReopenDeviceExt = Alc.IsExtensionPresent(_device, "ALC_SOFT_reopen_device");
+            _lastDefaultPlaybackDevice = GetDefaultPlaybackDeviceName();
+
+            if (!Alc.TryLoadDeviceChangeFunctions())
+            {
+                System.Diagnostics.Debug.WriteLine("OpenAL device change detection functions were not available");
+                return;
+            }
+
+            try
+            {
+                // Check if the system events extension is supported
+                var defaultDeviceChangeSupport = (AlcEventSupport)Alc.EventIsSupported(
+                    (int)AlcEventType.DefaultDeviceChanged,
+                    (int)AlcDeviceType.PlaybackDevice);
+
+                if (defaultDeviceChangeSupport == AlcEventSupport.Supported)
+                {
+                    // Store the callback to prevent it from being garbage collected
+                    _eventCallback = OnDeviceEvent;
+
+                    // Register the event callback
+                    Alc.EventCallback(_eventCallback, IntPtr.Zero);
+
+                    // Enable the default device changed/added/removed events
+                    int[] events =
+                    {
+                        (int)AlcEventType.DefaultDeviceChanged,
+                        (int)AlcEventType.DeviceAdded,
+                        (int)AlcEventType.DeviceRemoved
+                    };
+                    bool enableSuccess = Alc.EventControl(events.Length, events, true);
+
+                    if (enableSuccess)
+                    {
+                        System.Diagnostics.Debug.WriteLine("OpenAL device change detection enabled");
+                    }
+                    else
+                    {
+                        System.Diagnostics.Debug.WriteLine("Failed to enable OpenAL device change detection");
+                    }
+                }
+                else
+                {
+                    System.Diagnostics.Debug.WriteLine("OpenAL device change detection not supported on this platform");
+                }
+            }
+            catch (Exception ex)
+            {
+                // Extension may not be available or supported
+                // This is not a critical error, so just log and continue
+                System.Diagnostics.Debug.WriteLine($"Could not initialize device change detection: {ex.Message}");
+            }
+        }
+#endif
 
         /// <summary>
         /// Sets up the hardware resources used by the controller.
@@ -116,12 +322,17 @@ namespace Microsoft.Xna.Framework.Audio
             if (Alc.IsExtensionPresent(_device, "ALC_EXT_CAPTURE"))
                 Microphone.PopulateCaptureDevices();
 
-            SupportsStereoAngles = AL.IsExtensionPresent ("AL_EXT_STEREO_ANGLES");
+            SupportsStereoAngles = AL.IsExtensionPresent("AL_EXT_STEREO_ANGLES");
+
+#if DESKTOPGL || ANGLE
+            // Initialize device change detection if supported
+            InitializeDeviceChangeDetection();
+#endif
 
             // We have hardware here and it is ready
 
-			allSourcesArray = new int[MAX_NUMBER_OF_SOURCES];
-			AL.GenSources(allSourcesArray);
+            allSourcesArray = new int[MAX_NUMBER_OF_SOURCES];
+            AL.GenSources(allSourcesArray);
             ALHelper.CheckError("Failed to generate sources.");
             Filter = 0;
             if (Efx.IsInitialized)
@@ -129,8 +340,8 @@ namespace Microsoft.Xna.Framework.Audio
                 Filter = Efx.GenFilter();
             }
             availableSourcesCollection = new List<int>(allSourcesArray);
-			inUseSourcesCollection = new List<int>();
-		}
+            inUseSourcesCollection = new List<int>();
+        }
 
         ~OpenALSoundController()
         {
@@ -259,9 +470,9 @@ namespace Microsoft.Xna.Framework.Audio
                 // Activate the instance or else the interruption handler will not be called.
                 AVAudioSession.SharedInstance().SetActive(true);
 
-                int[] attribute = new int[0];
+                int[] attribute = Array.Empty<int>();
 #else
-                int[] attribute = new int[0];
+                int[] attribute = Array.Empty<int>();
 #endif
 
                 _context = Alc.CreateContext(_device, attribute);
@@ -308,15 +519,15 @@ namespace Microsoft.Xna.Framework.Audio
 
         public static OpenALSoundController Instance
         {
-			get
+            get
             {
                 if (_instance == null)
                     throw new NoAudioHardwareException("OpenAL context has failed to initialize. Call SoundEffect.Initialize() before sound operation to get more specific errors.");
-				return _instance;
-			}
-		}
+                return _instance;
+            }
+        }
 
-        public static EffectsExtension Efx
+        internal static EffectsExtension Efx
         {
             get
             {
@@ -349,12 +560,12 @@ namespace Microsoft.Xna.Framework.Audio
 
             if (_context != NullContext)
             {
-                Alc.DestroyContext (_context);
+                Alc.DestroyContext(_context);
                 _context = NullContext;
             }
             if (_device != IntPtr.Zero)
             {
-                Alc.CloseDevice (_device);
+                Alc.CloseDevice(_device);
                 _device = IntPtr.Zero;
             }
         }
@@ -373,11 +584,35 @@ namespace Microsoft.Xna.Framework.Audio
         /// </summary>
         /// <param name="disposing">If true, the managed resources are to be disposed.</param>
 		void Dispose(bool disposing)
-		{
+        {
             if (!_isDisposed)
             {
                 if (disposing)
                 {
+#if DESKTOPGL || ANGLE
+                    // Disable device change events before cleanup
+                    try
+                    {
+                        if (_eventCallback != null)
+                        {
+                            int[] events =
+                            {
+                                (int)AlcEventType.DefaultDeviceChanged,
+                                (int)AlcEventType.DeviceAdded,
+                                (int)AlcEventType.DeviceRemoved
+                            };
+
+                            Alc.EventControl(events.Length, events, false);
+                            Alc.EventCallback(null, IntPtr.Zero);
+                            _eventCallback = null;
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore errors during cleanup
+                    }
+#endif
+
                     for (int i = 0; i < allSourcesArray.Length; i++)
                     {
                         AL.DeleteSource(allSourcesArray[i]);
@@ -388,11 +623,11 @@ namespace Microsoft.Xna.Framework.Audio
                         Efx.DeleteFilter(Filter);
 
                     Microphone.StopMicrophones();
-                    CleanUpOpenAL();                    
+                    CleanUpOpenAL();
                 }
                 _isDisposed = true;
             }
-		}
+        }
 
         /// <summary>
         /// Reserves a sound buffer and return its identifier. If there are no available sources
@@ -401,11 +636,11 @@ namespace Microsoft.Xna.Framework.Audio
         /// </summary>
         /// <returns>The source number of the reserved sound buffer.</returns>
 		public int ReserveSource()
-		{
+        {
             int sourceNumber;
 
             lock (availableSourcesCollection)
-            {                
+            {
                 if (availableSourcesCollection.Count == 0)
                 {
                     throw new InstancePlayLimitException();
@@ -417,7 +652,7 @@ namespace Microsoft.Xna.Framework.Audio
             }
 
             return sourceNumber;
-		}
+        }
 
         public void RecycleSource(int sourceId)
         {
@@ -437,15 +672,15 @@ namespace Microsoft.Xna.Framework.Audio
             inst.SourceId = 0;
             inst.HasSourceId = false;
             inst.SoundState = SoundState.Stopped;
-		}
+        }
 
-        public double SourceCurrentPosition (int sourceId)
-		{
+        public double SourceCurrentPosition(int sourceId)
+        {
             int pos;
-			AL.GetSource (sourceId, ALGetSourcei.SampleOffset, out pos);
+            AL.GetSource(sourceId, ALGetSourcei.SampleOffset, out pos);
             ALHelper.CheckError("Failed to set source offset.");
-			return pos;
-		}
+            return pos;
+        }
 
 #if ANDROID
         void Activity_Paused(object sender, EventArgs e)
@@ -458,6 +693,19 @@ namespace Microsoft.Xna.Framework.Audio
         {
             // Resume all sounds that were playing when the activity was paused
             Alc.DeviceResume(_device);
+        }
+#endif
+
+#if DESKTOPGL || ANGLE
+        /// <summary>
+        /// Temporary diagnostic helper - remove before shipping.
+        /// </summary>
+        public static string GetExtensionSupportInfo()
+        {
+            bool hasReopen = Alc.IsExtensionPresent(IntPtr.Zero, "ALC_SOFT_reopen_device");
+            bool hasDisconnect = Alc.IsExtensionPresent(IntPtr.Zero, "ALC_EXT_disconnect");
+            bool hasSystemEvents = Alc.IsExtensionPresent(IntPtr.Zero, "ALC_SOFT_system_events");
+            return $"ALC_SOFT_reopen_device={hasReopen}, ALC_EXT_disconnect={hasDisconnect}, ALC_SOFT_system_events={hasSystemEvents}";
         }
 #endif
     }

--- a/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
@@ -695,18 +695,5 @@ namespace Microsoft.Xna.Framework.Audio
             Alc.DeviceResume(_device);
         }
 #endif
-
-#if DESKTOPGL || ANGLE
-        /// <summary>
-        /// Temporary diagnostic helper - remove before shipping.
-        /// </summary>
-        public static string GetExtensionSupportInfo()
-        {
-            bool hasReopen = Alc.IsExtensionPresent(IntPtr.Zero, "ALC_SOFT_reopen_device");
-            bool hasDisconnect = Alc.IsExtensionPresent(IntPtr.Zero, "ALC_EXT_disconnect");
-            bool hasSystemEvents = Alc.IsExtensionPresent(IntPtr.Zero, "ALC_SOFT_system_events");
-            return $"ALC_SOFT_reopen_device={hasReopen}, ALC_EXT_disconnect={hasDisconnect}, ALC_SOFT_system_events={hasSystemEvents}";
-        }
-#endif
     }
 }

--- a/MonoGame.Framework/Platform/OpenAL.targets
+++ b/MonoGame.Framework/Platform/OpenAL.targets
@@ -5,7 +5,7 @@
 
   <!-- iOS has its own Song and Video implementation -->
   <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('IOS'))">
-    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.24.3.2" />
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.25.2.1" />
     <Compile Include="Platform\Media\Song.iOS.cs" />
 	
 	<Compile Include="Platform\Media\MediaLibrary.iOS.cs" />
@@ -21,7 +21,7 @@
   
   <!-- Android has its own Song and Video implementation, and need OpenAL binaries -->
   <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('ANDROID'))">
-    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.24.3.2" />
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.25.2.1" />
     <Compile Include="Platform\Media\Song.Android.cs" />
 	
 	<Compile Include="Platform\Media\MediaLibrary.Android.cs" />
@@ -37,7 +37,7 @@
   
   <!-- DesktopGL has its own Song implementation, and need OpenAL binaries -->
   <ItemGroup Condition="$(DefineConstants.Contains('NO_AUDIO')) != 'true' And $(DefineConstants.Contains('DESKTOPGL'))">
-    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.24.3.4" />
+    <PackageReference Include="MonoGame.Library.OpenAL" Version="1.25.2.1" />
 	<PackageReference Include="NVorbis" Version="0.10.4" />
 
     <Compile Include="Platform\Media\OggStream.NVorbis.cs" />


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes #8695 

Needs: https://github.com/MonoGame/MonoGame.Library.OpenAL/pull/12

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

This uses the newly (relatively) device events to change outputs. Test by plugging in and removing headphones, for example, and the sound should now redirect to heaphones or speaker dynamically.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.




