### PR TITLE
[Content.Pipeline] Improve the default logger

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Reflection;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler;
+using MonoGame.Framework.Content.Pipeline.Builder.Logger;
 using MonoGame.Framework.Content.Pipeline.Builder.Server;
 
 namespace MonoGame.Framework.Content.Pipeline.Builder;
@@ -44,7 +45,7 @@ public abstract class ContentBuilder
     /// Gets or sets the logger to be used by the <see cref="ContentBuilder"/>.
     /// </summary>
     /// <value><see cref="ContentBuildLogger"/> by default.</value>
-    public ContentBuildLogger Logger { get; set; } = new ContentBuildLogger();
+    public ContentBuildLogger Logger { get; set; } = new ContentBuilderLogger();
 
     /// <summary>
     /// Gets or sets the content cahcing system to be used by the <see cref="ContentBuilder"/>.
@@ -76,7 +77,7 @@ public abstract class ContentBuilder
     /// <param name="parentContext">Only set when the method is being called by the ContentProcessorContext to build one of its children.</param>
     public void BuildAndWriteContent(string relativeSrcPath, ContentInfo contentInfo, string? relativeDstPath = null, ContentProcessorContext? parentContext = null)
     {
-        Logger.PushFile(relativeSrcPath);
+        Logger.PushFile(Path.Combine(Parameters.RootedSourceDirectory, relativeSrcPath));
         try
         {
             ProcessContent(relativeSrcPath, contentInfo, true, relativeDstPath, parentContext);
@@ -110,7 +111,7 @@ public abstract class ContentBuilder
     /// <returns>The built object that the <see cref="IContentProcessor.Process(object, ContentProcessorContext)"/> returned.</returns>
     public object? BuildAndLoadContent(string relativeSrcPath, ContentInfo contentInfo, string? relativeDstPath = null, ContentProcessorContext? parentContext = null)
     {
-        Logger.PushFile(relativeSrcPath);
+        Logger.PushFile(Path.Combine(Parameters.RootedSourceDirectory, relativeSrcPath));
         try
         {
             var content = ProcessContent(relativeSrcPath, contentInfo, false, relativeDstPath, parentContext);
@@ -153,8 +154,6 @@ public abstract class ContentBuilder
             Directory.CreateDirectory(outputDir);
         }
 
-        Logger.Log($"Output: {relativeDestPath}");
-
         if (contentInfo.ShouldBuild) // ensure importer and processor are set
         {
             if (!ContentBuilderHelper.GetImporter(relativePath, contentInfo.Importer, out IContentImporter importer))
@@ -178,7 +177,7 @@ public abstract class ContentBuilder
             var fileCache = ContentCache.ReadContentFileCache(this, relativeDestPath);
             if (fileCache != null && fileCache.IsValid(this, contentInfo))
             {
-                Logger.Log($"Cache: Found");
+                Logger.Log(LogLevel.Debug, $"Cache: Found");
                 ContentCache.MarkUsed(fileCache);
                 (parentContext as ContentBuilderProcessorContext)?.ContentFileCache.AddDependency(this, fileCache);
                 return null;
@@ -187,8 +186,7 @@ public abstract class ContentBuilder
 
         if (!contentInfo.ShouldBuild)
         {
-            Logger.Log($"Cache: Not Found");
-
+            Logger.Log(Path.GetRelativePath(Logger.LoggerRootDirectory, outputPath).Sanitize());
             if (File.Exists(outputPath))
             {
                 File.Delete(outputPath);
@@ -204,9 +202,10 @@ public abstract class ContentBuilder
             return null;
         }
 
-        Logger.Log($"Cache: Not Found");
-        Logger.Log($"Importer: {contentInfo.Importer!.GetType().Name}");
-        Logger.Log($"Processor: {contentInfo.Processor!.GetType().Name}");
+        Logger.Log(LogLevel.Debug, $"Cache: Not Found");
+        Logger.Log(LogLevel.Debug, $"Importer: {contentInfo.Importer!.GetType().Name}");
+        Logger.Log(LogLevel.Debug, $"Processor: {contentInfo.Processor!.GetType().Name}");
+        Logger.Log(Path.GetRelativePath(Logger.LoggerRootDirectory, outputPath).Sanitize());
 
         var contentFileCache = ContentCache.CreateContentFileCache(this, contentInfo);
         contentFileCache.AddDependency(this, relativePath);
@@ -240,6 +239,9 @@ public abstract class ContentBuilder
         ContentBuilderHelper.LoadAssemblies();
 
         Parameters = parameters;
+        Logger.LoggerLogLevel = Parameters.LogLevel;
+        Logger.LoggerRootDirectory = Parameters.WorkingDirectory;
+
         if (parameters.Mode == ContentBuilderMode.None)
         {
             // This means we are just showing the help menu.
@@ -248,27 +250,24 @@ public abstract class ContentBuilder
 
         Directory.SetCurrentDirectory(Parameters.WorkingDirectory);
 
-        Logger.IndentCharacter = ' ';
-        Logger.IndentCharacterSize = 2;
-        Logger.ShowRealTime = Parameters.Mode == ContentBuilderMode.Server;
-
-        Logger.PushFile("Starting Content Builder");
+        Logger.Log("Starting Content Builder");
+        Logger.Indent();
         foreach (var prop in Parameters.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
             if (prop.GetValue(Parameters) is IList list)
             {
-                Logger.Log($"{prop.Name}:");
+                Logger.Log(LogLevel.Debug, $"{prop.Name}:");
                 foreach (var item in list)
                 {
-                    Logger.Log($"- {item}");
+                    Logger.Log(LogLevel.Debug, $"- {item}");
                 }
             }
             else
             {
-                Logger.Log($"{prop.Name}: {prop.GetValue(Parameters)}");
+                Logger.Log(LogLevel.Debug, $"{prop.Name}: {prop.GetValue(Parameters)}");
             }
         }
-        Logger.PopFile();
+        Logger.Unindent();
 
         ContentCache.LoadCache(this);
         var contentCollection = GetContentCollection();
@@ -330,9 +329,10 @@ public abstract class ContentBuilder
         }
         ContentCache.FlushCache(this);
 
-        Logger.PushFile("Content Builder Finished");
+        Logger.Log("Content Builder Finished");
+        Logger.Indent();
         Logger.Log($"{SucceededToBuild} succeeded, {FailedToBuild} failed");
-        Logger.PopFile();
+        Logger.Unindent();
 
         return FailedToBuild == 0;
     }

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderLogger.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderLogger.cs
@@ -1,0 +1,56 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System.Diagnostics;
+using Microsoft.Xna.Framework.Content.Pipeline;
+
+namespace MonoGame.Framework.Content.Pipeline.Builder.Logger;
+
+class ContentBuilderLogger : ContentBuildLogger
+{
+    private readonly Stack<string> _relativePaths = [];
+    private int _indentCount = 0;
+    private readonly Stopwatch _stopWatch;
+
+    public ContentBuilderLogger()
+    {
+        _stopWatch = new();
+        _stopWatch.Start();
+    }
+
+    public override void Log(LogLevel level, string message)
+    {
+        if (level < LoggerLogLevel)
+            return;
+
+        Console.ForegroundColor = level switch
+        {
+            LogLevel.Debug => ConsoleColor.Black,
+            LogLevel.Warning => ConsoleColor.Yellow,
+            LogLevel.Error => ConsoleColor.Red,
+            _ => ConsoleColor.Gray
+        };
+
+        var currentPath = _relativePaths.Count > 0 ? $"{string.Join(": ", _relativePaths)}: " : "";
+        var spacing = string.Empty.PadLeft(Math.Max(0, _indentCount * 2), ' ');
+        var time = LoggerLogLevel <= LogLevel.Debug ?  $"{_stopWatch.Elapsed:hh\\:mm\\:ss\\.fff} " : "";
+
+        foreach (var subMessage in message.Split(['\r', '\n'], StringSplitOptions.None))
+            Console.WriteLine($"{time}[{level.ToString()[0]}] {currentPath}{spacing}{subMessage}");
+
+        Console.ForegroundColor = ConsoleColor.Gray;
+    }
+
+    public override void PushFile(string filename)
+    {
+        var filepath = Path.GetFullPath(filename);
+        _relativePaths.Push(Path.GetRelativePath(LoggerRootDirectory, filepath).Sanitize());
+    }
+
+    public override void PopFile() => _relativePaths.Pop();
+
+    public override void Indent() => _indentCount++;
+
+    public override void Unindent() => _indentCount = Math.Max(0, _indentCount - 1);
+}

--- a/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
@@ -2,8 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System.Diagnostics;
-using MonoGame.Framework.Content.Pipeline.Builder;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline;
 
@@ -13,72 +12,23 @@ namespace Microsoft.Xna.Framework.Content.Pipeline;
 /// </summary>
 public class ContentBuildLogger
 {
-    private readonly Stack<string> _filenames;
-    private int _indentCount;
-    private string _indentString;
-    private char _indentCharacter;
-    private bool _recreateIndentString;
-    private readonly Stopwatch _stopWatch;
-
-    /// <summary>
-    /// Initializes a new instance of ContentBuildLogger.
-    /// </summary>
-    public ContentBuildLogger()
-    {
-        _filenames = [];
-        _indentCount = 0;
-        _indentString = " ";
-        _recreateIndentString = false;
-        _stopWatch = new();
-        _stopWatch.Start();
-
-        IndentCharacter = '\t';
-        IndentCharacterSize = 1;
-        LoggerRootDirectory = "";
-    }
-
-    /// <summary>
-    /// Indicates if the log should should current time with each logged message as opposed to the time since the logging started.
-    /// </summary>
-    /// <value><c>false</c> by default.</value>
-    public bool ShowRealTime { get; set; }
-
-    /// <summary>
-    /// A character to be used for indentation of <see cref="Log(LogLevel, string)"/> messages.
-    /// </summary>
-    public char IndentCharacter
-    {
-        get => _indentCharacter;
-        set
-        {
-            _indentCharacter = value;
-            _recreateIndentString = true;
-        }
-    }
-
-    /// <summary>
-    /// Indicates how many of <see cref="IndentCharacter"/> should be used for indentation of <see cref="Log(LogLevel, string)"/> messages.
-    /// </summary>
-    public uint IndentCharacterSize { get; set; }
+    private readonly Stack<string> _filenames = [];
+    private int _indentCount = 0;
 
     /// <summary>
     /// Gets or sets the base reference path used when reporting errors during the content build process.
     /// </summary>
-    public string LoggerRootDirectory { get; set; }
+    public string LoggerRootDirectory { get; set; } = "";
 
     /// <summary>
-    /// Creates a string that is the combination of <see cref="IndentCharacter"/> * <see cref="Indent"/> * <see cref="IndentCharacterSize"/>.
+    /// Gets or sets the desired log level to report for.
     /// </summary>
-    protected string IndentString
-    {
-        get
-        {
-            if (_recreateIndentString || _indentString.Length != (_indentCount + _filenames.Count) * IndentCharacterSize)
-                _indentString = new string(_indentCharacter, (_indentCount + _filenames.Count) * (int)IndentCharacterSize);
+    public LogLevel LoggerLogLevel { get; set; }
 
-            return _indentString;
-        }
-    }
+    /// <summary>
+    /// Creates a string that has indentation characters equal to the current identation.
+    /// </summary>
+    protected string IndentString => string.Empty.PadLeft(Math.Max(0, _indentCount), '\t');
 
     /// <summary>
     /// Gets the filename currently being processed, for use in warning and error messages.
@@ -115,28 +65,14 @@ public class ContentBuildLogger
     /// <param name="message"></param>
     public virtual void Log(LogLevel level, string message)
     {
-        Console.ForegroundColor = level switch
-        {
-            LogLevel.Debug => ConsoleColor.Black,
-            LogLevel.Warning => ConsoleColor.Yellow,
-            LogLevel.Error => ConsoleColor.Red,
-            _ => ConsoleColor.Gray
-        };
-
         foreach (var subMessage in message.Split(['\r', '\n'], StringSplitOptions.None))
-        {
-            var time = ShowRealTime ? DateTime.Now.ToString("HH:mm:ss.fff") : _stopWatch.Elapsed.ToString("hh\\:mm\\:ss\\.fff");
-            Console.WriteLine($"{time} [{level.ToString()[0]}] {IndentString}{subMessage}");
-        }
-
-        Console.ForegroundColor = ConsoleColor.Gray;
+            Console.WriteLine($"{level.ToString()[0]}: {IndentString}{subMessage}");
     }
 
     /// <summary>
     /// Outputs a message from the content system with the <see cref="LogLevel.Info"/> log level.
     /// </summary>
-    public void Log(string message)
-        => Log(LogLevel.Info, message);
+    public void Log(string message) => Log(LogLevel.Info, message);
 
     /// <summary>
     /// Outputs a high-priority status message from the content system.
@@ -145,7 +81,7 @@ public class ContentBuildLogger
     /// <param name="messageArgs">Arguments for the reported message.</param>
     [Obsolete("LogImportantMessage is deprecated, please use Log instead.")]
     public virtual void LogImportantMessage(string message, params object[] messageArgs)
-        => Log(LogLevel.Error, string.Format(message, messageArgs));
+        => Log(LogLevel.Error, string.Format(CultureInfo.InvariantCulture, message, messageArgs));
 
     /// <summary>
     /// Outputs a low priority status message from the content system.
@@ -154,7 +90,7 @@ public class ContentBuildLogger
     /// <param name="messageArgs">Arguments for the reported message.</param>
     [Obsolete("LogMessage is deprecated, please use Log instead.")]
     public virtual void LogMessage(string message, params object[] messageArgs)
-        => Log(string.Format(message, messageArgs));
+        => Log(string.Format(CultureInfo.InvariantCulture, message, messageArgs));
 
     /// <summary>
     /// Outputs a warning message from the content system.
@@ -165,19 +101,14 @@ public class ContentBuildLogger
     /// <param name="messageArgs">Arguments for the reported message.</param>
     [Obsolete("LogWarning is deprecated, please use Log instead.")]
     public virtual void LogWarning(string helpLink, ContentIdentity contentIdentity, string message, params object[] messageArgs)
-        => Log(LogLevel.Warning, $"{string.Format(message, messageArgs)}: {GetCurrentFilename(contentIdentity)}");
+        => Log(LogLevel.Warning, $"{string.Format(CultureInfo.InvariantCulture, message, messageArgs)}: {GetCurrentFilename(contentIdentity)}");
 
     /// <summary>
     /// Outputs a message indicating that a content asset has begun processing.
     /// All logger warnings or error exceptions from this time forward to the next PopFile call refer to this file.
     /// </summary>
     /// <param name="filename">Name of the file containing future messages.</param>
-    public virtual void PushFile(string filename)
-    {
-        filename = filename.Sanitize();
-        Log(filename);
-        _filenames.Push(filename);
-    }
+    public virtual void PushFile(string filename) => _filenames.Push(filename);
 
     /// <summary>
     /// Outputs a message indicating that a content asset has completed processing.


### PR DESCRIPTION
Stuff done:
- Split out the base class logger from the new content builder logger
- Hooked up the `LogLevel` parameter to the content logger
- Hooked up the `LoggerRootDirectory` so we got some proper pathing showing up
- Reworked the default appearance of the log thats:
  - Friendly for msbuild to parse the warnings / errors from
  - Friendly appearance for threaded logging if we ever get to that
  - Honestly even better for looking at for me :D, technically if anyone liked the previous one they can just assign the `ContentBuilder.Logger` property to a custom made logger

Bellow are some examples on appearance based on log level.

Debug:
<img width="648" height="398" alt="debug" src="https://github.com/user-attachments/assets/534cb671-5616-438b-b005-4db79b2bce52" />

Info:
<img width="532" height="187" alt="info" src="https://github.com/user-attachments/assets/0cd5da1d-7fb9-47ae-92f0-2c38b00c874d" />

Warning:
<img width="397" height="101" alt="warning" src="https://github.com/user-attachments/assets/3393db82-0186-44d7-ab22-bc6250b27d43" />

