### PR TITLE
Fix content building for Windows DX12

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/DefaultAudioProfile.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                     platform == TargetPlatform.NativeClient ||
                     platform == TargetPlatform.RaspberryPi ||
                     platform == TargetPlatform.Windows ||
+                    platform == TargetPlatform.WindowsDX12 ||
                     platform == TargetPlatform.iOS ||
                     platform == TargetPlatform.Web;
         }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     platform == TargetPlatform.NativeClient ||
                     platform == TargetPlatform.RaspberryPi ||
                     platform == TargetPlatform.Windows ||
+                    platform == TargetPlatform.WindowsDX12 ||
                     platform == TargetPlatform.iOS ||
                     platform == TargetPlatform.Web;
         }
@@ -63,7 +64,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     if (format != TextureProcessorOutputFormat.PvrCompressed)
                         throw new PlatformNotSupportedException("iOS platform only supports PVR texture compression");
                 }
-                else if (platform == TargetPlatform.Windows ||
+                else if (   platform == TargetPlatform.Windows ||
+                            platform == TargetPlatform.WindowsDX12 ||
                             platform == TargetPlatform.DesktopGL ||
                             platform == TargetPlatform.DesktopVK ||
                             platform == TargetPlatform.MacOSX ||

--- a/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
+++ b/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
@@ -93,12 +93,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         DesktopVK,
 
         /// <summary>
-        /// Windows GDK
+        /// Windows using DirectX 12
         /// </summary>
-        WindowsGDK,
+        WindowsDX12,
 
         /// <summary>
-        /// Xbox Series
+        /// Xbox Series S|X
         /// </summary>
         XboxSeries
     }

--- a/MonoGame.Framework/Utilities/GraphicsBackend.cs
+++ b/MonoGame.Framework/Utilities/GraphicsBackend.cs
@@ -30,7 +30,7 @@ namespace MonoGame.Framework.Utilities
         Metal,
 
         /// <summary>
-        /// Represents the Microsoft DirectX 12 graphics backend. (GDKX only for now)
+        /// Represents the Microsoft DirectX 12 graphics backend.
         /// </summary>
         DirectX12
     }

--- a/MonoGame.Framework/Utilities/MonoGamePlatform.cs
+++ b/MonoGame.Framework/Utilities/MonoGamePlatform.cs
@@ -10,67 +10,67 @@ namespace MonoGame.Framework.Utilities
     public enum MonoGamePlatform
     {
         /// <summary>
-        /// MonoGame Android platform.
+        /// Android platform.
         /// </summary>
         Android,
 
         /// <summary>
-        /// MonoGame iOS platform.
+        /// iOS platform.
         /// </summary>
         iOS,
 
         /// <summary>
-        /// MonoGame tvOS platform.
+        /// tvOS platform.
         /// </summary>
         tvOS,
 
         /// <summary>
-        /// MonoGame cross platform desktop OpenGL platform.
+        /// Cross platform desktop using OpenGL.
         /// </summary>
         DesktopGL,
 
         /// <summary>
-        /// MonoGame Win32 Windows platform.
+        /// Windows platform using DirectX 11.
         /// </summary>
         Windows,
 
         /// <summary>
-        /// MonoGame WebGL platform.
+        /// WebGL platform.
         /// </summary>
         WebGL,
 
         /// <summary>
-        /// MonoGame Xbox One platform.
+        /// Xbox One platform.
         /// </summary>
         XboxOne,
         
         /// <summary>
-        /// MonoGame Windows GDK platform.
+        /// Windows platform using DirectX 12.
         /// </summary>
-        WindowsGDK,
+        WindowsDX12,
 
         /// <summary>
-        /// MonoGame Xbox Series platform.
+        /// Xbox Series X|S platform.
         /// </summary>
         XboxSeries,
 
         /// <summary>
-        /// MonoGame PlayStation 4 platform.
+        /// PlayStation 4 platform.
         /// </summary>
         PlayStation4,
 
         /// <summary>
-        /// MonoGame PlayStation 5 platform.
+        /// PlayStation 5 platform.
         /// </summary>
         PlayStation5,
 
         /// <summary>
-        /// MonoGame Nintendo Switch platform.
+        /// Nintendo Switch platform.
         /// </summary>
         NintendoSwitch,
 
         /// <summary>
-        /// All desktop versions using Vulkan.
+        /// Cross platform desktop using Vulkan.
         /// </summary>
         DesktopVK,
     }

--- a/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/ShaderProfile.cs
@@ -31,6 +31,8 @@ namespace MonoGame.Effect
 
         public static readonly ShaderProfile DirectX_11 = FromName("DirectX_11");
 
+        public static readonly ShaderProfile DirectX_12 = FromName("DirectX_12");
+
         public static readonly ShaderProfile Vulkan = FromName("Vulkan");
 
         /// <summary>
@@ -84,7 +86,7 @@ namespace MonoGame.Effect
             TargetPlatform.Windows => ShaderProfile.DirectX_11,
             TargetPlatform.iOS or TargetPlatform.Android or TargetPlatform.DesktopGL or TargetPlatform.MacOSX or TargetPlatform.RaspberryPi or TargetPlatform.Web => ShaderProfile.OpenGL,
             TargetPlatform.DesktopVK => ShaderProfile.Vulkan,
-            TargetPlatform.WindowsGDK or TargetPlatform.XboxOne or TargetPlatform.XboxSeries => new DirectX12ShaderProfile(),
+            TargetPlatform.WindowsDX12 or TargetPlatform.XboxOne or TargetPlatform.XboxSeries => ShaderProfile.DirectX_12,
             _ => ShaderProfile.FromName(platform.ToString())
         };
 

--- a/native/monogame/include/api_enums.h
+++ b/native/monogame/include/api_enums.h
@@ -510,7 +510,7 @@ enum class MGMonoGamePlatform : mgint
     Windows = 4,
     WebGL = 5,
     XboxOne = 6,
-    WindowsGDK = 7,
+    WindowsDX12 = 7,
     XboxSeries = 8,
     PlayStation4 = 9,
     PlayStation5 = 10,

--- a/native/monogame/sdl/MGP_sdl.cpp
+++ b/native/monogame/sdl/MGP_sdl.cpp
@@ -260,7 +260,7 @@ MGMonoGamePlatform MGP_Platform_GetPlatform()
 #if MG_VULKAN
     return MGMonoGamePlatform::DesktopVK;
 #elif MG_DIRECTX12
-    return MGMonoGamePlatform::Windows;
+    return MGMonoGamePlatform::WindowsDX12;
 #else
     assert(false);
     return (MGMonoGamePlatform)-1;


### PR DESCRIPTION
We renamed `WindowsGDK` `TargetPlatform` and `MonoGamePlatform` to `WindowsDX12`.

Also fixed shader, texture, and audio profiles for `WindowsDX12`.

