### PR TITLE
Update Copyright to MonoGame Foundation, Inc

### DIFF
--- a/MonoGame.Framework/Design/Byte4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Byte4TypeConverter.cs
@@ -1,4 +1,4 @@
-﻿// MonoGame - Copyright (C) The MonoGame Team
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/FileDropEventArgs.cs
+++ b/MonoGame.Framework/FileDropEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// MonoGame - Copyright (C) The MonoGame Team
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/MathF.cs
+++ b/MonoGame.Framework/MathF.cs
@@ -1,4 +1,4 @@
-﻿// MonoGame - Copyright (C) The MonoGame Team
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Media/Video.Default.cs
+++ b/MonoGame.Framework/Platform/Media/Video.Default.cs
@@ -1,4 +1,4 @@
-﻿// MonoGame - Copyright (C) The MonoGame Team
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Media/VideoPlayer.Default.cs
+++ b/MonoGame.Framework/Platform/Media/VideoPlayer.Default.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Audio.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Audio.Interop.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/BlendState.Native.cs
+++ b/MonoGame.Framework/Platform/Native/BlendState.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/ConstantBuffer.Native.cs
+++ b/MonoGame.Framework/Platform/Native/ConstantBuffer.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/DepthStencilState.Native.cs
+++ b/MonoGame.Framework/Platform/Native/DepthStencilState.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/DynamicSoundEffectInstance.Native.cs
+++ b/MonoGame.Framework/Platform/Native/DynamicSoundEffectInstance.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/EffectResource.Native.cs
+++ b/MonoGame.Framework/Platform/Native/EffectResource.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/GamePad.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GamePad.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/GameWindow.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GameWindow.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/GraphicsAdapter.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GraphicsAdapter.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/GraphicsCapabilities.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GraphicsCapabilities.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/GraphicsDebug.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GraphicsDebug.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Image.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Image.Interop.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/IndexBuffer.Native.cs
+++ b/MonoGame.Framework/Platform/Native/IndexBuffer.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Joystick.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Joystick.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Keyboard.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Keyboard.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/KeyboardInput.Native.cs
+++ b/MonoGame.Framework/Platform/Native/KeyboardInput.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/MGHandleAttribute.cs
+++ b/MonoGame.Framework/Platform/Native/MGHandleAttribute.cs
@@ -1,4 +1,4 @@
-﻿// MonoGame - Copyright (C) The MonoGame Team
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Media.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Media.Interop.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/MediaLibrary.Native.cs
+++ b/MonoGame.Framework/Platform/Native/MediaLibrary.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/MediaPlayer.Native.cs
+++ b/MonoGame.Framework/Platform/Native/MediaPlayer.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/MessageBox.Native.cs
+++ b/MonoGame.Framework/Platform/Native/MessageBox.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Microphone.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Microphone.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Mouse.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Mouse.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/MouseCursor.Native.cs
+++ b/MonoGame.Framework/Platform/Native/MouseCursor.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/OcclusionQuery.Native.cs
+++ b/MonoGame.Framework/Platform/Native/OcclusionQuery.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Platform.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Platform.Interop.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/PlatformInfo.Native.cs
+++ b/MonoGame.Framework/Platform/Native/PlatformInfo.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/RasterizerState.Native.cs
+++ b/MonoGame.Framework/Platform/Native/RasterizerState.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/RenderTarget2D.Native.cs
+++ b/MonoGame.Framework/Platform/Native/RenderTarget2D.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/RenderTarget3D.Native.cs
+++ b/MonoGame.Framework/Platform/Native/RenderTarget3D.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/RenderTargetCube.Native.cs
+++ b/MonoGame.Framework/Platform/Native/RenderTargetCube.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/SamplerStateCollection.Native.cs
+++ b/MonoGame.Framework/Platform/Native/SamplerStateCollection.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Shader.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Shader.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Song.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Song.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/SoundEffect.Native.cs
+++ b/MonoGame.Framework/Platform/Native/SoundEffect.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/SoundEffectInstance.Native.cs
+++ b/MonoGame.Framework/Platform/Native/SoundEffectInstance.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Texture.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Texture.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Texture2D.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Texture2D.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Texture3D.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Texture3D.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/TextureCollection.Native.cs
+++ b/MonoGame.Framework/Platform/Native/TextureCollection.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/TextureCube.Native.cs
+++ b/MonoGame.Framework/Platform/Native/TextureCube.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/TitleContainer.Native.cs
+++ b/MonoGame.Framework/Platform/Native/TitleContainer.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 using System;

--- a/MonoGame.Framework/Platform/Native/VertexBuffer.Native.cs
+++ b/MonoGame.Framework/Platform/Native/VertexBuffer.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/Video.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Video.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/VideoPlayer.Native.cs
+++ b/MonoGame.Framework/Platform/Native/VideoPlayer.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/WaveBank.Native.cs
+++ b/MonoGame.Framework/Platform/Native/WaveBank.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/Tests/Framework/Audio/SoundEffectInstanceTest.cs
+++ b/Tests/Framework/Audio/SoundEffectInstanceTest.cs
@@ -1,4 +1,4 @@
-﻿// MonoGame - Copyright (C) The MonoGame Team
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/Tools/MonoGame.Content.Builder.Editor.Launcher.Bootstrap/Program.cs
+++ b/Tools/MonoGame.Content.Builder.Editor.Launcher.Bootstrap/Program.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/Tools/MonoGame.Content.Builder.Editor.Launcher/Program.cs
+++ b/Tools/MonoGame.Content.Builder.Editor.Launcher/Program.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/Tools/MonoGame.Generator.CTypes/EnumWritter.cs
+++ b/Tools/MonoGame.Generator.CTypes/EnumWritter.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -15,7 +15,7 @@ class EnumWritter
     public EnumWritter()
     {
         _outputText = new StringBuilder($"""
-        // MonoGame - Copyright (C) The MonoGame Team
+        // MonoGame - Copyright (C) MonoGame Foundation, Inc
         // This file is subject to the terms and conditions defined in
         // file 'LICENSE.txt', which is part of this source code package.
 

--- a/Tools/MonoGame.Generator.CTypes/PInvokeWritter.cs
+++ b/Tools/MonoGame.Generator.CTypes/PInvokeWritter.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -32,7 +32,7 @@ class PinvokeWritter
         _structWritter = structWritter;
 
         _outputText = new StringBuilder($"""
-        // MonoGame - Copyright (C) The MonoGame Team
+        // MonoGame - Copyright (C) MonoGame Foundation, Inc
         // This file is subject to the terms and conditions defined in
         // file 'LICENSE.txt', which is part of this source code package.
                         

--- a/Tools/MonoGame.Generator.CTypes/Program.cs
+++ b/Tools/MonoGame.Generator.CTypes/Program.cs
@@ -1,4 +1,4 @@
-﻿// MonoGame - Copyright (C) The MonoGame Team
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/Tools/MonoGame.Generator.CTypes/StructWritter.cs
+++ b/Tools/MonoGame.Generator.CTypes/StructWritter.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -22,7 +22,7 @@ class StructWritter
         _enumWritter = enumWritter;
 
         _outputText = new StringBuilder($"""
-        // MonoGame - Copyright (C) The MonoGame Team
+        // MonoGame - Copyright (C) MonoGame Foundation, Inc
         // This file is subject to the terms and conditions defined in
         // file 'LICENSE.txt', which is part of this source code package.
 

--- a/Tools/MonoGame.Generator.CTypes/Util.cs
+++ b/Tools/MonoGame.Generator.CTypes/Util.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/Tools/MonoGame.Tools.Tests/NormalMappingModelProcessor.cs
+++ b/Tools/MonoGame.Tools.Tests/NormalMappingModelProcessor.cs
@@ -1,11 +1,6 @@
-#region File Description
-//-----------------------------------------------------------------------------
-// NormalMappingModelProcessor.cs
-//
-// This file is subject to the terms and conditions defined in file 'LICENSE.txt', which is part of this source code package.
-// MonoGame - Copyright (C) The MonoGame Team
-//-----------------------------------------------------------------------------
-#endregion
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 #region Using Statements
 using Microsoft.Xna.Framework.Content.Pipeline;

--- a/native/monogame/common/MGI.cpp
+++ b/native/monogame/common/MGI.cpp
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/common/MGM.cpp
+++ b/native/monogame/common/MGM.cpp
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/common/MG_Asset.cpp
+++ b/native/monogame/common/MG_Asset.cpp
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/common/mg_audio.cpp
+++ b/native/monogame/common/mg_audio.cpp
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/common/mg_hash.cpp
+++ b/native/monogame/common/mg_hash.cpp
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/directx12/directx12.h
+++ b/native/monogame/directx12/directx12.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/faudio/MGA_faudio.cpp
+++ b/native/monogame/faudio/MGA_faudio.cpp
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/include/MGM_common.h
+++ b/native/monogame/include/MGM_common.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/include/api_MGA.h
+++ b/native/monogame/include/api_MGA.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
                 

--- a/native/monogame/include/api_MGG.h
+++ b/native/monogame/include/api_MGG.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
                 

--- a/native/monogame/include/api_MGI.h
+++ b/native/monogame/include/api_MGI.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
                 

--- a/native/monogame/include/api_MGM.h
+++ b/native/monogame/include/api_MGM.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
                 

--- a/native/monogame/include/api_MGP.h
+++ b/native/monogame/include/api_MGP.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
                 

--- a/native/monogame/include/api_MG_Asset.h
+++ b/native/monogame/include/api_MG_Asset.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
                 

--- a/native/monogame/include/api_common.h
+++ b/native/monogame/include/api_common.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/include/api_enums.h
+++ b/native/monogame/include/api_enums.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/include/api_structs.h
+++ b/native/monogame/include/api_structs.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/include/mg_common.h
+++ b/native/monogame/include/mg_common.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/include/mg_effect.h
+++ b/native/monogame/include/mg_effect.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/sdl/MGP_sdl.cpp
+++ b/native/monogame/sdl/MGP_sdl.cpp
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/monogame/xaudio/MGA_xaudio2.cpp
+++ b/native/monogame/xaudio/MGA_xaudio2.cpp
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/pipeline/include/api_MGCP.h
+++ b/native/pipeline/include/api_MGCP.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
                 

--- a/native/pipeline/include/api_enums.h
+++ b/native/pipeline/include/api_enums.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/native/pipeline/include/api_structs.h
+++ b/native/pipeline/include/api_structs.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 


### PR DESCRIPTION
More Fixes going all the way back to #[8101](https://github.com/MonoGame/MonoGame/issues/8101)

### Description of Change

Updates remaining Headers with the previous **The MonoGame Team** copyright to match the new Foundation Copyright standard. I happened to be playing around with the newer native implementations and noticed the CType generators had the older copyright text and then I went down this rabbit hole of finding more and more. 

I apologize for the big PR! It really is just comment updates with the exception of these files that have impactful changes to the comments created on newly generated CTypes files:

Tools/MonoGame.Generator.CTypes/EnumWritter.cs
Tools/MonoGame.Generator.CTypes/PInvokeWritter.cs
Tools/MonoGame.Generator.CTypes/StructWritter.cs





