### PR TITLE
Vulkan: fix incorrect variable lifetime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,16 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
     steps:
+      - name: Free disk space
+        if: runner.environment == 'github-hosted' && runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: false
+          dotnet: false 
+          docker-images: true
+          large-packages: true
+          swap-storage: true
+
       - name: Clone repository
         uses: actions/checkout@v5
         with:

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1293,19 +1293,19 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 
 	void* lastFeature = nullptr;
 
+	VkPhysicalDeviceCustomBorderColorFeaturesEXT customBorderColorFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT };
 	if (device->customBorderColorSupported)
 	{
 		extensions.push_back(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
-		VkPhysicalDeviceCustomBorderColorFeaturesEXT customBorderColorFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT };
 		customBorderColorFeatures.customBorderColors = VK_TRUE;
 		customBorderColorFeatures.customBorderColorWithoutFormat = VK_TRUE;
 		customBorderColorFeatures.pNext = lastFeature;
 		lastFeature = &customBorderColorFeatures;
 	}
+	VkPhysicalDeviceScalarBlockLayoutFeatures scalarFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES };
 	if (scalarBlockLayoutSupported)
 	{
 		extensions.push_back(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
-		VkPhysicalDeviceScalarBlockLayoutFeatures scalarFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES };
 		scalarFeatures.scalarBlockLayout = VK_TRUE;
 		scalarFeatures.pNext = lastFeature;
 		lastFeature = &scalarFeatures;
@@ -1315,9 +1315,9 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 	if (userTypeSupported)
 		extensions.push_back(VK_GOOGLE_USER_TYPE_EXTENSION_NAME);
 
+	VkPhysicalDeviceFeatures2 deviceFeatures2 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
 	if (lastFeature != nullptr)
 	{
-		VkPhysicalDeviceFeatures2 deviceFeatures2 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
 		deviceFeatures2.features = enabledFeatures;
 		deviceFeatures2.pNext = lastFeature;
 


### PR DESCRIPTION
I **suspect** this is supposed to fix the following issues (the circumstances when this reproduces are a bit different for me, but the stack is similar to what #9164 has reported; I suspect they all are relatively about the same, and it would make sense to at least ask the folks to re-check their issues after merging this fix):
- fix #9164
- fix #9161
- fix #9156

### Description of Change
Previously, the pointers `lastFeature` and `deviceFeatures2` could outlive the variables they are pointing to. These pointers are then exposed as part of the `deviceCreateInfo` — which could cause crash if the stack memory is reused for any purpose.

The problem was reproduced for me when debugging a MonoGame program by Rider on Windows, but not under any other circumstances (e.g. debugging via VS or just running the program — no luck, doesn't reproduce).

Also note that it was only reproducing if using the **Release** build of `mgruntime.dll` — not the **Debug** one.

Rebuilt MonoGame locally, can confirm I have stable repro before the fix (on the official binaries and on the ones I build myself), and after the fix the issue no longer reproduces.
