### PR TITLE
Added nullable return types for #9166, added bool return for RemoveService

### DIFF
--- a/MonoGame.Framework/GameServiceContainer.cs
+++ b/MonoGame.Framework/GameServiceContainer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Xna.Framework
         {
             services = new Dictionary<Type, object>();
         }
-
+#nullable enable
         /// <summary>
         /// Add a service provider to this container.
         /// </summary>
@@ -55,11 +55,11 @@ namespace Microsoft.Xna.Framework
         /// no suitable service provider is registered in this container.
         /// </returns>
         /// <exception cref="ArgumentNullException">If the specified type is <code>null</code>.</exception>
-        public object GetService(Type type)
+        public object? GetService(Type type)
         {
             if (type == null)
                 throw new ArgumentNullException("type");
-						
+
             object service;
             if (services.TryGetValue(type, out service))
                 return service;
@@ -72,12 +72,13 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="type">The type of the service to remove.</param>
         /// <exception cref="ArgumentNullException">If the specified type is <code>null</code>.</exception>
-        public void RemoveService(Type type)
+        /// <returns><c>true</c> if a service of the indicated type was found and removed, otherwise <c>false</c>.</returns>
+        public bool RemoveService(Type type)
         {
             if (type == null)
                 throw new ArgumentNullException("type");
 
-            services.Remove(type);
+            return services.Remove(type);
         }
         
         /// <summary>
@@ -90,6 +91,9 @@ namespace Microsoft.Xna.Framework
         /// </exception>
         public void AddService<T>(T provider)
         {
+            if (provider == null)
+                throw new ArgumentNullException("provider");
+
             AddService(typeof(T), provider);
         }
 
@@ -101,7 +105,7 @@ namespace Microsoft.Xna.Framework
         /// A service provider of the specified type or <code>null</code> if
         /// no suitable service provider is registered in this container.
         /// </returns>
- 	public T GetService<T>() where T : class
+ 	public T? GetService<T>() where T : class
         {
             var service = GetService(typeof(T));
 
@@ -111,4 +115,5 @@ namespace Microsoft.Xna.Framework
             return (T)service;
         }
     }
+#nullable restore
 }


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes #9166

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

<!-- 
Enter description of the fix in this section.
Please be as descriptive as possible, future contributors will need to know *why* these changes are being made.
For inspiration review the commit/PR history in the MonoGame repository.
-->

- Added a `#nullable enable` section to GameServiceContainer.cs to mark the return types of the `GetService` overloads as nullable.
- Changed the return type of the `RemoveService` method to `bool` because the underlying `Dictionary<Type, object>.Remove` returns `bool` and knowing whether something was found and removed can be useful.