### PR TITLE
Fix Color.FromHSV hue progression and parameter normalization

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -2037,7 +2037,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="x"></param>
         /// <param name="rh"></param>
         /// <returns>the hue for R, G or B</returns>
-        private float HtoRGB(float c, float x, float rh)
+        private static float HtoRGB(float c, float x, float rh)
         {
             if ((6 * rh) < 1)
                 return (c + (x - c) * 6 * rh);
@@ -2056,7 +2056,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="s">Saturation component value, from 0.0f to 100.0f</param>
         /// <param name="l">Luminosity (brightness) component value, from 0.0f to 100.0f</param>
         /// <returns><see cref="Color"/> with the HSL values</returns>
-        public Color FromHSL(float h, float s, float l)
+        public static Color FromHSL(float h, float s, float l)
         {
             s /= 100;
             l /= 100;

--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -2095,7 +2095,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="s">Saturation component value, ranging from 0.0f to 1.0f</param>
         /// <param name="v">Value component value, ranging from 0.0f to 1.0f</param>
         /// <returns><see cref="Color"/> with the HSV values</returns>
-        public Color FromHSV(float h, float s, float v)
+        public static Color FromHSV(float h, float s, float v)
         {
             //defining values for easier colour conversion at end
             float r = 0f;

--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -2110,7 +2110,7 @@ namespace Microsoft.Xna.Framework
                 r = g = b = v;
             //working out which segment of colour wheel the hue is.
             int i = (int)(h / 60.0f);
-            int f = (int)(h / 60.0f) - i;
+            float f = (h % 60.0f) / 60.0f;
             float p = v * (1.0f - s);
             float q = v * (1.0f - s * f);
             float t = v * (1.0f - s * (1.0f - f));

--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -2103,8 +2103,8 @@ namespace Microsoft.Xna.Framework
             float b = 0f;
 
             h %= 360.0f;
-            s /= 100;
-            v /= 100;
+            s = MathHelper.Clamp(s, 0.0f, 1.0f);
+            v = MathHelper.Clamp(v, 0.0f, 1.0f);
 
             if (s == 0)
                 r = g = b = v;

--- a/Tests/Framework/ColorTest.cs
+++ b/Tests/Framework/ColorTest.cs
@@ -287,10 +287,63 @@ namespace MonoGame.Tests.Framework
             float s = 100;
             float v = 100;
 
-            Color color2 = color1.FromHSV(h, s, v);
+            Color color2 = Color.FromHSV(h, s, v);
 
             Assert.AreEqual(color1, color2);
-            
+
+        }
+
+        [Test]
+        public void FromHSV_HueWrapsAround_Above360()
+        {
+            // Hue values should wrap around the color wheel.
+            // 370 degrees should equal 10 degrees
+            // https://github.com/MonoGame/MonoGame/issues/9131
+            var color1 = Color.FromHSV(10.0f, 1.0f, 1.0f);
+            var color2 = Color.FromHSV(370.0f, 1.0f, 1.0f);
+
+            Assert.AreEqual(color1, color2);
+        }
+
+        [Test]
+        public void FromHSV_SmoothProgressionWithinSegment()
+        {
+            // Test that hue progresses smoothly within a 60-degree segment
+            // This catches the bug where f = (int)(h/60) - i always equals 0
+            // https://github.com/MonoGame/MonoGame/issues/9131
+
+            // In the red segment (0-60), colors should transition smoothly
+            // At hue 0: R should be max, G should be min
+            var color0 = Color.FromHSV(0.0f, 1.0f, 1.0f);
+            Assert.AreEqual(255, color0.R);
+            Assert.AreEqual(0, color0.G);
+
+            // At hue 30: R should still be max, but G should be increasing (around 128)
+            var color30 = Color.FromHSV(30.0f, 1.0f, 1.0f);
+            Assert.AreEqual(255, color30.R);
+            Assert.AreEqual(128, color30.G, 1);
+
+            // At hue 60: R should still be max, G should be max
+            var color60 = Color.FromHSV(60.0f, 1.0f, 1.0f);
+            Assert.AreEqual(255, color60.R);
+            Assert.AreEqual(255, color60.G);
+
+            // At hue 0: R should be max, G should be min
+            Assert.AreEqual(255, color0.R);
+            Assert.AreEqual(0, color0.G);
+
+            // Verify smooth progression: G should be monotonically increasing
+            var color10 = Color.FromHSV(10f, 1f, 1f);
+            var color20 = Color.FromHSV(20f, 1f, 1f);
+            var color40 = Color.FromHSV(40f, 1f, 1f);
+            var color50 = Color.FromHSV(50f, 1f, 1f);
+
+            Assert.IsTrue(color0.G < color10.G);
+            Assert.IsTrue(color10.G < color20.G);
+            Assert.IsTrue(color20.G < color30.G);
+            Assert.IsTrue(color30.G < color40.G);
+            Assert.IsTrue(color40.G < color50.G);
+            Assert.IsTrue(color50.G < color60.G);
         }
     }
 }

--- a/Tests/Framework/ColorTest.cs
+++ b/Tests/Framework/ColorTest.cs
@@ -274,7 +274,7 @@ namespace MonoGame.Tests.Framework
             float s = 100;
             float l = 50;
 
-            Color color2 = color1.FromHSL(h, s, l);
+            Color color2 = Color.FromHSL(h, s, l);
 
             Assert.AreEqual(color1, color2);
         }


### PR DESCRIPTION
## Description

Fixes two bugs in `Color.FromHSV()`

1. Fixes fractional hue calculation within color wheel segments.  The fractional position `f` within each 60deg segment was calcualted as `int f = (int)(h / 60.0f) - i`, which always resulted in a `0` due to integer arithmetic.  Changed to `float f = (h % 60.0f) / 60.0f` to correctly calcualte fractional position within [0,1] range.
2. Removed incorrect normalization of saturation and value parameters.  The documentation for the method states that these values should be in the [0,1] range.  By normalizing them by dividing by 100, this causes colors to be nearly black in all cases (e.g. passing `s=1.0, v=1.0` would result in RGB values of `2` instead of `255`)

Additionally, `Color.FromHSV()`, `Color.FromHSL()` were changed to `static` methods. These are factory methods for creating a `Color` value from a different structure, it doesn't make sense to have them as instance members that require an instance before using.

## Breaking Changes

Since `Color.FromHSV()` and `Color.FromHSL()` are changed to static factory methods, this would be considered a breaking change as it changes the public API that already existed.  Not sure if you want to keep this change since it's technically a breaking change or we can obsolete the existing ones with a warning and forward them to the new static ones, then remove the instance methods in a future release where breaking changes are good.

## Related Issues
- Closes #9131 



