### PR TITLE
Allow content builder importers to match more than the extension

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
@@ -3,14 +3,15 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System.Collections;
+using System.Diagnostics.Contracts;
 using System.Reflection;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline;
+using MonoGame.Framework.Content.Pipeline.Builder.Server;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
-using MonoGame.Framework.Content.Pipeline.Builder.Server;
 
 namespace MonoGame.Framework.Content.Pipeline.Builder;
 
@@ -47,6 +48,19 @@ static class ContentBuilderHelper
         public required Type Type { get; init; }
     }
 
+    readonly record struct FileEndingImporterPair : IComparable<FileEndingImporterPair>
+    {
+        public required string FileNameEnding { get; init; }
+        public required ImporterInfo ImporterInfo { get; init; }
+
+        [Pure]
+        public int CompareTo(FileEndingImporterPair other)
+        {
+            // Sort by length of file ending, longest first.
+            return other.FileNameEnding.Length.CompareTo(FileNameEnding.Length);
+        }
+    }
+
     record ProcessorInfo
     {
         public required ContentProcessorAttribute? Attribute { get; init; }
@@ -60,7 +74,7 @@ static class ContentBuilderHelper
     }
 
     private static readonly HashSet<AssemblyName> _loadedAssemblies = [];
-    private static readonly List<ImporterInfo> _importers = [];
+    private static readonly List<FileEndingImporterPair> _importers = [];
     private static readonly List<ProcessorInfo> _processors = [];
     private static readonly Dictionary<Type, List<ServerPropertyInfo>> _serverOptions = [];
 
@@ -104,11 +118,23 @@ static class ContentBuilderHelper
                     serializer.WithTagMapping("!" + t.ToString(), t);
                     deserializer.WithTagMapping("!" + t.ToString(), t);
 
-                    _importers.Add(new ImporterInfo
+                    var importerInfo = new ImporterInfo
                     {
                         Attribute = GetImporterAttribute(t),
                         Type = t
-                    });
+                    };
+
+                    // The importer gets added once per file extension it supports,
+                    // and the list is sorted by file extension length later to ensure
+                    // that longer extensions are matched first.
+                    foreach (string ext in importerInfo.Attribute.FileExtensions)
+                    {
+                        _importers.Add(new FileEndingImporterPair
+                        {
+                            FileNameEnding = ext,
+                            ImporterInfo = importerInfo
+                        });
+                    }
                 }
                 else if (t.GetInterface(nameof(IContentProcessor)) != null)
                 {
@@ -148,6 +174,7 @@ static class ContentBuilderHelper
             }
         }
 
+        _importers.Sort();
         Serializer = serializer.Build();
         Deserializer = deserializer.Build();
     }
@@ -243,9 +270,9 @@ static class ContentBuilderHelper
 
         foreach (var info in _importers)
         {
-            if (info.Attribute?.FileExtensions.Any(e => relativePath.EndsWith(e, StringComparison.InvariantCultureIgnoreCase)) ?? false)
+            if (relativePath.EndsWith(info.FileNameEnding, StringComparison.InvariantCultureIgnoreCase))
             {
-                outImporter = (IContentImporter)Activator.CreateInstance(info.Type)!;
+                outImporter = (IContentImporter)Activator.CreateInstance(info.ImporterInfo.Type)!;
                 return true;
             }
         }

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
@@ -243,8 +243,7 @@ static class ContentBuilderHelper
 
         foreach (var info in _importers)
         {
-            string fileExtension = Path.GetExtension(relativePath);
-            if (info.Attribute?.FileExtensions.Any(e => e.Equals(fileExtension, StringComparison.InvariantCultureIgnoreCase)) ?? false)
+            if (info.Attribute?.FileExtensions.Any(e => relativePath.EndsWith(e, StringComparison.InvariantCultureIgnoreCase)) ?? false)
             {
                 outImporter = (IContentImporter)Activator.CreateInstance(info.Type)!;
                 return true;

--- a/MonoGame.Framework.Content.Pipeline/ContentImporterAttribute.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentImporterAttribute.cs
@@ -31,12 +31,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         public virtual string DisplayName { get; set; }
 
         /// <summary>
-        /// Gets or sets the priority of this importer: when multiple importers support the same file extension or ending, the importer with the higher priority value is chosen.
-        /// When importers have the same priority the selection is undefined.
-        /// </summary>
-        public virtual int Priority { get; set; }
-
-        /// <summary>
         /// Gets the supported file name extensions of the importer.
         /// </summary>
         public IEnumerable<string> FileExtensions { get { return extensions; } }

--- a/MonoGame.Framework.Content.Pipeline/ContentImporterAttribute.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentImporterAttribute.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         public virtual string DisplayName { get; set; }
 
         /// <summary>
+        /// Gets or sets the priority of this importer: when multiple importers support the same file extension or ending, the importer with the higher priority value is chosen.
+        /// When importers have the same priority the selection is undefined.
+        /// </summary>
+        public virtual int Priority { get; set; }
+
+        /// <summary>
         /// Gets the supported file name extensions of the importer.
         /// </summary>
         public IEnumerable<string> FileExtensions { get { return extensions; } }

--- a/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PipelineManager.cs
@@ -354,26 +354,6 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         }
 
         /// <summary>
-        /// Returns the importer type name based on the file extension.
-        /// </summary>
-        /// <param name="ext">File extension to search for.</param>
-        /// <returns>Importer type name or <see langword="null"/> if not found.</returns>
-        public string FindImporterByExtension(string ext)
-        {
-            if (_importers == null)
-                ResolveAssemblies();
-
-            // Search for the importer.
-            foreach (var info in _importers)
-            {
-                if (info.attribute.FileExtensions.Any(e => e.Equals(ext, StringComparison.InvariantCultureIgnoreCase)))
-                    return info.type.Name;
-            }
-
-            return null;
-        }
-
-        /// <summary>
         /// Returns the importer type name based on the file name (including extension).
         /// </summary>
         /// <param name="fileNameWithExt">Then name of the file including the extension.</param>

--- a/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PipelineManager.cs
@@ -1,4 +1,4 @@
-﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -31,6 +31,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         };
 
         private List<ImporterInfo> _importers;
+        private List<(string fileNameEnding, ImporterInfo importerInfo)> _importersByFileEnding;
 
         [DebuggerDisplay("ProcessorInfo: {type.Name}")]
         private struct ProcessorInfo
@@ -183,6 +184,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 //TODO need better way to update caches
                 _processors = null;
                 _importers = null;
+                _importersByFileEnding = null;
                 _writers = null;
             }
         }
@@ -190,6 +192,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         private void ResolveAssemblies()
         {
             _importers = new List<ImporterInfo>();
+            _importersByFileEnding = new List<(string fileNameEnding, ImporterInfo importerInfo)>();
             _processors = new List<ProcessorInfo>();
             _writers = new List<Type>();
 
@@ -235,12 +238,19 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                         if (attributes.Length != 0)
                         {
                             var importerAttribute = attributes[0] as ContentImporterAttribute;
-                            _importers.Add(new ImporterInfo
+                            var importerInfo = new ImporterInfo
                             {
                                 attribute = importerAttribute,
                                 type = t,
                                 assemblyTimestamp = assemblyTimestamp
-                            });
+                            };
+
+                            _importers.Add(importerInfo);
+
+                            foreach (var ext in importerAttribute.FileExtensions)
+                            {
+                                _importersByFileEnding.Add((ext, importerInfo));
+                            }
                         }
                         else
                         {
@@ -278,13 +288,13 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 }
             }
 
-            // Sort importers by priority descending.
+            // Sort importer-extension pairs by extension length descending.
             // This makes sure that in methods where they are looped through, the one with
             // the highest priority is found first.
-            // This is important for file extensions that are supported by multiple importers.
-            _importers.Sort((a, b) => b.attribute.Priority.CompareTo(a.attribute.Priority));
+            // This is important for file endings that are matched by multiple importers.
+            _importersByFileEnding.Sort((a, b) => b.fileNameEnding.Length.CompareTo(a.fileNameEnding.Length));
         }
-        
+
         /// <summary>
         /// Gets the importer types.
         /// </summary>
@@ -374,10 +384,10 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 ResolveAssemblies();
 
             // Search for the importer.
-            foreach (var info in _importers)
+            foreach (var pair in _importersByFileEnding)
             {
-                if (info.attribute.FileExtensions.Any(e => fileNameWithExt.EndsWith(e, StringComparison.InvariantCultureIgnoreCase)))
-                    return info.type.Name;
+                if (fileNameWithExt.EndsWith(pair.fileNameEnding, StringComparison.InvariantCultureIgnoreCase))
+                    return pair.importerInfo.type.Name;
             }
 
             return null;

--- a/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PipelineManager.cs
@@ -229,7 +229,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                     if (t.IsAbstract)
                         continue;
 
-                    if (t.GetInterface(@"IContentImporter") != null)
+                    if (t.GetInterface(nameof(IContentImporter)) != null)
                     {
                         var attributes = t.GetCustomAttributes(typeof (ContentImporterAttribute), false);
                         if (attributes.Length != 0)
@@ -256,7 +256,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                             });
                         }
                     }
-                    else if (t.GetInterface(@"IContentProcessor") != null)
+                    else if (t.GetInterface(nameof(IContentProcessor)) != null)
                     {
                         var attributes = t.GetCustomAttributes(typeof (ContentProcessorAttribute), false);
                         if (attributes.Length != 0)
@@ -270,15 +270,21 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                             });
                         }
                     }
-                    else if (t.GetInterface(@"ContentTypeWriter") != null)
+                    else if (t.GetInterface(nameof(ContentTypeWriter)) != null)
                     {
 						// TODO: This doesn't work... how do i find these?
                         _writers.Add(t);
                     }
                 }
             }
-        }
 
+            // Sort importers by priority descending.
+            // This makes sure that in methods where they are looped through, the one with
+            // the highest priority is found first.
+            // This is important for file extensions that are supported by multiple importers.
+            _importers.Sort((a, b) => b.attribute.Priority.CompareTo(a.attribute.Priority));
+        }
+        
         /// <summary>
         /// Gets the importer types.
         /// </summary>
@@ -358,6 +364,26 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         }
 
         /// <summary>
+        /// Returns the importer type name based on the file name (including extension).
+        /// </summary>
+        /// <param name="fileNameWithExt">Then name of the file including the extension.</param>
+        /// <returns>Importer type name or <see langword="null"/> if not found.</returns>
+        public string FindImporterByFileName(string fileNameWithExt)
+        {
+            if (_importers == null)
+                ResolveAssemblies();
+
+            // Search for the importer.
+            foreach (var info in _importers)
+            {
+                if (info.attribute.FileExtensions.Any(e => fileNameWithExt.EndsWith(e, StringComparison.InvariantCultureIgnoreCase)))
+                    return info.type.Name;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Gets the importer assembly timestamp.
         /// </summary>
         /// <param name="name">Assembly name.</param>
@@ -428,7 +454,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         {
             // Resolve the importer name.
             if (string.IsNullOrEmpty(importerName))
-                importerName = FindImporterByExtension(Path.GetExtension(sourceFilepath));
+                importerName = FindImporterByFileName(Path.GetExtension(sourceFilepath));
             if (string.IsNullOrEmpty(importerName))
                 throw new Exception(string.Format("Couldn't find a default importer for '{0}'!", sourceFilepath));
 


### PR DESCRIPTION
### Description of Change
I wanted to be able to automatically import files such as `Sprites.atlas.json` using a custom importer, but currently the only way to do this is to manually specify the importer: not all `.json` files will be sprite atlases, only the ones ending in `.atlas.json`.  
It is possible, in some cases, to give your files a custom file extension but that is annoying since it will no longer open in the expected programs, might not be displayed correctly in version control etc.

This PR changes the way that importers are selected to allow them to match the end of the file name rather than strictly the extension only. This allows `[ContentImporter(".atlas.json")]` to work as expected, whereas previously this was impossible.

This did also raise the question of how to handle the following kind of setup, which importer should be selected?
- A generic '.png' importer i.e. the built-in texture importer.
- A custom '.lightmap.png' importer.

To solve this I have also added a `Priority` property to the importer attribute.  
Importers with higher priority number are earlier in the list and will therefore match first. In the example above, you would give the lightmap importer higher priority.

The method `FindImporterByExtension(ext)` was left unchanged since this is public API. It will still strictly match on the extension alone.
I have added a `FindImporterByFileName(fn)` method instead that does the same thing but matching on the end of the file name, and the single internal usage of FindImporterByExtension has been replaced by this new method.

This change should not affect the behaviour of any existing importers or content setups.  
I have not included tests for this since there don't seem to be any existing tests for the importer selection system.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

