### PR TITLE
Disable CoPilot when in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,9 @@
     "dotnetCoreExplorer.searchpatterns": [
         "Artifacts/Tests/**/MonoGame.Tests.dll",
         "Artifacts/Tests/**/MonoGame.Tools.Tests.dll"
-    ]
+    ],
+    "github.copilot.enable": {
+        "*": false
+    },
+    "chat.agent.enabled": false
 }

--- a/MonoGame.code-workspace
+++ b/MonoGame.code-workspace
@@ -1,0 +1,13 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"github.copilot.enable": {
+			"*": false
+		},
+		"chat.agent.enabled": false
+	}
+}


### PR DESCRIPTION
Disable VSCode based CoPilot features so that contributors who need to use CoPilot for work or other projects do not need to disable it manually.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

