### PR TITLE
Added functionality to set the offset/position of a Song or SoundEffect(Instance)

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/SoundEffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/SoundEffectProcessor.cs
@@ -24,10 +24,20 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         public ConversionQuality Quality { get { return quality; } set { quality = value; } }
 
         /// <summary>
+        /// Currently assigned audio profile.
+        /// </summary>
+        private AudioProfile? _profile;
+
+        /// <summary>
         /// Initializes a new instance of SoundEffectProcessor.
         /// </summary>
         public SoundEffectProcessor()
-        {
+        { 
+        }
+
+        public SoundEffectProcessor(AudioProfile profile)
+        { 
+            _profile = profile;
         }
 
         /// <summary>
@@ -42,8 +52,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                 throw new ArgumentNullException("input");
             if (context == null)
                 throw new ArgumentNullException("context");
-
-            var profile = AudioProfile.ForPlatform(context.TargetPlatform);
+            
+            var profile = _profile ?? AudioProfile.ForPlatform(context.TargetPlatform);
             var finalQuality = profile.ConvertAudio(context.TargetPlatform, quality, input);
             if (quality != finalQuality)
                 context.Logger.LogMessage("Failed to convert using \"{0}\" quality, used \"{1}\" quality", quality, finalQuality);

--- a/MonoGame.Framework.Content.Pipeline/Processors/SoundEffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/SoundEffectProcessor.cs
@@ -21,12 +21,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         /// Gets or sets the target format quality of the audio content.
         /// </summary>
         /// <value>The ConversionQuality of this audio data.</value>
-        public ConversionQuality Quality { get { return quality; } set { quality = value; } }
-
-        /// <summary>
-        /// Currently assigned audio profile.
-        /// </summary>
-        private AudioProfile? _profile;
+        public ConversionQuality Quality { get { return quality; } set { quality = value; } } 
 
         /// <summary>
         /// Initializes a new instance of SoundEffectProcessor.
@@ -34,12 +29,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         public SoundEffectProcessor()
         { 
         }
-
-        public SoundEffectProcessor(AudioProfile profile)
-        { 
-            _profile = profile;
-        }
-
+         
         /// <summary>
         /// Builds the content for the source audio.
         /// </summary>
@@ -53,7 +43,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             if (context == null)
                 throw new ArgumentNullException("context");
             
-            var profile = _profile ?? AudioProfile.ForPlatform(context.TargetPlatform);
+            var profile = AudioProfile.ForPlatform(context.TargetPlatform);
             var finalQuality = profile.ConvertAudio(context.TargetPlatform, quality, input);
             if (quality != finalQuality)
                 context.Logger.LogMessage("Failed to convert using \"{0}\" quality, used \"{1}\" quality", quality, finalQuality);

--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -19,10 +19,8 @@ namespace Microsoft.Xna.Framework.Audio
 
         private string _name = string.Empty;
         
-        private bool _isDisposed;
-        private readonly TimeSpan _duration;
-
-        internal readonly uint _bitsPerSample;
+        private bool _isDisposed = false;
+        private readonly TimeSpan _duration; 
 
         #endregion
 

--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 ﻿
@@ -19,8 +19,10 @@ namespace Microsoft.Xna.Framework.Audio
 
         private string _name = string.Empty;
         
-        private bool _isDisposed = false;
+        private bool _isDisposed;
         private readonly TimeSpan _duration;
+
+        internal readonly uint _bitsPerSample;
 
         #endregion
 

--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -20,7 +20,7 @@ namespace Microsoft.Xna.Framework.Audio
         private float _pan;
         private float _volume;
         private float _pitch;
-        private bool _isLooped;
+        private bool _isLooped; 
 
         /// <summary>Enables or Disables whether the SoundEffectInstance should repeat after playback.</summary>
         /// <remarks>This value has no effect on an already playing sound.</remarks>
@@ -78,7 +78,36 @@ namespace Microsoft.Xna.Framework.Audio
             }
         }
 
-        /// <summary>Gets or sets the volume of the SoundEffectInstance.</summary>
+        /// <summary>
+        /// The current playback offset position of the <see cref="SoundEffectInstance"/>.
+        /// </summary>
+        /// <remarks>
+        /// Assigning a value works reliably for uncompressed formats (e.g. PCM WAV). Other formats may cause incorrect behavior.
+        /// </remarks>
+        /// <value>Ranging from <see cref="TimeSpan.Zero"/> to the length of the audio track.</value>
+        /// <exception cref="InvalidOperationException">(only for OpenAL!) Thrown if the assigned value is the duration of the track (or a later moment),
+        /// or if a value is assigned while <see langword="this" /> instance is playing.</exception>
+        public TimeSpan Offset
+        {
+            get { return PlatformGetOffset(); }
+            set
+            {
+                if (value >= _effect.Duration)
+                {
+                    throw new InvalidOperationException(
+                        "The new position cannot be at a later position than the duration of the sound effect! (or the duration itself)");
+                }
+
+                if (State == SoundState.Playing)
+                {
+                    throw new InvalidOperationException("You cannot set the offset while the sound is playing!");
+                }
+
+                PlatformSetOffset(value);
+            }
+        }
+
+        /// <summary>Gets or sets the volume of the <see cref="SoundEffectInstance"/>.</summary>
         /// <value>Volume, ranging from 0.0 (silence) to 1.0 (full volume). Volume during playback is scaled by SoundEffect.MasterVolume.</value>
         /// <remarks>
         /// This is the volume relative to SoundEffect.MasterVolume. Before playback, this Volume property is multiplied by SoundEffect.MasterVolume when determining the final mix volume.
@@ -169,12 +198,9 @@ namespace Microsoft.Xna.Framework.Audio
 
             // We don't need to check if we're at the instance play limit
             // if we're resuming from a paused state.
-            if (state != SoundState.Paused)
-            {
-                if (!SoundEffectInstancePool.SoundsAvailable)
-                    throw new InstancePlayLimitException();
-            }
-            
+            if (!SoundEffectInstancePool.SoundsAvailable)
+                throw new InstancePlayLimitException();
+
             // For non-XAct sounds we need to be sure the latest
             // master volume level is applied before playback.
             if (!_isXAct)

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Audio/OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenAL.cs
@@ -67,8 +67,9 @@ namespace MonoGame.OpenAL
 
     internal enum ALSourcef
     {
-        Pitch = 0x1003,
         Gain = 0x100A,
+        Offset = 0x1024,
+        Pitch = 0x1003,
         ReferenceDistance = 0x1020,
         StereoAngles = 0x1030
     }
@@ -80,7 +81,7 @@ namespace MonoGame.OpenAL
         BuffersQueued = 0x1015,
         BuffersProcessed = 0x1016,
     }
-
+     
     internal enum ALSourceState
     {
         Initial = 0x1011,
@@ -390,8 +391,12 @@ namespace MonoGame.OpenAL
         internal static extern void alSourcefv(int sourceId, ALSourcef i, float[] values);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void alGetSourcef(int sourceId, ALSourcef f, out float state);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alGetSourcei(int sourceId, ALGetSourcei i, out int state);
         internal static void GetSource(int sourceId, ALGetSourcei i, out int state) => alGetSourcei(sourceId, i, out state);
+        
 
         internal static ALSourceState GetSourceState(int sourceId)
         {

--- a/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
@@ -439,13 +439,19 @@ namespace Microsoft.Xna.Framework.Audio
             inst.SoundState = SoundState.Stopped;
 		}
 
-        public double SourceCurrentPosition (int sourceId)
+        public float SourceCurrentOffset (int sourceId)
 		{
-            int pos;
-			AL.GetSource (sourceId, ALGetSourcei.SampleOffset, out pos);
+            float pos;
+			AL.alGetSourcef(sourceId, ALSourcef.Offset, out pos);
             ALHelper.CheckError("Failed to set source offset.");
 			return pos;
 		}
+
+        public void SetSourceCurrentPosition(int sourceId, TimeSpan position)
+        {
+            int pos;
+            AL.Source(sourceId, ALSourcef.Offset, (float)position.TotalSeconds);
+        }
 
 #if ANDROID
         void Activity_Paused(object sender, EventArgs e)

--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.OpenAL.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -300,6 +300,27 @@ namespace Microsoft.Xna.Framework.Audio
 
             return SoundState;
         }
+
+        private TimeSpan PlatformGetOffset()
+        { 
+            if (HasSourceId)
+            {
+                var result = OpenALSoundController.Instance.SourceCurrentOffset(SourceId);
+                AlcHelper.CheckError("Failed to set position.");
+                return TimeSpan.FromSeconds(result);
+            }
+
+            return TimeSpan.Zero;
+        }
+
+        private void PlatformSetOffset(TimeSpan position)
+        {
+            if (HasSourceId)
+            {
+                AL.Source(SourceId, ALSourcef.Offset, (float)position.TotalSeconds);
+            }
+        }
+        
 
         private void PlatformSetVolume(float value)
         {

--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
@@ -2,7 +2,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using Microsoft.VisualBasic;
 using SharpDX.Mathematics.Interop;
 using SharpDX.Multimedia;
 using SharpDX.X3DAudio;

--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
@@ -327,11 +327,7 @@ namespace Microsoft.Xna.Framework.Audio
         private void PlatformSetOffset(TimeSpan offset)
         {
             if (_voice != null && SoundEffect.MasterVoice != null)
-            {
-                if (_voice.State.BuffersQueued > 0)
-                {
-                    _voice.Stop(); 
-                }
+            { 
                 _voice.FlushSourceBuffers();
 
                 if (_isLooped)
@@ -346,9 +342,6 @@ namespace Microsoft.Xna.Framework.Audio
                      _effect._buffer.PlayLength = 0;
                      _voice.SubmitSourceBuffer(_effect._buffer, null); 
                 } 
-                 
-                // Restart playback
-                _voice.Start();
             }
         }
 

--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
@@ -2,11 +2,12 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using SharpDX.XAudio2;
-using SharpDX.X3DAudio;
-using SharpDX.Multimedia;
+using Microsoft.VisualBasic;
 using SharpDX.Mathematics.Interop;
+using SharpDX.Multimedia;
+using SharpDX.X3DAudio;
+using SharpDX.XAudio2;
+using System;
 
 namespace Microsoft.Xna.Framework.Audio
 {
@@ -47,7 +48,7 @@ namespace Microsoft.Xna.Framework.Audio
             {
                 e.ChannelRadius = 0;
                 e.ChannelAzimuths = _defaultChannelAzimuths;
-             }
+            }
 
             // Convert from XNA Listener to a SharpDX Listener
             var l = ToDXListener(listener);
@@ -307,11 +308,47 @@ namespace Microsoft.Xna.Framework.Audio
                 return SoundState.Stopped;
 
             // Because XAudio2 does not actually provide if a SourceVoice is Started / Stopped
-            // we have to save the "paused" state ourself.
+            // we have to save the "paused" state ourselves.
             if (_paused)
                 return SoundState.Paused;
 
             return SoundState.Playing;
+        }
+
+        private TimeSpan PlatformGetOffset()
+        {
+            if (_voice != null && SoundEffect.MasterVoice != null && _voice.State.BuffersQueued > 0)
+            {
+                return TimeSpan.FromMilliseconds((_voice.State.SamplesPlayed * 1000) / _format.SampleRate);
+            }
+
+            return TimeSpan.Zero;
+        }
+
+        private void PlatformSetOffset(TimeSpan offset)
+        {
+            if (_voice != null && SoundEffect.MasterVoice != null)
+            {
+                if (_voice.State.BuffersQueued > 0)
+                {
+                    _voice.Stop();
+                    _voice.FlushSourceBuffers();
+                }
+
+                if (_isLooped)
+                {
+                    _effect._loopedBuffer.PlayBegin = (int)(offset.TotalSeconds * _effect._format.SampleRate) * _effect._format.BlockAlign;
+                    _voice.SubmitSourceBuffer(_effect._loopedBuffer, null);
+                }
+                else
+                {
+                    _effect._buffer.PlayBegin = (int)(offset.TotalSeconds * _effect._format.SampleRate) * _effect._format.BlockAlign;
+                    _voice.SubmitSourceBuffer(_effect._buffer, null); 
+                } 
+                 
+                // Restart playback
+                _voice.Start();
+            }
         }
 
         private void PlatformSetVolume(float value)

--- a/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Platform/Audio/SoundEffectInstance.XAudio.cs
@@ -331,19 +331,21 @@ namespace Microsoft.Xna.Framework.Audio
             {
                 if (_voice.State.BuffersQueued > 0)
                 {
-                    _voice.Stop();
-                    _voice.FlushSourceBuffers();
+                    _voice.Stop(); 
                 }
+                _voice.FlushSourceBuffers();
 
                 if (_isLooped)
                 {
-                    _effect._loopedBuffer.PlayBegin = (int)(offset.TotalSeconds * _effect._format.SampleRate) * _effect._format.BlockAlign;
+                    _effect._loopedBuffer.PlayBegin = (int)(offset.TotalSeconds * _effect._format.SampleRate);
+                    _effect._loopedBuffer.PlayLength = 0;
                     _voice.SubmitSourceBuffer(_effect._loopedBuffer, null);
                 }
                 else
                 {
-                    _effect._buffer.PlayBegin = (int)(offset.TotalSeconds * _effect._format.SampleRate) * _effect._format.BlockAlign;
-                    _voice.SubmitSourceBuffer(_effect._buffer, null); 
+                     _effect._buffer.PlayBegin = (int)(offset.TotalSeconds * _effect._format.SampleRate);
+                     _effect._buffer.PlayLength = 0;
+                     _voice.SubmitSourceBuffer(_effect._buffer, null); 
                 } 
                  
                 // Restart playback

--- a/MonoGame.Framework/Platform/Native/Audio.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Audio.Interop.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -176,6 +176,9 @@ internal static unsafe partial class MGA
 
     [DllImport(MGP.MonoGameNativeDLL, EntryPoint = "MGA_Voice_SetPitch", ExactSpelling = true)]
     public static extern void Voice_SetPitch(MGA_Voice* voice, float pitch);
+     
+    [DllImport(MGP.MonoGameNativeDLL, EntryPoint = "MGA_Voice_SetPosition", ExactSpelling = true)]
+    public static extern void Voice_SetPosition(MGA_Voice* voice, ulong position);
 
     [DllImport(MGP.MonoGameNativeDLL, EntryPoint = "MGA_Voice_SetVolume", ExactSpelling = true)]
     public static extern void Voice_SetVolume(MGA_Voice* voice, float volume);

--- a/MonoGame.Framework/Platform/Native/Audio.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Audio.Interop.cs
@@ -178,7 +178,7 @@ internal static unsafe partial class MGA
     public static extern void Voice_SetPitch(MGA_Voice* voice, float pitch);
      
     [DllImport(MGP.MonoGameNativeDLL, EntryPoint = "MGA_Voice_SetPosition", ExactSpelling = true)]
-    public static extern void Voice_SetPosition(MGA_Voice* voice, ulong position);
+    public static extern void Voice_SetPosition(MGA_Voice* voice, double position);
 
     [DllImport(MGP.MonoGameNativeDLL, EntryPoint = "MGA_Voice_SetVolume", ExactSpelling = true)]
     public static extern void Voice_SetVolume(MGA_Voice* voice, float volume);

--- a/MonoGame.Framework/Platform/Native/Song.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Song.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -134,6 +134,16 @@ public sealed partial class Song : IEquatable<Song>, IDisposable
             milliseconds %= (ulong)_duration.TotalMilliseconds;
 
             return TimeSpan.FromMilliseconds(milliseconds);
+        }
+
+        set
+        {
+            if (_voice == null)
+            {
+                throw new InvalidOperationException("Song is not initialized.");
+            }
+
+            MGA.Voice_SetPosition(_voice, (ulong)value.Milliseconds);
         }
     }
 

--- a/MonoGame.Framework/Platform/Native/SoundEffect.Native.cs
+++ b/MonoGame.Framework/Platform/Native/SoundEffect.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Platform/Native/SoundEffectInstance.Native.cs
+++ b/MonoGame.Framework/Platform/Native/SoundEffectInstance.Native.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -78,6 +78,21 @@ public partial class SoundEffectInstance : IDisposable
             return MGA.Voice_GetState(Voice);
 
         return SoundState.Stopped;
+    }
+
+    private unsafe TimeSpan PlatformGetOffset()
+    {
+        if (Voice != null)
+            return TimeSpan.FromMilliseconds(MGA.Voice_GetPosition(Voice));
+
+        return TimeSpan.Zero;
+    }
+
+
+    private unsafe void PlatformSetOffset(TimeSpan offset)
+    {
+        if (Voice != null)
+            MGA.Voice_SetPosition(Voice, (ulong)offset.TotalMilliseconds);
     }
 
     private unsafe void PlatformSetVolume(float volume)

--- a/MonoGame.Framework/Platform/Native/SoundEffectInstance.Native.cs
+++ b/MonoGame.Framework/Platform/Native/SoundEffectInstance.Native.cs
@@ -92,7 +92,7 @@ public partial class SoundEffectInstance : IDisposable
     private unsafe void PlatformSetOffset(TimeSpan offset)
     {
         if (Voice != null)
-            MGA.Voice_SetPosition(Voice, (ulong)offset.TotalMilliseconds);
+            MGA.Voice_SetPosition(Voice, offset.TotalSeconds);
     }
 
     private unsafe void PlatformSetVolume(float volume)

--- a/Tests/Framework/Audio/SoundEffectTest.cs
+++ b/Tests/Framework/Audio/SoundEffectTest.cs
@@ -471,21 +471,24 @@ namespace MonoGame.Tests.Audio
         }
 
 
-        [TestCase(@"Assets/Audio/rock_loop_stereo.wav", 5f, 1f)]
+        [TestCase(@"Assets/Audio/rock_loop_stereo.wav", 3.0d, 1.0d)]
         public void SoundEffectChangePosition(string filename, double firstPosition, double secondPosition)
         {
             using (var stream = File.OpenRead(filename))
             {
                 var sound = SoundEffect.FromStream(stream); 
                 var instance = sound.CreateInstance();
+                instance.Play();
+                instance.Pause();
                 instance.Offset = TimeSpan.FromSeconds(firstPosition);
+                instance.Resume();
 
                 // Set position exceeds length of sound.
                 Assert.Throws<InvalidOperationException>(() => instance.Offset = TimeSpan.FromMinutes(10));
                 // Fails because the file hasn't been paused.
                 Assert.Throws<InvalidOperationException>(() => instance.Offset = TimeSpan.FromSeconds(1));
                  
-                Task.Delay(TimeSpan.FromSeconds(2)).Wait();
+                Task.Delay(TimeSpan.FromSeconds(3)).Wait();
                 instance.Pause();
                 instance.Offset = TimeSpan.FromSeconds(secondPosition);
                 instance.Resume();

--- a/Tests/Framework/Audio/SoundEffectTest.cs
+++ b/Tests/Framework/Audio/SoundEffectTest.cs
@@ -9,6 +9,7 @@ using Microsoft.Xna.Framework.Audio;
 using NUnit.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+using System.Threading.Tasks;
 
 namespace MonoGame.Tests.Audio
 {
@@ -467,6 +468,29 @@ namespace MonoGame.Tests.Audio
         {
             var soundEffect = _content.Load<SoundEffect>(Paths.Audio(filename));
             Assert.AreEqual(durationTicks, soundEffect.Duration.Ticks);
+        }
+
+
+        [TestCase(@"Assets/Audio/rock_loop_stereo.wav", 5f, 1f)]
+        public void SoundEffectChangePosition(string filename, double firstPosition, double secondPosition)
+        {
+            using (var stream = File.OpenRead(filename))
+            {
+                var sound = SoundEffect.FromStream(stream); 
+                var instance = sound.CreateInstance();
+                instance.Offset = TimeSpan.FromSeconds(firstPosition);
+
+                // Set position exceeds length of sound.
+                Assert.Throws<InvalidOperationException>(() => instance.Offset = TimeSpan.FromMinutes(10));
+                // Fails because the file hasn't been paused.
+                Assert.Throws<InvalidOperationException>(() => instance.Offset = TimeSpan.FromSeconds(1));
+                 
+                Task.Delay(TimeSpan.FromSeconds(2)).Wait();
+                instance.Pause();
+                instance.Offset = TimeSpan.FromSeconds(secondPosition);
+                instance.Resume();
+                Task.Delay(TimeSpan.FromSeconds(5)).Wait();
+            }
         }
     }
 }

--- a/Tests/Framework/Audio/SoundEffectTest.cs
+++ b/Tests/Framework/Audio/SoundEffectTest.cs
@@ -492,7 +492,9 @@ namespace MonoGame.Tests.Audio
                 instance.Pause();
                 instance.Offset = TimeSpan.FromSeconds(secondPosition);
                 instance.Resume();
-                Task.Delay(TimeSpan.FromSeconds(5)).Wait();
+                Task.Delay(TimeSpan.FromSeconds(2)).Wait();
+
+                instance.Stop();
             }
         }
     }

--- a/native/monogame/faudio/MGA_faudio.cpp
+++ b/native/monogame/faudio/MGA_faudio.cpp
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -684,6 +684,29 @@ mgulong MGA_Voice_GetPosition(MGA_Voice* voice)
 
 	float msec = (state.SamplesPlayed / (float)voice->format.nSamplesPerSec) * 1000.0f;
 	return (mgulong)msec;
+}
+
+void MGA_Voice_SetPosition(MGA_Voice* voice, mgulong position)
+{
+	assert(voice != nullptr);
+	if (voice->voice == nullptr)
+		return;
+	 
+	FAudioSourceVoice_Stop(voice->voice, 0, FAUDIO_COMMIT_NOW);
+	FAudioSourceVoice_FlushSourceBuffers(voice->voice); 
+	// Calculate the sample to seek to.
+	uint32_t sample = ((position / 1000.0f) * voice->format.nSamplesPerSec);
+	auto buffer = voice->buffer->buffer;
+	if (voice->looped)
+		buffer.LoopCount = FAUDIO_LOOP_INFINITE;
+	else
+		buffer.LoopBegin = buffer.LoopLength = buffer.LoopCount = 0;
+
+	buffer.PlayBegin = (uint32_t)sample;
+	FAudioSourceVoice_SubmitSourceBuffer(voice->voice, &buffer, nullptr);  
+	voice->finishedBuffers = 0;
+	voice->state = MGSoundState::Playing;
+	FAudioSourceVoice_Start(voice->voice, 0, FAUDIO_COMMIT_NOW);
 }
 
 static void MGA_Voice_UpdateOutputMatrix(MGA_Voice* voice)

--- a/native/monogame/faudio/MGA_faudio.cpp
+++ b/native/monogame/faudio/MGA_faudio.cpp
@@ -686,27 +686,41 @@ mgulong MGA_Voice_GetPosition(MGA_Voice* voice)
 	return (mgulong)msec;
 }
 
-void MGA_Voice_SetPosition(MGA_Voice* voice, mgulong position)
+void MGA_Voice_SetPosition(MGA_Voice* voice, mgdouble position)
 {
 	assert(voice != nullptr);
-	if (voice->voice == nullptr)
+	if (!voice->voice)
 		return;
 	 
-	FAudioSourceVoice_Stop(voice->voice, 0, FAUDIO_COMMIT_NOW);
-	FAudioSourceVoice_FlushSourceBuffers(voice->voice); 
-	// Calculate the sample to seek to.
-	uint32_t sample = ((position / 1000.0f) * voice->format.nSamplesPerSec);
-	auto buffer = voice->buffer->buffer;
-	if (voice->looped)
-		buffer.LoopCount = FAUDIO_LOOP_INFINITE;
-	else
-		buffer.LoopBegin = buffer.LoopLength = buffer.LoopCount = 0;
+	FAudioSourceVoice_FlushSourceBuffers(voice->voice);
 
-	buffer.PlayBegin = (uint32_t)sample;
-	FAudioSourceVoice_SubmitSourceBuffer(voice->voice, &buffer, nullptr);  
-	voice->finishedBuffers = 0;
-	voice->state = MGSoundState::Playing;
+	// Note: currenly, SoundEffectInstances don't have their format initialized,
+	// causing their values to always be 0, making this method unusable (it will restart the audio instead)
+	assert(voice->format.nBlockAlign > 0);
+	assert(voice->format.nChannels > 0);
+	assert(voice->format.nSamplesPerSec > 0);
+	assert(voice->format.wBitsPerSample > 0);
+
+	uint32_t sample = (uint32_t)(position * voice->format.nSamplesPerSec); 
+
+	auto buffer = voice->buffer->buffer;
+	buffer.PlayBegin = sample;
+	buffer.PlayLength = 0;
+
+	if (voice->looped)
+	{
+		buffer.LoopCount = FAUDIO_LOOP_INFINITE;
+		buffer.LoopBegin = sample;
+	}
+	else
+	{
+		buffer.LoopCount = 0;
+	}
+
+	FAudioSourceVoice_SubmitSourceBuffer(voice->voice, &buffer, nullptr);
 	FAudioSourceVoice_Start(voice->voice, 0, FAUDIO_COMMIT_NOW);
+
+	voice->state = MGSoundState::Playing;
 }
 
 static void MGA_Voice_UpdateOutputMatrix(MGA_Voice* voice)

--- a/native/monogame/faudio/MGA_faudio.cpp
+++ b/native/monogame/faudio/MGA_faudio.cpp
@@ -717,10 +717,7 @@ void MGA_Voice_SetPosition(MGA_Voice* voice, mgdouble position)
 		buffer.LoopCount = 0;
 	}
 
-	FAudioSourceVoice_SubmitSourceBuffer(voice->voice, &buffer, nullptr);
-	FAudioSourceVoice_Start(voice->voice, 0, FAUDIO_COMMIT_NOW);
-
-	voice->state = MGSoundState::Playing;
+	FAudioSourceVoice_SubmitSourceBuffer(voice->voice, &buffer, nullptr); 
 }
 
 static void MGA_Voice_UpdateOutputMatrix(MGA_Voice* voice)

--- a/native/monogame/include/api_MGA.h
+++ b/native/monogame/include/api_MGA.h
@@ -38,7 +38,7 @@ MG_EXPORT void MGA_Voice_Resume(MGA_Voice* voice);
 MG_EXPORT void MGA_Voice_Stop(MGA_Voice* voice, mgbyte immediate);
 MG_EXPORT MGSoundState MGA_Voice_GetState(MGA_Voice* voice);
 MG_EXPORT mgulong MGA_Voice_GetPosition(MGA_Voice* voice);
-MG_EXPORT void MGA_Voice_SetPosition(MGA_Voice* voice, mgulong position);
+MG_EXPORT void MGA_Voice_SetPosition(MGA_Voice* voice, mgdouble position);
 MG_EXPORT void MGA_Voice_SetPan(MGA_Voice* voice, mgfloat pan);
 MG_EXPORT void MGA_Voice_SetPitch(MGA_Voice* voice, mgfloat pitch);
 MG_EXPORT void MGA_Voice_SetVolume(MGA_Voice* voice, mgfloat volume);

--- a/native/monogame/include/api_MGA.h
+++ b/native/monogame/include/api_MGA.h
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
                 
@@ -38,6 +38,7 @@ MG_EXPORT void MGA_Voice_Resume(MGA_Voice* voice);
 MG_EXPORT void MGA_Voice_Stop(MGA_Voice* voice, mgbyte immediate);
 MG_EXPORT MGSoundState MGA_Voice_GetState(MGA_Voice* voice);
 MG_EXPORT mgulong MGA_Voice_GetPosition(MGA_Voice* voice);
+MG_EXPORT void MGA_Voice_SetPosition(MGA_Voice* voice, mgulong position);
 MG_EXPORT void MGA_Voice_SetPan(MGA_Voice* voice, mgfloat pan);
 MG_EXPORT void MGA_Voice_SetPitch(MGA_Voice* voice, mgfloat pitch);
 MG_EXPORT void MGA_Voice_SetVolume(MGA_Voice* voice, mgfloat volume);


### PR DESCRIPTION

### Description of Change

Allow the programmer to move to a specific position/offset (in TimeSpan format) of an AudioEffect(Instance) or Song to play from, in OpenAL/XAudio/MGA_*. (Or to receive the current position/offset position the player is at). 

Historically it's been noted that changing the offset/position of a audio while it's still playing causes runtime errors, so I've enforced that it cannot be changed **unless** it has been stopped beforehand. 


**OpenAL**
In OpenAL, I use alGetSourcef with AL_SEC_OFFSET to set the offset.  I've also removed a redundant if-statement, given no other value is possible once that code is reached. 

**XAudio**
In XAudio, I reset the buffer and assign a PlayBegin value according to the desired input. (This was recommended online)

**MGA (Native)**

Given the volatility of native code, given the many platforms it can run on, I decided to play it safe; stop the sound, reset the buffer, set the beginning value (similar to XAudio) and then hit play again.  Although the audio shouldn't be playing at that point, I decided to play it safe and presume it is somehow still playing.


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

**Note:** I have tested this on MonoGame DesktopGL, DirectX and Native, but I cannot verify it works as intended on Android, iOS or consoles. Also, myy C++ skills are rusty (as I was trained back in the day in C++03 and haven't really touched it since) so I do not know if the code I created is 100% memory-leak or process-issues safe. I would like someone to reproduce locally, to prevent potential issues, I've made it mandatory that one must stop the audio before changing the offset. 
