### PR TITLE
Added some bitwise operators to keyboard state

### DIFF
--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -18,10 +18,13 @@ namespace Microsoft.Xna.Framework.Input
         /// <summary>
         /// Returns a <see cref="KeyboardState"/> with no keys or modifiers set.
         /// </summary>
-        public static KeyboardState Empty => default;
+        public static KeyboardState Empty = default;
 
         // Used for the common situation where GetPressedKeys will return an empty array
         private static Keys[] empty = new Keys[0];
+
+        // Used to mask out modifier keys when checking for any key presses
+        private static KeyboardState modifiers = new KeyboardState(Keys.LeftShift, Keys.RightShift, Keys.LeftControl, Keys.RightControl, Keys.LeftAlt, Keys.RightAlt);
 
         #region Key Data
 
@@ -177,6 +180,71 @@ namespace Microsoft.Xna.Framework.Input
         public KeyState this[Keys key]
         {
             get { return InternalGetKey(key) ? KeyState.Down : KeyState.Up; }
+        }
+
+        /// <summary>
+        /// Gets whether any non-modifier key is currently pressed.
+        /// </summary>
+        /// <returns>true if any non-modifier key is pressed; false otherwise.</returns>
+        public bool AnyKeyDown()
+        {
+            return (_keys0 & ~modifiers._keys0) != 0
+                || (_keys1 & ~modifiers._keys1) != 0
+                || (_keys2 & ~modifiers._keys2) != 0
+                || (_keys3 & ~modifiers._keys3) != 0
+                || (_keys4 & ~modifiers._keys4) != 0
+                || (_keys5 & ~modifiers._keys5) != 0
+                || (_keys6 & ~modifiers._keys6) != 0
+                || (_keys7 & ~modifiers._keys7) != 0;
+        }
+
+        /// <summary>
+        /// Gets whether any key or modifier is currently pressed.
+        /// </summary>
+        /// <returns>true if any key or modifier is pressed; false otherwise.</returns>
+        public bool AnyKeyOrModifierDown()
+        {
+            return (_keys0 | _keys1 | _keys2 | _keys3 | _keys4 | _keys5 | _keys6 | _keys7) != 0;
+        }
+
+        /// <summary>
+        /// Gets whether any of the specified non-modifier keys are currently pressed.
+        /// </summary>
+        /// <param name="keys">The keys to query.</param>
+        /// <returns>true if any of the specified non-modifier keys are pressed; false otherwise.</returns>
+        public bool AnyKeyDown(KeyboardState keys)
+        {
+            return (this & keys).AnyKeyDown();
+        }
+
+        /// <summary>
+        /// Gets whether any of the specified keys or modifiers are currently pressed.
+        /// </summary>
+        /// <param name="keys">The keys to query.</param>
+        /// <returns>true if any of the specified keys or modifiers are pressed; false otherwise.</returns>
+        public bool AnyKeyOrModifierDown(KeyboardState keys)
+        {
+            return (this & keys).AnyKeyOrModifierDown();
+        }
+
+        /// <summary>
+        /// Gets whether any non-modifier key, excluding the specified keys, is currently pressed.
+        /// </summary>
+        /// <param name="keys">The keys to query.</param>
+        /// <returns>true if any non-modifier key, excluding the specified keys, is pressed; false otherwise.</returns>
+        public bool AnyKeyDownExcept(KeyboardState keys)
+        {
+            return (this & ~keys).AnyKeyDown();
+        }
+
+        /// <summary>
+        /// Gets whether any key or modifier, excluding the specified keys, is currently pressed.
+        /// </summary>
+        /// <param name="keys">The keys to query.</param>
+        /// <returns>true if any key or modifier, excluding the specified keys, is pressed; false otherwise.</returns>
+        public bool AnyKeyOrModifierDownExcept(KeyboardState keys)
+        {
+            return (this & ~keys).AnyKeyOrModifierDown();
         }
 
         /// <summary>
@@ -338,25 +406,6 @@ namespace Microsoft.Xna.Framework.Input
         public override bool Equals(object obj)
         {
             return obj is KeyboardState && this == (KeyboardState)obj;
-        }
-
-        /// <summary>
-        /// Compares whether current instance shares any keys or modifiers in the specified object.
-        /// </summary>
-        /// <param name="obj">The <see cref="KeyboardState"/> to compare.</param>
-        /// <returns>true if the provided <see cref="KeyboardState"/> instance shares any keys or modifiers as the current; false otherwise.</returns>
-        public bool Any(KeyboardState obj)
-        {
-            return
-                (_keys0 & obj._keys0) != 0
-                || (_keys1 & obj._keys1) != 0
-                || (_keys2 & obj._keys2) != 0
-                || (_keys3 & obj._keys3) != 0
-                || (_keys4 & obj._keys4) != 0
-                || (_keys5 & obj._keys5) != 0
-                || (_keys6 & obj._keys6) != 0
-                || (_keys7 & obj._keys7) != 0
-                || (_modifiers & obj._modifiers) != 0;
         }
 
         /// <summary>

--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Xna.Framework.Input
     /// </summary>
 	public struct KeyboardState
     {
-        private const byte CapsLockModifier = 1;
-        private const byte NumLockModifier = 2;
+        private const byte CapsLockToggle = 1;
+        private const byte NumLockToggle = 2;
 
         /// <summary>
         /// Returns a <see cref="KeyboardState"/> with no keys or modifiers set.
@@ -30,7 +30,7 @@ namespace Microsoft.Xna.Framework.Input
 
         // Array of 256 bits:
         private uint _keys0, _keys1, _keys2, _keys3, _keys4, _keys5, _keys6, _keys7;
-        private byte _modifiers;
+        private byte _toggles;
 
         bool InternalGetKey(Keys key)
         {
@@ -102,7 +102,7 @@ namespace Microsoft.Xna.Framework.Input
 
         #region XNA Interface
 
-        internal KeyboardState(uint keys0, uint keys1, uint keys2, uint keys3, uint keys4, uint keys5, uint keys6, uint keys7, byte modifiers) : this()
+        internal KeyboardState(uint keys0, uint keys1, uint keys2, uint keys3, uint keys4, uint keys5, uint keys6, uint keys7, byte toggles) : this()
         {
             _keys0 = keys0;
             _keys1 = keys1;
@@ -112,12 +112,12 @@ namespace Microsoft.Xna.Framework.Input
             _keys5 = keys5;
             _keys6 = keys6;
             _keys7 = keys7;
-            _modifiers = modifiers;
+            _toggles = toggles;
         }
 
         internal KeyboardState(List<Keys> keys, bool capsLock = false, bool numLock = false) : this()
         {
-            _modifiers = (byte)(0 | (capsLock ? CapsLockModifier : 0) | (numLock ? NumLockModifier : 0));
+            _toggles = (byte)(0 | (capsLock ? CapsLockToggle : 0) | (numLock ? NumLockToggle : 0));
 
             if (keys != null)
                 for (var i = 0; i < keys.Count; i++)
@@ -132,7 +132,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="numLock">Num Lock state.</param>
         public KeyboardState(Keys[] keys, bool capsLock = false, bool numLock = false) : this()
         {
-            _modifiers = (byte)(0 | (capsLock ? CapsLockModifier : 0) | (numLock ? NumLockModifier : 0));
+            _toggles = (byte)(0 | (capsLock ? CapsLockToggle : 0) | (numLock ? NumLockToggle : 0));
 
             if (keys != null)
                 for (var i = 0; i < keys.Length; i++)
@@ -157,7 +157,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return (_modifiers & CapsLockModifier) > 0;
+                return (_toggles & CapsLockToggle) > 0;
             }
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return (_modifiers & NumLockModifier) > 0;
+                return (_toggles & NumLockToggle) > 0;
             }
         }
 
@@ -183,68 +183,45 @@ namespace Microsoft.Xna.Framework.Input
         }
 
         /// <summary>
-        /// Gets whether any non-modifier key is currently pressed.
+        /// Gets whether any key is currently pressed.
         /// </summary>
-        /// <returns>true if any non-modifier key is pressed; false otherwise.</returns>
-        public bool AnyKeyDown()
+        /// <param name="includeModifiers">Whether to include modifier keys in the query.</param>
+        /// <returns>true if any key is pressed; false otherwise.</returns>
+        public bool AnyKeyDown(bool includeModifiers = true)
         {
-            return (_keys0 & ~modifiers._keys0) != 0
-                || (_keys1 & ~modifiers._keys1) != 0
-                || (_keys2 & ~modifiers._keys2) != 0
-                || (_keys3 & ~modifiers._keys3) != 0
-                || (_keys4 & ~modifiers._keys4) != 0
-                || (_keys5 & ~modifiers._keys5) != 0
-                || (_keys6 & ~modifiers._keys6) != 0
-                || (_keys7 & ~modifiers._keys7) != 0;
+            if(includeModifiers)
+                return (_keys0 | _keys1 | _keys2 | _keys3 | _keys4 | _keys5 | _keys6 | _keys7) != 0;
+            else
+                return (_keys0 & ~modifiers._keys0) != 0
+                    || (_keys1 & ~modifiers._keys1) != 0
+                    || (_keys2 & ~modifiers._keys2) != 0
+                    || (_keys3 & ~modifiers._keys3) != 0
+                    || (_keys4 & ~modifiers._keys4) != 0
+                    || (_keys5 & ~modifiers._keys5) != 0
+                    || (_keys6 & ~modifiers._keys6) != 0
+                    || (_keys7 & ~modifiers._keys7) != 0;
         }
 
         /// <summary>
-        /// Gets whether any key or modifier is currently pressed.
-        /// </summary>
-        /// <returns>true if any key or modifier is pressed; false otherwise.</returns>
-        public bool AnyKeyOrModifierDown()
-        {
-            return (_keys0 | _keys1 | _keys2 | _keys3 | _keys4 | _keys5 | _keys6 | _keys7) != 0;
-        }
-
-        /// <summary>
-        /// Gets whether any of the specified non-modifier keys are currently pressed.
+        /// Gets whether any of the specified keys are currently pressed.
         /// </summary>
         /// <param name="keys">The keys to query.</param>
-        /// <returns>true if any of the specified non-modifier keys are pressed; false otherwise.</returns>
-        public bool AnyKeyDown(KeyboardState keys)
+        /// <param name="includeModifiers">Whether to include modifier keys in the query.</param>
+        /// <returns>true if any of the specified keys are pressed; false otherwise.</returns>
+        public bool AnyKeyDown(KeyboardState keys, bool includeModifiers = true)
         {
-            return (this & keys).AnyKeyDown();
+            return (this & keys).AnyKeyDown(includeModifiers);
         }
 
         /// <summary>
-        /// Gets whether any of the specified keys or modifiers are currently pressed.
+        /// Gets whether any key, excluding the specified keys, is currently pressed.
         /// </summary>
         /// <param name="keys">The keys to query.</param>
-        /// <returns>true if any of the specified keys or modifiers are pressed; false otherwise.</returns>
-        public bool AnyKeyOrModifierDown(KeyboardState keys)
+        /// <param name="includeModifiers">Whether to include modifier keys in the query.</param>
+        /// <returns>true if any key, excluding the specified keys, is pressed; false otherwise.</returns>
+        public bool AnyKeyDownExcept(KeyboardState keys, bool includeModifiers = true)
         {
-            return (this & keys).AnyKeyOrModifierDown();
-        }
-
-        /// <summary>
-        /// Gets whether any non-modifier key, excluding the specified keys, is currently pressed.
-        /// </summary>
-        /// <param name="keys">The keys to query.</param>
-        /// <returns>true if any non-modifier key, excluding the specified keys, is pressed; false otherwise.</returns>
-        public bool AnyKeyDownExcept(KeyboardState keys)
-        {
-            return (this & ~keys).AnyKeyDown();
-        }
-
-        /// <summary>
-        /// Gets whether any key or modifier, excluding the specified keys, is currently pressed.
-        /// </summary>
-        /// <param name="keys">The keys to query.</param>
-        /// <returns>true if any key or modifier, excluding the specified keys, is pressed; false otherwise.</returns>
-        public bool AnyKeyOrModifierDownExcept(KeyboardState keys)
-        {
-            return (this & ~keys).AnyKeyOrModifierDown();
+            return (this & ~keys).AnyKeyDown(includeModifiers);
         }
 
         /// <summary>
@@ -413,7 +390,7 @@ namespace Microsoft.Xna.Framework.Input
         /// </summary>
         /// <param name="a"><see cref="KeyboardState"/> instance to the left of the bitwise AND operator.</param>
         /// <param name="b"><see cref="KeyboardState"/> instance to the right of the bitwise AND operator.</param>
-        /// <returns>A <see cref="KeyboardState"/> containing only the keys and modifiers present in both instances.</returns>
+        /// <returns>A <see cref="KeyboardState"/> containing only the keys and toggles present in both instances.</returns>
         public static KeyboardState operator &(KeyboardState a, KeyboardState b)
         {
             return new KeyboardState(
@@ -425,7 +402,7 @@ namespace Microsoft.Xna.Framework.Input
                 a._keys5 & b._keys5,
                 a._keys6 & b._keys6,
                 a._keys7 & b._keys7,
-                (byte)(a._modifiers & b._modifiers)
+                (byte)(a._toggles & b._toggles)
             );
         }
 
@@ -434,7 +411,7 @@ namespace Microsoft.Xna.Framework.Input
         /// </summary>
         /// <param name="a"><see cref="KeyboardState"/> instance to the left of the bitwise OR operator.</param>
         /// <param name="b"><see cref="KeyboardState"/> instance to the right of the bitwise OR operator.</param>
-        /// <returns>A <see cref="KeyboardState"/> containing all the keys and modifiers present in either instance.</returns>
+        /// <returns>A <see cref="KeyboardState"/> containing all the keys and toggles present in either instance.</returns>
         public static KeyboardState operator |(KeyboardState a, KeyboardState b)
         {
             return new KeyboardState(
@@ -446,7 +423,28 @@ namespace Microsoft.Xna.Framework.Input
                 a._keys5 | b._keys5,
                 a._keys6 | b._keys6,
                 a._keys7 | b._keys7,
-                (byte)(a._modifiers | b._modifiers)
+                (byte)(a._toggles | b._toggles)
+            );
+        }
+
+        /// <summary>
+        /// Performs a bitwise XOR operation between two <see cref="KeyboardState"/> instances.
+        /// </summary>
+        /// <param name="a"><see cref="KeyboardState"/> instance to the left of the bitwise XOR operator.</param>
+        /// <param name="b"><see cref="KeyboardState"/> instance to the right of the bitwise XOR operator.</param>
+        /// <returns>A <see cref="KeyboardState"/> containing only the keys and toggles present in one instance but not both.</returns>
+        public static KeyboardState operator ^(KeyboardState a, KeyboardState b)
+        {
+            return new KeyboardState(
+                a._keys0 ^ b._keys0,
+                a._keys1 ^ b._keys1,
+                a._keys2 ^ b._keys2,
+                a._keys3 ^ b._keys3,
+                a._keys4 ^ b._keys4,
+                a._keys5 ^ b._keys5,
+                a._keys6 ^ b._keys6,
+                a._keys7 ^ b._keys7,
+                (byte)(a._toggles ^ b._toggles)
             );
         }
 
@@ -454,7 +452,7 @@ namespace Microsoft.Xna.Framework.Input
         /// Performs a bitwise NOT operation on a <see cref="KeyboardState"/> instance.
         /// </summary>
         /// <param name="obj"><see cref="KeyboardState"/> instance to perform the bitwise NOT operation on.</param>
-        /// <returns>A <see cref="KeyboardState"/> with the all keys and modifiers inverted.</returns>
+        /// <returns>A <see cref="KeyboardState"/> with all the keys and toggles inverted.</returns>
         public static KeyboardState operator ~(KeyboardState obj)
         {
             return new KeyboardState(
@@ -466,7 +464,7 @@ namespace Microsoft.Xna.Framework.Input
                 ~obj._keys5,
                 ~obj._keys6,
                 ~obj._keys7,
-                (byte)~obj._modifiers
+                (byte)~obj._toggles
             );
         }
 

--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -94,6 +94,19 @@ namespace Microsoft.Xna.Framework.Input
 
         #region XNA Interface
 
+        internal KeyboardState(uint keys0, uint keys1, uint keys2, uint keys3, uint keys4, uint keys5, uint keys6, uint keys7, byte modifiers) : this()
+        {
+            _keys0 = keys0;
+            _keys1 = keys1;
+            _keys2 = keys2;
+            _keys3 = keys3;
+            _keys4 = keys4;
+            _keys5 = keys5;
+            _keys6 = keys6;
+            _keys7 = keys7;
+            _modifiers = modifiers;
+        }
+
         internal KeyboardState(List<Keys> keys, bool capsLock = false, bool numLock = false) : this()
         {
             _modifiers = (byte)(0 | (capsLock ? CapsLockModifier : 0) | (numLock ? NumLockModifier : 0));
@@ -320,6 +333,68 @@ namespace Microsoft.Xna.Framework.Input
         public override bool Equals(object obj)
         {
             return obj is KeyboardState && this == (KeyboardState)obj;
+        }
+
+        /// <summary>
+        /// Performs a bitwise AND operation between two <see cref="KeyboardState"/> instances.
+        /// </summary>
+        /// <param name="a"><see cref="KeyboardState"/> instance to the left of the bitwise AND operator.</param>
+        /// <param name="b"><see cref="KeyboardState"/> instance to the right of the bitwise AND operator.</param>
+        /// <returns>A <see cref="KeyboardState"/> containing only the keys and modifiers present in both instances.</returns>
+        public static KeyboardState operator &(KeyboardState a, KeyboardState b)
+        {
+            return new KeyboardState(
+                a._keys0 & b._keys0,
+                a._keys1 & b._keys1,
+                a._keys2 & b._keys2,
+                a._keys3 & b._keys3,
+                a._keys4 & b._keys4,
+                a._keys5 & b._keys5,
+                a._keys6 & b._keys6,
+                a._keys7 & b._keys7,
+                (byte)(a._modifiers & b._modifiers)
+            );
+        }
+
+        /// <summary>
+        /// Performs a bitwise OR operation between two <see cref="KeyboardState"/> instances.
+        /// </summary>
+        /// <param name="a"><see cref="KeyboardState"/> instance to the left of the bitwise OR operator.</param>
+        /// <param name="b"><see cref="KeyboardState"/> instance to the right of the bitwise OR operator.</param>
+        /// <returns>A <see cref="KeyboardState"/> containing all the keys and modifiers present in either instance.</returns>
+        public static KeyboardState operator |(KeyboardState a, KeyboardState b)
+        {
+            return new KeyboardState(
+                a._keys0 | b._keys0,
+                a._keys1 | b._keys1,
+                a._keys2 | b._keys2,
+                a._keys3 | b._keys3,
+                a._keys4 | b._keys4,
+                a._keys5 | b._keys5,
+                a._keys6 | b._keys6,
+                a._keys7 | b._keys7,
+                (byte)(a._modifiers | b._modifiers)
+            );
+        }
+
+        /// <summary>
+        /// Performs a bitwise NOT operation on a <see cref="KeyboardState"/> instance.
+        /// </summary>
+        /// <param name="obj"><see cref="KeyboardState"/> instance to perform the bitwise NOT operation on.</param>
+        /// <returns>A <see cref="KeyboardState"/> with the all keys and modifiers inverted.</returns>
+        public static KeyboardState operator ~(KeyboardState obj)
+        {
+            return new KeyboardState(
+                ~obj._keys0,
+                ~obj._keys1,
+                ~obj._keys2,
+                ~obj._keys3,
+                ~obj._keys4,
+                ~obj._keys5,
+                ~obj._keys6,
+                ~obj._keys7,
+                (byte)~obj._modifiers
+            );
         }
 
         #endregion

--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Xna.Framework.Input
         private const byte CapsLockModifier = 1;
         private const byte NumLockModifier = 2;
 
+        /// <summary>
+        /// Returns a <see cref="KeyboardState"/> with no keys or modifiers set.
+        /// </summary>
+        public static KeyboardState Empty => default;
+
         // Used for the common situation where GetPressedKeys will return an empty array
         private static Keys[] empty = new Keys[0];
 
@@ -333,6 +338,25 @@ namespace Microsoft.Xna.Framework.Input
         public override bool Equals(object obj)
         {
             return obj is KeyboardState && this == (KeyboardState)obj;
+        }
+
+        /// <summary>
+        /// Compares whether current instance shares any keys or modifiers in the specified object.
+        /// </summary>
+        /// <param name="obj">The <see cref="KeyboardState"/> to compare.</param>
+        /// <returns>true if the provided <see cref="KeyboardState"/> instance shares any keys or modifiers as the current; false otherwise.</returns>
+        public bool Any(KeyboardState obj)
+        {
+            return
+                (_keys0 & obj._keys0) != 0
+                || (_keys1 & obj._keys1) != 0
+                || (_keys2 & obj._keys2) != 0
+                || (_keys3 & obj._keys3) != 0
+                || (_keys4 & obj._keys4) != 0
+                || (_keys5 & obj._keys5) != 0
+                || (_keys6 & obj._keys6) != 0
+                || (_keys7 & obj._keys7) != 0
+                || (_modifiers & obj._modifiers) != 0;
         }
 
         /// <summary>

--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -120,8 +120,8 @@ namespace Microsoft.Xna.Framework.Input
             _modifiers = (byte)(0 | (capsLock ? CapsLockModifier : 0) | (numLock ? NumLockModifier : 0));
 
             if (keys != null)
-                foreach (Keys k in keys)
-                    InternalSetKey(k);
+                for (var i = 0; i < keys.Count; i++)
+                    InternalSetKey(keys[i]);
         }
 
         /// <summary>
@@ -135,8 +135,8 @@ namespace Microsoft.Xna.Framework.Input
             _modifiers = (byte)(0 | (capsLock ? CapsLockModifier : 0) | (numLock ? NumLockModifier : 0));
 
             if (keys != null)
-                foreach (Keys k in keys)
-                    InternalSetKey(k);
+                for (var i = 0; i < keys.Length; i++)
+                    InternalSetKey(keys[i]);
         }
 
         /// <summary>
@@ -146,8 +146,8 @@ namespace Microsoft.Xna.Framework.Input
         public KeyboardState(params Keys[] keys) : this()
         {
             if (keys != null)
-                foreach (Keys k in keys)
-                    InternalSetKey(k);
+                for (var i = 0; i < keys.Length; i++)
+                    InternalSetKey(keys[i]);
         }
 
         /// <summary>

--- a/Tests/Framework/Input/KeyboardTest.cs
+++ b/Tests/Framework/Input/KeyboardTest.cs
@@ -72,5 +72,30 @@ namespace MonoGame.Tests.Input
 
             CollectionAssert.AreEquivalent(keys, newKeysArray);
         }
+
+        [Test]
+        public void TestBitwiseOperations()
+        {
+            var azState = new KeyboardState(Keys.A, Keys.B, Keys.C, Keys.D, Keys.E, Keys.F, Keys.G, Keys.H, Keys.I, Keys.J, Keys.K, Keys.L, Keys.M, Keys.N, Keys.O, Keys.P, Keys.Q, Keys.R, Keys.S, Keys.T, Keys.U, Keys.V, Keys.W, Keys.X, Keys.Y, Keys.Z);
+
+            var numState = new KeyboardState(Keys.D0, Keys.D1, Keys.D2, Keys.D3, Keys.D4, Keys.D5, Keys.D6, Keys.D7, Keys.D8, Keys.D9);
+
+            var randState = new KeyboardState(Keys.A, Keys.D0, Keys.F1);
+
+            var orState = azState | numState;
+            Assert.AreEqual(true, orState.IsKeyDown(Keys.A));
+            Assert.AreEqual(true, orState.IsKeyDown(Keys.D0));
+            Assert.AreEqual(false, orState.IsKeyDown(Keys.F1));
+
+            var invState = ~orState;
+            Assert.AreEqual(false, invState.IsKeyDown(Keys.A));
+            Assert.AreEqual(false, invState.IsKeyDown(Keys.D0));
+            Assert.AreEqual(true, invState.IsKeyDown(Keys.F1));
+
+            var andState = invState & randState;
+            Assert.AreEqual(false, andState.IsKeyDown(Keys.A));
+            Assert.AreEqual(false, andState.IsKeyDown(Keys.D0));
+            Assert.AreEqual(true, andState.IsKeyDown(Keys.F1));
+        }
     }
 }

--- a/Tests/Framework/Input/KeyboardTest.cs
+++ b/Tests/Framework/Input/KeyboardTest.cs
@@ -97,12 +97,85 @@ namespace MonoGame.Tests.Input
             Assert.AreEqual(true, invState.IsKeyDown(Keys.F1));
 
             var andState = invState & randState;
-            Assert.AreEqual(false, andState.Any(azState));
-            Assert.AreEqual(false, andState.Any(numState));
-            Assert.AreEqual(true, andState.Any(randState));
+            Assert.AreEqual(false, andState.AnyKeyDown(azState));
+            Assert.AreEqual(false, andState.AnyKeyDown(numState));
+            Assert.AreEqual(true, andState.AnyKeyDown(randState));
 
             var emptyState = andState & ~andState;
             Assert.AreEqual(emptyState, KeyboardState.Empty);
+
+            var aState = new KeyboardState(Keys.A);
+            var shfitAState = new KeyboardState(Keys.LeftShift, Keys.A);
+            var bState = new KeyboardState(Keys.B);
+            var shiftBState = new KeyboardState(Keys.LeftShift, Keys.B);
+            var shiftState = new KeyboardState(Keys.LeftShift);
+            var ctrlCState = new KeyboardState(Keys.LeftControl, Keys.C);
+
+            Assert.AreEqual(true, aState.AnyKeyDown());
+            Assert.AreEqual(false, shiftState.AnyKeyDown());
+            Assert.AreEqual(true, shfitAState.AnyKeyDown());
+
+            Assert.AreEqual(true, aState.AnyKeyOrModifierDown());
+            Assert.AreEqual(true, shiftState.AnyKeyOrModifierDown());
+            Assert.AreEqual(true, shfitAState.AnyKeyOrModifierDown());
+
+            // when keys == [A]
+            //   A =         true
+            //   Shift + A = true
+            //   Shift =     false
+            //   B =         false
+            //   Shift + B = false
+            // when keys == [Shift]
+            //   Shift     = false
+            Assert.AreEqual(true, aState.AnyKeyDown(aState));
+            Assert.AreEqual(true, shfitAState.AnyKeyDown(aState));
+            Assert.AreEqual(false, shiftState.AnyKeyDown(aState));
+            Assert.AreEqual(false, bState.AnyKeyDown(aState));
+            Assert.AreEqual(false, shiftBState.AnyKeyDown(aState));
+            Assert.AreEqual(false, ctrlCState.AnyKeyDown(aState));
+            Assert.AreEqual(false, shiftState.AnyKeyDown(shiftState));
+
+            // when keys == [A]
+            //   A =         true
+            //   Shift + A = true
+            //   Shift =     false
+            //   B =         false
+            //   Shift + B = false
+            // when keys == [Shift]
+            //   Shift     = true
+            Assert.AreEqual(true, aState.AnyKeyOrModifierDown(aState));
+            Assert.AreEqual(true, shfitAState.AnyKeyOrModifierDown(aState));
+            Assert.AreEqual(false, shiftState.AnyKeyOrModifierDown(aState));
+            Assert.AreEqual(false, bState.AnyKeyOrModifierDown(aState));
+            Assert.AreEqual(false, shiftBState.AnyKeyOrModifierDown(aState));
+            Assert.AreEqual(false, ctrlCState.AnyKeyOrModifierDown(aState));
+            Assert.AreEqual(true, shiftState.AnyKeyOrModifierDown(shiftState));
+
+            // when keys == [A]
+            //   A =         false
+            //   Shift + A = false
+            //   Shift =     false
+            //   B =         true
+            //   Shift + B = true
+            Assert.AreEqual(false, aState.AnyKeyDownExcept(aState));
+            Assert.AreEqual(false, shfitAState.AnyKeyDownExcept(aState));
+            Assert.AreEqual(false, shiftState.AnyKeyDownExcept(aState));
+            Assert.AreEqual(true, bState.AnyKeyDownExcept(aState));
+            Assert.AreEqual(true, shiftBState.AnyKeyDownExcept(aState));
+            Assert.AreEqual(true, ctrlCState.AnyKeyDownExcept(aState));
+
+            // when keys == [A]
+            //   A =         false
+            //   Shift + A = true
+            //   Shift =     true
+            //   B =         true
+            //   Shift + B = true
+            Assert.AreEqual(false, aState.AnyKeyOrModifierDownExcept(aState));
+            Assert.AreEqual(true, shfitAState.AnyKeyOrModifierDownExcept(aState));
+            Assert.AreEqual(true, shiftState.AnyKeyOrModifierDownExcept(aState));
+            Assert.AreEqual(true, bState.AnyKeyOrModifierDownExcept(aState));
+            Assert.AreEqual(true, shiftBState.AnyKeyOrModifierDownExcept(aState));
+            Assert.AreEqual(true, ctrlCState.AnyKeyOrModifierDownExcept(aState));
         }
     }
 }

--- a/Tests/Framework/Input/KeyboardTest.cs
+++ b/Tests/Framework/Input/KeyboardTest.cs
@@ -84,18 +84,25 @@ namespace MonoGame.Tests.Input
 
             var orState = azState | numState;
             Assert.AreEqual(true, orState.IsKeyDown(Keys.A));
+            Assert.AreEqual(true, orState.IsKeyDown(Keys.Z));
             Assert.AreEqual(true, orState.IsKeyDown(Keys.D0));
+            Assert.AreEqual(true, orState.IsKeyDown(Keys.D9));
             Assert.AreEqual(false, orState.IsKeyDown(Keys.F1));
 
             var invState = ~orState;
             Assert.AreEqual(false, invState.IsKeyDown(Keys.A));
+            Assert.AreEqual(false, invState.IsKeyDown(Keys.Z));
             Assert.AreEqual(false, invState.IsKeyDown(Keys.D0));
+            Assert.AreEqual(false, invState.IsKeyDown(Keys.D9));
             Assert.AreEqual(true, invState.IsKeyDown(Keys.F1));
 
             var andState = invState & randState;
-            Assert.AreEqual(false, andState.IsKeyDown(Keys.A));
-            Assert.AreEqual(false, andState.IsKeyDown(Keys.D0));
-            Assert.AreEqual(true, andState.IsKeyDown(Keys.F1));
+            Assert.AreEqual(false, andState.Any(azState));
+            Assert.AreEqual(false, andState.Any(numState));
+            Assert.AreEqual(true, andState.Any(randState));
+
+            var emptyState = andState & ~andState;
+            Assert.AreEqual(emptyState, KeyboardState.Empty);
         }
     }
 }

--- a/Tests/Framework/Input/KeyboardTest.cs
+++ b/Tests/Framework/Input/KeyboardTest.cs
@@ -89,6 +89,13 @@ namespace MonoGame.Tests.Input
             Assert.AreEqual(true, orState.IsKeyDown(Keys.D9));
             Assert.AreEqual(false, orState.IsKeyDown(Keys.F1));
 
+            var xorState = orState ^ randState;
+            Assert.AreEqual(false, xorState.IsKeyDown(Keys.A));
+            Assert.AreEqual(true, xorState.IsKeyDown(Keys.B));
+            Assert.AreEqual(false, xorState.IsKeyDown(Keys.D0));
+            Assert.AreEqual(true, xorState.IsKeyDown(Keys.D1));
+            Assert.AreEqual(true, xorState.IsKeyDown(Keys.F1));
+
             var invState = ~orState;
             Assert.AreEqual(false, invState.IsKeyDown(Keys.A));
             Assert.AreEqual(false, invState.IsKeyDown(Keys.Z));
@@ -111,13 +118,13 @@ namespace MonoGame.Tests.Input
             var shiftState = new KeyboardState(Keys.LeftShift);
             var ctrlCState = new KeyboardState(Keys.LeftControl, Keys.C);
 
-            Assert.AreEqual(true, aState.AnyKeyDown());
-            Assert.AreEqual(false, shiftState.AnyKeyDown());
-            Assert.AreEqual(true, shfitAState.AnyKeyDown());
+            Assert.AreEqual(true, aState.AnyKeyDown(includeModifiers: false));
+            Assert.AreEqual(false, shiftState.AnyKeyDown(includeModifiers: false));
+            Assert.AreEqual(true, shfitAState.AnyKeyDown(includeModifiers: false));
 
-            Assert.AreEqual(true, aState.AnyKeyOrModifierDown());
-            Assert.AreEqual(true, shiftState.AnyKeyOrModifierDown());
-            Assert.AreEqual(true, shfitAState.AnyKeyOrModifierDown());
+            Assert.AreEqual(true, aState.AnyKeyDown());
+            Assert.AreEqual(true, shiftState.AnyKeyDown());
+            Assert.AreEqual(true, shfitAState.AnyKeyDown());
 
             // when keys == [A]
             //   A =         true
@@ -127,13 +134,13 @@ namespace MonoGame.Tests.Input
             //   Shift + B = false
             // when keys == [Shift]
             //   Shift     = false
-            Assert.AreEqual(true, aState.AnyKeyDown(aState));
-            Assert.AreEqual(true, shfitAState.AnyKeyDown(aState));
-            Assert.AreEqual(false, shiftState.AnyKeyDown(aState));
-            Assert.AreEqual(false, bState.AnyKeyDown(aState));
-            Assert.AreEqual(false, shiftBState.AnyKeyDown(aState));
-            Assert.AreEqual(false, ctrlCState.AnyKeyDown(aState));
-            Assert.AreEqual(false, shiftState.AnyKeyDown(shiftState));
+            Assert.AreEqual(true, aState.AnyKeyDown(aState, includeModifiers: false));
+            Assert.AreEqual(true, shfitAState.AnyKeyDown(aState, includeModifiers: false));
+            Assert.AreEqual(false, shiftState.AnyKeyDown(aState, includeModifiers: false));
+            Assert.AreEqual(false, bState.AnyKeyDown(aState, includeModifiers: false));
+            Assert.AreEqual(false, shiftBState.AnyKeyDown(aState, includeModifiers: false));
+            Assert.AreEqual(false, ctrlCState.AnyKeyDown(aState, includeModifiers: false));
+            Assert.AreEqual(false, shiftState.AnyKeyDown(shiftState, includeModifiers: false));
 
             // when keys == [A]
             //   A =         true
@@ -143,13 +150,13 @@ namespace MonoGame.Tests.Input
             //   Shift + B = false
             // when keys == [Shift]
             //   Shift     = true
-            Assert.AreEqual(true, aState.AnyKeyOrModifierDown(aState));
-            Assert.AreEqual(true, shfitAState.AnyKeyOrModifierDown(aState));
-            Assert.AreEqual(false, shiftState.AnyKeyOrModifierDown(aState));
-            Assert.AreEqual(false, bState.AnyKeyOrModifierDown(aState));
-            Assert.AreEqual(false, shiftBState.AnyKeyOrModifierDown(aState));
-            Assert.AreEqual(false, ctrlCState.AnyKeyOrModifierDown(aState));
-            Assert.AreEqual(true, shiftState.AnyKeyOrModifierDown(shiftState));
+            Assert.AreEqual(true, aState.AnyKeyDown(aState));
+            Assert.AreEqual(true, shfitAState.AnyKeyDown(aState));
+            Assert.AreEqual(false, shiftState.AnyKeyDown(aState));
+            Assert.AreEqual(false, bState.AnyKeyDown(aState));
+            Assert.AreEqual(false, shiftBState.AnyKeyDown(aState));
+            Assert.AreEqual(false, ctrlCState.AnyKeyDown(aState));
+            Assert.AreEqual(true, shiftState.AnyKeyDown(shiftState));
 
             // when keys == [A]
             //   A =         false
@@ -157,12 +164,12 @@ namespace MonoGame.Tests.Input
             //   Shift =     false
             //   B =         true
             //   Shift + B = true
-            Assert.AreEqual(false, aState.AnyKeyDownExcept(aState));
-            Assert.AreEqual(false, shfitAState.AnyKeyDownExcept(aState));
-            Assert.AreEqual(false, shiftState.AnyKeyDownExcept(aState));
-            Assert.AreEqual(true, bState.AnyKeyDownExcept(aState));
-            Assert.AreEqual(true, shiftBState.AnyKeyDownExcept(aState));
-            Assert.AreEqual(true, ctrlCState.AnyKeyDownExcept(aState));
+            Assert.AreEqual(false, aState.AnyKeyDownExcept(aState, includeModifiers: false));
+            Assert.AreEqual(false, shfitAState.AnyKeyDownExcept(aState, includeModifiers: false));
+            Assert.AreEqual(false, shiftState.AnyKeyDownExcept(aState, includeModifiers: false));
+            Assert.AreEqual(true, bState.AnyKeyDownExcept(aState, includeModifiers: false));
+            Assert.AreEqual(true, shiftBState.AnyKeyDownExcept(aState, includeModifiers: false));
+            Assert.AreEqual(true, ctrlCState.AnyKeyDownExcept(aState, includeModifiers: false));
 
             // when keys == [A]
             //   A =         false
@@ -170,12 +177,12 @@ namespace MonoGame.Tests.Input
             //   Shift =     true
             //   B =         true
             //   Shift + B = true
-            Assert.AreEqual(false, aState.AnyKeyOrModifierDownExcept(aState));
-            Assert.AreEqual(true, shfitAState.AnyKeyOrModifierDownExcept(aState));
-            Assert.AreEqual(true, shiftState.AnyKeyOrModifierDownExcept(aState));
-            Assert.AreEqual(true, bState.AnyKeyOrModifierDownExcept(aState));
-            Assert.AreEqual(true, shiftBState.AnyKeyOrModifierDownExcept(aState));
-            Assert.AreEqual(true, ctrlCState.AnyKeyOrModifierDownExcept(aState));
+            Assert.AreEqual(false, aState.AnyKeyDownExcept(aState));
+            Assert.AreEqual(true, shfitAState.AnyKeyDownExcept(aState));
+            Assert.AreEqual(true, shiftState.AnyKeyDownExcept(aState));
+            Assert.AreEqual(true, bState.AnyKeyDownExcept(aState));
+            Assert.AreEqual(true, shiftBState.AnyKeyDownExcept(aState));
+            Assert.AreEqual(true, ctrlCState.AnyKeyDownExcept(aState));
         }
     }
 }


### PR DESCRIPTION
Fixes #9180

The goal here is to provide quicker way of checking multiple key states by using bitwise operations.

I also am creating an internal constructor that would be very useful on a specific console.

- Should XOR be added for full support?
- Should a `IsEmpty` boolean be added

