### PR TITLE
[Content.Pipeline] Add FontImporter

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/FontImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/FontImporter.cs
@@ -36,7 +36,7 @@ public class FontImporter : ContentImporter<FontDescription>
     /// <summary>
     /// Indicates if kerning information is used when drawing characters.
     /// </summary>
-    public bool UseKrning { get; set; }
+    public bool UseKerning { get; set; }
 
     /// <summary>
     /// Retrieves the set of characters to include in the processor output.
@@ -101,7 +101,7 @@ public class FontImporter : ContentImporter<FontDescription>
             Size = Size,
             Spacing = Spacing,
             Style = Style,
-            UseKerning = UseKrning,
+            UseKerning = UseKerning,
             Characters = characters,
             Identity = new ContentIdentity(new FileInfo(filename).FullName, "FontImporter")
         };

--- a/MonoGame.Framework.Content.Pipeline/FontImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/FontImporter.cs
@@ -1,0 +1,109 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System.Xml;
+using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline;
+
+/// <summary>
+/// Provides methods for reading font files for use in the Content Pipeline.
+/// </summary>
+[ContentImporter(".ttf", ".otf", DisplayName = "Sprite Font Importer - MonoGame", DefaultProcessor = "FontDescriptionProcessor")]
+public class FontImporter : ContentImporter<FontDescription>
+{
+    /// <summary>
+    /// Gets or sets the default character for the font.
+    /// </summary>
+    public char? DefaultCharacter { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size, in points, of the font.
+    /// </summary>
+    public float Size { get; set; } = 12;
+
+    /// <summary>
+    /// Gets or sets the amount of space, in pixels, to insert between letters in a string.
+    /// </summary>
+    public float Spacing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the style of the font, expressed as a combination of one or more FontDescriptionStyle flags.
+    /// </summary>
+    public FontDescriptionStyle Style { get; set; } = FontDescriptionStyle.Regular;
+
+    /// <summary>
+    /// Indicates if kerning information is used when drawing characters.
+    /// </summary>
+    public bool UseKrning { get; set; }
+
+    /// <summary>
+    /// Retrieves the set of characters to include in the processor output.
+    /// </summary>
+    public List<CharacterRegion> CharacterRegions { get; set; } = [new CharacterRegion((char)32, (char)126)];
+
+    /// <summary>
+    /// Allows including extra characters as specified by the resource files.
+    /// </summary>
+    public List<string> ResourceFiles { get; set; } = [];
+
+    /// <summary>
+    /// Called by the XNA Framework when importing a font file to be used as a game asset. This is the method called by the XNA Framework when an asset is to be imported into an object that can be recognized by the Content Pipeline.
+    /// </summary>
+    /// <param name="filename">Name of a game asset file.</param>
+    /// <param name="context">Contains information for importing a game asset, such as a logger interface.</param>
+    /// <returns>Resulting game asset.</returns>
+    public override FontDescription Import(string filename, ContentImporterContext context)
+    {
+        var characters = new HashSet<char>();
+
+        foreach (var characterRegion in CharacterRegions)
+        {
+            if (characterRegion.End < characterRegion.Start)
+                throw new ArgumentException("CharacterRegion.End must be greater than CharacterRegion.Start");
+
+            for (var start = characterRegion.Start; start <= characterRegion.End; start++)
+                characters.Add(start);
+        }
+
+        var fontDir = Path.GetDirectoryName(filename) ?? "";
+        foreach (var resourceFile in ResourceFiles)
+        {
+            var absolutePath = Path.Combine(Path.Combine(fontDir, resourceFile.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar)));
+            if (!File.Exists(absolutePath))
+            {
+                throw new InvalidContentException("Can't find " + absolutePath);
+            }
+
+            var xmlDocument = new XmlDocument();
+            xmlDocument.Load(absolutePath);
+
+            // Scan each string from the .resx file.
+            var modeList = xmlDocument.SelectNodes("root/data/value");
+            if (modeList != null)
+            {
+                foreach (XmlNode xmlNode in modeList)
+                {
+                    foreach (char usedCharacter in xmlNode.InnerText)
+                        characters.Add(usedCharacter);
+                }
+            }
+
+            // Mark that this font should be rebuilt if the resource file changes.
+            context.AddDependency(absolutePath);
+        }
+
+        return new()
+        {
+            DefaultCharacter = DefaultCharacter,
+            FontName = filename,
+            Size = Size,
+            Spacing = Spacing,
+            Style = Style,
+            UseKerning = UseKrning,
+            Characters = characters,
+            Identity = new ContentIdentity(new FileInfo(filename).FullName, "FontImporter")
+        };
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Processors/LocalizedFontProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/LocalizedFontProcessor.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
     /// use a small fraction of these. Building only the characters we need is far more
     /// efficient than if we tried to include the entire CJK character region.
     /// </summary>
+    [Obsolete($"Please use {nameof(FontImporter)} for importing and {nameof(FontDescriptionProcessor)} for processing instead.")]
     [ContentProcessor]
     public class LocalizedFontProcessor : ContentProcessor<LocalizedFontDescription,
                                                     SpriteFontContent>


### PR DESCRIPTION
Add a new `FontImporter` in which you can directly specify the properties that would otherwise go into a .spritefont file.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.