### PR TITLE
Nullable context for GraphicsDevice

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private Rectangle _scissorRectangle;
         private bool _scissorRectangleDirty;
 
+        // This is set to a non-null value in Initialize, so null forgiveness is safe after that
         private VertexBufferBindings? _vertexBuffers;
         private bool _vertexBuffersDirty;
 
@@ -246,7 +247,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Gets the graphics adapter.
         /// </summary>
-        public GraphicsAdapter Adapter => _adapter!;
+        public GraphicsAdapter Adapter { get => _adapter!; set => _adapter = value ?? throw new ArgumentNullException(nameof(value)); }
 
         internal GraphicsMetrics _graphicsMetrics;
 
@@ -256,6 +257,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         public GraphicsMetrics Metrics { get { return _graphicsMetrics; } set { _graphicsMetrics = value; } }
 
+        // This is set to a non-null value in CreateDeviceResources of the different platform implementations,
+        // so null forgiveness is safe after that
         private GraphicsDebug? _graphicsDebug;
 
         /// <summary>
@@ -290,7 +293,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new NoSuitableGraphicsDeviceException(String.Format("Adapter '{0}' does not support the {1} profile.", adapter.Description, graphicsProfile));
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
-            _adapter = adapter;
+            Adapter = adapter;
             PresentationParameters = presentationParameters;
             _graphicsProfile = graphicsProfile;
             Setup();
@@ -322,7 +325,7 @@ namespace Microsoft.Xna.Framework.Graphics
             // TODO we need to figure out how to inject the half pixel offset into DX shaders
             preferHalfPixelOffset = false;
 #endif
-            _adapter = adapter;
+            Adapter = adapter;
             _graphicsProfile = graphicsProfile;
             UseHalfPixelOffset = preferHalfPixelOffset;
             PresentationParameters = presentationParameters;
@@ -509,7 +512,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 // Static state properties never actually get bound;
                 // instead we use our GraphicsDevice-specific version of them.
-                var newBlendState = _blendState!;
+                BlendState newBlendState = _blendState!;
                 if (ReferenceEquals(_blendState, BlendState.Additive))
                     newBlendState = _blendStateAdditive;
                 else if (ReferenceEquals(_blendState, BlendState.AlphaBlend))

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -1005,7 +1005,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             int renderTargetWidth;
             int renderTargetHeight;
-            if (renderTargets == null)
+            if (renderTargets == null || renderTargets.Length == 0)
             {
                 _currentRenderTargetCount = 0;
 
@@ -1021,7 +1021,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 Array.Copy(renderTargets, _currentRenderTargetBindings, renderTargets.Length);
                 _currentRenderTargetCount = renderTargets.Length;
 
-                var renderTarget = PlatformApplyRenderTargets();
+                // This null forgiveness assumes that there will be at least 1 render target
+                // returned from PlatformApplyRenderTargets, because of the condition of this if block
+                var renderTarget = PlatformApplyRenderTargets()!;
 
                 // We clear the render target if asked.
                 clearTarget = renderTarget.RenderTargetUsage == RenderTargetUsage.DiscardContents;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -51,38 +53,38 @@ namespace Microsoft.Xna.Framework.Graphics
         private Color _blendFactor = Color.White;
         private bool _blendFactorDirty;
 
-        private BlendState _blendState;
-        private BlendState _actualBlendState;
+        private BlendState? _blendState;
+        private BlendState? _actualBlendState;
         private bool _blendStateDirty;
 
-        private BlendState _blendStateAdditive;
-        private BlendState _blendStateAlphaBlend;
-        private BlendState _blendStateNonPremultiplied;
-        private BlendState _blendStateOpaque;
+        private readonly BlendState _blendStateAdditive = BlendState.Additive.Clone();
+        private readonly BlendState _blendStateAlphaBlend = BlendState.AlphaBlend.Clone();
+        private readonly BlendState _blendStateNonPremultiplied = BlendState.NonPremultiplied.Clone();
+        private readonly BlendState _blendStateOpaque = BlendState.Opaque.Clone();
 
-        private DepthStencilState _depthStencilState;
-        private DepthStencilState _actualDepthStencilState;
+        private DepthStencilState? _depthStencilState;
+        private DepthStencilState? _actualDepthStencilState;
         private bool _depthStencilStateDirty;
 
-        private DepthStencilState _depthStencilStateDefault;
-        private DepthStencilState _depthStencilStateDepthRead;
-        private DepthStencilState _depthStencilStateNone;
+        private readonly DepthStencilState _depthStencilStateDefault = DepthStencilState.Default.Clone();
+        private readonly DepthStencilState _depthStencilStateDepthRead = DepthStencilState.DepthRead.Clone();
+        private readonly DepthStencilState _depthStencilStateNone = DepthStencilState.None.Clone();
 
-        private RasterizerState _rasterizerState;
-        private RasterizerState _actualRasterizerState;
+        private RasterizerState? _rasterizerState;
+        private RasterizerState? _actualRasterizerState;
         private bool _rasterizerStateDirty;
 
-        private RasterizerState _rasterizerStateCullClockwise;
-        private RasterizerState _rasterizerStateCullCounterClockwise;
-        private RasterizerState _rasterizerStateCullNone;
+        private readonly RasterizerState _rasterizerStateCullClockwise = RasterizerState.CullClockwise.Clone();
+        private readonly RasterizerState _rasterizerStateCullCounterClockwise = RasterizerState.CullCounterClockwise.Clone();
+        private readonly RasterizerState _rasterizerStateCullNone = RasterizerState.CullNone.Clone();
 
         private Rectangle _scissorRectangle;
         private bool _scissorRectangleDirty;
 
-        private VertexBufferBindings _vertexBuffers;
+        private VertexBufferBindings? _vertexBuffers;
         private bool _vertexBuffersDirty;
 
-        private IndexBuffer _indexBuffer;
+        private IndexBuffer? _indexBuffer;
         private bool _indexBufferDirty;
 
         private readonly RenderTargetBinding[] _currentRenderTargetBindings = new RenderTargetBinding[8];
@@ -91,40 +93,44 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal GraphicsCapabilities GraphicsCapabilities { get; private set; }
 
+        TextureCollection? _vertexTextures;
         /// <summary>
         /// Gets the collection of vertex textures that support texture lookup
         /// in the vertex shader using the texldl statement.
         /// The vertex engine contains four texture sampler stages.
         /// </summary>
-        public TextureCollection VertexTextures { get; private set; }
+        public TextureCollection VertexTextures => _vertexTextures!;
 
+        SamplerStateCollection? _vertexSamplerStates;
         /// <summary>
         /// Returns the collection of vertex sampler states.
         /// </summary>
-        public SamplerStateCollection VertexSamplerStates { get; private set; }
+        public SamplerStateCollection VertexSamplerStates => _vertexSamplerStates!;
 
+        TextureCollection? _textures;
         /// <summary>
         /// Returns the collection of textures that have been assigned to the texture stages of the device.
         /// </summary>
-        public TextureCollection Textures { get; private set; }
+        public TextureCollection Textures => _textures!;
 
+        SamplerStateCollection? _samplerStates;
         /// <summary>
         /// Retrieves a collection of <see cref="SamplerState"/> objects for the current <see cref="GraphicsDevice"/>.
         /// </summary>
-        public SamplerStateCollection SamplerStates { get; private set; }
+        public SamplerStateCollection SamplerStates => _samplerStates!;
 
         /// <summary>
         /// Get or set the color a <see cref="RenderTarget2D"/> is cleared to when it is set.
         /// </summary>
         public static Color DiscardColor {
-			get { return _discardColor; }
-			set { _discardColor = value; }
-		}
+            get { return _discardColor; }
+            set { _discardColor = value; }
+        }
 
         /// <summary>
         /// The active vertex shader.
         /// </summary>
-        private Shader _vertexShader;
+        private Shader? _vertexShader;
         private bool _vertexShaderDirty;
         private bool VertexShaderDirty
         {
@@ -134,7 +140,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// The active pixel shader.
         /// </summary>
-        private Shader _pixelShader;
+        private Shader? _pixelShader;
         private bool _pixelShaderDirty;
         private bool PixelShaderDirty
         {
@@ -147,7 +153,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// The cache of effects from unique byte streams.
         /// </summary>
-        internal Dictionary<int, Effect> EffectCache;
+        internal Dictionary<int, Effect>? EffectCache;
 
         // Resources may be added to and removed from the list from many threads.
         private readonly object _resourcesLock = new object();
@@ -161,36 +167,36 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Occurs when a GraphicsDevice is about to be lost (for example, immediately before a reset).
         /// </summary>
-        public event EventHandler<EventArgs> DeviceLost;
+        public event EventHandler<EventArgs> DeviceLost = delegate { };
 
         /// <summary>
         /// Occurs after a GraphicsDevice is reset, allowing an application to recreate all resources.
         /// </summary>
-		public event EventHandler<EventArgs> DeviceReset;
+		public event EventHandler<EventArgs> DeviceReset = delegate { };
 
         /// <summary>
         /// Occurs when a GraphicsDevice is resetting,
         /// allowing the application to cancel the default handling of the reset.
         /// </summary>
-		public event EventHandler<EventArgs> DeviceResetting;
+		public event EventHandler<EventArgs> DeviceResetting = delegate { };
 
         /// <summary>
         /// Occurs when a resource is created.
         /// </summary>
-		public event EventHandler<ResourceCreatedEventArgs> ResourceCreated;
+		public event EventHandler<ResourceCreatedEventArgs> ResourceCreated = delegate { };
 
         /// <summary>
         /// Occurs when a resource is destroyed.
         /// </summary>
-		public event EventHandler<ResourceDestroyedEventArgs> ResourceDestroyed;
+		public event EventHandler<ResourceDestroyedEventArgs> ResourceDestroyed = delegate { };
 
         /// <summary>
         /// Occurs when <see cref="Dispose()"/> is called
         /// or when this object is finalized and collected by the garbage collector.
         /// </summary>
-        public event EventHandler<EventArgs> Disposing;
+        public event EventHandler<EventArgs> Disposing = delegate { };
 
-        internal event EventHandler<PresentationEventArgs> PresentationChanged;
+        internal event EventHandler<PresentationEventArgs> PresentationChanged = delegate { };
 
         private int _maxVertexBufferSlots;
         internal int MaxTextureSlots;
@@ -212,11 +218,11 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
 		public bool IsContentLost {
 			get {
-				// We will just return IsDisposed for now
-				// as that is the only case I can see for now
-				return IsDisposed;
-			}
-		}
+                // We will just return IsDisposed for now
+                // as that is the only case I can see for now
+                return IsDisposed;
+            }
+        }
 
         internal bool IsRenderTargetBound
         {
@@ -236,14 +242,11 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        private GraphicsAdapter? _adapter;
         /// <summary>
         /// Gets the graphics adapter.
         /// </summary>
-        public GraphicsAdapter Adapter
-        {
-            get;
-            private set;
-        }
+        public GraphicsAdapter Adapter => _adapter!;
 
         internal GraphicsMetrics _graphicsMetrics;
 
@@ -253,15 +256,15 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         public GraphicsMetrics Metrics { get { return _graphicsMetrics; } set { _graphicsMetrics = value; } }
 
-        private GraphicsDebug _graphicsDebug;
+        private GraphicsDebug? _graphicsDebug;
 
         /// <summary>
         /// Access debugging APIs for the graphics subsystem.
         /// </summary>
-        public GraphicsDebug GraphicsDebug { get { return _graphicsDebug; } set { _graphicsDebug = value; } }
+        public GraphicsDebug GraphicsDebug { get { return _graphicsDebug!; } set { _graphicsDebug = value; } }
 
         internal GraphicsDevice()
-		{
+        {
             PresentationParameters = new PresentationParameters();
             PresentationParameters.DepthStencilFormat = DepthFormat.Depth24;
             Setup();
@@ -287,7 +290,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new NoSuitableGraphicsDeviceException(String.Format("Adapter '{0}' does not support the {1} profile.", adapter.Description, graphicsProfile));
             if (presentationParameters == null)
                 throw new ArgumentNullException("presentationParameters");
-            Adapter = adapter;
+            _adapter = adapter;
             PresentationParameters = presentationParameters;
             _graphicsProfile = graphicsProfile;
             Setup();
@@ -319,7 +322,7 @@ namespace Microsoft.Xna.Framework.Graphics
             // TODO we need to figure out how to inject the half pixel offset into DX shaders
             preferHalfPixelOffset = false;
 #endif
-            Adapter = adapter;
+            _adapter = adapter;
             _graphicsProfile = graphicsProfile;
             UseHalfPixelOffset = preferHalfPixelOffset;
             PresentationParameters = presentationParameters;
@@ -344,32 +347,19 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Initialize the main viewport
             _viewport = new Viewport (0, 0, DisplayMode.Width, DisplayMode.Height);
-			_viewport.MaxDepth = 1.0f;
+            _viewport.MaxDepth = 1.0f;
 
             PlatformSetup();
 
-            VertexTextures = new TextureCollection(this, MaxVertexTextureSlots, ShaderStage.Vertex);
-            VertexSamplerStates = new SamplerStateCollection(this, MaxVertexTextureSlots, ShaderStage.Vertex);
+            _vertexTextures = new TextureCollection(this, MaxVertexTextureSlots, ShaderStage.Vertex);
+            _vertexSamplerStates = new SamplerStateCollection(this, MaxVertexTextureSlots, ShaderStage.Vertex);
 
-            Textures = new TextureCollection(this, MaxTextureSlots, ShaderStage.Pixel);
-            SamplerStates = new SamplerStateCollection(this, MaxTextureSlots, ShaderStage.Pixel);
-
-            _blendStateAdditive = BlendState.Additive.Clone();
-            _blendStateAlphaBlend = BlendState.AlphaBlend.Clone();
-            _blendStateNonPremultiplied = BlendState.NonPremultiplied.Clone();
-            _blendStateOpaque = BlendState.Opaque.Clone();
+            _textures = new TextureCollection(this, MaxTextureSlots, ShaderStage.Pixel);
+            _samplerStates = new SamplerStateCollection(this, MaxTextureSlots, ShaderStage.Pixel);
 
             BlendState = BlendState.Opaque;
 
-            _depthStencilStateDefault = DepthStencilState.Default.Clone();
-            _depthStencilStateDepthRead = DepthStencilState.DepthRead.Clone();
-            _depthStencilStateNone = DepthStencilState.None.Clone();
-
             DepthStencilState = DepthStencilState.Default;
-
-            _rasterizerStateCullClockwise = RasterizerState.CullClockwise.Clone();
-            _rasterizerStateCullCounterClockwise = RasterizerState.CullCounterClockwise.Clone();
-            _rasterizerStateCullNone = RasterizerState.CullNone.Clone();
 
             RasterizerState = RasterizerState.CullCounterClockwise;
 
@@ -447,11 +437,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         public RasterizerState RasterizerState
         {
-            get
-            {
-                return _rasterizerState;
-            }
-
+            get => _rasterizerState ??= _rasterizerStateCullCounterClockwise;
             set
             {
                 if (value == null)
@@ -509,8 +495,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         public BlendState BlendState
         {
-			get { return _blendState; }
-			set
+            get => _blendState ??= _blendStateOpaque;
+            set
             {
                 if (value == null)
                     throw new ArgumentNullException("value");
@@ -519,11 +505,11 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (_blendState == value)
                     return;
 
-				_blendState = value;
+                _blendState = value;
 
                 // Static state properties never actually get bound;
                 // instead we use our GraphicsDevice-specific version of them.
-                var newBlendState = _blendState;
+                var newBlendState = _blendState!;
                 if (ReferenceEquals(_blendState, BlendState.Additive))
                     newBlendState = _blendStateAdditive;
                 else if (ReferenceEquals(_blendState, BlendState.AlphaBlend))
@@ -546,7 +532,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 _blendStateDirty = true;
             }
-		}
+        }
 
         /// <summary>
         /// Gets or sets a system-defined instance of a depth-stencil state object.
@@ -554,7 +540,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         public DepthStencilState DepthStencilState
         {
-            get { return _depthStencilState; }
+            get => _depthStencilState ??= _depthStencilStateDefault;
             set
             {
                 if (value == null)
@@ -590,15 +576,18 @@ namespace Microsoft.Xna.Framework.Graphics
 
             PlatformApplyBlend();
 
+            // Non-null assertions on _actualDepthStencilState and _actualRasterizerState here are because they are
+            // never null unless this graphics device has been disposed of or not yet initialized.
+
             if (_depthStencilStateDirty)
             {
-                _actualDepthStencilState.PlatformApplyState(this);
+                _actualDepthStencilState!.PlatformApplyState(this);
                 _depthStencilStateDirty = false;
             }
 
             if (_rasterizerStateDirty)
             {
-                _actualRasterizerState.PlatformApplyState(this);
+                _actualRasterizerState!.PlatformApplyState(this);
                 _rasterizerStateDirty = false;
             }
 
@@ -647,7 +636,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="depth">Set this depth value in the buffer.</param>
         /// <param name="stencil">Set this stencil value in the buffer.</param>
         public void Clear(ClearOptions options, Vector4 color, float depth, int stencil)
-		{
+        {
             PlatformClear(options, color, depth, stencil);
 
             unchecked
@@ -683,7 +672,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
 
                     // Clear the effect cache.
-                    EffectCache.Clear();
+                    EffectCache?.Clear();
 
                     _blendState = null;
                     _actualBlendState = null;
@@ -914,18 +903,18 @@ namespace Microsoft.Xna.Framework.Graphics
         /// A new render target for the device, or <see langword="null"/>
         /// to set the device render target to the back buffer of the device.
         /// </param>
-		public void SetRenderTarget(RenderTarget2D renderTarget)
-		{
-			if (renderTarget == null)
-		    {
+		public void SetRenderTarget(RenderTarget2D? renderTarget)
+        {
+            if (renderTarget == null)
+            {
                 SetRenderTargets(null);
-		    }
-			else
-			{
-				_tempRenderTargetBinding[0] = new RenderTargetBinding(renderTarget);
-				SetRenderTargets(_tempRenderTargetBinding);
-			}
-		}
+            }
+            else
+            {
+                _tempRenderTargetBinding[0] = new RenderTargetBinding(renderTarget);
+                SetRenderTargets(_tempRenderTargetBinding);
+            }
+        }
 
         /// <summary>
         /// Sets a new render target for this <see cref="GraphicsDevice"/>.
@@ -935,7 +924,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// to set the device render target to the back buffer of the device.
         /// </param>
         /// <param name="cubeMapFace">The cube map face type.</param>
-        public void SetRenderTarget(RenderTargetCube renderTarget, CubeMapFace cubeMapFace)
+        public void SetRenderTarget(RenderTargetCube? renderTarget, CubeMapFace cubeMapFace)
         {
             if (renderTarget == null)
             {
@@ -952,10 +941,10 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Sets an array of render targets.
         /// </summary>
         /// <param name="renderTargets">An array of render targets.</param>
-		public void SetRenderTargets(params RenderTargetBinding[] renderTargets)
-		{
+		public void SetRenderTargets(params RenderTargetBinding[]? renderTargets)
+        {
             // Avoid having to check for null and zero length.
-            var renderTargetCount = 0;
+            int renderTargetCount;
             if (renderTargets != null)
             {
                 renderTargetCount = renderTargets.Length;
@@ -964,9 +953,13 @@ namespace Microsoft.Xna.Framework.Graphics
                     renderTargets = null;
                 }
             }
+            else
+            {
+                renderTargetCount = 0;
+            }
 
             // Try to early out if the current and new bindings are equal.
-            if (_currentRenderTargetCount == renderTargetCount)
+            if (_currentRenderTargetCount == renderTargetCount && renderTargets is not null)
             {
                 var isEqual = true;
                 for (var i = 0; i < _currentRenderTargetCount; i++)
@@ -1001,7 +994,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        internal void ApplyRenderTargets(RenderTargetBinding[] renderTargets)
+        internal void ApplyRenderTargets(RenderTargetBinding[]? renderTargets)
         {
             var clearTarget = false;
 
@@ -1055,12 +1048,12 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         /// <returns>An array of bound render targets.</returns>
 		public RenderTargetBinding[] GetRenderTargets()
-		{
-            // Return a correctly sized copy our internal array.
+        {
+            // Return a correctly sized copy of our internal array.
             var bindings = new RenderTargetBinding[_currentRenderTargetCount];
             Array.Copy(_currentRenderTargetBindings, bindings, _currentRenderTargetCount);
             return bindings;
-		}
+        }
 
         /// <summary>
         /// Gets render target surfaces.
@@ -1079,11 +1072,12 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Sets or binds a vertex buffer to a device.
         /// </summary>
         /// <param name="vertexBuffer">A vertex buffer.</param>
-        public void SetVertexBuffer(VertexBuffer vertexBuffer)
+        public void SetVertexBuffer(VertexBuffer? vertexBuffer)
         {
+            // Non-null assertions here are justified because Initialize should have been called before this method is callable
             _vertexBuffersDirty |= (vertexBuffer == null)
-                                   ? _vertexBuffers.Clear()
-                                   : _vertexBuffers.Set(vertexBuffer, 0);
+                                   ? _vertexBuffers!.Clear()
+                                   : _vertexBuffers!.Set(vertexBuffer, 0);
         }
 
         /// <summary>
@@ -1095,7 +1089,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <paramref name="vertexOffset"/> is less than 0
         /// OR is greater than or equal to <paramref name="vertexBuffer"/>.VertexCount.
         /// </exception>
-        public void SetVertexBuffer(VertexBuffer vertexBuffer, int vertexOffset)
+        public void SetVertexBuffer(VertexBuffer? vertexBuffer, int vertexOffset)
         {
             // Validate vertexOffset.
             if (vertexOffset < 0
@@ -1105,9 +1099,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentOutOfRangeException("vertexOffset");
             }
 
+            // Non-null assertions here are justified because Initialize should have been called before this method is callable
             _vertexBuffersDirty |= (vertexBuffer == null)
-                                   ? _vertexBuffers.Clear()
-                                   : _vertexBuffers.Set(vertexBuffer, vertexOffset);
+                                   ? _vertexBuffers!.Clear()
+                                   : _vertexBuffers!.Set(vertexBuffer, vertexOffset);
         }
 
         /// <summary>
@@ -1117,11 +1112,11 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <exception cref="ArgumentOutOfRangeException">
         /// Length of <paramref name="vertexBuffers"/> is more than max allowed number of vertex buffers.
         /// </exception>
-        public void SetVertexBuffers(params VertexBufferBinding[] vertexBuffers)
+        public void SetVertexBuffers(params VertexBufferBinding[]? vertexBuffers)
         {
             if (vertexBuffers == null || vertexBuffers.Length == 0)
             {
-                _vertexBuffersDirty |= _vertexBuffers.Clear();
+                _vertexBuffersDirty |= _vertexBuffers!.Clear();
             }
             else
             {
@@ -1131,25 +1126,27 @@ namespace Microsoft.Xna.Framework.Graphics
                     throw new ArgumentOutOfRangeException("vertexBuffers", message);
                 }
 
-                _vertexBuffersDirty |= _vertexBuffers.Set(vertexBuffers);
+                _vertexBuffersDirty |= _vertexBuffers!.Set(vertexBuffers);
             }
-        }
-
-        private void SetIndexBuffer(IndexBuffer indexBuffer)
-        {
-            if (_indexBuffer == indexBuffer)
-                return;
-
-            _indexBuffer = indexBuffer;
-            _indexBufferDirty = true;
         }
 
         /// <summary>
         /// Gets or sets index data. The default value is <see langword="null"/>.
         /// </summary>
-        public IndexBuffer Indices { set { SetIndexBuffer(value); } get { return _indexBuffer; } }
+        public IndexBuffer? Indices
+        {
+            get => _indexBuffer;
+            set
+            {
+                if (_indexBuffer == value)
+                    return;
 
-        internal Shader VertexShader
+                _indexBuffer = value;
+                _indexBufferDirty = true;
+            }
+        }
+
+        internal Shader? VertexShader
         {
             get { return _vertexShader; }
 
@@ -1164,7 +1161,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        internal Shader PixelShader
+        internal Shader? PixelShader
         {
             get { return _pixelShader; }
 
@@ -1220,7 +1217,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (_vertexShader == null)
                 throw new InvalidOperationException("Vertex shader must be set before calling DrawIndexedPrimitives.");
 
-            if (_vertexBuffers.Count == 0)
+            if (_vertexBuffers?.Count == 0)
                 throw new InvalidOperationException("Vertex buffer must be set before calling DrawIndexedPrimitives.");
 
             if (_indexBuffer == null)
@@ -1307,7 +1304,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (_vertexShader == null)
                 throw new InvalidOperationException("Vertex shader must be set before calling DrawPrimitives.");
 
-            if (_vertexBuffers.Count == 0)
+            if (_vertexBuffers?.Count == 0)
                 throw new InvalidOperationException("Vertex buffer must be set before calling DrawPrimitives.");
 
             if (primitiveCount <= 0)
@@ -1531,7 +1528,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (_vertexShader == null)
                 throw new InvalidOperationException("Vertex shader must be set before calling DrawInstancedPrimitives.");
 
-            if (_vertexBuffers.Count == 0)
+            if (_vertexBuffers?.Count == 0)
                 throw new InvalidOperationException("Vertex buffer must be set before calling DrawInstancedPrimitives.");
 
             if (_indexBuffer == null)

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -18,37 +20,32 @@ namespace Microsoft.Xna.Framework.Graphics
     public partial class GraphicsDevice
     {
         // Core Direct3D Objects
-        internal SharpDX.Direct3D11.Device _d3dDevice;
-        internal SharpDX.Direct3D11.DeviceContext _d3dContext;
-        internal SharpDX.Direct3D11.RenderTargetView _renderTargetView;
-        internal SharpDX.Direct3D11.DepthStencilView _depthStencilView;
+        // Null forgiveness is safe for these from initialization to disposal
+        internal SharpDX.Direct3D11.Device? _d3dDevice;
+        internal SharpDX.Direct3D11.DeviceContext? _d3dContext;
+        internal SharpDX.Direct3D11.RenderTargetView? _renderTargetView;
+        internal SharpDX.Direct3D11.DepthStencilView? _depthStencilView;
         private int _vertexBufferSlotsUsed;
 
 #if WINDOWS
-        SwapChain _swapChain;
+        SwapChain? _swapChain;
 #endif
 
         // The active render targets.
         readonly SharpDX.Direct3D11.RenderTargetView[] _currentRenderTargets = new SharpDX.Direct3D11.RenderTargetView[8];
 
         // The active depth view.
-        SharpDX.Direct3D11.DepthStencilView _currentDepthStencilView;
+        SharpDX.Direct3D11.DepthStencilView? _currentDepthStencilView;
 
         private readonly Dictionary<VertexDeclaration, DynamicVertexBuffer> _userVertexBuffers = new Dictionary<VertexDeclaration, DynamicVertexBuffer>();
-        private DynamicIndexBuffer _userIndexBuffer16;
-        private DynamicIndexBuffer _userIndexBuffer32;
+        private DynamicIndexBuffer? _userIndexBuffer16;
+        private DynamicIndexBuffer? _userIndexBuffer32;
 
         /// <summary>
         /// Returns a handle to internal device object. Valid only on DirectX platforms.
         /// For usage, convert this to SharpDX.Direct3D11.Device.
         /// </summary>
-        public object Handle
-        {
-            get
-            {
-                return _d3dDevice;
-            }
-        }
+        public object Handle => _d3dDevice!;
 
         private void PlatformSetup()
         {
@@ -59,7 +56,7 @@ namespace Microsoft.Xna.Framework.Graphics
             CreateDeviceResources();
 #endif
 
-            _maxVertexBufferSlots = _d3dDevice.FeatureLevel >= FeatureLevel.Level_11_0 ? SharpDX.Direct3D11.InputAssemblerStage.VertexInputResourceSlotCount : 16;
+            _maxVertexBufferSlots = _d3dDevice!.FeatureLevel >= FeatureLevel.Level_11_0 ? SharpDX.Direct3D11.InputAssemblerStage.VertexInputResourceSlotCount : 16;
         }
 
         private void PlatformInitialize()
@@ -107,10 +104,8 @@ namespace Microsoft.Xna.Framework.Graphics
         protected virtual void CreateDeviceResources()
         {
             // Dispose previous references.
-            if (_d3dDevice != null)
-                _d3dDevice.Dispose();
-            if (_d3dContext != null)
-                _d3dContext.Dispose();
+            _d3dDevice?.Dispose();
+            _d3dContext?.Dispose();
 
             // Windows requires BGRA support out of DX.
             var creationFlags = SharpDX.Direct3D11.DeviceCreationFlags.BgraSupport;
@@ -184,12 +179,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void SetHardwareFullscreen()
         {
-            _swapChain.SetFullscreenState(PresentationParameters.IsFullScreen && PresentationParameters.HardwareModeSwitch, null);
+            _swapChain!.SetFullscreenState(PresentationParameters.IsFullScreen && PresentationParameters.HardwareModeSwitch, null);
         }
 
         internal void ClearHardwareFullscreen()
         {
-            _swapChain.SetFullscreenState(false, null);
+            _swapChain!.SetFullscreenState(false, null);
         }
 
         internal void ResizeTargets()
@@ -203,12 +198,12 @@ namespace Microsoft.Xna.Framework.Graphics
                 Height = PresentationParameters.BackBufferHeight,
             };
 
-            _swapChain.ResizeTarget(ref descr);
+            _swapChain!.ResizeTarget(ref descr);
         }
 
         internal void GetModeSwitchedSize(out int width, out int height)
         {
-            Output output = null;
+            Output? output = null;
             if (_swapChain == null)
             {
                 // get the primary output
@@ -261,19 +256,13 @@ namespace Microsoft.Xna.Framework.Graphics
             PresentationParameters.MultiSampleCount =
                 GetClampedMultisampleCount(PresentationParameters.MultiSampleCount);
 
-            _d3dContext.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView)null,
-                                                (SharpDX.Direct3D11.RenderTargetView)null);
+            _d3dContext!.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView?)null,
+                                                (SharpDX.Direct3D11.RenderTargetView?)null);
+            _renderTargetView?.Dispose();
+            _renderTargetView = null;
 
-            if (_renderTargetView != null)
-            {
-                _renderTargetView.Dispose();
-                _renderTargetView = null;
-            }
-            if (_depthStencilView != null)
-            {
-                _depthStencilView.Dispose();
-                _depthStencilView = null;
-            }
+            _depthStencilView?.Dispose();
+            _depthStencilView = null;
 
             // Clear the current render targets.
             _currentDepthStencilView = null;
@@ -287,11 +276,8 @@ namespace Microsoft.Xna.Framework.Graphics
             // We need presentation parameters to continue here.
             if (PresentationParameters == null || PresentationParameters.DeviceWindowHandle == IntPtr.Zero)
             {
-                if (_swapChain != null)
-                {
-                    _swapChain.Dispose();
-                    _swapChain = null;
-                }
+                _swapChain?.Dispose();
+                _swapChain = null;
 
                 return;
             }
@@ -351,7 +337,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 // First, retrieve the underlying DXGI Device from the D3D Device.
                 // Creates the swap chain 
-                using (var dxgiDevice = _d3dDevice.QueryInterface<SharpDX.DXGI.Device1>())
+                using (var dxgiDevice = _d3dDevice!.QueryInterface<SharpDX.DXGI.Device1>())
                 using (var dxgiAdapter = dxgiDevice.Adapter)
                 using (var dxgiFactory = dxgiAdapter.GetParent<SharpDX.DXGI.Factory1>())
                 {
@@ -419,7 +405,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (_swapChain == null)
                 return;
 
-            Output output = null;
+            Output? output = null;
             try
             {
                 output = _swapChain.ContainingOutput;
@@ -464,7 +450,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             // The valid range is between zero and one less than the level returned by CheckMultisampleQualityLevels
             // https://msdn.microsoft.com/en-us/library/windows/desktop/bb173072(v=vs.85).aspx
-            var quality = _d3dDevice.CheckMultisampleQualityLevels(format, multiSampleCount) - 1;
+            var quality = _d3dDevice!.CheckMultisampleQualityLevels(format, multiSampleCount) - 1;
             // NOTE: should we always return highest quality?
             return Math.Max(quality, 0); // clamp minimum to 0 
         }
@@ -498,7 +484,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 options &= ~ClearOptions.Stencil;
             }
 
-            lock (_d3dContext)
+            lock (_d3dContext!)
             {
                 // Clear the diffuse render buffer.
                 if ((options & ClearOptions.Target) == ClearOptions.Target)
@@ -531,10 +517,8 @@ namespace Microsoft.Xna.Framework.Graphics
             SharpDX.Utilities.Dispose(ref _renderTargetView);
             SharpDX.Utilities.Dispose(ref _depthStencilView);
 
-            if (_userIndexBuffer16 != null)
-                _userIndexBuffer16.Dispose();
-            if (_userIndexBuffer32 != null)
-                _userIndexBuffer32.Dispose();
+            _userIndexBuffer16?.Dispose();
+            _userIndexBuffer32?.Dispose();
 
             foreach (var vb in _userVertexBuffers.Values)
                 vb.Dispose();
@@ -553,8 +537,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 var syncInterval = PresentationParameters.PresentationInterval.GetSyncInterval();
 
                 // The first argument instructs DXGI to block n VSyncs before presenting.
-                lock (_d3dContext)
-                    _swapChain.Present(syncInterval, PresentFlags.None);
+                lock (_d3dContext!)
+                    _swapChain!.Present(syncInterval, PresentFlags.None);
             }
             catch (SharpDX.SharpDXException)
             {
@@ -582,7 +566,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         // Only implemented for DirectX right now, so not in GraphicsDevice.cs
-        public void SetRenderTarget(RenderTarget2D renderTarget, int arraySlice)
+        public void SetRenderTarget(RenderTarget2D? renderTarget, int arraySlice)
         {
             if (!GraphicsCapabilities.SupportsTextureArrays)
                 throw new InvalidOperationException("Texture arrays are not supported on this graphics device");
@@ -597,7 +581,7 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
         // Only implemented for DirectX right now, so not in GraphicsDevice.cs
-        public void SetRenderTarget(RenderTarget3D renderTarget, int arraySlice)
+        public void SetRenderTarget(RenderTarget3D? renderTarget, int arraySlice)
         {
             if (renderTarget == null)
                 SetRenderTarget(null);
@@ -612,10 +596,10 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             // Set the default swap chain.
             Array.Clear(_currentRenderTargets, 0, _currentRenderTargets.Length);
-            _currentRenderTargets[0] = _renderTargetView;
+            _currentRenderTargets[0] = _renderTargetView!;
             _currentDepthStencilView = _depthStencilView;
 
-            lock (_d3dContext)
+            lock (_d3dContext!)
                 _d3dContext.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
         }
 
@@ -633,7 +617,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // Generate mipmaps.
                 if (renderTargetBinding.RenderTarget.LevelCount > 1)
                 {
-                    lock (_d3dContext)
+                    lock (_d3dContext!)
                         _d3dContext.GenerateMips(renderTargetBinding.RenderTarget.GetShaderResourceView());
                 }
             }
@@ -647,7 +631,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Make sure none of the new targets are bound
             // to the device as a texture resource.
-            lock (_d3dContext)
+            lock (_d3dContext!)
             {
                 VertexTextures.ClearTargets(this, _currentRenderTargetBindings);
                 Textures.ClearTargets(this, _currentRenderTargetBindings);
@@ -699,9 +683,11 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (_blendFactorDirty || _blendStateDirty)
             {
-                var state = _actualBlendState.GetDxState(this);
+                // This null forgiveness should work because _actualBlendState is assigned in the BlendState property,
+                // where an exception is thrown if the assigned value is null, and in Dispose after which this method should not be called
+                var state = _actualBlendState!.GetDxState(this);
                 var factor = GetBlendFactor();
-                _d3dContext.OutputMerger.SetBlendState(state, factor);
+                _d3dContext!.OutputMerger.SetBlendState(state, factor);
 
                 _blendFactorDirty = false;
                 _blendStateDirty = false;
@@ -723,7 +709,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (_scissorRectangleDirty)
             {
-                _d3dContext.Rasterizer.SetScissorRectangle(
+                _d3dContext!.Rasterizer.SetScissorRectangle(
                     _scissorRectangle.X,
                     _scissorRectangle.Y,
                     _scissorRectangle.Right,
@@ -739,7 +725,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 if (_indexBuffer != null)
                 {
-                    _d3dContext.InputAssembler.SetIndexBuffer(
+                    _d3dContext!.InputAssembler.SetIndexBuffer(
                         _indexBuffer.Buffer,
                         _indexBuffer.IndexElementSize == IndexElementSize.SixteenBits ?
                             SharpDX.DXGI.Format.R16_UInt : SharpDX.DXGI.Format.R32_UInt,
@@ -750,7 +736,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (_vertexBuffersDirty)
             {
-                if (_vertexBuffers.Count > 0)
+                if (_vertexBuffers!.Count > 0) // Dirtiness implies a non-null value
                 {
                     for (int slot = 0; slot < _vertexBuffers.Count; slot++)
                     {
@@ -759,7 +745,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         var vertexDeclaration = vertexBuffer.VertexDeclaration;
                         int vertexStride = vertexDeclaration.VertexStride;
                         int vertexOffsetInBytes = vertexBufferBinding.VertexOffset * vertexStride;
-                        _d3dContext.InputAssembler.SetVertexBuffers(
+                        _d3dContext!.InputAssembler.SetVertexBuffers(
                             slot, new SharpDX.Direct3D11.VertexBufferBinding(vertexBuffer.Buffer, vertexStride, vertexOffsetInBytes));
                     }
                     _vertexBufferSlotsUsed = _vertexBuffers.Count;
@@ -767,7 +753,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 else
                 {
                     for (int slot = 0; slot < _vertexBufferSlotsUsed; slot++)
-                        _d3dContext.InputAssembler.SetVertexBuffers(slot, new SharpDX.Direct3D11.VertexBufferBinding());
+                        _d3dContext!.InputAssembler.SetVertexBuffers(slot, new SharpDX.Direct3D11.VertexBufferBinding());
 
                     _vertexBufferSlotsUsed = 0;
                 }
@@ -780,7 +766,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (_vertexShaderDirty)
             {
-                _d3dContext.VertexShader.Set(_vertexShader.VertexShader);
+                _d3dContext!.VertexShader.Set(_vertexShader.VertexShader);
 
                 unchecked
                 {
@@ -789,13 +775,13 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             if (_vertexShaderDirty || _vertexBuffersDirty)
             {
-                _d3dContext.InputAssembler.InputLayout = _vertexShader.InputLayouts.GetOrCreate(_vertexBuffers);
+                _d3dContext!.InputAssembler.InputLayout = _vertexShader.InputLayouts.GetOrCreate(_vertexBuffers);
                 _vertexShaderDirty = _vertexBuffersDirty = false;
             }
 
             if (_pixelShaderDirty)
             {
-                _d3dContext.PixelShader.Set(_pixelShader.PixelShader);
+                _d3dContext!.PixelShader.Set(_pixelShader.PixelShader);
                 _pixelShaderDirty = false;
 
                 unchecked
@@ -816,13 +802,10 @@ namespace Microsoft.Xna.Framework.Graphics
         private int SetUserVertexBuffer<T>(T[] vertexData, int vertexOffset, int vertexCount, VertexDeclaration vertexDecl)
             where T : struct
         {
-            DynamicVertexBuffer buffer;
-
-            if (!_userVertexBuffers.TryGetValue(vertexDecl, out buffer) || buffer.VertexCount < vertexCount)
+            if (!_userVertexBuffers.TryGetValue(vertexDecl, out DynamicVertexBuffer? buffer) || buffer.VertexCount < vertexCount)
             {
                 // Dispose the previous buffer if we have one.
-                if (buffer != null)
-                    buffer.Dispose();
+                buffer?.Dispose();
 
                 buffer = new DynamicVertexBuffer(this, vertexDecl, Math.Max(vertexCount, 2000), BufferUsage.WriteOnly);
                 _userVertexBuffers[vertexDecl] = buffer;
@@ -861,8 +844,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 if (_userIndexBuffer16 == null || _userIndexBuffer16.IndexCount < requiredIndexCount)
                 {
-                    if (_userIndexBuffer16 != null)
-                        _userIndexBuffer16.Dispose();
+                    _userIndexBuffer16?.Dispose();
 
                     _userIndexBuffer16 = new DynamicIndexBuffer(this, indexElementSize, requiredIndexCount, BufferUsage.WriteOnly);
                 }
@@ -873,8 +855,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 if (_userIndexBuffer32 == null || _userIndexBuffer32.IndexCount < requiredIndexCount)
                 {
-                    if (_userIndexBuffer32 != null)
-                        _userIndexBuffer32.Dispose();
+                    _userIndexBuffer32?.Dispose();
 
                     _userIndexBuffer32 = new DynamicIndexBuffer(this, indexElementSize, requiredIndexCount, BufferUsage.WriteOnly);
                 }
@@ -903,7 +884,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformDrawIndexedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount)
         {
-            lock (_d3dContext)
+            lock (_d3dContext!)
             {
                 ApplyState(true);
 
@@ -918,7 +899,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             var startVertex = SetUserVertexBuffer(vertexData, vertexOffset, vertexCount, vertexDeclaration);
 
-            lock (_d3dContext)
+            lock (_d3dContext!)
             {
                 ApplyState(true);
 
@@ -929,7 +910,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformDrawPrimitives(PrimitiveType primitiveType, int vertexStart, int vertexCount)
         {
-            lock (_d3dContext)
+            lock (_d3dContext!)
             {
                 ApplyState(true);
 
@@ -944,7 +925,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var startVertex = SetUserVertexBuffer(vertexData, vertexOffset, numVertices, vertexDeclaration);
             var startIndex = SetUserIndexBuffer(indexData, indexOffset, indexCount);
 
-            lock (_d3dContext)
+            lock (_d3dContext!)
             {
                 ApplyState(true);
 
@@ -959,7 +940,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var startVertex = SetUserVertexBuffer(vertexData, vertexOffset, numVertices, vertexDeclaration);
             var startIndex = SetUserIndexBuffer(indexData, indexOffset, indexCount);
 
-            lock (_d3dContext)
+            lock (_d3dContext!)
             {
                 ApplyState(true);
 
@@ -971,7 +952,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformDrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex,
             int primitiveCount, int baseInstance, int instanceCount)
         {
-            lock (_d3dContext)
+            lock (_d3dContext!)
             {
                 ApplyState(true);
 
@@ -998,7 +979,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 using (var stagingTex = new SharpDX.Direct3D11.Texture2D(_d3dDevice, desc))
                 {
-                    lock (_d3dContext)
+                    lock (_d3dContext!)
                     {
                         // Copy the data from the GPU to the staging texture.
                         // if MSAA is enabled we need to first copy to a resource without MSAA
@@ -1033,7 +1014,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         }
 
                         // Copy the data to the array.
-                        DataStream stream = null;
+                        DataStream? stream = null;
                         try
                         {
                             var databox = _d3dContext.MapSubresource(stagingTex, 0, MapMode.Read, SharpDX.Direct3D11.MapFlags.None, out stream);
@@ -1087,7 +1068,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         public void Flush()
         {
-            _d3dContext.Flush();
+            _d3dContext!.Flush();
         }
 
         private static Rectangle PlatformGetTitleSafeArea(int x, int y, int width, int height)

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,7 +21,7 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         internal class FramebufferHelper
         {
-            private static FramebufferHelper _instance;
+            private static FramebufferHelper? _instance;
 
             public static FramebufferHelper Create(GraphicsDevice gd)
             {
@@ -37,12 +39,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 return _instance;
             }
 
-            public static FramebufferHelper Get()
-            {
-                if (_instance == null)
-                    throw new InvalidOperationException("The FramebufferHelper has not been created yet!");
-                return _instance;
-            }
+            public static FramebufferHelper Get() => _instance ?? throw new InvalidOperationException("The FramebufferHelper has not been created yet!");
 
             public bool SupportsInvalidateFramebuffer { get; private set; }
 

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -18,11 +20,12 @@ namespace Microsoft.Xna.Framework.Graphics
     public partial class GraphicsDevice
     {
 #if DESKTOPGL || ANGLE
-        internal IGraphicsContext Context { get; private set; }
+        // Null forgiveness is safe from after PlatformSetup is called until disposal
+        internal IGraphicsContext? Context { get; private set; }
 #endif
 
 #if !GLES
-        private DrawBuffersEnum[] _drawBuffers;
+        private DrawBuffersEnum[]? _drawBuffers;
 #endif
 
         enum ResourceType
@@ -110,18 +113,20 @@ namespace Microsoft.Xna.Framework.Graphics
         static List<IntPtr> _disposeContexts = new List<IntPtr>();
         static object _disposeContextsLock = new object();
 
-        private ShaderProgramCache _programCache;
-        private ShaderProgram _shaderProgram = null;
+        private ShaderProgramCache? _programCache;
+        private ShaderProgram? _shaderProgram = null;
 
         static readonly float[] _posFixup = new float[4];
 
-        private static BufferBindingInfo[] _bufferBindingInfos;
+        // Null forgiveness is safe after PlatformInitialize
+        private static BufferBindingInfo[]? _bufferBindingInfos;
         private static int _activeBufferBindingInfosCount;
-        private static bool[] _newEnabledVertexAttributes;
+        // Null forgiveness is safe after PlatformSetup
+        private static bool[]? _newEnabledVertexAttributes;
         internal static readonly List<int> _enabledVertexAttributes = new List<int>();
         internal static bool _attribsDirty;
 
-        internal FramebufferHelper framebufferHelper;
+        internal FramebufferHelper? framebufferHelper;
 
         internal int glMajorVersion = 0;
         internal int glMinorVersion = 0;
@@ -144,13 +149,12 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             get
             {
-                if (_vertexShader == null && _pixelShader == null)
-                    throw new InvalidOperationException("There is no shader bound!");
                 if (_vertexShader == null)
-                    return _pixelShader.HashKey;
-                if (_pixelShader == null)
+                    return _pixelShader?.HashKey ?? throw new InvalidOperationException("There is no shader bound!");
+                else if (_pixelShader == null)
                     return _vertexShader.HashKey;
-                return _vertexShader.HashKey ^ _pixelShader.HashKey;
+                else
+                    return _vertexShader.HashKey ^ _pixelShader.HashKey;
             }
         }
 
@@ -178,7 +182,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var programHash = ShaderProgramHash;
             var bindingsChanged = false;
 
-            for (var slot = 0; slot < _vertexBuffers.Count; slot++)
+            for (var slot = 0; slot < _vertexBuffers!.Count; slot++)
             {
                 var vertexBufferBinding = _vertexBuffers.Get(slot);
                 var vertexDeclaration = vertexBufferBinding.VertexBuffer.VertexDeclaration;
@@ -189,7 +193,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 if (!_attribsDirty &&
                     slot < _activeBufferBindingInfosCount &&
-                    _bufferBindingInfos[slot].VertexOffset == offset &&
+                    _bufferBindingInfos![slot].VertexOffset == offset &&
                     ReferenceEquals(_bufferBindingInfos[slot].AttributeInfo, attrInfo) &&
                     _bufferBindingInfos[slot].InstanceFrequency == vertexBufferBinding.InstanceFrequency &&
                     _bufferBindingInfos[slot].Vbo == vertexBufferBinding.VertexBuffer.vbo)
@@ -220,7 +224,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     GraphicsExtensions.CheckGLError();
                 }
 
-                _bufferBindingInfos[slot].VertexOffset = offset;
+                _bufferBindingInfos![slot].VertexOffset = offset;
                 _bufferBindingInfos[slot].AttributeInfo = attrInfo;
                 _bufferBindingInfos[slot].InstanceFrequency = vertexBufferBinding.InstanceFrequency;
                 _bufferBindingInfos[slot].Vbo = vertexBufferBinding.VertexBuffer.vbo;
@@ -230,15 +234,15 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (bindingsChanged)
             {
-                Array.Clear(_newEnabledVertexAttributes, 0, _newEnabledVertexAttributes.Length);
+                Array.Clear(_newEnabledVertexAttributes!, 0, _newEnabledVertexAttributes!.Length);
                 for (var slot = 0; slot < _vertexBuffers.Count; slot++)
                 {
-                    foreach (var element in _bufferBindingInfos[slot].AttributeInfo.Elements)
+                    foreach (var element in _bufferBindingInfos![slot].AttributeInfo!.Elements)
                         _newEnabledVertexAttributes[element.AttributeLocation] = true;
                 }
                 _activeBufferBindingInfosCount = _vertexBuffers.Count;
             }
-            SetVertexAttributeArray(_newEnabledVertexAttributes);
+            SetVertexAttributeArray(_newEnabledVertexAttributes!);
         }
 
         private void PlatformSetup()
@@ -339,7 +343,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _enabledVertexAttributes.Clear();
 
             // Free all the cached shader programs. 
-            _programCache.Clear();
+            _programCache!.Clear();
             _shaderProgram = null;
 
             framebufferHelper = FramebufferHelper.Create(this);
@@ -435,10 +439,10 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformDispose()
         {
             // Free all the cached shader programs.
-            _programCache.Dispose();
+            _programCache?.Dispose();
 
 #if DESKTOPGL || ANGLE
-            Context.Dispose();
+            Context?.Dispose();
             Context = null;
 #endif
         }
@@ -533,7 +537,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformPresent()
         {
 #if DESKTOPGL || ANGLE
-            Context.SwapBuffers();
+            Context!.SwapBuffers();
 #endif
             GraphicsExtensions.CheckGLError();
 
@@ -571,7 +575,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformApplyDefaultRenderTarget()
         {
-            this.framebufferHelper.BindFramebuffer(this.glFramebuffer);
+            this.framebufferHelper!.BindFramebuffer(this.glFramebuffer);
 
             // Reset the raster state because we flip vertices
             // when rendering offscreen and hence the cull direction.
@@ -583,7 +587,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private class RenderTargetBindingArrayComparer : IEqualityComparer<RenderTargetBinding[]>
         {
-            public bool Equals(RenderTargetBinding[] first, RenderTargetBinding[] second)
+            public bool Equals(RenderTargetBinding[]? first, RenderTargetBinding[]? second)
             {
                 if (object.ReferenceEquals(first, second))
                     return true;
@@ -636,7 +640,7 @@ namespace Microsoft.Xna.Framework.Graphics
             var depth = 0;
             var stencil = 0;
             
-            if (preferredMultiSampleCount > 0 && this.framebufferHelper.SupportsBlitFramebuffer)
+            if (preferredMultiSampleCount > 0 && this.framebufferHelper!.SupportsBlitFramebuffer)
             {
                 this.framebufferHelper.GenRenderbuffer(out color);
                 this.framebufferHelper.BindRenderbuffer(color);
@@ -688,7 +692,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 if (depthInternalFormat != 0)
                 {
-                    this.framebufferHelper.GenRenderbuffer(out depth);
+                    this.framebufferHelper!.GenRenderbuffer(out depth);
                     this.framebufferHelper.BindRenderbuffer(depth);
                     this.framebufferHelper.RenderbufferStorageMultisample(preferredMultiSampleCount, (int)depthInternalFormat, width, height);
                     if (preferredDepthFormat == DepthFormat.Depth24Stencil8)
@@ -727,11 +731,11 @@ namespace Microsoft.Xna.Framework.Graphics
             if (color != 0)
             {
                 if (colorIsRenderbuffer)
-                    this.framebufferHelper.DeleteRenderbuffer(color);
+                    this.framebufferHelper!.DeleteRenderbuffer(color);
                 if (stencil != 0 && stencil != depth)
-                    this.framebufferHelper.DeleteRenderbuffer(stencil);
+                    this.framebufferHelper!.DeleteRenderbuffer(stencil);
                 if (depth != 0)
-                    this.framebufferHelper.DeleteRenderbuffer(depth);
+                    this.framebufferHelper!.DeleteRenderbuffer(depth);
 
                 var bindingsToDelete = new List<RenderTargetBinding[]>();
                 foreach (var bindings in this.glFramebuffers.Keys)
@@ -751,12 +755,12 @@ namespace Microsoft.Xna.Framework.Graphics
                     var fbo = 0;
                     if (this.glFramebuffers.TryGetValue(bindings, out fbo))
                     {
-                        this.framebufferHelper.DeleteFramebuffer(fbo);
+                        this.framebufferHelper!.DeleteFramebuffer(fbo);
                         this.glFramebuffers.Remove(bindings);
                     }
                     if (this.glResolveFramebuffers.TryGetValue(bindings, out fbo))
                     {
-                        this.framebufferHelper.DeleteFramebuffer(fbo);
+                        this.framebufferHelper!.DeleteFramebuffer(fbo);
                         this.glResolveFramebuffers.Remove(bindings);
                     }
                 }
@@ -769,8 +773,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 return;
 
             var renderTargetBinding = this._currentRenderTargetBindings[0];
-            var renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
-            if (renderTarget.MultiSampleCount > 0 && this.framebufferHelper.SupportsBlitFramebuffer)
+            IRenderTarget renderTarget = (renderTargetBinding.RenderTarget as IRenderTarget)!;
+            if (renderTarget.MultiSampleCount > 0 && this.framebufferHelper!.SupportsBlitFramebuffer)
             {
                 var glResolveFramebuffer = 0;
                 if (!this.glResolveFramebuffers.TryGetValue(this._currentRenderTargetBindings, out glResolveFramebuffer))
@@ -779,7 +783,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     this.framebufferHelper.BindFramebuffer(glResolveFramebuffer);
                     for (var i = 0; i < this._currentRenderTargetCount; ++i)
                     {
-                        var rt = this._currentRenderTargetBindings[i].RenderTarget as IRenderTarget;
+                        IRenderTarget rt = (this._currentRenderTargetBindings[i].RenderTarget as IRenderTarget)!;
                         this.framebufferHelper.FramebufferTexture2D((int)(FramebufferAttachment.ColorAttachment0 + i), (int) rt.GetFramebufferTarget(renderTargetBinding), rt.GLTexture);
                     }
                     this.glResolveFramebuffers.Add((RenderTargetBinding[])this._currentRenderTargetBindings.Clone(), glResolveFramebuffer);
@@ -799,7 +803,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 for (var i = 0; i < this._currentRenderTargetCount; ++i)
                 {
                     renderTargetBinding = this._currentRenderTargetBindings[i];
-                    renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
+                    renderTarget = (renderTargetBinding.RenderTarget as IRenderTarget)!;
                     this.framebufferHelper.BlitFramebuffer(i, renderTarget.Width, renderTarget.Height);
                 }
                 if (renderTarget.RenderTargetUsage == RenderTargetUsage.DiscardContents && this.framebufferHelper.SupportsInvalidateFramebuffer)
@@ -813,12 +817,12 @@ namespace Microsoft.Xna.Framework.Graphics
             for (var i = 0; i < this._currentRenderTargetCount; ++i)
             {
                 renderTargetBinding = this._currentRenderTargetBindings[i];
-                renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
+                renderTarget = (renderTargetBinding.RenderTarget as IRenderTarget)!;
                 if (renderTarget.LevelCount > 1)
                 {
                     GL.BindTexture((TextureTarget)renderTarget.GLTarget, renderTarget.GLTexture);
                     GraphicsExtensions.CheckGLError();
-                    this.framebufferHelper.GenerateMipmap((int)renderTarget.GLTarget);
+                    this.framebufferHelper!.GenerateMipmap((int)renderTarget.GLTarget);
                 }
             }
         }
@@ -828,16 +832,16 @@ namespace Microsoft.Xna.Framework.Graphics
             var glFramebuffer = 0;
             if (!this.glFramebuffers.TryGetValue(this._currentRenderTargetBindings, out glFramebuffer))
             {
-                this.framebufferHelper.GenFramebuffer(out glFramebuffer);
+                this.framebufferHelper!.GenFramebuffer(out glFramebuffer);
                 this.framebufferHelper.BindFramebuffer(glFramebuffer);
                 var renderTargetBinding = this._currentRenderTargetBindings[0];
-                var renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
+                IRenderTarget renderTarget = (renderTargetBinding.RenderTarget as IRenderTarget)!;
                 this.framebufferHelper.FramebufferRenderbuffer((int)FramebufferAttachment.DepthAttachment, renderTarget.GLDepthBuffer, 0);
                 this.framebufferHelper.FramebufferRenderbuffer((int)FramebufferAttachment.StencilAttachment, renderTarget.GLStencilBuffer, 0);
                 for (var i = 0; i < this._currentRenderTargetCount; ++i)
                 {
                     renderTargetBinding = this._currentRenderTargetBindings[i];
-                    renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
+                    renderTarget = (renderTargetBinding.RenderTarget as IRenderTarget)!;
                     var attachement = (int)(FramebufferAttachment.ColorAttachment0 + i);
                     if (renderTarget.GLColorBuffer != renderTarget.GLTexture)
                         this.framebufferHelper.FramebufferRenderbuffer(attachement, renderTarget.GLColorBuffer, 0);
@@ -852,7 +856,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
-                this.framebufferHelper.BindFramebuffer(glFramebuffer);
+                this.framebufferHelper!.BindFramebuffer(glFramebuffer);
             }
 #if !GLES
             GL.DrawBuffers(this._currentRenderTargetCount, this._drawBuffers);
@@ -865,7 +869,7 @@ namespace Microsoft.Xna.Framework.Graphics
             // Textures will need to be rebound to render correctly in the new render target.
             Textures.Dirty();
 
-            return _currentRenderTargetBindings[0].RenderTarget as IRenderTarget;
+            return (_currentRenderTargetBindings[0].RenderTarget as IRenderTarget)!;
         }
 
         private static GLPrimitiveType PrimitiveTypeGL(PrimitiveType primitiveType)
@@ -893,7 +897,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private unsafe void ActivateShaderProgram()
         {
             // Lookup the shader program.
-            var shaderProgram = _programCache.GetProgram(VertexShader, PixelShader);
+            var shaderProgram = _programCache!.GetProgram(VertexShader, PixelShader);
             if (shaderProgram.Program == -1)
                 return;
             // Set the new program if it has changed.
@@ -969,7 +973,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformApplyBlend(bool force = false)
         {
-            _actualBlendState.PlatformApplyState(this, force);
+            _actualBlendState!.PlatformApplyState(this, force);
             ApplyBlendFactor(force);
         }
 
@@ -1052,7 +1056,8 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             ApplyState(true);
 
-            var shortIndices = _indexBuffer.IndexElementSize == IndexElementSize.SixteenBits;
+            // The caller should have ensured that _indexBuffer is not null
+            var shortIndices = _indexBuffer!.IndexElementSize == IndexElementSize.SixteenBits;
 
 			var indexElementType = shortIndices ? DrawElementsType.UnsignedShort : DrawElementsType.UnsignedInt;
             var indexElementSize = shortIndices ? 2 : 4;
@@ -1060,7 +1065,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			var indexElementCount = GetElementCountArray(primitiveType, primitiveCount);
 			var target = PrimitiveTypeGL(primitiveType);
 
-            ApplyAttribs(_vertexShader, baseVertex);
+            // The caller should have ensured that _vertexShader is not null
+            ApplyAttribs(_vertexShader!, baseVertex);
 
             GL.DrawElements(target,
                                      indexElementCount,
@@ -1105,9 +1111,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformDrawPrimitives(PrimitiveType primitiveType, int vertexStart, int vertexCount)
         {
-            ApplyState(true);   
+            ApplyState(true);
 
-            ApplyAttribs(_vertexShader, 0);
+            // The caller should have ensured that _vertexShader is not null
+            ApplyAttribs(_vertexShader!, 0);
 
             if (vertexStart < 0)
                 vertexStart = 0;
@@ -1204,7 +1211,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new PlatformNotSupportedException("Instanced geometry drawing requires at least OpenGL 3.2 or GLES 3.2. Try upgrading your graphics card drivers.");
             ApplyState(true);
 
-            var shortIndices = _indexBuffer.IndexElementSize == IndexElementSize.SixteenBits;
+            // The caller should have ensured that _indexBuffer is not null
+            var shortIndices = _indexBuffer!.IndexElementSize == IndexElementSize.SixteenBits;
 
             var indexElementType = shortIndices ? DrawElementsType.UnsignedShort : DrawElementsType.UnsignedInt;
             var indexElementSize = shortIndices ? 2 : 4;
@@ -1212,7 +1220,8 @@ namespace Microsoft.Xna.Framework.Graphics
             var indexElementCount = GetElementCountArray(primitiveType, primitiveCount);
             var target = PrimitiveTypeGL(primitiveType);
 
-            ApplyAttribs(_vertexShader, baseVertex);
+            // The caller should have ensured that _vertexShader is not null
+            ApplyAttribs(_vertexShader!, baseVertex);
 
             if (baseInstance > 0)
             {
@@ -1274,7 +1283,7 @@ namespace Microsoft.Xna.Framework.Graphics
         internal void OnPresentationChanged()
         {
 #if DESKTOPGL || ANGLE
-            Context.MakeCurrent(new WindowInfo(SdlGameWindow.Instance.Handle));
+            Context!.MakeCurrent(new WindowInfo(SdlGameWindow.Instance.Handle));
             Context.SwapInterval = PresentationParameters.PresentationInterval.GetSwapInterval();
 #endif
 
@@ -1284,12 +1293,12 @@ namespace Microsoft.Xna.Framework.Graphics
         // Holds information for caching
         private class BufferBindingInfo
         {
-            public VertexDeclaration.VertexDeclarationAttributeInfo AttributeInfo;
+            public VertexDeclaration.VertexDeclarationAttributeInfo? AttributeInfo;
             public IntPtr VertexOffset;
             public int InstanceFrequency;
             public int Vbo;
 
-            public BufferBindingInfo(VertexDeclaration.VertexDeclarationAttributeInfo attributeInfo, IntPtr vertexOffset, int instanceFrequency, int vbo)
+            public BufferBindingInfo(VertexDeclaration.VertexDeclarationAttributeInfo? attributeInfo, IntPtr vertexOffset, int instanceFrequency, int vbo)
             {
                 AttributeInfo = attributeInfo;
                 VertexOffset = vertexOffset;

--- a/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using MonoGame.Framework.Utilities;
 using MonoGame.Interop;
 using System;
@@ -16,13 +18,13 @@ public partial class GraphicsDevice
 {
     internal unsafe MGG_GraphicsDevice* Handle;
 
-    internal Texture2D DefaultTexture;
+    internal Texture2D? DefaultTexture;
 
     private int _currentFrame = -1;
 
     private readonly Dictionary<int, DynamicVertexBuffer> _userVertexBuffers = new Dictionary<int, DynamicVertexBuffer>();
-    private DynamicIndexBuffer _userIndexBuffer16;
-    private DynamicIndexBuffer _userIndexBuffer32;
+    private DynamicIndexBuffer? _userIndexBuffer16;
+    private DynamicIndexBuffer? _userIndexBuffer32;
 
     private unsafe readonly MGG_Texture*[] _curRenderTargets = new MGG_Texture*[4];
     private readonly int[] _currentRenderTargetArraySlices = new int[4];
@@ -209,13 +211,13 @@ public partial class GraphicsDevice
         MGG.GraphicsDevice_ResolveRenderTargets(Handle);
     }
 
-    private unsafe IRenderTarget PlatformApplyRenderTargets()
+    private unsafe IRenderTarget? PlatformApplyRenderTargets()
     {
         BeginFrame();
 
         Array.Clear(_curRenderTargets, 0, 4);
 
-        IRenderTarget first = null;
+        IRenderTarget? first = null;
 
         for (var i = 0; i < _currentRenderTargetCount; i++)
         {
@@ -230,7 +232,7 @@ public partial class GraphicsDevice
         fixed (MGG_Texture** targets = _curRenderTargets)
         fixed (int* arraySlices = _currentRenderTargetArraySlices)
             MGG.GraphicsDevice_SetRenderTargets(Handle, targets, arraySlices, _currentRenderTargetCount);
-        
+
         return first;
     }
 
@@ -390,8 +392,7 @@ public partial class GraphicsDevice
         {
             if (_userIndexBuffer32 == null || _userIndexBuffer32.IndexCount < requiredIndexCount)
             {
-                if (_userIndexBuffer32 != null)
-                    _userIndexBuffer32.Dispose();
+                _userIndexBuffer32?.Dispose();
 
                 _userIndexBuffer32 = new DynamicIndexBuffer(this, indexElementSize, requiredIndexCount, BufferUsage.WriteOnly);
             }

--- a/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
@@ -243,7 +243,7 @@ public partial class GraphicsDevice
     {
         if (_blendStateDirty)
         {
-            _actualBlendState.PlatformApplyState(this);
+            _actualBlendState!.PlatformApplyState(this);
             _blendStateDirty = false;
         }
 
@@ -307,8 +307,8 @@ public partial class GraphicsDevice
         }
 
         if (_vertexBuffersDirty)
-       {
-            for (var slot = 0; slot < _vertexBuffers.Count; slot++)
+        {
+            for (var slot = 0; slot < _vertexBuffers?.Count; slot++)
             {
                 var vertexBufferBinding = _vertexBuffers.Get(slot);
                 var buffer = vertexBufferBinding.VertexBuffer;

--- a/Tests/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceTest.cs
@@ -901,6 +901,19 @@ namespace MonoGame.Tests.Graphics
             Assert.DoesNotThrow(() => unused = gd.SamplerStates);
         }
 
+#if DESKTOPGL
+        [Test]
+        public void NullableInternalFieldsShouldHaveValuesAfterInitialization()
+        {
+            // Nullable fields that are null-forgiven all over the place with the assumption they should have values after initialization,
+            // should have values after initialization.
+            var gd = new GraphicsDevice();
+            object unused;
+            Assert.DoesNotThrow(() => unused = gd.Context!.GetHashCode());
+            Assert.DoesNotThrow(() => unused = gd.framebufferHelper!.GetHashCode());
+        }
+#endif
+
         [Test]
         public void NullableBackingFieldsWithDefaultsAreCorrect()
         {

--- a/Tests/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceTest.cs
@@ -892,7 +892,6 @@ namespace MonoGame.Tests.Graphics
             // initializing the backing fields inside the constructor, resulting in CS8618.
             // See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings?f1url=%3FappId%3Droslyn%26k%3Dk(CS8618)#nonnullable-reference-not-initialized
 
-            var gd = new GraphicsDevice();
             object unused;
             Assert.DoesNotThrow(() => unused = gd.Adapter);
             Assert.DoesNotThrow(() => unused = gd.VertexTextures);
@@ -907,7 +906,6 @@ namespace MonoGame.Tests.Graphics
         {
             // Nullable fields that are null-forgiven all over the place with the assumption they should have values after initialization,
             // should have values after initialization.
-            var gd = new GraphicsDevice();
             object unused;
             Assert.DoesNotThrow(() => unused = gd.Context!.GetHashCode());
             Assert.DoesNotThrow(() => unused = gd.framebufferHelper!.GetHashCode());
@@ -919,7 +917,6 @@ namespace MonoGame.Tests.Graphics
         {
             // Properties that are backed by nullable fields and have a default value indicated in their documentation
             // should return the indicated default value.
-            var gd = new GraphicsDevice();
             Assert.AreEqual(gd.RasterizerState, RasterizerState.CullCounterClockwise);
             Assert.AreEqual(gd.BlendState, BlendState.Opaque);
             Assert.AreEqual(gd.DepthStencilState, DepthStencilState.Default);
@@ -929,7 +926,6 @@ namespace MonoGame.Tests.Graphics
         public void CanSetNullRenderTargets()
         {
             // Passing null values to the SetRenderTarget* methods should not throw exceptions
-            var gd = new GraphicsDevice();
             RenderTarget2D? renderTarget = null;
             RenderTargetCube? renderTargetCube = null;
             RenderTargetBinding[]? array = null;

--- a/Tests/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceTest.cs
@@ -879,5 +879,55 @@ namespace MonoGame.Tests.Graphics
 
             Assert.IsTrue(rtc.IsDisposed);
         }
+
+        #region Nullable context tests
+
+#nullable enable
+
+        [Test]
+        public void NullableBackingFieldsShouldNotCauseExceptions()
+        {
+            // Properties that are backed by nullable fields and return them with non-null assertions should not throw exceptions.
+            // These properties are necessary because the GraphicsDevice constructors all call Setup and Initialize rather than
+            // initializing the backing fields inside the constructor, resulting in CS8618.
+            // See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings?f1url=%3FappId%3Droslyn%26k%3Dk(CS8618)#nonnullable-reference-not-initialized
+
+            var gd = new GraphicsDevice();
+            object unused;
+            Assert.DoesNotThrow(() => unused = gd.Adapter);
+            Assert.DoesNotThrow(() => unused = gd.VertexTextures);
+            Assert.DoesNotThrow(() => unused = gd.VertexSamplerStates);
+            Assert.DoesNotThrow(() => unused = gd.Textures);
+            Assert.DoesNotThrow(() => unused = gd.SamplerStates);
+        }
+
+        [Test]
+        public void NullableBackingFieldsWithDefaultsAreCorrect()
+        {
+            // Properties that are backed by nullable fields and have a default value indicated in their documentation
+            // should return the indicated default value.
+            var gd = new GraphicsDevice();
+            Assert.AreEqual(gd.RasterizerState, RasterizerState.CullCounterClockwise);
+            Assert.AreEqual(gd.BlendState, BlendState.Opaque);
+            Assert.AreEqual(gd.DepthStencilState, DepthStencilState.Default);
+        }
+
+        [Test]
+        public void CanSetNullRenderTargets()
+        {
+            // Passing null values to the SetRenderTarget* methods should not throw exceptions
+            var gd = new GraphicsDevice();
+            RenderTarget2D? renderTarget = null;
+            RenderTargetCube? renderTargetCube = null;
+            RenderTargetBinding[]? array = null;
+
+            Assert.DoesNotThrow(() => gd.SetRenderTarget(renderTarget));
+            Assert.DoesNotThrow(() => gd.SetRenderTarget(renderTargetCube, default));
+            Assert.DoesNotThrow(() => gd.SetRenderTargets(array));
+        }
+
+#nullable restore
+
+        #endregion
     }
 }


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes #9192 

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change
This adds `#nullable enable` to the top of `GraphicsDevice.cs` and the platform implementations partial classes, and fixes all warnings that result from doing so.

<!-- 
Enter description of the fix in this section.
Please be as descriptive as possible, future contributors will need to know *why* these changes are being made.
For inspiration review the commit/PR history in the MonoGame repository.
-->

- The warnings in `GraphicsDevice.cs` were mostly around referencing properties that were not marked as nullable and were not assigned in the constructors. Each of the constructors used the `Setup` and `Initialize` methods to assign values to those properties, so now those properties are backed by nullable fields that are initialized instead. The properties return the backing fields with the null-forgiving operator, which should correctly result in `NullReferenceException` if somehow the backing fields are not initialized before the properties are accessed.

- Warnings in the platform implementation files were mostly about uninitialized private and internal fields, almost all of which were initialized similarly to the properties in `GraphicsDevice.cs`. These fields were changed to nullable with null forgiveness used in every context where they should be expected to have been initialized.

- Public properties where a default value was indicated in the documentation comments now assign that default value to their backing field and return it, only if the backing field is null.

- Fields that were initialized in `Setup` to be clones of static graphics resources now use field initializers so the compiler can guarantee the fields are non-null when they're used as null-coalescing assignment values for the backing values of properties with default values.

- Methods and properties that return null in any cases now have a nullable return type in the signature. This should not break any existing callers until they are also in a nullable context, and then only if they use a returned nullable as if it's guaranteed to not be null.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

