### PR TITLE
Update Unload to match Load / format

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -699,9 +699,17 @@ namespace Microsoft.Xna.Framework.Content
                 throw new ObjectDisposedException("ContentManager");
             }
 
+            // On some platforms, name and slash direction matter.
+            // We store the asset by a /-separating key rather than how the
+            // path to the file was passed to us to avoid
+            // loading "content/asset1.xnb" and "content\\ASSET1.xnb" as if they were two
+            // different files. This matches stock XNA behavior.
+            // The dictionary will ignore case differences
+            var key = assetName.Replace('\\', '/');
+
             //Check if the asset exists
             object asset;
-            if (loadedAssets.TryGetValue(assetName, out asset))
+            if (loadedAssets.TryGetValue(key, out asset))
             {
                 //Check if it's disposable and remove it from the disposable list if so
                 var disposable = asset as IDisposable;
@@ -711,7 +719,7 @@ namespace Microsoft.Xna.Framework.Content
                     disposableAssets.Remove(disposable);
                 }
 
-                loadedAssets.Remove(assetName);
+                loadedAssets.Remove(key);
             }
         }
 


### PR DESCRIPTION

Fixes #9189 

### Description of Change

Takes the same logic used in Load and handles converting \\\ to the / format when trying to UnloadAssets. 
Verified that it works using a simple Repro project based on the provided code in the issue.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

