### PR TITLE
Updated the Keys.None xml description to align with other "none" implementations to avoid confusion.

### DIFF
--- a/MonoGame.Framework/Input/Keys.cs
+++ b/MonoGame.Framework/Input/Keys.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xna.Framework.Input
 	public enum Keys
 	{
         /// <summary>
-        /// Reserved.
+        /// No key set.
         /// </summary>
 		None = 0,
         /// <summary>


### PR DESCRIPTION
# Summary

It was repoted there was confusion regardind the description of `Keys.None` as it was different to other implementations.

On review, this has now been updated to "No Key Set" which aligns with all other "None" enum definitions, including `Buttons.None`

Resolves - #7826