### PR TITLE
#9192: Nullable contexts for Graphics namespace (part 1)

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
@@ -5,6 +5,8 @@
 // Microsoft XNA Community Game Platform
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
+#nullable enable
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
@@ -22,7 +24,7 @@ namespace Microsoft.Xna.Framework.Graphics
         public SpriteEffect(GraphicsDevice device)
             : base(device, EffectResource.SpriteEffect.Bytecode)
         {
-            CacheEffectParameters();
+            _matrixParam = Parameters["MatrixTransform"];
         }
 
         /// <summary>
@@ -36,7 +38,7 @@ namespace Microsoft.Xna.Framework.Graphics
         protected SpriteEffect(SpriteEffect cloneSource)
             : base(cloneSource)
         {
-            CacheEffectParameters();
+            _matrixParam = Parameters["MatrixTransform"];
         }
 
 
@@ -46,15 +48,6 @@ namespace Microsoft.Xna.Framework.Graphics
         public override Effect Clone()
         {
             return new SpriteEffect(this);
-        }
-
-
-        /// <summary>
-        /// Looks up shortcut references to our effect parameters.
-        /// </summary>
-        void CacheEffectParameters()
-        {
-            _matrixParam = Parameters["MatrixTransform"];
         }
 
         /// <summary>

--- a/MonoGame.Framework/Graphics/RenderTarget2D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.cs
@@ -99,11 +99,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			DepthFormat selectedDepthFormat;
 			int selectedMultiSampleCount;
 
-            if (graphicsDevice != null)
-            {
-                graphicsDevice.Adapter.QueryRenderTargetFormat(graphicsDevice.GraphicsProfile, preferredFormat, DepthFormat.None, 0,
+            graphicsDevice?.Adapter.QueryRenderTargetFormat(graphicsDevice.GraphicsProfile, preferredFormat, DepthFormat.None, 0,
                     out selectedFormat, out selectedDepthFormat, out selectedMultiSampleCount);
-            }
 
             return selectedFormat;
         }

--- a/MonoGame.Framework/Graphics/RenderTarget2D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -50,7 +52,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// This event is never called.  It is included for XNA compatibility.
         /// </remarks>
         [Obsolete("This is provided for XNA compatibility is never called by MonoGame")]
-		public event EventHandler<EventArgs> ContentLost;
+        public event EventHandler<EventArgs> ContentLost = delegate { };
 
         private bool SuppressEventHandlerWarningsUntilEventsAreProperlyImplemented()
         {

--- a/MonoGame.Framework/Graphics/RenderTarget3D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget3D.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -16,7 +18,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		
 		public bool IsContentLost { get { return false; } }
 		
-		public event EventHandler<EventArgs> ContentLost;
+		public event EventHandler<EventArgs> ContentLost = delegate { };
 
         private bool SuppressEventHandlerWarningsUntilEventsAreProperlyImplemented()
         {

--- a/MonoGame.Framework/Graphics/RenderTargetBinding.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetBinding.cs
@@ -4,6 +4,8 @@
 //
 // Author: Kenneth James Pouncey
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/RenderTargetCube.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -58,7 +60,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// This event is never called.  It is included for XNA compatibility.
         /// </remarks>
         [Obsolete("This is provided for XNA compatibility is never called by MonoGame")]
-		public event EventHandler<EventArgs> ContentLost;
+		public event EventHandler<EventArgs> ContentLost = delegate { };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RenderTargetCube"/> class.

--- a/MonoGame.Framework/Graphics/RenderTargetCube.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.cs
@@ -102,11 +102,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			DepthFormat selectedDepthFormat;
 			int selectedMultiSampleCount;
 
-            if (graphicsDevice != null)
-            {
-                graphicsDevice.Adapter.QueryRenderTargetFormat(graphicsDevice.GraphicsProfile, preferredFormat, DepthFormat.None, 0,
+            graphicsDevice?.Adapter.QueryRenderTargetFormat(graphicsDevice.GraphicsProfile, preferredFormat, DepthFormat.None, 0,
                     out selectedFormat, out selectedDepthFormat, out selectedMultiSampleCount);
-            }
 
             return selectedFormat;
         }

--- a/MonoGame.Framework/Graphics/RenderTargetUsage.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetUsage.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>

--- a/MonoGame.Framework/Graphics/ResourceCreatedEventArgs.cs
+++ b/MonoGame.Framework/Graphics/ResourceCreatedEventArgs.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#nullable enable
+
+using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -10,6 +16,6 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// The newly created resource object.
         /// </summary>
-        public Object Resource { get; internal set; }
+        public Object? Resource { get; internal set; }
     }
 }

--- a/MonoGame.Framework/Graphics/ResourceDestroyedEventArgs.cs
+++ b/MonoGame.Framework/Graphics/ResourceDestroyedEventArgs.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#nullable enable
+
+using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -10,11 +16,11 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// The name of the destroyed resource.
         /// </summary>
-        public string Name { get; internal set; }
+        public string? Name { get; internal set; }
 
         /// <summary>
         /// The resource manager tag of the destroyed resource.
         /// </summary>
-        public Object Tag { get; internal set; }
+        public Object? Tag { get; internal set; }
     }
 }

--- a/MonoGame.Framework/Graphics/SamplerStateCollection.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.Text;
 
@@ -16,11 +18,11 @@ namespace Microsoft.Xna.Framework.Graphics
         readonly SpriteBatcher _batcher;
 
 		SpriteSortMode _sortMode;
-		BlendState _blendState;
-		SamplerState _samplerState;
-		DepthStencilState _depthStencilState; 
-		RasterizerState _rasterizerState;		
-		Effect _effect;
+		BlendState? _blendState;
+		SamplerState? _samplerState;
+		DepthStencilState? _depthStencilState;
+		RasterizerState? _rasterizerState;		
+		Effect? _effect;
         bool _beginCalled;
 
 		SpriteEffect _spriteEffect;
@@ -79,11 +81,11 @@ namespace Microsoft.Xna.Framework.Graphics
         public void Begin
         (
              SpriteSortMode sortMode = SpriteSortMode.Deferred,
-             BlendState blendState = null,
-             SamplerState samplerState = null,
-             DepthStencilState depthStencilState = null,
-             RasterizerState rasterizerState = null,
-             Effect effect = null,
+             BlendState? blendState = null,
+             SamplerState? samplerState = null,
+             DepthStencilState? depthStencilState = null,
+             RasterizerState? rasterizerState = null,
+             Effect? effect = null,
              Matrix? transformMatrix = null
         )
         {
@@ -131,7 +133,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			gd.BlendState = _blendState;
 			gd.DepthStencilState = _depthStencilState;
 			gd.RasterizerState = _rasterizerState;
-			gd.SamplerStates[0] = _samplerState;
+			gd.SamplerStates[0] = _samplerState!; // This should not be null when Setup is called
 
             _spritePass.Apply();
 		}
@@ -1512,7 +1514,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     if (_spriteEffect != null)
                     {
                         _spriteEffect.Dispose();
+#nullable disable // Disable nullability checks to free the reference, which is safely assumed non-null everywhere else
                         _spriteEffect = null;
+#nullable enable
                     }
                 }
             }

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		BlendState? _blendState;
 		SamplerState? _samplerState;
 		DepthStencilState? _depthStencilState;
-		RasterizerState? _rasterizerState;		
+		RasterizerState? _rasterizerState;
 		Effect? _effect;
         bool _beginCalled;
 

--- a/MonoGame.Framework/Graphics/SpriteBatchItem.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatchItem.cs
@@ -2,13 +2,15 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
     internal class SpriteBatchItem : IComparable<SpriteBatchItem>
 	{
-		public Texture2D Texture;
+		public Texture2D? Texture;
         public float SortKey;
 
         public VertexPositionColorTexture vertexTL;

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 
@@ -50,9 +52,9 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Vertex index array. The values in this array never change.
         /// </summary>
-        private short[] _index;
+        private short[]? _index;
 
-        private VertexPositionColorTexture[] _vertexArray;
+        private VertexPositionColorTexture[]? _vertexArray;
 
         public SpriteBatcher(GraphicsDevice device, int capacity = 0)
 		{
@@ -149,7 +151,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         /// <param name="sortMode">The type of depth sorting desired for the rendering.</param>
         /// <param name="effect">The custom effect to apply to the drawn geometry</param>
-        public unsafe void DrawBatch(SpriteSortMode sortMode, Effect effect)
+        public unsafe void DrawBatch(SpriteSortMode sortMode, Effect? effect)
 		{
             if (effect != null && effect.IsDisposed)
                 throw new ObjectDisposedException("effect");
@@ -184,7 +186,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // setup the vertexArray array
                 var startIndex = 0;
                 var index = 0;
-                Texture2D tex = null;
+                Texture2D? tex = null;
 
                 int numBatchesToProcess = batchCount;
                 if (numBatchesToProcess > MaxBatchSize)
@@ -239,7 +241,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="end">End index of vertices to draw. Not used except to compute the count of vertices to draw.</param>
         /// <param name="effect">The custom effect to apply to the geometry</param>
         /// <param name="texture">The texture to draw.</param>
-        private void FlushVertexArray(int start, int end, Effect effect, Texture texture)
+        private void FlushVertexArray(int start, int end, Effect? effect, Texture? texture)
         {
             if (start == end)
                 return;
@@ -260,7 +262,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                     _device.DrawUserIndexedPrimitives(
                         PrimitiveType.TriangleList,
-                        _vertexArray,
+                        _vertexArray!,
                         0,
                         vertexCount,
                         _index,
@@ -274,7 +276,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // If no custom effect is defined, then simply render.
                 _device.DrawUserIndexedPrimitives(
                     PrimitiveType.TriangleList,
-                    _vertexArray,
+                    _vertexArray!,
                     0,
                     vertexCount,
                     _index,

--- a/MonoGame.Framework/Graphics/SpriteEffects.cs
+++ b/MonoGame.Framework/Graphics/SpriteEffects.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -3,6 +3,9 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 // Original code from SilverSprite Project
+
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -331,10 +334,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 return glyphIdx;
         }
         
-        internal struct CharacterSource 
+        internal readonly struct CharacterSource
         {
-			private readonly string _string;
-			private readonly StringBuilder _builder;
+			private readonly string? _string;
+			private readonly StringBuilder? _builder;
 
 			public CharacterSource(string s)
 			{
@@ -351,13 +354,14 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 
 			public readonly int Length;
-			public char this [int index] 
+			public readonly char this [int index]
             {
 				get 
                 {
 					if (_string != null)
 						return _string[index];
-					return _builder[index];
+                    // The constructors are designed so _builder is not null when _string is null
+                    return _builder![index];
 				}
 			}
 		}

--- a/MonoGame.Framework/Graphics/SpriteSortMode.cs
+++ b/MonoGame.Framework/Graphics/SpriteSortMode.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>

--- a/MonoGame.Framework/Graphics/SurfaceFormat.cs
+++ b/MonoGame.Framework/Graphics/SurfaceFormat.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -643,8 +643,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void GetData<T> (T[] data) where T : struct
 		{
-		    if (data == null)
-		        throw new ArgumentNullException("data");
+            ArgumentNullException.ThrowIfNull(data);
 			this.GetData(0, null, data, 0, data.Length);
 		}
 
@@ -662,8 +661,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </remarks>
         public static Texture2D FromFile(GraphicsDevice graphicsDevice, string path, Action<byte[]> colorProcessor)
         {
-            if (path == null)
-                throw new ArgumentNullException("path");
+            ArgumentNullException.ThrowIfNull(path);
 
             using (var stream = File.OpenRead(path))
                 return FromStream(graphicsDevice, stream, colorProcessor);
@@ -699,10 +697,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </remarks>
         public static Texture2D FromStream(GraphicsDevice graphicsDevice, Stream stream, Action<byte[]> colorProcessor)
 		{
-            if (graphicsDevice == null)
-                throw new ArgumentNullException("graphicsDevice");
-            if (stream == null)
-                throw new ArgumentNullException("stream");
+            ArgumentNullException.ThrowIfNull(graphicsDevice);
+            ArgumentNullException.ThrowIfNull(stream);
 
             try
             {
@@ -788,8 +784,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("arraySlice must be smaller than the ArraySize of this texture and larger than 0.", "arraySlice");
             if (!textureBounds.Contains(checkedRect) || checkedRect.Width <= 0 || checkedRect.Height <= 0)
                 throw new ArgumentException("Rectangle must be inside the texture bounds", "rect");
-            if (data == null)
-                throw new ArgumentNullException("data");
+            ArgumentNullException.ThrowIfNull(data);
             var tSize = ReflectionHelpers.FastSizeOf<T>();
             var fSize = Format.GetSize();
             if (tSize > fSize || fSize % tSize != 0)

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -643,8 +643,9 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void GetData<T> (T[] data) where T : struct
 		{
-            ArgumentNullException.ThrowIfNull(data);
-			this.GetData(0, null, data, 0, data.Length);
+            if (data == null)
+                throw new ArgumentNullException("data");
+            this.GetData(0, null, data, 0, data.Length);
 		}
 
         /// <summary>
@@ -661,7 +662,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </remarks>
         public static Texture2D FromFile(GraphicsDevice graphicsDevice, string path, Action<byte[]> colorProcessor)
         {
-            ArgumentNullException.ThrowIfNull(path);
+            if (path == null)
+                throw new ArgumentNullException("path");
 
             using (var stream = File.OpenRead(path))
                 return FromStream(graphicsDevice, stream, colorProcessor);
@@ -697,8 +699,10 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </remarks>
         public static Texture2D FromStream(GraphicsDevice graphicsDevice, Stream stream, Action<byte[]> colorProcessor)
 		{
-            ArgumentNullException.ThrowIfNull(graphicsDevice);
-            ArgumentNullException.ThrowIfNull(stream);
+            if (graphicsDevice == null)
+                throw new ArgumentNullException("grphicsDevice");
+            if (stream == null)
+                throw new ArgumentNullException("stream");
 
             try
             {
@@ -784,7 +788,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("arraySlice must be smaller than the ArraySize of this texture and larger than 0.", "arraySlice");
             if (!textureBounds.Contains(checkedRect) || checkedRect.Width <= 0 || checkedRect.Height <= 0)
                 throw new ArgumentException("Rectangle must be inside the texture bounds", "rect");
-            ArgumentNullException.ThrowIfNull(data);
+            if (data == null)
+                throw new ArgumentNullException("data");
             var tSize = ReflectionHelpers.FastSizeOf<T>();
             var fSize = Format.GetSize();
             if (tSize > fSize || fSize % tSize != 0)

--- a/MonoGame.Framework/Graphics/Texture3D.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -12,7 +14,7 @@ namespace Microsoft.Xna.Framework.Graphics
     public sealed partial class TextureCollection
     {
         private readonly GraphicsDevice _graphicsDevice;
-        private readonly Texture[] _textures;
+        private readonly Texture?[] _textures;
         private ShaderStage _stage;
         private int _dirty;
 
@@ -28,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Gets or sets the <see cref="Texture"/> at the specified sampler number.
         /// </summary>
-        public Texture this[int index]
+        public Texture? this[int index]
         {
             get
             {

--- a/MonoGame.Framework/Graphics/TextureCube.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.cs
@@ -93,7 +93,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void GetData<T>(CubeMapFace cubeMapFace, T[] data) where T : struct
         {
-            ArgumentNullException.ThrowIfNull(data);
+            if (data == null)
+		        throw new ArgumentNullException("data");
             GetData(cubeMapFace, 0, null, data, 0, data.Length);
         }
 
@@ -208,7 +209,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
 		public void SetData<T> (CubeMapFace face, T[] data) where T : struct
 		{
-            ArgumentNullException.ThrowIfNull(data);
+            if (data == null)
+                throw new ArgumentNullException("data");
             SetData(face, 0, null, data, 0, data.Length);
 		}
 
@@ -308,7 +310,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("level must be smaller than the number of levels in this texture.");
             if (!textureBounds.Contains(checkedRect) || checkedRect.Width <= 0 || checkedRect.Height <= 0)
                 throw new ArgumentException("Rectangle must be inside the texture bounds", "rect");
-            ArgumentNullException.ThrowIfNull(data);
+            if (data == null)
+                throw new ArgumentNullException("data");
             var tSize = ReflectionHelpers.FastSizeOf<T>();
             var fSize = Format.GetSize();
             if (tSize > fSize || fSize % tSize != 0)

--- a/MonoGame.Framework/Graphics/TextureCube.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using MonoGame.Framework.Utilities;

--- a/MonoGame.Framework/Graphics/TextureCube.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.cs
@@ -58,12 +58,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal TextureCube(GraphicsDevice graphicsDevice, int size, bool mipMap, SurfaceFormat format, bool renderTarget)
         {
-            if (graphicsDevice == null)
-                throw new ArgumentNullException("graphicsDevice", FrameworkResources.ResourceCreationWhenDeviceIsNull);
             if (size <= 0)
                 throw new ArgumentOutOfRangeException("size","Cube size must be greater than zero");
 
-            this.GraphicsDevice = graphicsDevice;
+            this.GraphicsDevice = graphicsDevice ?? throw new ArgumentNullException(nameof(graphicsDevice), FrameworkResources.ResourceCreationWhenDeviceIsNull);
 			this.size = size;
             this._format = format;
             this._levelCount = mipMap ? CalculateMipLevels(size) : 1;
@@ -95,8 +93,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
         public void GetData<T>(CubeMapFace cubeMapFace, T[] data) where T : struct
         {
-            if (data == null)
-                throw new ArgumentNullException("data");
+            ArgumentNullException.ThrowIfNull(data);
             GetData(cubeMapFace, 0, null, data, 0, data.Length);
         }
 
@@ -211,8 +208,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <exception cref="ArgumentNullException">The <paramref name="data"/> parameter is null.</exception>
 		public void SetData<T> (CubeMapFace face, T[] data) where T : struct
 		{
-            if (data == null)
-                throw new ArgumentNullException("data");
+            ArgumentNullException.ThrowIfNull(data);
             SetData(face, 0, null, data, 0, data.Length);
 		}
 
@@ -312,8 +308,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("level must be smaller than the number of levels in this texture.");
             if (!textureBounds.Contains(checkedRect) || checkedRect.Width <= 0 || checkedRect.Height <= 0)
                 throw new ArgumentException("Rectangle must be inside the texture bounds", "rect");
-            if (data == null)
-                throw new ArgumentNullException("data");
+            ArgumentNullException.ThrowIfNull(data);
             var tSize = ReflectionHelpers.FastSizeOf<T>();
             var fSize = Format.GetSize();
             if (tSize > fSize || fSize % tSize != 0)

--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.DirectX.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using SharpDX.Direct3D11;
 using SharpDX.DXGI;
 
@@ -9,9 +11,9 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class RenderTarget2D
     {
-        internal RenderTargetView[] _renderTargetViews;
-        internal DepthStencilView _depthStencilView;
-        private SharpDX.Direct3D11.Texture2D _msTexture;
+        internal RenderTargetView[]? _renderTargetViews;
+        internal DepthStencilView? _depthStencilView;
+        private SharpDX.Direct3D11.Texture2D? _msTexture;
 
         private SampleDescription _msSampleDescription;
 
@@ -125,13 +127,13 @@ namespace Microsoft.Xna.Framework.Graphics
         RenderTargetView IRenderTarget.GetRenderTargetView(int arraySlice)
         {
             GenerateIfRequired();
-            return _renderTargetViews[arraySlice];
+            return _renderTargetViews![arraySlice];
         }
 
         DepthStencilView IRenderTarget.GetDepthStencilView()
         {
             GenerateIfRequired();
-            return _depthStencilView;
+            return _depthStencilView!;
         }
 
         internal virtual void ResolveSubresource()

--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.OpenGL.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using MonoGame.OpenGL;
 

--- a/MonoGame.Framework/Platform/Graphics/RenderTarget3D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget3D.DirectX.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using SharpDX.Direct3D11;
 
@@ -10,7 +12,7 @@ namespace Microsoft.Xna.Framework.Graphics
     public partial class RenderTarget3D
     {
         private int _currentSlice;
-        private RenderTargetView _renderTargetView;
+        private RenderTargetView? _renderTargetView;
         private DepthStencilView _depthStencilView;
 
         private void PlatformConstruct(GraphicsDevice graphicsDevice, int width, int height, bool mipMap,

--- a/MonoGame.Framework/Platform/Graphics/RenderTargetCube.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTargetCube.DirectX.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using SharpDX.DXGI;
 using SharpDX.Direct3D11;
@@ -10,7 +12,7 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class RenderTargetCube
     {
-        private RenderTargetView[] _renderTargetViews;
+        private RenderTargetView[]? _renderTargetViews;
         private DepthStencilView _depthStencilView;
 
         private void PlatformConstruct(GraphicsDevice graphicsDevice, bool mipMap, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
@@ -87,7 +89,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <inheritdoc/>
         public RenderTargetView GetRenderTargetView(int arraySlice)
         {
-            return _renderTargetViews[arraySlice];
+            return _renderTargetViews![arraySlice];
         }
 
         /// <inheritdoc/>

--- a/MonoGame.Framework/Platform/Graphics/RenderTargetCube.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTargetCube.OpenGL.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using MonoGame.OpenGL;
 

--- a/MonoGame.Framework/Platform/Graphics/SamplerStateCollection.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/SamplerStateCollection.DirectX.cs
@@ -4,6 +4,8 @@
 //
 // Author: Kenneth James Pouncey
 
+#nullable enable
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     public sealed partial class SamplerStateCollection
@@ -49,7 +51,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     continue;
 
                 var sampler = _actualSamplers[i];
-                SharpDX.Direct3D11.SamplerState state = null;
+                SharpDX.Direct3D11.SamplerState? state = null;
                 if (sampler != null)
                     state = sampler.GetState(device);
 

--- a/MonoGame.Framework/Platform/Graphics/SamplerStateCollection.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/SamplerStateCollection.OpenGL.cs
@@ -4,6 +4,8 @@
 //
 // Author: Kenneth James Pouncey
 
+#nullable enable
+
 using MonoGame.OpenGL;
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -27,7 +29,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private bool _mipmap;
         private SampleDescription _sampleDescription;
 
-        private SharpDX.Direct3D11.Texture2D _cachedStagingTexture;
+        private SharpDX.Direct3D11.Texture2D? _cachedStagingTexture;
 
         private void PlatformConstruct(int width, int height, bool mipmap, SurfaceFormat format, SurfaceType type, bool shared)
         {
@@ -148,7 +150,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 d3dContext.CopySubresourceRegion(GetTexture(), subresourceIndex, region, _cachedStagingTexture, 0);
 
                 // Copy the data to the array.
-                DataStream stream = null;
+                DataStream? stream = null;
                 try
                 {
                     var databox = d3dContext.MapSubresource(_cachedStagingTexture, 0, MapMode.Read, MapFlags.None, out stream);

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.OpenGL.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -346,14 +348,14 @@ namespace Microsoft.Xna.Framework.Graphics
             bitmapContext.Dispose();
             colorSpace.Dispose();
 
-            Texture2D texture = null;
+            Texture2D? texture = null;
             Threading.BlockOnUIThread(() =>
             {
                 texture = new Texture2D(graphicsDevice, (int)width, (int)height, false, SurfaceFormat.Color);
                 texture.SetData(data);
             });
 
-            return texture;
+            return texture!;
         }
 #elif ANDROID
         private static Texture2D PlatformFromStream(GraphicsDevice graphicsDevice, Bitmap image)
@@ -382,14 +384,14 @@ namespace Microsoft.Xna.Framework.Graphics
             // Convert from ARGB to ABGR
             ConvertToABGR(height, width, pixels);
 
-            Texture2D texture = null;
+            Texture2D? texture = null;
             Threading.BlockOnUIThread(() =>
             {
                 texture = new Texture2D(graphicsDevice, width, height, false, SurfaceFormat.Color);
                 texture.SetData<int>(pixels);
             });
 
-            return texture;
+            return texture!;
         }
 #endif
 

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.StbSharp.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using StbImageSharp;
 using StbImageWriteSharp;
 using System;
@@ -41,8 +43,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 colorProcessor(result.Data);
             }
 
-            Texture2D texture = null;
-            texture = new Texture2D(graphicsDevice, result.Width, result.Height);
+            Texture2D texture = new Texture2D(graphicsDevice, result.Width, result.Height);
             texture.SetData(result.Data);
 
             return texture;
@@ -78,7 +79,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 throw new ArgumentOutOfRangeException("height", height, "'height' cannot be less than or equal to zero");
             }
-            Color[] data = null;
+            Color[]? data = null;
             try
             {
                 data = GetColorData();

--- a/MonoGame.Framework/Platform/Graphics/Texture3D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture3D.DirectX.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -122,7 +124,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     d3dContext.CopySubresourceRegion(GetTexture(), level, new ResourceRegion(left, top, front, right, bottom, back), stagingTex, 0);
 
                     // Copy the data to the array.
-                    DataStream stream = null;
+                    DataStream? stream = null;
                     try
                     {
                         var databox = d3dContext.MapSubresource(stagingTex, 0, MapMode.Read, MapFlags.None, out stream);

--- a/MonoGame.Framework/Platform/Graphics/Texture3D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture3D.OpenGL.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using MonoGame.Framework.Utilities;

--- a/MonoGame.Framework/Platform/Graphics/TextureCollection.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/TextureCollection.DirectX.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     public sealed partial class TextureCollection
@@ -72,11 +74,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 var tex = _textures[i];
 
-                if (_textures[i] == null || _textures[i].IsDisposed)
+                if (tex?.IsDisposed ?? true)
                     shaderStage.SetShaderResource(i, null);
                 else
                 {
-                    shaderStage.SetShaderResource(i, _textures[i].GetShaderResourceView());
+                    shaderStage.SetShaderResource(i, tex.GetShaderResourceView());
                     unchecked
                     {
                         _graphicsDevice._graphicsMetrics._textureCount++;

--- a/MonoGame.Framework/Platform/Graphics/TextureCollection.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/TextureCollection.OpenGL.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using MonoGame.OpenGL;
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Platform/Graphics/TextureCube.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/TextureCube.DirectX.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -90,7 +92,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     d3dContext.CopySubresourceRegion(GetTexture(), subresourceIndex, region, stagingTex, 0);
 
                     // Copy the data to the array.
-                    DataStream stream = null;
+                    DataStream? stream = null;
                     try
                     {
                         var databox = d3dContext.MapSubresource(stagingTex, 0, MapMode.Read, MapFlags.None, out stream);

--- a/MonoGame.Framework/Platform/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/TextureCube.OpenGL.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using MonoGame.OpenGL;

--- a/MonoGame.Framework/Platform/Native/RenderTarget2D.Native.cs
+++ b/MonoGame.Framework/Platform/Native/RenderTarget2D.Native.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using MonoGame.Interop;
 namespace Microsoft.Xna.Framework.Graphics;
 

--- a/MonoGame.Framework/Platform/Native/RenderTarget3D.Native.cs
+++ b/MonoGame.Framework/Platform/Native/RenderTarget3D.Native.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using MonoGame.Interop;
 
 namespace Microsoft.Xna.Framework.Graphics;

--- a/MonoGame.Framework/Platform/Native/RenderTargetCube.Native.cs
+++ b/MonoGame.Framework/Platform/Native/RenderTargetCube.Native.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using MonoGame.Interop;
 
 namespace Microsoft.Xna.Framework.Graphics;

--- a/MonoGame.Framework/Platform/Native/SamplerStateCollection.Native.cs
+++ b/MonoGame.Framework/Platform/Native/SamplerStateCollection.Native.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using MonoGame.Interop;
 
 namespace Microsoft.Xna.Framework.Graphics;

--- a/MonoGame.Framework/Platform/Native/Texture2D.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Texture2D.Native.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -122,7 +124,6 @@ public partial class Texture2D : Texture
         ProcessorType processor = 0;
         if (colorProcessor == DefaultColorProcessors.ZeroTransparentPixels)
         {
-            colorProcessor = null;
             processor |= ProcessorType.ZeroTransparentPixels;
         }
 
@@ -161,7 +162,7 @@ public partial class Texture2D : Texture
         var texture = new Texture2D(graphicsDevice, width, height);
         var rgbaBytes = (width * height) * 4;
 
-        if (colorProcessor == null)
+        if ((processor & ProcessorType.ZeroTransparentPixels) != 0)
         {
             // Without a color processor take the fast path.
 

--- a/MonoGame.Framework/Platform/Native/Texture3D.Native.cs
+++ b/MonoGame.Framework/Platform/Native/Texture3D.Native.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using MonoGame.Interop;

--- a/MonoGame.Framework/Platform/Native/TextureCollection.Native.cs
+++ b/MonoGame.Framework/Platform/Native/TextureCollection.Native.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using MonoGame.Interop;
 
 namespace Microsoft.Xna.Framework.Graphics;
@@ -30,7 +32,7 @@ public sealed partial class TextureCollection
 
             var tex = _textures[i];
 
-            if (_textures[i] == null || _textures[i].IsDisposed)
+            if (tex?.IsDisposed ?? true)
                 MGG.GraphicsDevice_SetTexture(device.Handle, _stage, i, null);
             else
             {

--- a/MonoGame.Framework/Platform/Native/TextureCube.Native.cs
+++ b/MonoGame.Framework/Platform/Native/TextureCube.Native.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using MonoGame.Interop;


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes #9192 

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

This adds `#nullable enable` to 20 classes in the Graphics namespace. Most of the classes already handle null values appropriately so many files only have the pragma added and nothing else changed, and most of the rest only have nullable annotation changes, like null propagation instead of if blocks, and marking variables and returns that are already treated as nullable by callers.

<!-- 
Enter description of the fix in this section.
Please be as descriptive as possible, future contributors will need to know *why* these changes are being made.
For inspiration review the commit/PR history in the MonoGame repository.
-->


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

