### PR TITLE
#9205 Unit tests for SaveAsPng and SaveAsJpeg

### DIFF
--- a/Tests/Framework/Graphics/Texture2DTest.cs
+++ b/Tests/Framework/Graphics/Texture2DTest.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 using System;
+using System.IO;
+using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using NUnit.Framework;
@@ -250,6 +252,117 @@ namespace MonoGame.Tests.Graphics
             sb.Dispose();
 
             CheckFrames();
+        }
+
+        static readonly Color[] sampleTextureColors = [Color.CornflowerBlue, Color.Red, Color.Green, Color.Blue, Color.White, Color.Black, Color.Transparent, new Color(Color.DarkSlateBlue, 0.5f), Color.Chartreuse];
+        static Texture2D MakeSampleTexture(GraphicsDevice gd, int width, int height, out Color[] pixels)
+        {
+            // Make an array of colors matching the width and height
+            static Color getExpectedColor(int index) => sampleTextureColors[index % sampleTextureColors.Length];
+            pixels =
+                Enumerable.Range(0, width * height)
+                .Select(getExpectedColor)
+                .ToArray();
+
+            // Make a texture with the data
+            Texture2D tex = new Texture2D(gd, width, height);
+            tex.SetData(pixels);
+
+            return tex;
+        }
+
+        [Test]
+        [RunOnUI]
+        // Nice small square
+        [TestCase(64, 64)]
+        // One pixel
+        [TestCase(1, 1)]
+        // Large square
+        [TestCase(2048, 2048)]
+        // Large non-square
+        [TestCase(2048, 1234)]
+        // Small non-power-of-2 square
+        [TestCase(7, 7)]
+        // Small non-square
+        [TestCase(15, 31)]
+        public void SaveAsPngShouldWork(int width, int height)
+        {
+            using var source = MakeSampleTexture(gd, width, height, out var expectedPixels);
+            // Save the texture to a memory stream
+            using var stream = new MemoryStream(width * height * 4); // 4 bytes in a Color;
+            source.SaveAsPng(stream, width, height);
+
+            source.Dispose();
+
+            // Create a new texture from the stream
+            using var result = Texture2D.FromStream(gd, stream);
+
+            // The result should be the same size
+            Assert.AreEqual(result.width, width);
+            Assert.AreEqual(result.height, height);
+
+            Color[] resultPixels = new Color[width * height];
+            result.GetData(resultPixels);
+
+            // It should have the same pixels
+            Assert.AreEqual(expectedPixels, resultPixels);
+
+            result.Dispose();
+        }
+
+        [Test]
+        [RunOnUI]
+        // Nice small square
+        [TestCase(64, 64)]
+        // One pixel
+        [TestCase(1, 1)]
+        // Large square
+        [TestCase(1024, 1024)]
+        // Large non-square
+        [TestCase(1024, 1234)]
+        // Small non-power-of-2 square
+        [TestCase(7, 7)]
+        // Small non-square
+        [TestCase(15, 31)]
+        public void SaveAsJpegShouldWork(int width, int height)
+        {
+            // Make a test texture and save it to a memory stream
+            using var source = MakeSampleTexture(gd, width, height, out var expectedPixels);
+            using var stream = new MemoryStream(width * height * 4); // 4 bytes in a Color;
+            source.SaveAsJpeg(stream, width, height);
+
+            // Create a new texture from the stream.
+            using var result = Texture2D.FromStream(gd, stream);
+            // Read back pixels
+            var resultPixels = new Color[width * height];
+            result.GetData(resultPixels);
+
+            // The maximum value by which a source pixel and the destination pixel can vary in one color channel
+            const int tolerance = 35;// This is arbitrary and was chosen just because it works with the test cases and the generated sample images
+
+            // Compare the source pixels to the result pixels, with tolerance
+            for (int i = 0; i < expectedPixels.Length; i++)
+            {
+                Color expectedPixel = expectedPixels[i];
+                Color resultPixel = resultPixels[i];
+                int rDiff = Math.Abs(expectedPixel.R - resultPixel.R);
+                int gDiff = Math.Abs(expectedPixel.G - resultPixel.G);
+                int bDiff = Math.Abs(expectedPixel.B - resultPixel.B);
+                // Don't test alpha because jpeg doesn't support it
+
+                bool withinTolerance =
+                    rDiff <= tolerance &&
+                    gDiff <= tolerance &&
+                    bDiff <= tolerance;
+                Assert.True(withinTolerance,
+                    "Pixel {0} ({1}, {2}) differs beyond tolerance: {3} expected, got {4}.",
+                    i,
+                    i % width,
+                    i / width,
+                    expectedPixel,
+                    resultPixel
+                    );
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes #9205 

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

This adds `SaveAsPngShouldWork` and `SaveAsJpegShouldWork` to Texture2DTests.cs, plus some static helpers for building test textures.

Both tests rely on `Texture2D.FromStream`. They make a sample texture, save to a `MemoryStream` with the method being tested, and then compare the sample against the result of `Texture2D.FromStream` on the same memory stream.

The PNG tests require all pixels to be identical between the two images, and the JPEG tests require that all result pixels be within 35 of the source on R, G, and B channels. Alpha is not tested for JPEG. 35 was arbitrary to get my test cases to pass so I won't lose any sleep over it if someone who understands JPEG better than me wants to improve the result comparison.
 
<!-- 
Enter description of the fix in this section.
Please be as descriptive as possible, future contributors will need to know *why* these changes are being made.
For inspiration review the commit/PR history in the MonoGame repository.
-->


### Contributor Declaration

- [X] I certify that no LLM's were used to generate any code or documentation in this contribution.

