### PR TITLE
Rosyln Analzyer (base setup)

### DIFF
--- a/MonoGame.Analyzers/AnalyzerReleases.Shipped.md
+++ b/MonoGame.Analyzers/AnalyzerReleases.Shipped.md
@@ -4,4 +4,4 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-MG0001 | MonoGame.Compatibility | Error | API Unsupported on platform
+MG0001 | MonoGame.Compatibility | Warning | API Unsupported on platform

--- a/MonoGame.Analyzers/AnalyzerReleases.Shipped.md
+++ b/MonoGame.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,7 @@
+## Release 3.8.5
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+MG0001 | MonoGame.Compatibility | Error | API Unsupported on platform

--- a/MonoGame.Analyzers/MonoGame.Analyzers.csproj
+++ b/MonoGame.Analyzers/MonoGame.Analyzers.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <Import Project="..\MonoGame.props" />
+
+    <PropertyGroup>
+        <!-- Build Settings -->
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <BaseOutputPath>..\Artifacts\MonoGame.Analyzers</BaseOutputPath>
+        <AssemblyName>MonoGame.Analyzers</AssemblyName>
+        <RootNamespace>MonoGame.Analyzers</RootNamespace>
+        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+
+        <!-- Pack Settings -->
+        <IsPackable>True</IsPackable>
+        <Description>Roslyn analyzers for MonoGame project.</Description>
+        <PackageTags>monogame;roslyn;analyzers</PackageTags>
+        <PackageReadmeFile>README-packages.md</PackageReadmeFile>
+
+        <!-- Put the analyzer dll in the NuGet analyzer folder -->
+        <NoPackageAnalysis>true</NoPackageAnalysis>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <!-- Pack the analyzer DLL into analyzers/dotnet/cs/ -->
+        <None Include="$(TargetPath)"
+              Pack="true"
+              PackagePath="analyzers/dotnet/cs/" />
+
+        <!--
+              Additional files to include for analyzer releases
+              Read more at: https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+        -->
+        <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+        <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+
+        <None Include="..\README-packages.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp"
+                          Version="4.8.0"
+                          PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers"
+                          Version="3.3.4"
+                          PrivateAssets="all" />
+    </ItemGroup>
+
+</Project>

--- a/MonoGame.Analyzers/UnsupportedonAnalyzers.cs
+++ b/MonoGame.Analyzers/UnsupportedonAnalyzers.cs
@@ -17,7 +17,7 @@ public sealed class UnsupportedOnAnalyzer : DiagnosticAnalyzer
         "API is not supported on this MonoGame platform",
         "{0}",
         "MonoGame.Compatibility",
-        DiagnosticSeverity.Error,
+        DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);

--- a/MonoGame.Analyzers/UnsupportedonAnalyzers.cs
+++ b/MonoGame.Analyzers/UnsupportedonAnalyzers.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace MonoGame.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UnsupportedOnAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "MG0001";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "API is not supported on this MonoGame platform",
+        "{0}",
+        "MonoGame.Compatibility",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(startContext =>
+        {
+            INamedTypeSymbol unsupportedOnAttr = startContext.Compilation.GetTypeByMetadataName("MonoGame.Framework.UnsupportedOnAttribute");
+
+            if (unsupportedOnAttr is null)
+            {
+                return;
+            }
+
+            startContext.RegisterOperationAction(
+                ctx => AnalyzeObjectCreation(ctx, unsupportedOnAttr),
+                OperationKind.ObjectCreation);
+        });
+    }
+
+    private static void AnalyzeObjectCreation(OperationAnalysisContext context, INamedTypeSymbol unsupportedOnAttrSymbol)
+    {
+        if (context.Operation is not IObjectCreationOperation creation)
+        {
+            return;
+        }
+
+        IMethodSymbol ctor = creation.Constructor;
+        if (ctor is null)
+        {
+            return;
+        }
+
+        // Read MonoGamePlatform from consuming project
+        AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GlobalOptions;
+        if (!options.TryGetValue("build_property.MonoGamePlatform", out string monogamePlatform))
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(monogamePlatform))
+        {
+            return;
+        }
+
+        AttributeData[] attrs = ctor.GetAttributes()
+            .Where(a => a.AttributeClass is not null &&
+                        SymbolEqualityComparer.Default.Equals(a.AttributeClass, unsupportedOnAttrSymbol))
+            .ToArray();
+
+        if (attrs.Length == 0)
+        {
+            return;
+        }
+
+        foreach (AttributeData attr in attrs)
+        {
+            if (attr.ConstructorArguments.Length < 2)
+                continue;
+
+            string platforms = attr.ConstructorArguments[0].Value as string;
+            string message = attr.ConstructorArguments[1].Value as string;
+
+            if (string.IsNullOrWhiteSpace(platforms) || string.IsNullOrWhiteSpace(message))
+                continue;
+
+            if (IsPlatformMatch(platforms, monogamePlatform))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, creation.Syntax.GetLocation(), message));
+                return;
+            }
+        }
+    }
+
+    private static bool IsPlatformMatch(string semicolonList, string platform)
+    {
+        ImmutableHashSet<string> set = semicolonList
+                                       .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                                       .Select(p => p.Trim())
+                                       .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return set.Contains(platform.Trim());
+    }
+}

--- a/MonoGame.Framework/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Framework;
 
 namespace Microsoft.Xna.Framework.Media
 {
@@ -82,10 +83,10 @@ namespace Microsoft.Xna.Framework.Media
         /// Gets the media playback state, <see cref="MediaState"/>.
         /// </summary>
         public MediaState State
-        { 
+        {
             get
             {
-                // Give the platform code a chance to update 
+                // Give the platform code a chance to update
                 // the playback state before we return the result.
                 PlatformGetState(ref _state);
                 return _state;
@@ -103,7 +104,7 @@ namespace Microsoft.Xna.Framework.Media
         public float Volume
         {
             get { return _volume; }
-            
+
             set
             {
                 if (value < 0.0f || value > 1.0f)
@@ -123,6 +124,7 @@ namespace Microsoft.Xna.Framework.Media
         /// <summary>
         /// Creates a new instance of <see cref="VideoPlayer"/> class.
         /// </summary>
+        [UnsupportedOn("DesktopGL;Windows", "VideoPlayer is not implemented on this platform.")]
         public VideoPlayer()
         {
             _state = MediaState.Stopped;
@@ -191,7 +193,7 @@ namespace Microsoft.Xna.Framework.Media
             if (_currentVideo == video)
             {
                 var state = State;
-							
+
                 // No work to do if we're already
                 // playing this video.
                 if (state == MediaState.Playing)
@@ -205,7 +207,7 @@ namespace Microsoft.Xna.Framework.Media
                     return;
                 }
             }
-            
+
             _currentVideo = video;
 
             PlatformPlay();
@@ -230,7 +232,7 @@ namespace Microsoft.Xna.Framework.Media
             {
                 //We timed out - attempt to stop to fix any bad state
                 Stop();
-                throw new InvalidOperationException("cannot start video"); 
+                throw new InvalidOperationException("cannot start video");
             }
         }
 

--- a/MonoGame.Framework/MonoGame.Framework.Android.targets
+++ b/MonoGame.Framework/MonoGame.Framework.Android.targets
@@ -4,5 +4,8 @@
     <MonoGamePlatform>Android</MonoGamePlatform>
   </PropertyGroup>
 
-</Project>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="MonoGamePlatform" />
+  </ItemGroup>
 
+</Project>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.targets
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.targets
@@ -4,4 +4,8 @@
     <MonoGamePlatform>DesktopGL</MonoGamePlatform>
   </PropertyGroup>
 
+  <ItemGroup>
+    <CompilerVisibleProperty Include="MonoGamePlatform" />
+  </ItemGroup>
+
 </Project>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.targets
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.targets
@@ -4,5 +4,8 @@
     <MonoGamePlatform>Windows</MonoGamePlatform>
   </PropertyGroup>
 
-</Project>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="MonoGamePlatform" />
+  </ItemGroup>
 
+</Project>

--- a/MonoGame.Framework/MonoGame.Framework.iOS.targets
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.targets
@@ -5,5 +5,8 @@
     <AppBundleExtraOptions>$(AppBundleExtraOptions) -gcc_flags '-framework CoreAudio -framework AudioToolbox'</AppBundleExtraOptions>
   </PropertyGroup>
 
-</Project>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="MonoGamePlatform" />
+  </ItemGroup>
 
+</Project>

--- a/MonoGame.Framework/UnsupportedOnAttribute.cs
+++ b/MonoGame.Framework/UnsupportedOnAttribute.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace MonoGame.Framework
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Method |
+                    AttributeTargets.Property | AttributeTargets.Field,
+                    AllowMultiple = true)]
+    public sealed class UnsupportedOnAttribute : Attribute
+    {
+        public string MonoGamePlatforms { get; }
+        public string Message { get; }
+
+        public UnsupportedOnAttribute(string monogamePlatforms, string message)
+        {
+            MonoGamePlatforms = monogamePlatforms;
+            Message = message;
+        }
+    }
+}

--- a/build/BuildAnalyzerTask/BuildAnalyzerTask.cs
+++ b/build/BuildAnalyzerTask/BuildAnalyzerTask.cs
@@ -1,0 +1,12 @@
+
+namespace BuildScripts;
+
+[TaskName("Build Analyzer")]
+public sealed class BuildAnalyzerTask : FrostingTask<BuildContext>
+{
+    public override void Run(BuildContext context)
+    {
+        context.DotNetPack(context.GetProjectPath(ProjectType.Analyzer), context.DotNetPackSettings);
+        context.PublishAnalyzerBinaries("MonoGame.Analyzers");
+    }
+}

--- a/build/BuildContext.cs
+++ b/build/BuildContext.cs
@@ -16,7 +16,8 @@ public enum ProjectType
     ContentPipeline,
     DevTools,
     MGCBEditor,
-    MGCBEditorLauncher
+    MGCBEditorLauncher,
+    Analyzer
 }
 
 public class BuildContext : FrostingContext
@@ -167,6 +168,7 @@ public class BuildContext : FrostingContext
         ProjectType.DevTools => "src/MonoGame.Framework.DevTools/MonoGame.Framework.DevTools.csproj",
         ProjectType.MGCBEditor => $"Tools/MonoGame.Content.Builder.Editor/MonoGame.Content.Builder.Editor.{id}.csproj",
         ProjectType.MGCBEditorLauncher => $"Tools/MonoGame.Content.Builder.Editor.Launcher/MonoGame.Content.Builder.Editor.Launcher.{id}.csproj",
+        ProjectType.Analyzer => "MonoGame.Analyzers/MonoGame.Analyzers.csproj",
         _ => throw new ArgumentOutOfRangeException(nameof(type))
     };
 
@@ -298,6 +300,13 @@ public static class BuildContextExtensions
     {
         context.Information($"Packaging Tools Binaries {inputPath}...");
         context.DotNetBinariesPublishSettings.OutputDirectory = $"{context.BinariesDirectory}/MonoGame.Framework.Content.Pipeline/";
+        context.DotNetPublish(inputPath, context.DotNetBinariesPublishSettings);
+    }
+
+    public static void PublishAnalyzerBinaries(this BuildContext context, string inputPath)
+    {
+        context.Information($"Packaging Analyzers Binaries {inputPath}...");
+        context.DotNetBinariesPublishSettings.OutputDirectory = $"{context.BinariesDirectory}/MonoGame.Analyzers/";
         context.DotNetPublish(inputPath, context.DotNetBinariesPublishSettings);
     }
 

--- a/build/Tasks.cs
+++ b/build/Tasks.cs
@@ -35,13 +35,13 @@ public sealed class BuildTemplatesTask : FrostingTask<BuildContext> { }
 [IsDependentOn(typeof(BuildToolTestsTask))]
 public sealed class BuildAllTestsTask : FrostingTask<BuildContext> { }
 
-
 [TaskName("Build All")]
 [IsDependentOn(typeof(BuildShadersTask))]
 [IsDependentOn(typeof(BuildFrameworksTask))]
 [IsDependentOn(typeof(BuildToolsTask))]
 [IsDependentOn(typeof(BuildTemplatesTask))]
 [IsDependentOn(typeof(BuildAllTestsTask))]
+[IsDependentOn(typeof(BuildAnalyzerTask))]
 public sealed class BuildAllTask : FrostingTask<BuildContext> { }
 
 [TaskName("Deploy")]


### PR DESCRIPTION
## Description of Change

This PR adds a new **`MonoGame.Analyzers`** NuGet package containing Roslyn analyzers for MonoGame projects. Included in this PR is an initial rule, **MG0001**, which reports a warning when using APIs marked as unsupported on the MonoGame platform being developed for.

The first example is `VideoPlayer` on the **DesktopGL** and **WindowsDX** platforms. The constructor for `VideoPlayer` currently throws a `NotImplementedException` at runtime. With this PR, developers now receive a compiler warning to indicate the API is unsupported before encountering a runtime exception.

### Changes include

- Added **`UnsupportedOnAttribute`**
  This attribute is used to annotate APIs that are unsupported on specific MonoGame platforms. It can be applied to classes, constructors, fields, properties, or methods, and uses the existing `<MonoGamePlatform>` MSBuild property values to specify unsupported platforms.

  ```csharp
  [UnsupportedOn("DesktopGL;Windows", "VideoPlayer is not implemented on this platform.")]
  public VideoPlayer()
  {
  }
  ```

- Exposed the `<MonoGamePlatform>` MSBuild property to analyzers using the `<CompilerVisibleProperty>` element in each platform `.targets` file

- Added an example analyzer for `UnsupportedOn`
  This adds a Roslyn analyzer that emits **MG0001** for unsupported API usage based on the consuming project’s `<MonoGamePlatform>` value

- Integrated analyzer build and packaging into the existing build system

## Motivation

Some MonoGame APIs are only implemented on certain platform targets. Currently, using an unsupported API can fail late at runtime with `NotImplementedException`s.

This PR enables platform-aware diagnostics at build time with MonoGame-specific diagnostic IDs, which can later be linked to documentation on the MonoGame website.

## Local Testing

A local test project is not included in this PR. To test the analyzer locally:

1. Clone the MonoGame repository from my fork:

   ```sh
   git clone https://github.com/aristurtledev/monogame.git
   cd monogame
   ```

2. Checkout the `feature/analyzer` branch:

   ```sh
   git switch feature/analyzer
   ```

3. Update submodules so all MonoGame projects will build:

   ```sh
   git submodule update --init --recursive
   ```

4. Run the build script to build everything locally and create the NuGet packages
   (note that only the DesktopGL and Analyzer NuGets are required here):

   ```sh
   ./build.sh --target="Build DesktopGL" --target="Build Analyzer"
   ```

5. Create a new MonoGame project (DesktopGL recommended).
   For simplicity, it is recommended to create it inside the MonoGame project directory so the NuGet paths work as-is:

   ```sh
   dotnet new mgdesktopgl -n AnalyzerTest
   ```

6. In the newly created sample project, add a `nuget.config` file with the following contents:

   ```xml
   <?xml version="1.0" encoding="utf-8"?>
   <configuration>
     <packageSources>
       <add key="LocalPackages" value="../Artifacts/NuGet/" />
     </packageSources>
   </configuration>
   ```

   **Note:** If the sample project is created outside the MonoGame directory, update the `LocalPackages` path to point to the location where the MonoGame NuGets are built.

7. Update the package references in the sample project `.csproj` file to reference the development NuGets built in step 4:

   ```xml
   <ItemGroup>
     <PackageReference Include="MonoGame.Analyzers" Version="3.8.4.1-develop" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1-develop" />
   </ItemGroup>
   ```

   **Note:** The `MonoGame.Content.Builder.Task` package reference was removed for this test.

8. Open `Game1.cs` in the sample project and add the following to the `Initialize()` method:

   ```csharp
   VideoPlayer player = new VideoPlayer();
   ```

You should now see an analyzer warning indicating that `VideoPlayer` is not supported on the current platform (DesktopGL). Building the project will also emit the warning in the build output.

<img width="1144" height="250" alt="image" src="https://github.com/user-attachments/assets/49d74f0b-8a66-4a85-aac1-83b509eebaff" />


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

