### PR TITLE
Test switching back to macos-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           - os: windows-latest
             platform: windows
             shell: pwsh
-          - os: macos-26
+          - os: macos-latest
             platform: macos
             shell: bash
           - os: ubuntu-24.04


### PR DESCRIPTION
# Summary

Macos-26 is now throwing errors on use, trialing automation with macos-latest to see if the mac estate is now updated