### PR TITLE
Let's try dotnet 10 again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  DotnetVersion: 9.0.307
+  DotnetVersion: 10.0.101
   
 jobs:
   build:


### PR DESCRIPTION
# Summary

Running builds in a DotNet 9 environment is breaking MacOS builds.

Let's try the DotNet 10 rodeo again

> [!NOTE]
> This is NOT building MonoGame for DotNet 10, just the environment.
> MonoGame remains a DotNet 8 compiled library, for "reasons"