### PR TITLE
Add step to pin Xcode version to 26.0.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,12 @@ jobs:
         run: |
           dotnet workload install macos ios
 
+      - name: Pin xcode to 26.0.1
+        uses: maxim-lobanov/setup-xcode@v1
+        if: runner.environment == 'github-hosted' && runner.os == 'macos'
+        with:
+          xcode-version: '26.0.1'
+
       - name: Add msbuild to PATH
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v1.0.2


### PR DESCRIPTION
Fixes #9213 

Lets pin xcode for 26.0.1 to fix this error

```
error : This version of .NET for iOS (26.0.9783) requires Xcode 26.0. The current version of Xcode is 26.2. Either install Xcode 26.0, or use a different version of .NET for iOS. See https://aka.ms/xcode-requirement for more information. 
```

26.0.1 is already installed on the macos images, we just need to select it until its no longer available.


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

