### PR TITLE
Update ToVkImageViewType to support VK_IMAGE_VIEW_TYPE_2D_ARRAY

### DIFF
--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -636,12 +636,12 @@ static VkPrimitiveTopology ToVkPrimitiveTopology(MGPrimitiveType type)
 	}
 }
 
-static VkImageViewType ToVkImageViewType(MGTextureType type)
+static VkImageViewType ToVkImageViewType(MGTextureType type, int layerCount = 1)
 {
 	switch (type)
 	{
 	case MGTextureType::_2D:
-		return VK_IMAGE_VIEW_TYPE_2D;
+		return layerCount > 1 ? VK_IMAGE_VIEW_TYPE_2D_ARRAY : VK_IMAGE_VIEW_TYPE_2D;
 	case MGTextureType::_3D:
 		return VK_IMAGE_VIEW_TYPE_3D;
 	case MGTextureType::Cube:
@@ -1056,7 +1056,7 @@ static VkImageView CreateImageView(MGG_GraphicsDevice* device, MGG_Texture* text
 
 	VkImageViewCreateInfo image_view_create_info = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
 	image_view_create_info.image = texture->image;
-	image_view_create_info.viewType = ToVkImageViewType(texture->type);
+	image_view_create_info.viewType = ToVkImageViewType(texture->type, layer_count);
 	image_view_create_info.format = format;
 	image_view_create_info.subresourceRange.aspectMask = aspect_mask;
 	image_view_create_info.subresourceRange.baseMipLevel = 0;


### PR DESCRIPTION
Fixes #9212 


### Description of Change
This PR addresses an issue on the Vulkan where textures that were 2D arrays were getting mapped to `VK_IMAGE_VIEW_TYPE_2D` instead of `VK_IMAGE_VIEW_TYPE_2D_ARRAY`.  On MacOS, this mismatch causes an application crash.

The approach chosen was to add an additional optional `layerCount` parameter to `ToVkImageViewType` that can be used to distinguish between 2D and 2D Array types.

Note that there is a similarly named `ToVkImageType` that performs a conversion between `MGTextureType` and Vulkan constants.  It does not include this new switching logic because it doesn't seem to affect the MacOS runtime problem which is what motivated the creation of #9212.  

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

