### PR TITLE
make GamePadButtons._buttons public

### DIFF
--- a/MonoGame.Framework/Input/GamePadButtons.cs
+++ b/MonoGame.Framework/Input/GamePadButtons.cs
@@ -9,7 +9,10 @@ namespace Microsoft.Xna.Framework.Input
     /// </summary>
     public struct GamePadButtons
     {
-        internal readonly Buttons _buttons;
+        /// <summary>
+        /// A value representing all currently pressed buttons
+        /// </summary>
+        public readonly Buttons Buttons;
 
         /// <summary>
         /// Gets a value indicating if the button A is pressed.
@@ -19,7 +22,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return ((_buttons & Buttons.A) == Buttons.A) ? ButtonState.Pressed : ButtonState.Released;
+                return ((Buttons & Buttons.A) == Buttons.A) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
 
@@ -31,7 +34,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return ((_buttons & Buttons.B) == Buttons.B) ? ButtonState.Pressed : ButtonState.Released;
+                return ((Buttons & Buttons.B) == Buttons.B) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
 
@@ -43,7 +46,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return ((_buttons & Buttons.Back) == Buttons.Back) ? ButtonState.Pressed : ButtonState.Released;
+                return ((Buttons & Buttons.Back) == Buttons.Back) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
 
@@ -55,7 +58,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return ((_buttons & Buttons.X) == Buttons.X) ? ButtonState.Pressed : ButtonState.Released;
+                return ((Buttons & Buttons.X) == Buttons.X) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
 
@@ -67,7 +70,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return ((_buttons & Buttons.Y) == Buttons.Y) ? ButtonState.Pressed : ButtonState.Released;
+                return ((Buttons & Buttons.Y) == Buttons.Y) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
 
@@ -79,7 +82,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return ((_buttons & Buttons.Start) == Buttons.Start) ? ButtonState.Pressed : ButtonState.Released;
+                return ((Buttons & Buttons.Start) == Buttons.Start) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
 
@@ -91,7 +94,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return ((_buttons & Buttons.LeftShoulder) == Buttons.LeftShoulder) ? ButtonState.Pressed : ButtonState.Released;
+                return ((Buttons & Buttons.LeftShoulder) == Buttons.LeftShoulder) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
 
@@ -103,7 +106,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return ((_buttons & Buttons.LeftStick) == Buttons.LeftStick) ? ButtonState.Pressed : ButtonState.Released;
+                return ((Buttons & Buttons.LeftStick) == Buttons.LeftStick) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
 
@@ -115,7 +118,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return ((_buttons & Buttons.RightShoulder) == Buttons.RightShoulder) ? ButtonState.Pressed : ButtonState.Released;
+                return ((Buttons & Buttons.RightShoulder) == Buttons.RightShoulder) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
 
@@ -127,7 +130,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return ((_buttons & Buttons.RightStick) == Buttons.RightStick) ? ButtonState.Pressed : ButtonState.Released;
+                return ((Buttons & Buttons.RightStick) == Buttons.RightStick) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
 
@@ -139,7 +142,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             get
             {
-                return ((_buttons & Buttons.BigButton) == Buttons.BigButton) ? ButtonState.Pressed : ButtonState.Released;
+                return ((Buttons & Buttons.BigButton) == Buttons.BigButton) ? ButtonState.Pressed : ButtonState.Released;
             }
         }
 
@@ -150,13 +153,13 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="buttons">Buttons to be set as pressed in.</param>
         public GamePadButtons(Buttons buttons)
         {
-            _buttons = buttons;
+            Buttons = buttons;
         }
 
         internal GamePadButtons(params Buttons[] buttons) : this()
         {
             foreach (Buttons b in buttons)
-                _buttons |= b;
+                Buttons |= b;
         }
 
         /// <summary>
@@ -167,7 +170,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are equal; otherwise, false.</returns>
         public static bool operator ==(GamePadButtons left, GamePadButtons right)
         {
-            return left._buttons == right._buttons;
+            return left.Buttons == right.Buttons;
         }
 
         /// <summary>
@@ -198,7 +201,7 @@ namespace Microsoft.Xna.Framework.Input
         /// hash table.</returns>
         public override int GetHashCode ()
         {
-            return (int)_buttons;
+            return (int)Buttons;
         }
 
         /// <summary>

--- a/MonoGame.Framework/Input/GamePadState.cs
+++ b/MonoGame.Framework/Input/GamePadState.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Xna.Framework.Input
         /// </summary>
         private Buttons GetVirtualButtons ()
         {
-            var result = Buttons._buttons;
+            var result = Buttons.Buttons;
 
             result |= ThumbSticks._virtualButtons;
 

--- a/Tests/Framework/Input/GamePadTest.cs
+++ b/Tests/Framework/Input/GamePadTest.cs
@@ -306,7 +306,7 @@ namespace MonoGame.Tests.Input
 
 #if !XNA
             var gamePadButtons = state.Buttons;
-            Assert.AreEqual(joinedButtons, gamePadButtons._buttons);
+            Assert.AreEqual(joinedButtons, gamePadButtons.Buttons);
 #endif
 
             // all buttons except for thumbstick position buttons and triggers (they're not controlled via buttons here)


### PR DESCRIPTION
### Description of Change

Make GamePadButtons._buttons public, rename to Buttons, and add documentation.

The internal access of this field is inconvenient in some cases. For example, in order to merge multiple GamePadButtons together, you must check each property individually. With the field public, you can simply or them together.

As far as I can tell, there is no compelling reason for this field to remain internal.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

