### PR TITLE
added missing documentation (CS1591 errors) and CA1834 (use char, not string) warnings in the project.

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1,4 +1,4 @@
-// MIT License - Copyright (C) The Mono.Xna Team
+﻿// MIT License - Copyright (C) The Mono.Xna Team
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -1867,7 +1867,7 @@ namespace Microsoft.Xna.Framework
             sb.Append(B);
             sb.Append(" A:");
             sb.Append(A);
-            sb.Append("}");
+            sb.Append('}');
             return sb.ToString();
         }
 

--- a/MonoGame.Framework/Devices/Sensors/Accelerometer.cs
+++ b/MonoGame.Framework/Devices/Sensors/Accelerometer.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -68,6 +68,7 @@ namespace MonoGame.Framework.Devices.Sensors
             PlatformStop();
         }
 
+        /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
             PlatformDispose(disposing);

--- a/MonoGame.Framework/Devices/Sensors/Compass.cs
+++ b/MonoGame.Framework/Devices/Sensors/Compass.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -68,6 +68,7 @@ namespace MonoGame.Framework.Devices.Sensors
             PlatformStop();
         }
 
+        /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
             PlatformDispose(disposing);

--- a/MonoGame.Framework/Devices/Sensors/SensorBase.cs
+++ b/MonoGame.Framework/Devices/Sensors/SensorBase.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -7,6 +7,12 @@ using System;
 
 namespace MonoGame.Framework.Devices.Sensors
 {
+
+    /// <summary>
+    /// The base class for the use of physical sensors attached to the device the player uses,
+    /// which can be utilized for gameplay events.
+    /// </summary>
+    /// <typeparam name="TSensorReading">The reading value from the sensor.</typeparam>
 	public abstract class SensorBase<TSensorReading> : IDisposable
 		where TSensorReading : ISensorReading
 	{
@@ -15,6 +21,9 @@ namespace MonoGame.Framework.Devices.Sensors
 	    private TSensorReading currentValue;
         private SensorReadingEventArgs<TSensorReading> eventArgs = new SensorReadingEventArgs<TSensorReading>(default(TSensorReading));
 
+        /// <summary>
+        /// The current reading from the sensor.
+        /// </summary>
 		public TSensorReading CurrentValue 
         {
             get { return currentValue; }
@@ -31,7 +40,15 @@ namespace MonoGame.Framework.Devices.Sensors
                 }
 		    }
 		}
+
+        /// <summary>
+        /// Whether the data is deemed valid by the device or is outside the device's error range.  
+        /// </summary>
 		public bool IsDataValid { get; protected set; }
+
+        /// <summary>
+        /// The time between the two most recent updates of the sensor.   
+        /// </summary>
 		public TimeSpan TimeBetweenUpdates
 		{
 			get { return this.timeBetweenUpdates; }
@@ -45,21 +62,39 @@ namespace MonoGame.Framework.Devices.Sensors
 			}
 		}
 
+        /// <summary>
+        /// Invoked when the <see cref="CurrentValue"/> property changes. 
+        /// </summary>
 		public event EventHandler<SensorReadingEventArgs<TSensorReading>> CurrentValueChanged;
+
+        /// <summary>
+        /// Invoked when the <see cref="TimeBetweenUpdates"/> property changes.  
+        /// </summary>
 		protected event EventHandler<EventArgs> TimeBetweenUpdatesChanged;
+
+        /// <summary>
+        /// Whether the sensor has been disposed. 
+        /// </summary>
         protected bool IsDisposed { get { return disposed; } }
 
-		public SensorBase()
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        protected SensorBase()
 		{
 			this.TimeBetweenUpdates = TimeSpan.FromMilliseconds(2);
 		}
 
+        /// <summary>
+        /// Default deconstructor.
+        /// </summary>
         ~SensorBase()
         {
             Dispose(false);
         }
 
-		public void Dispose()
+        /// <inheritdoc />
+        public void Dispose()
         {
             if (disposed)
                 throw new ObjectDisposedException(GetType().Name);
@@ -76,8 +111,14 @@ namespace MonoGame.Framework.Devices.Sensors
             disposed = true;
         }
 
+        /// <summary>
+        /// Starts data acquisition from the sensor, allowing it to begin updating its value and firing events.
+        /// </summary>
 		public abstract void Start();
 
+        /// <summary>
+        /// Stops data acquisition from the sensor, preventing it from updating its value and firing events.
+        /// </summary>
 		public abstract void Stop();
 	}
 }

--- a/MonoGame.Framework/Graphics/Effect/Effect.cs
+++ b/MonoGame.Framework/Graphics/Effect/Effect.cs
@@ -104,6 +104,11 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="count">Number of bytes to read from the <paramref name="effectCode"/> array.</param>
         /// <exception cref="Exception">Invoked when the <paramref name="effectCode"/> is not a valid MGFX effect file or is for an incompatible version of MonoGame.</exception>
         /// <exception cref="ArgumentException">This <paramref name="effectCode"/> is invalid.</exception>
+        /// <remarks>
+        /// The <paramref name="index"/> and <paramref name="count"/> parameters do not need to take the header of the file into account; this will be calculated first,
+        /// and the <paramref name="index"/> and <paramref name="count"/> will be adjusted to point to the effect content after the header. <br/>
+        /// Therefore,do <strong>not</strong> enter the size of the header into those parameters! This is done for you!
+        /// </remarks>
         public Effect (GraphicsDevice graphicsDevice, byte[] effectCode, int index, int count)
             : this(graphicsDevice)
 		{

--- a/MonoGame.Framework/Graphics/Effect/Effect.cs
+++ b/MonoGame.Framework/Graphics/Effect/Effect.cs
@@ -1,4 +1,4 @@
-// MonoGame - Copyright (C) MonoGame Foundation, Inc
+﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -100,13 +100,14 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         /// <param name="graphicsDevice">Graphics device</param>
         /// <param name="effectCode">The effect code.</param>
-        /// <param name="index"></param>
-        /// <param name="count"></param>
+        /// <param name="index">Start position to read from in the <paramref name="effectCode"/> array.</param>
+        /// <param name="count">Number of bytes to read from the <paramref name="effectCode"/> array.</param>
+        /// <exception cref="Exception">Invoked when the <paramref name="effectCode"/> is not a valid MGFX effect file or is for an incompatible version of MonoGame.</exception>
         /// <exception cref="ArgumentException">This <paramref name="effectCode"/> is invalid.</exception>
         public Effect (GraphicsDevice graphicsDevice, byte[] effectCode, int index, int count)
             : this(graphicsDevice)
 		{
-			// By default we currently cache all unique byte streams
+			// By default, we currently cache all unique byte streams
 			// and use cloning to populate the effect with parameters,
 			// techniques, and passes.
 			//

--- a/MonoGame.Framework/Graphics/Shader/ShaderStage.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderStage.cs
@@ -4,11 +4,18 @@
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// The shader stage to compile or set shader resources for.
+    /// </summary>
     public enum ShaderStage
     {
+        /// <summary>
+        /// Vertex related shader resources, such as vertex shader and vertex buffers.
+        /// </summary>
         Vertex,
-        Pixel,
-
-        Count,
+        /// <summary>
+        /// Pixel related shader resources, such as pixel shader and pixel buffers.
+        /// </summary>
+        Pixel
     }
 }

--- a/MonoGame.Framework/Graphics/ShaderCompilerException.cs
+++ b/MonoGame.Framework/Graphics/ShaderCompilerException.cs
@@ -71,6 +71,7 @@ public sealed class ShaderCompilerException : Exception
         SourceCode = sourceCode;
     }
 
+    /// <inheritdoc />
     public override string ToString()
     {
         // Return all the data we got by default.

--- a/MonoGame.Framework/Input/JoystickState.cs
+++ b/MonoGame.Framework/Input/JoystickState.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Xna.Framework.Input
                 ret.Length--;
             }
 
-            ret.Append("]");
+            ret.Append(']');
             return ret.ToString();
         }
     }

--- a/MonoGame.Framework/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework/Utilities/FileHelpers.cs
@@ -77,7 +77,7 @@ namespace MonoGame.Framework.Utilities
 
                     foreach (var num in bytes)
                     {
-                        safeline.Append("%");
+                        safeline.Append('%');
                         safeline.Append(num.ToString("X"));
                     }
                 }

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -1,4 +1,4 @@
-// MIT License - Copyright (C) The Mono.Xna Team
+﻿// MIT License - Copyright (C) The Mono.Xna Team
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -1028,7 +1028,7 @@ namespace Microsoft.Xna.Framework
             sb.Append(this.Y);
             sb.Append(" Z:");
             sb.Append(this.Z);
-            sb.Append("}");
+            sb.Append('}');
             return sb.ToString();
         }
 


### PR DESCRIPTION
**Fixes** 

- Improved documentation for Effect constructor where a thrown Exception was not mentioned and parameters not filled in. Also added some information regarding two parameters which make it easy for programmers to make mistakes they can get stuck on, thinking they need to set the index according to the header of the mgfx file, which the method does for them. 
- Added documentation for SensorBase (Given I work with IoT devices for my dialy work, I felt I could fill this in)
- Fixed missing documentation warnings.
- Removed "Count" from ShaderStage given it was not in use.
- Fixed stringbuilder warnings where a string the size of a single char was added, rather than just a single char. 

  
### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

