### PR TITLE
Add readonly public accessor for GamePadButtons._buttons

### DIFF
--- a/MonoGame.Framework/Input/GamePadButtons.cs
+++ b/MonoGame.Framework/Input/GamePadButtons.cs
@@ -9,6 +9,11 @@ namespace Microsoft.Xna.Framework.Input
     /// </summary>
     public struct GamePadButtons
     {
+        /// <summary>
+        /// A value representing all currently pressed buttons
+        /// </summary>
+        public readonly Buttons Buttons => _buttons;
+
         internal readonly Buttons _buttons;
 
         /// <summary>
@@ -196,7 +201,7 @@ namespace Microsoft.Xna.Framework.Input
         /// </summary>
         /// <returns>A hash code for this instance that is suitable for use in hashing algorithms and data structures such as a
         /// hash table.</returns>
-        public override int GetHashCode ()
+        public override int GetHashCode()
         {
             return (int)_buttons;
         }


### PR DESCRIPTION
(I accidentally closed my last PR about this, so I had to make a new one. Sorry about that.)

The internal access of this field is inconvenient in some cases. For example, in order to merge multiple GamePadButtons together, you must check each property individually. With the public accessor, you can simply or them together.