### PR TITLE
Fix issue #9235(make SamplerState.Clone public)

### DIFF
--- a/MonoGame.Framework/Graphics/States/BlendState.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.cs
@@ -444,7 +444,7 @@ namespace Microsoft.Xna.Framework.Graphics
             Opaque = new BlendState("BlendState.Opaque", Blend.One, Blend.Zero);
 		}
 
-	    internal BlendState Clone()
+	    public BlendState Clone()
 	    {
 	        return new BlendState(this);
 	    }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -524,7 +524,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		    None = new DepthStencilState("DepthStencilState.None", false, false);
 		}
 
-        internal DepthStencilState Clone()
+        public DepthStencilState Clone()
         {
             return new DepthStencilState(this);
         }

--- a/MonoGame.Framework/Graphics/States/RasterizerState.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		    CullNone = new RasterizerState("RasterizerState.CullNone", CullMode.None);
 		}
 
-	    internal RasterizerState Clone()
+	    public RasterizerState Clone()
 	    {
 	        return new RasterizerState(this);
 	    }

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _filterMode = cloneSource._filterMode;
         }
 
-        internal SamplerState Clone()
+        public SamplerState Clone()
         {
             return new SamplerState(this);
         }

--- a/MonoGame.Framework/Graphics/States/TargetBlendState.cs
+++ b/MonoGame.Framework/Graphics/States/TargetBlendState.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Xna.Framework.Graphics
             ColorWriteChannels = ColorWriteChannels.All;
         }
 
-	    internal TargetBlendState Clone(BlendState parent)
+	    public TargetBlendState Clone(BlendState parent)
 	    {
 	        return new TargetBlendState(parent)
 	        {
@@ -302,4 +302,3 @@ namespace Microsoft.Xna.Framework.Graphics
 
 	}
 }
-


### PR DESCRIPTION


Fixes #9235 


### Description of Change

Make SamplerState.Clone() public in order to allow people to change only a few vars of a samplerstate, instead of having to copy everything


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

