### PR TITLE
Fixed WavImporter InvalidContentException string unit error, correcting units from KHz to Hz where appropriate.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/WavImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/WavImporter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 
             // Validate the format of the input.
             if (content.Format.SampleRate < 8000 || content.Format.SampleRate > 48000)
-                throw new InvalidContentException(string.Format("Audio file {0} contains audio data with unsupported sample rate of {1}KHz. Supported sample rates are from 8KHz up to 48KHz.", Path.GetFileName(filename), content.Format.SampleRate));
+                throw new InvalidContentException(string.Format("Audio file {0} contains audio data with unsupported sample rate of {1}Hz. Supported sample rates are from 8000Hz up to 48000Hz.", Path.GetFileName(filename), content.Format.SampleRate));
             var validPcm = content.Format.Format == 1 && (content.Format.BitsPerSample == 8 || content.Format.BitsPerSample == 16 || content.Format.BitsPerSample == 24);
             var validAdpcm = (content.Format.Format == 2 || content.Format.Format == 17) && content.Format.BitsPerSample == 4;
             var validIeeeFloat = content.Format.Format == 3 && content.Format.BitsPerSample == 32;


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes #9237

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

This pull request changes the error string for `WavImporter`'s `InvalidContentException` when a `.wav` file outside of the supported sample rate range is supplied. Previously, this error string incorrectly displayed the offending file's sample rate in `Hz` yet labeled it as `KHz`. This pull request changes the unit label to `Hz` and, for the sake of consistency, further changes the part of the error string that informs the user of the 8KHz-48KHz bounds to be displayed in `Hz`.

<!-- 
Enter description of the fix in this section.
Please be as descriptive as possible, future contributors will need to know *why* these changes are being made.
For inspiration review the commit/PR history in the MonoGame repository.
-->


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

