### PR TITLE
#9221 - Set mouse visibility when calling NativeGamePlatform

### DIFF
--- a/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
@@ -43,6 +43,7 @@ class NativeGamePlatform : GamePlatform
         Mouse.WindowHandle = _window.Handle;
         MessageBox._window = _window._handle;
         GamePad.Handle = Handle;
+        OnIsMouseVisibleChanged();
     }
 
     internal static unsafe MGG_GraphicsSystem* GraphicsSystem
@@ -328,7 +329,7 @@ class NativeGamePlatform : GamePlatform
 
     protected override unsafe void OnIsMouseVisibleChanged()
     {
-        MGP.Mouse_SetVisible(Handle, (byte)(Game.IsMouseVisible ? 1 : 0));
+        MGP.Mouse_SetVisible(Handle, (byte)(IsMouseVisible ? 1 : 0));
     }
 
     protected unsafe override void Dispose(bool disposing)


### PR DESCRIPTION
Fixes #9221

In Linux using DesktopVK, setting `IsMouseVisible` is not respected.

### Description of Change

1. Call `OnIsMouseVisibleChanged()` in `NativeGamePlatform` class constructor.
2. In `OnIsMouseVisibleChanged`, directly pull visibility from `IsMouseVisible` rather than `Game.IsMouseVisible` as `Game` is sometimes not yet initialized.

### Contributor Declaration

- [x ] I certify that no LLM's were used to generate any code or documentation in this contribution.

