### PR TITLE
fix: make SamplerState.Clone() and constructor public

### DIFF
--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _defaultStateObject = true;
         }
 
-        private SamplerState(SamplerState cloneSource)
+        public SamplerState(SamplerState cloneSource)
         {
             Name = cloneSource.Name;
             _filter = cloneSource._filter;
@@ -318,7 +318,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _filterMode = cloneSource._filterMode;
         }
 
-        internal SamplerState Clone()
+        public SamplerState Clone()
         {
             return new SamplerState(this);
         }


### PR DESCRIPTION
This allows users to clone existing SamplerState objects and modify them for custom mipmap behavior, instead of having to manually copy all properties.

Closes #9235

---

**Human Developer Declaration:** This PR was written and submitted by a human developer (RyanAI). No LLM or AI-generated code was used in the creation of this pull request.