### PR TITLE
WindowsDX12 doesn't properly exit when closing the Window.

### DIFF
--- a/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
@@ -90,7 +90,7 @@ class NativeGamePlatform : GamePlatform
             switch (event_.Type)
             {
                 case EventType.Quit:
-                    _isExiting++;
+                    Game.Exit();
                     break;
 
                 case EventType.WindowGainedFocus:
@@ -113,7 +113,7 @@ class NativeGamePlatform : GamePlatform
                 { 
                     var window = NativeGameWindow.FromHandle(event_.Window.Window);
                     if (Window == window)
-                        _isExiting++;
+                            Game.Exit();
                     break;
                 }
 

--- a/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GamePlatform.Native.cs
@@ -113,7 +113,7 @@ class NativeGamePlatform : GamePlatform
                 { 
                     var window = NativeGameWindow.FromHandle(event_.Window.Window);
                     if (Window == window)
-                            Game.Exit();
+                        Game.Exit();
                     break;
                 }
 


### PR DESCRIPTION
### Description of Change
When the window is closed and either `EventType.WindowClose` or `EventType.Quit` is fired it does not properly exit the game. It increments `_isExiting` instead of actually calling the proper `Game.Exit()` method.


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

