### PR TITLE
Add SetNativeTexture and FromSharedHandle for zero-copy texture sharing

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/Texture.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture.DirectX.cs
@@ -44,6 +44,13 @@ namespace Microsoft.Xna.Framework.Graphics
             return _resourceView;
         }
 
+        internal void SetNativeTexture(Resource texture)
+        {
+            SharpDX.Utilities.Dispose(ref _resourceView);
+            SharpDX.Utilities.Dispose(ref _texture);
+            _texture = texture;
+        }
+
         private void PlatformGraphicsDeviceResetting()
         {
             SharpDX.Utilities.Dispose(ref _resourceView);

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
@@ -237,6 +237,20 @@ namespace Microsoft.Xna.Framework.Graphics
             return new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc);
         }
 
+        public static Texture2D FromSharedHandle(
+            GraphicsDevice graphicsDevice,
+            IntPtr sharedHandle,
+            int width,
+            int height,
+            SurfaceFormat format)
+        {
+            var d3dTexture = graphicsDevice._d3dDevice
+                .OpenSharedResource<SharpDX.Direct3D11.Texture2D>(sharedHandle);
+            var texture = new Texture2D(graphicsDevice, width, height, false, format);
+            texture.SetNativeTexture(d3dTexture);
+            return texture;
+        }
+
         private void PlatformReload(Stream textureStream)
         {
         }


### PR DESCRIPTION
### Description of Change

Enable external code to wrap an already-opened D3D11 shared texture as a MonoGame Texture2D, avoiding a per-frame CopyResource when interoperating with other D3D11 devices (e.g. LibVLC).

I don't know if this is a change you're interested to take it, and if so if other targets (opengl, vulkan) could be candidate for it as well, just wanted to share in case.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

