### PR TITLE
Fixes game staying in Fullscreen when switching back to Windowed

### DIFF
--- a/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
@@ -223,15 +223,16 @@ namespace Microsoft.Xna.Framework
             Sdl.Rectangle displayRect;
             Sdl.Display.GetBounds(displayIndex, out displayRect);
 
-            var changeFullscreenType = _hardwareSwitch != _game.graphicsDeviceManager.HardwareModeSwitch && IsFullScreen;
+            // fullcreen mode needs to change
+            var setFullscreen = _willBeFullScreen != IsFullScreen || _hardwareSwitch != _game.graphicsDeviceManager.HardwareModeSwitch;
             _hardwareSwitch = _game.graphicsDeviceManager.HardwareModeSwitch;
 
-            // setting fullscreen to false before resizing if going windowed
-            if (!_willBeFullScreen && IsFullScreen)
+            // set fullscreen to windowed mode
+            if (setFullscreen && !_willBeFullScreen)
                 Sdl.Window.SetFullscreen(Handle, 0);
 
-            // setting fullscreen to desktop fullscreen or if hardware mode changed to false
-            if ((_willBeFullScreen && !IsFullScreen) || (changeFullscreenType && !_hardwareSwitch))
+            // set fullscreen to desktop fullscreen
+            if (setFullscreen && _willBeFullScreen && !_game.graphicsDeviceManager.HardwareModeSwitch)
                 Sdl.Window.SetFullscreen(Handle, Sdl.Window.State.FullscreenDesktop);
 
             // If going to exclusive full-screen mode, force the window to minimize on focus loss (Windows only)
@@ -240,7 +241,7 @@ namespace Microsoft.Xna.Framework
                 Sdl.SetHint("SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS", _willBeFullScreen && _hardwareSwitch ? "1" : "0");
             }
 
-            if (!_willBeFullScreen || _game.graphicsDeviceManager.HardwareModeSwitch)
+            if (!_willBeFullScreen || _hardwareSwitch)
             {
                 Sdl.Window.SetSize(Handle, clientWidth, clientHeight);
                 _width = clientWidth;
@@ -252,8 +253,8 @@ namespace Microsoft.Xna.Framework
                 _height = displayRect.Height;
             }
 
-            // setting fullscreen to hardware fulscreen after resizing if using hardware mode
-            if (((_willBeFullScreen && !IsFullScreen) || changeFullscreenType) && _hardwareSwitch)
+            // set fullscreen to hardware fullscreen
+            if (setFullscreen && _willBeFullScreen && _game.graphicsDeviceManager.HardwareModeSwitch)
                 Sdl.Window.SetFullscreen(Handle, Sdl.Window.State.Fullscreen);
 
             int ignore, minx = 0, miny = 0;

--- a/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Xna.Framework
                 Sdl.Window.SetFullscreen(Handle, 0);
 
             // set fullscreen to desktop fullscreen
-            if (setFullscreen && _willBeFullScreen && !_game.graphicsDeviceManager.HardwareModeSwitch)
+            if (setFullscreen && _willBeFullScreen && !_hardwareSwitch)
                 Sdl.Window.SetFullscreen(Handle, Sdl.Window.State.FullscreenDesktop);
 
             // If going to exclusive full-screen mode, force the window to minimize on focus loss (Windows only)
@@ -254,7 +254,7 @@ namespace Microsoft.Xna.Framework
             }
 
             // set fullscreen to hardware fullscreen
-            if (setFullscreen && _willBeFullScreen && _game.graphicsDeviceManager.HardwareModeSwitch)
+            if (setFullscreen && _willBeFullScreen && _hardwareSwitch)
                 Sdl.Window.SetFullscreen(Handle, Sdl.Window.State.Fullscreen);
 
             int ignore, minx = 0, miny = 0;

--- a/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/Platform/SDL/SDLGameWindow.cs
@@ -224,15 +224,16 @@ namespace Microsoft.Xna.Framework
             Sdl.Display.GetBounds(displayIndex, out displayRect);
 
             // fullcreen mode needs to change
-            var setFullscreen = _willBeFullScreen != IsFullScreen || _hardwareSwitch != _game.graphicsDeviceManager.HardwareModeSwitch;
+            var fullScreenChanged = _willBeFullScreen != IsFullScreen;
+            var hardwareSwitchChanged = _hardwareSwitch != _game.graphicsDeviceManager.HardwareModeSwitch;
             _hardwareSwitch = _game.graphicsDeviceManager.HardwareModeSwitch;
 
             // set fullscreen to windowed mode
-            if (setFullscreen && !_willBeFullScreen)
+            if (!_willBeFullScreen && fullScreenChanged)
                 Sdl.Window.SetFullscreen(Handle, 0);
 
             // set fullscreen to desktop fullscreen
-            if (setFullscreen && _willBeFullScreen && !_hardwareSwitch)
+            if (_willBeFullScreen && !_hardwareSwitch && (fullScreenChanged || hardwareSwitchChanged))
                 Sdl.Window.SetFullscreen(Handle, Sdl.Window.State.FullscreenDesktop);
 
             // If going to exclusive full-screen mode, force the window to minimize on focus loss (Windows only)
@@ -254,7 +255,7 @@ namespace Microsoft.Xna.Framework
             }
 
             // set fullscreen to hardware fullscreen
-            if (setFullscreen && _willBeFullScreen && _hardwareSwitch)
+            if (_willBeFullScreen && _hardwareSwitch  && (fullScreenChanged || hardwareSwitchChanged))
                 Sdl.Window.SetFullscreen(Handle, Sdl.Window.State.Fullscreen);
 
             int ignore, minx = 0, miny = 0;


### PR DESCRIPTION
Fixes #9255

This fixes a bug where the game will stay in Fullscreen mode when switching between Fullscreen Desktop and Windowed and changing the `HardwareModeSwitch`.

Outlined more in detail in the issue.

### Description of Change

Simplifies the code for when to change the fullscreen mode. 

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

