### PR TITLE
Fix documentation for EffectProcessorDebugMode.Auto

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessorDebugMode.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/EffectProcessorDebugMode.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
     public enum EffectProcessorDebugMode
     {
         /// <summary>
-        /// Enables effect debugging when built with Debug profile.
+        /// Will use the Optimize behaviour, disabling debugging and producing optimized shaders.
         /// </summary>
         Auto = 0,
 


### PR DESCRIPTION
### Description of Change

There is no code that looks for `EffectProcessorDebugMode.Auto` meaning that the current documentation is incorrect.
In order to save others the time of looking for how to control the Auto behaviour I would like to make this change to clarify that there is no way to enable debugging shaders outside of using `EffectProcessorDebugMode.Debug`.

### Contributor Declaration

- [X] I certify that no LLM's were used to generate any code or documentation in this contribution.

