### PR TITLE
Minor updates to the TitleContainer for Native

### DIFF
--- a/MonoGame.Framework/Platform/Native/TitleContainer.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/TitleContainer.Interop.cs
@@ -101,7 +101,7 @@ internal static unsafe partial class MG
     public static extern byte AssetOpen(string assetname, out MG_Asset* file, out long length);
 
     [DllImport(MonoGameNativeDLL, EntryPoint = "MG_Asset_Read", ExactSpelling = true)]
-    public static extern int AssetRead(MG_Asset* file, byte* buffer, int count);
+    public static extern int AssetRead(MG_Asset* file, byte* buffer, long count);
 
     [DllImport(MonoGameNativeDLL, EntryPoint = "MG_Asset_Seek", ExactSpelling = true)]
     public static extern long AssetSeek(MG_Asset* file, long offset, int origin);

--- a/MonoGame.Framework/Platform/Native/TitleContainer.Native.cs
+++ b/MonoGame.Framework/Platform/Native/TitleContainer.Native.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using MonoGame.Interop;
 
 
@@ -13,6 +14,18 @@ partial class TitleContainer
 
     static partial void PlatformInit()
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            Location = Path.Combine(AppContext.BaseDirectory, "..", "Resources");
+            if (!Directory.Exists(Location))
+            {
+                Location = Path.Combine(AppContext.BaseDirectory, "..", "..", "Resources");
+            }
+        }
+        if (string.IsNullOrEmpty(Location) || !Directory.Exists(Location))
+        {
+            Location = AppContext.BaseDirectory;
+        }
     }
 
     private static Stream PlatformOpenStream(string safeName)


### PR DESCRIPTION
- Updated AssetRead function to accept a long count parameter instead of int. This is because the underlying native API uses `mglong`.
- Add platform-specific resource location handling for macOS. When in an .app package resources are NOT next to the executable, they are in a Resources folder further up the package path. This change brings the native platform on MacOS inline with the way DesktopGL works.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

