### PR TITLE
Update Xcode version to 26.2 in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,11 +73,11 @@ jobs:
         run: |
           dotnet workload install macos ios
 
-      - name: Pin xcode to 26.0.1
+      - name: Pin xcode to 26.2
         uses: maxim-lobanov/setup-xcode@v1
         if: runner.environment == 'github-hosted' && runner.os == 'macos'
         with:
-          xcode-version: '26.0.1'
+          xcode-version: '26.2'
 
       - name: Add msbuild to PATH
         if: runner.os == 'Windows'


### PR DESCRIPTION
Pin Xcode to use 26.2 to fix the CI builds

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

