### PR TITLE
Centralise SoundEffect shutdown and resetting the _systemState to SoundSystemState.NotInitialized

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Xna.Framework.Audio
         #region Internal Audio Data
 
         private string _name = string.Empty;
-        
+
         private bool _isDisposed = false;
         private readonly TimeSpan _duration;
 
@@ -424,8 +424,8 @@ namespace Microsoft.Xna.Framework.Audio
         /// <para>Each SoundEffectInstance has its own Volume property that is independent to SoundEffect.MasterVolume. During playback SoundEffectInstance.Volume is multiplied by SoundEffect.MasterVolume.</para>
         /// <para>This property is used to adjust the volume on all current and newly created SoundEffectInstances. The volume of an individual SoundEffectInstance can be adjusted on its own.</para>
         /// </remarks>
-        public static float MasterVolume 
-        { 
+        public static float MasterVolume
+        {
             get { return _masterVolume; }
             set
             {
@@ -434,7 +434,7 @@ namespace Microsoft.Xna.Framework.Audio
 
                 if (_masterVolume == value)
                     return;
-                
+
                 _masterVolume = value;
                 SoundEffectInstancePool.UpdateMasterVolume();
             }
@@ -454,7 +454,7 @@ namespace Microsoft.Xna.Framework.Audio
             set
             {
                 if (value <= 0f)
-                    throw new ArgumentOutOfRangeException ("value", "value of DistanceScale");
+                    throw new ArgumentOutOfRangeException("value", "value of DistanceScale");
 
                 _distanceScale = value;
             }
@@ -478,7 +478,7 @@ namespace Microsoft.Xna.Framework.Audio
                 //   although the documentation does not say it throws an error we will anyway
                 //   just so it is like the DistanceScale
                 if (value < 0.0f)
-                    throw new ArgumentOutOfRangeException ("value", "value of DopplerScale");
+                    throw new ArgumentOutOfRangeException("value", "value of DopplerScale");
 
                 _dopplerScale = value;
             }
@@ -537,5 +537,10 @@ namespace Microsoft.Xna.Framework.Audio
 
         #endregion
 
+        internal static void Shutdown()
+        {
+            PlatformShutdown();
+            _systemState = SoundSystemState.NotInitialized;
+        }
     }
 }

--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -121,6 +121,12 @@ namespace Microsoft.Xna.Framework.Audio
                 throw;
             }
         }
+        
+        internal static void Shutdown()
+        {
+            PlatformShutdown();
+            _systemState = SoundSystemState.NotInitialized;
+        }
 
         #endregion
 
@@ -536,11 +542,5 @@ namespace Microsoft.Xna.Framework.Audio
         }
 
         #endregion
-
-        internal static void Shutdown()
-        {
-            PlatformShutdown();
-            _systemState = SoundSystemState.NotInitialized;
-        }
     }
 }

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -147,7 +147,9 @@ namespace Microsoft.Xna.Framework
                     ContentTypeReaderManager.ClearTypeCreators();
 
                     if (SoundEffect._systemState == SoundEffect.SoundSystemState.Initialized)
-                        SoundEffect.PlatformShutdown();
+                    {
+                        SoundEffect.Shutdown();
+                    }
                 }
 #if ANDROID
                 Activity = null;


### PR DESCRIPTION
Fixes #9026

### Description of Change

Based on OP's suggestion, but setting:
`_systemState = SoundSystemState.NotInitialized`

In a centralised location, so that all soundeffects follow this pattern, regardless of platform.


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

