### PR TITLE
Add Missing scalar * Matrix operator

### DIFF
--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -2281,8 +2281,8 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Multiplies the elements of matrix by a scalar.
         /// </summary>
-        /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
-        /// <param name="matrix">Source <see cref="Matrix"/> on the left of the mul sign.</param>
+        /// <param name="scaleFactor">Scalar value on the left of the mul sign.</param>
+        /// <param name="matrix">Source <see cref="Matrix"/> on the right of the mul sign.</param>
         /// <returns>Result of the matrix multiplication with a scalar.</returns>
         public static Matrix operator *(float scaleFactor, Matrix matrix)
         {

--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -2279,6 +2279,33 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Multiplies the elements of matrix by a scalar.
+        /// </summary>
+        /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
+        /// <param name="matrix">Source <see cref="Matrix"/> on the left of the mul sign.</param>
+        /// <returns>Result of the matrix multiplication with a scalar.</returns>
+        public static Matrix operator *(float scaleFactor, Matrix matrix)
+        {
+		    matrix.M11 = matrix.M11 * scaleFactor;
+		    matrix.M12 = matrix.M12 * scaleFactor;
+		    matrix.M13 = matrix.M13 * scaleFactor;
+		    matrix.M14 = matrix.M14 * scaleFactor;
+		    matrix.M21 = matrix.M21 * scaleFactor;
+		    matrix.M22 = matrix.M22 * scaleFactor;
+		    matrix.M23 = matrix.M23 * scaleFactor;
+		    matrix.M24 = matrix.M24 * scaleFactor;
+		    matrix.M31 = matrix.M31 * scaleFactor;
+		    matrix.M32 = matrix.M32 * scaleFactor;
+		    matrix.M33 = matrix.M33 * scaleFactor;
+		    matrix.M34 = matrix.M34 * scaleFactor;
+		    matrix.M41 = matrix.M41 * scaleFactor;
+		    matrix.M42 = matrix.M42 * scaleFactor;
+		    matrix.M43 = matrix.M43 * scaleFactor;
+		    matrix.M44 = matrix.M44 * scaleFactor;
+		    return matrix;
+        }
+
+        /// <summary>
         /// Subtracts the values of one <see cref="Matrix"/> from another <see cref="Matrix"/>.
         /// </summary>
         /// <param name="matrix1">Source <see cref="Matrix"/> on the left of the sub sign.</param>


### PR DESCRIPTION
Turns out we were missing the float * Matrix operator on the Matrix class all these years. We have Matrix * float, but not the other. This adds it.

https://learn.microsoft.com/en-us/previous-versions/windows/xna/bb198123(v=xnagamestudio.40)

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

