### PR TITLE
Fixes new Content Builder duplicate asset dependencies

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
@@ -73,20 +73,18 @@ public abstract class ContentBuilder
     /// </summary>
     /// <param name="relativeSrcPath">A relative path to the source asset.</param>
     /// <param name="contentInfo">The desired <see cref="ContentInfo"/> to be used for the content building.</param>
-    /// <param name="assetName">Optional name of the final compiled content.</param>
+    /// <param name="relativeDstPath">Optional name of the final compiled content.</param>
     /// <param name="parentContext">Set when building content dependencies by the ContentProcessorContext.</param>
-    public string BuildAndWriteContent(string relativeSrcPath, ContentInfo contentInfo, string? assetName = null, ContentProcessorContext? parentContext = null)
+    /// <returns>The complete name of the final compiled content including the content root.</returns>
+    public string BuildAndWriteContent(string relativeSrcPath, ContentInfo contentInfo, string? relativeDstPath = null, ContentProcessorContext? parentContext = null)
     {
-        // If we get a absolute path to a source asset fix it.
-        // TODO: Should we be doing this or erroring out? or warning?
+        // If we get a absolute path to a source asset try
+        // to make it relative as ProcessContent expects that. 
         if (Path.IsPathRooted(relativeSrcPath))
         {
             if (parentContext != null)
             {
-                var assetRoot = parentContext.ProjectDirectory;
-                if (!assetRoot.EndsWith("\\") || !assetRoot.EndsWith("/"))
-                    assetRoot += "\\";
-
+                var assetRoot = PathHelper.NormalizeDirectory(parentContext.ProjectDirectory);
                 relativeSrcPath = PathHelper.GetRelativePath(assetRoot, relativeSrcPath);
             }
         }
@@ -94,9 +92,9 @@ public abstract class ContentBuilder
         Logger.PushFile(Path.Combine(Parameters.RootedSourceDirectory, relativeSrcPath));
         try
         {
-            ProcessContent(relativeSrcPath, contentInfo, true, ref assetName, parentContext);
+            ProcessContent(relativeSrcPath, contentInfo, true, ref relativeDstPath, parentContext);
             SucceededToBuild++;
-            return assetName;
+            return relativeDstPath;
         }
         catch (Exception ex)
         {
@@ -153,12 +151,12 @@ public abstract class ContentBuilder
         return null;
     }
 
-    private object? ProcessContent(string relativePath, ContentInfo contentInfo, bool writeToDisk, ref string? assetName, ContentProcessorContext? parentContext)
+    private object? ProcessContent(string relativePath, ContentInfo contentInfo, bool writeToDisk, ref string? relativeDstPath, ContentProcessorContext? parentContext)
     {
         var filePath = Path.Combine(Parameters.RootedSourceDirectory, relativePath);
 
-        if (string.IsNullOrEmpty(assetName))
-            assetName = relativePath.GetDestinationPath(contentInfo.ShouldBuild, contentInfo.GetOutputPath);
+        if (string.IsNullOrEmpty(relativeDstPath))
+            relativeDstPath = relativePath.GetDestinationPath(contentInfo.ShouldBuild, contentInfo.GetOutputPath);
 
         if (contentInfo.ShouldBuild) // ensure importer and processor are set
         {
@@ -178,19 +176,17 @@ public abstract class ContentBuilder
             }
         }
 
-        var relativeDestPath = Path.Combine(contentInfo.ContentRoot, assetName).Sanitize();
+        var relativeDestPath = Path.Combine(contentInfo.ContentRoot, relativeDstPath).Sanitize();
 
         // Dependency content gets a hash to avoid conflicts.
         if (parentContext != null)
-        {
-            var hash = new HashCode();
-            ContentBuilderHelper.GetHash(contentInfo.Importer, ref hash);
-            ContentBuilderHelper.GetHash(contentInfo.Processor, ref hash);
-            assetName = relativeDestPath = relativeDestPath.Replace(".xnb", $".{hash.ToHashCode():x}.xnb");
-        }
+            relativeDestPath = relativeDestPath.Replace(".xnb", $".{contentInfo.MakeHash():x}.xnb");
 
         var outputPath = Path.Combine(Parameters.RootedOutputDirectory, relativeDestPath).Sanitize();
         var outputDir = Path.GetDirectoryName(outputPath);
+
+        // Return the caller the final completed content path.
+        relativeDstPath = relativeDestPath;
 
         if (string.IsNullOrWhiteSpace(outputDir))
             return null;

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
@@ -178,9 +178,10 @@ public abstract class ContentBuilder
 
         var relativeDestPath = Path.Combine(contentInfo.ContentRoot, relativeDstPath).Sanitize();
 
-        // Dependency content gets a hash to avoid conflicts.
-        if (parentContext != null)
-            relativeDestPath = relativeDestPath.Replace(".xnb", $".{contentInfo.MakeHash():x}.xnb");
+        // Dependency content that is imported/processed gets a
+        // hash code appended to the file name to avoid conflicts.
+        if (parentContext != null && contentInfo.ShouldBuild)
+            relativeDestPath = relativeDestPath.Replace(".xnb", $".{contentInfo.MakeBuildHash():x}.xnb");
 
         var outputPath = Path.Combine(Parameters.RootedOutputDirectory, relativeDestPath).Sanitize();
         var outputDir = Path.GetDirectoryName(outputPath);

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilder.cs
@@ -73,15 +73,30 @@ public abstract class ContentBuilder
     /// </summary>
     /// <param name="relativeSrcPath">A relative path to the source asset.</param>
     /// <param name="contentInfo">The desired <see cref="ContentInfo"/> to be used for the content building.</param>
-    /// <param name="relativeDstPath">The desired relative output path.</param>
-    /// <param name="parentContext">Only set when the method is being called by the ContentProcessorContext to build one of its children.</param>
-    public void BuildAndWriteContent(string relativeSrcPath, ContentInfo contentInfo, string? relativeDstPath = null, ContentProcessorContext? parentContext = null)
+    /// <param name="assetName">Optional name of the final compiled content.</param>
+    /// <param name="parentContext">Set when building content dependencies by the ContentProcessorContext.</param>
+    public string BuildAndWriteContent(string relativeSrcPath, ContentInfo contentInfo, string? assetName = null, ContentProcessorContext? parentContext = null)
     {
+        // If we get a absolute path to a source asset fix it.
+        // TODO: Should we be doing this or erroring out? or warning?
+        if (Path.IsPathRooted(relativeSrcPath))
+        {
+            if (parentContext != null)
+            {
+                var assetRoot = parentContext.ProjectDirectory;
+                if (!assetRoot.EndsWith("\\") || !assetRoot.EndsWith("/"))
+                    assetRoot += "\\";
+
+                relativeSrcPath = PathHelper.GetRelativePath(assetRoot, relativeSrcPath);
+            }
+        }
+
         Logger.PushFile(Path.Combine(Parameters.RootedSourceDirectory, relativeSrcPath));
         try
         {
-            ProcessContent(relativeSrcPath, contentInfo, true, relativeDstPath, parentContext);
+            ProcessContent(relativeSrcPath, contentInfo, true, ref assetName, parentContext);
             SucceededToBuild++;
+            return assetName;
         }
         catch (Exception ex)
         {
@@ -94,6 +109,7 @@ public abstract class ContentBuilder
             {
                 throw new SkipLogException();
             }
+            return null;
         }
         finally
         {
@@ -114,7 +130,7 @@ public abstract class ContentBuilder
         Logger.PushFile(Path.Combine(Parameters.RootedSourceDirectory, relativeSrcPath));
         try
         {
-            var content = ProcessContent(relativeSrcPath, contentInfo, false, relativeDstPath, parentContext);
+            var content = ProcessContent(relativeSrcPath, contentInfo, false, ref relativeDstPath, parentContext);
             SucceededToBuild++;
             return content;
         }
@@ -137,22 +153,12 @@ public abstract class ContentBuilder
         return null;
     }
 
-    private object? ProcessContent(string relativePath, ContentInfo contentInfo, bool writeToDisk, string? relativeOutputPath, ContentProcessorContext? parentContext)
+    private object? ProcessContent(string relativePath, ContentInfo contentInfo, bool writeToDisk, ref string? assetName, ContentProcessorContext? parentContext)
     {
         var filePath = Path.Combine(Parameters.RootedSourceDirectory, relativePath);
-        var relativeDestPath = Path.Combine(contentInfo.ContentRoot, string.IsNullOrEmpty(relativeOutputPath) ? relativePath.GetDestinationPath(contentInfo.ShouldBuild, contentInfo.GetOutputPath) : relativeOutputPath).Sanitize();
-        var outputPath = Path.Combine(Parameters.RootedOutputDirectory, relativeDestPath).Sanitize();
-        var outputDir = Path.GetDirectoryName(outputPath);
 
-        if (string.IsNullOrWhiteSpace(outputDir))
-        {
-            return null;
-        }
-
-        if (!Directory.Exists(outputDir))
-        {
-            Directory.CreateDirectory(outputDir);
-        }
+        if (string.IsNullOrEmpty(assetName))
+            assetName = relativePath.GetDestinationPath(contentInfo.ShouldBuild, contentInfo.GetOutputPath);
 
         if (contentInfo.ShouldBuild) // ensure importer and processor are set
         {
@@ -172,16 +178,33 @@ public abstract class ContentBuilder
             }
         }
 
-        if (!Parameters.Rebuild)
+        var relativeDestPath = Path.Combine(contentInfo.ContentRoot, assetName).Sanitize();
+
+        // Dependency content gets a hash to avoid conflicts.
+        if (parentContext != null)
         {
-            var fileCache = ContentCache.ReadContentFileCache(this, relativeDestPath);
-            if (fileCache != null && fileCache.IsValid(this, contentInfo))
-            {
-                Logger.Log(LogLevel.Debug, $"Cache: Found");
-                ContentCache.MarkUsed(fileCache);
-                (parentContext as ContentBuilderProcessorContext)?.ContentFileCache.AddDependency(this, fileCache);
-                return null;
-            }
+            var hash = new HashCode();
+            ContentBuilderHelper.GetHash(contentInfo.Importer, ref hash);
+            ContentBuilderHelper.GetHash(contentInfo.Processor, ref hash);
+            assetName = relativeDestPath = relativeDestPath.Replace(".xnb", $".{hash.ToHashCode():x}.xnb");
+        }
+
+        var outputPath = Path.Combine(Parameters.RootedOutputDirectory, relativeDestPath).Sanitize();
+        var outputDir = Path.GetDirectoryName(outputPath);
+
+        if (string.IsNullOrWhiteSpace(outputDir))
+            return null;
+
+        if (!Directory.Exists(outputDir))
+            Directory.CreateDirectory(outputDir);
+
+        var fileCache = ContentCache.ReadContentFileCache(this, relativeDestPath);
+        if (fileCache != null && fileCache.IsValid(this, contentInfo))
+        {
+            Logger.Log(LogLevel.Debug, $"Cache: Found");
+            ContentCache.MarkUsed(fileCache);
+            (parentContext as ContentBuilderProcessorContext)?.ContentFileCache.AddDependency(this, fileCache);
+            return null;
         }
 
         if (!contentInfo.ShouldBuild)
@@ -193,11 +216,11 @@ public abstract class ContentBuilder
             }
             File.Copy(filePath, outputPath);
 
-            var fileCache = ContentCache.CreateContentFileCache(this, contentInfo);
-            fileCache.AddDependency(this, relativePath);
-            fileCache.AddOutputFile(this, outputPath);
-            ContentCache.WriteContentFileCache(this, relativeDestPath, fileCache);
-            ContentCache.MarkUsed(fileCache);
+            var fileCopyCache = ContentCache.CreateContentFileCache(this, contentInfo);
+            fileCopyCache.AddDependency(this, relativePath);
+            fileCopyCache.AddOutputFile(this, outputPath);
+            ContentCache.WriteContentFileCache(this, relativeDestPath, fileCopyCache);
+            ContentCache.MarkUsed(fileCopyCache);
             (parentContext as ContentBuilderProcessorContext)?.ContentFileCache.AddDependency(this, fileCache);
             return null;
         }
@@ -271,6 +294,12 @@ public abstract class ContentBuilder
         Logger.Unindent();
 
         ContentCache.LoadCache(this);
+
+        // If we're rebuilding then clear all previously
+        // built content which will force a rebuild.
+        if (Parameters.Rebuild)
+            ContentCache.CleanCache(this);
+
         var contentCollection = GetContentCollection();
         ScanFiles(contentCollection, Parameters.RootedSourceDirectory);
 

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
@@ -225,22 +225,6 @@ static class ContentBuilderHelper
         return true;
     }
 
-    public static void GetHash(object importerOrProcessor, ref HashCode hash)
-    {
-        var type = importerOrProcessor.GetType();
-        hash.Add(type.FullName);
-
-        var props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-        foreach (var prop in props)
-        {
-            if (prop.CanRead)
-            {
-                var value = prop.GetValue(importerOrProcessor);
-                hash.Add(value);
-            }
-        }
-    }
-
     public static ContentImporterAttribute GetImporterAttribute(Type t)
     {
         var attributes = t.GetCustomAttributes(typeof(ContentImporterAttribute), false);

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
@@ -2,12 +2,12 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System.Collections;
-using System.Diagnostics.Contracts;
-using System.Reflection;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using MonoGame.Framework.Content.Pipeline.Builder.Server;
+using System.Collections;
+using System.Diagnostics.Contracts;
+using System.Reflection;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
@@ -223,6 +223,22 @@ static class ContentBuilderHelper
         }
 
         return true;
+    }
+
+    public static void GetHash(object importerOrProcessor, ref HashCode hash)
+    {
+        var type = importerOrProcessor.GetType();
+        hash.Add(type.FullName);
+
+        var props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        foreach (var prop in props)
+        {
+            if (prop.CanRead)
+            {
+                var value = prop.GetValue(importerOrProcessor);
+                hash.Add(value);
+            }
+        }
     }
 
     public static ContentImporterAttribute GetImporterAttribute(Type t)

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderHelper.cs
@@ -5,6 +5,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using MonoGame.Framework.Content.Pipeline.Builder.Server;
+using MonoGame.Framework.Utilities;
 using System.Collections;
 using System.Diagnostics.Contracts;
 using System.Reflection;
@@ -223,6 +224,20 @@ static class ContentBuilderHelper
         }
 
         return true;
+    }
+
+    public static void HashTypeAndProperties(object importerOrProcessor, ref Hash hash)
+    {
+        // Use the YAML serializer to generate a string with the
+        // type and properties of this importer/processor.
+        var text = Serializer.Serialize(importerOrProcessor);
+
+        // Normalize Windows line endings so we get
+        // consistent strings across all systems.
+        text = text.Replace("\r\n", "\n");
+
+        // Add the string to the hasher.
+        hash.Add(text);
     }
 
     public static ContentImporterAttribute GetImporterAttribute(Type t)

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderLogger.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderLogger.cs
@@ -32,7 +32,7 @@ class ContentBuilderLogger : ContentBuildLogger
             _ => ConsoleColor.Gray
         };
 
-        var currentPath = _relativePaths.Count > 0 ? $"{string.Join(": ", _relativePaths)}: " : "";
+        var currentPath = _relativePaths.Count > 0 ? $"{string.Join(" > ", _relativePaths.Reverse())}: " : "";
         var spacing = string.Empty.PadLeft(Math.Max(0, _indentCount * 2), ' ');
         var time = LoggerLogLevel <= LogLevel.Debug ?  $"{_stopWatch.Elapsed:hh\\:mm\\:ss\\.fff} " : "";
 

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderProcessorContext.cs
@@ -76,8 +76,7 @@ class ContentBuilderProcessorContext(ContentBuilder builder, string relativePath
     public override ExternalReference<TOutput> BuildAsset<TInput, TOutput>(ExternalReference<TInput> sourceAsset,
         IContentImporter importer, IContentProcessor processor, string? assetName)
     {
-        var outputRelativePath = string.IsNullOrWhiteSpace(assetName) ? GetNextOutputPath() : assetName;
-        _builder.BuildAndWriteContent(sourceAsset.Filename, new ContentInfo(_contentInfo.ContentRoot, true, importer, processor), outputRelativePath, this);
+        var outputRelativePath = _builder.BuildAndWriteContent(sourceAsset.Filename, new ContentInfo(_contentInfo.ContentRoot, true, importer, processor), assetName, this);
 
         return new ExternalReference<TOutput>(Path.Combine(_builder.Parameters.RootedOutputDirectory, outputRelativePath));
     }

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderProcessorContext.cs
@@ -25,7 +25,7 @@ class ContentBuilderProcessorContext(ContentBuilder builder, string relativePath
 
     public override ContentBuildLogger Logger => _builder.Logger;
 
-    public override ContentIdentity SourceIdentity => throw new NotImplementedException();
+    public override ContentIdentity SourceIdentity => new ContentIdentity(sourceFilename: _relativeContentPath);
 
     public override string OutputDirectory => _builder.Parameters.OutputDirectory;
 

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentInfo.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentInfo.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using Microsoft.Xna.Framework.Content.Pipeline;
+using MonoGame.Framework.Utilities;
 
 namespace MonoGame.Framework.Content.Pipeline.Builder;
 
@@ -46,4 +47,15 @@ public class ContentInfo(string contentRoot = "", bool shouldBuild = true, ICont
     /// <param name="filePath">A relative path to the content file (without extension in case of build action).</param>
     /// <returns>Desired relative path for the output content.</returns>
     public string GetOutputPath(string filePath) => _outputPath(filePath);
+
+    /// <summary>
+    /// Returns a hash code that is unique to the importer and processor used.
+    /// </summary>
+    public int MakeHash()
+    {
+        var hash = new Hash();
+        Hash.FromTypeAndProperties(Importer, ref hash);
+        Hash.FromTypeAndProperties(Processor, ref hash);
+        return hash.Value;
+    }
 }

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentInfo.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentInfo.cs
@@ -54,8 +54,8 @@ public class ContentInfo(string contentRoot = "", bool shouldBuild = true, ICont
     public int MakeHash()
     {
         var hash = new Hash();
-        Hash.FromTypeAndProperties(Importer, ref hash);
-        Hash.FromTypeAndProperties(Processor, ref hash);
+        ContentBuilderHelper.HashTypeAndProperties(Importer, ref hash);
+        ContentBuilderHelper.HashTypeAndProperties(Processor, ref hash);
         return hash.Value;
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentInfo.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentInfo.cs
@@ -49,9 +49,10 @@ public class ContentInfo(string contentRoot = "", bool shouldBuild = true, ICont
     public string GetOutputPath(string filePath) => _outputPath(filePath);
 
     /// <summary>
-    /// Returns a hash code that is unique to the importer and processor used.
+    /// Returns a hash code that is unique to the importer and processor
+    /// settings used to build the content.
     /// </summary>
-    public int MakeHash()
+    public int MakeBuildHash()
     {
         var hash = new Hash();
         ContentBuilderHelper.HashTypeAndProperties(Importer, ref hash);

--- a/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PathHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/PipelineBuilder/PathHelper.cs
@@ -27,7 +27,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
         /// <summary>
         /// Returns a directory path string normalized to the/universal/standard
-        /// with a trailing seperator.
+        /// with a trailing separator.
         /// </summary>
         public static string NormalizeDirectory(string path)
         {

--- a/MonoGame.Framework/Utilities/Hash.cs
+++ b/MonoGame.Framework/Utilities/Hash.cs
@@ -58,40 +58,6 @@ namespace MonoGame.Framework.Utilities
             }
         }
 
-        public void Add(object value)
-        {
-            if (value is string string_)
-            {
-                // In recent .NET releases string.GetHashCode()
-                // will use a random seed when creating the string
-                // hash code... so we need to avoid it.
-                Add(string_);
-                return;
-            }
-
-            // This is safe for primitive numerical
-            // types as well as custom types that return
-            // consistent hash values.
-            Add(value == null ? 0 : value.GetHashCode());
-        }
-
-        public static void FromTypeAndProperties(object importerOrProcessor, ref Hash hash)
-        {
-            var type = importerOrProcessor.GetType();
-            hash.Add(type.FullName);
-
-            var props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-            foreach (var prop in props)
-            {
-                if (prop.CanRead)
-                {
-                    var value = prop.GetValue(importerOrProcessor);
-                    hash.Add(value);
-                }
-            }
-        }
-
-
         /// <summary>
         /// Compute a hash from a byte array.
         /// </summary>

--- a/MonoGame.Framework/Utilities/Hash.cs
+++ b/MonoGame.Framework/Utilities/Hash.cs
@@ -3,11 +3,95 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System.IO;
+using System.Reflection;
 
 namespace MonoGame.Framework.Utilities
 {
-    internal static class Hash
+    internal struct Hash
     {
+        private const int Prime = 16777619;
+        private const int Default = unchecked((int)(2166136261));
+
+        public bool _initialize;
+        private int _hash;
+
+        public readonly int Value => _hash;
+
+        private void Init()
+        {
+            if (!_initialize)
+            {
+                _initialize = true;
+                _hash = Default;
+            }
+        }
+
+        public void Add(int value)
+        {
+            Init();
+
+            unchecked
+            {
+                _hash = (_hash ^ value) * Prime;
+                _hash += _hash << 13;
+                _hash ^= _hash >> 7;
+                _hash += _hash << 3;
+                _hash ^= _hash >> 17;
+                _hash += _hash << 5;
+            }
+        }
+
+        public void Add(string value)
+        {
+            Init();
+
+            unchecked
+            {
+                for (var i = 0; i < value.Length; i++)
+                    _hash = (_hash ^ value[i]) * Prime;
+
+                _hash += _hash << 13;
+                _hash ^= _hash >> 7;
+                _hash += _hash << 3;
+                _hash ^= _hash >> 17;
+                _hash += _hash << 5;
+            }
+        }
+
+        public void Add(object value)
+        {
+            if (value is string string_)
+            {
+                // In recent .NET releases string.GetHashCode()
+                // will use a random seed when creating the string
+                // hash code... so we need to avoid it.
+                Add(string_);
+                return;
+            }
+
+            // This is safe for primitive numerical
+            // types as well as custom types that return
+            // consistent hash values.
+            Add(value == null ? 0 : value.GetHashCode());
+        }
+
+        public static void FromTypeAndProperties(object importerOrProcessor, ref Hash hash)
+        {
+            var type = importerOrProcessor.GetType();
+            hash.Add(type.FullName);
+
+            var props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            foreach (var prop in props)
+            {
+                if (prop.CanRead)
+                {
+                    var value = prop.GetValue(importerOrProcessor);
+                    hash.Add(value);
+                }
+            }
+        }
+
+
         /// <summary>
         /// Compute a hash from a byte array.
         /// </summary>
@@ -19,11 +103,10 @@ namespace MonoGame.Framework.Utilities
         {
             unchecked
             {
-                const int p = 16777619;
-                var hash = (int)2166136261;
+                var hash = Default;
 
                 for (var i = 0; i < data.Length; i++)
-                    hash = (hash ^ data[i]) * p;
+                    hash = (hash ^ data[i]) * Prime;
 
                 hash += hash << 13;
                 hash ^= hash >> 7;
@@ -47,8 +130,7 @@ namespace MonoGame.Framework.Utilities
 
             unchecked
             {
-                const int p = 16777619;
-                var hash = (int)2166136261;
+                var hash = Default;
 
                 var prevPosition = stream.Position;
                 stream.Position = 0;
@@ -58,7 +140,7 @@ namespace MonoGame.Framework.Utilities
                 while((length = stream.Read(data, 0, data.Length)) != 0)
                 {
                     for (var i = 0; i < length; i++)
-                        hash = (hash ^ data[i]) * p;
+                        hash = (hash ^ data[i]) * Prime;
                 }
 
                 // Restore stream position.

--- a/MonoGame.Framework/Utilities/Hash.cs
+++ b/MonoGame.Framework/Utilities/Hash.cs
@@ -7,14 +7,20 @@ using System.Reflection;
 
 namespace MonoGame.Framework.Utilities
 {
+    /// This works similar to .NET System.HashCode
+    /// for building hash values incrementally.
+    /// <remarks>
+    /// Uses a modified FNV Hash in C#: http://stackoverflow.com/a/468084
+    /// </remarks>
     internal struct Hash
     {
         private const int Prime = 16777619;
         private const int Default = unchecked((int)(2166136261));
 
-        public bool _initialize;
+        private bool _initialize;
         private int _hash;
 
+        // The currently calculated hash.
         public readonly int Value => _hash;
 
         private void Init()
@@ -26,6 +32,9 @@ namespace MonoGame.Framework.Utilities
             }
         }
 
+        /// <summary>
+        /// Adds an integer to the hash.
+        /// </summary>
         public void Add(int value)
         {
             Init();
@@ -41,6 +50,9 @@ namespace MonoGame.Framework.Utilities
             }
         }
 
+        /// <summary>
+        /// Adds a string to the hash.
+        /// </summary>
         public void Add(string value)
         {
             Init();
@@ -61,11 +73,7 @@ namespace MonoGame.Framework.Utilities
         /// <summary>
         /// Compute a hash from a byte array.
         /// </summary>
-        /// <remarks>
-        /// Modified FNV Hash in C#
-        /// http://stackoverflow.com/a/468084
-        /// </remarks>
-        internal static int ComputeHash(params byte[] data)
+        public static int ComputeHash(params byte[] data)
         {
             unchecked
             {
@@ -86,11 +94,7 @@ namespace MonoGame.Framework.Utilities
         /// <summary>
         /// Compute a hash from the content of a stream and restore the position.
         /// </summary>
-        /// <remarks>
-        /// Modified FNV Hash in C#
-        /// http://stackoverflow.com/a/468084
-        /// </remarks>
-        internal static int ComputeHash(Stream stream)
+        public static int ComputeHash(Stream stream)
         {
             System.Diagnostics.Debug.Assert(stream.CanSeek);
 


### PR DESCRIPTION
This PR rewrites how dependent assets... for example when an FBX references different Effects and Textures.

Previously in XNA it would write the original asset name with an underscored number for dependencies.  So you would see `mytexture_0.xnb`. `mytexture_1.xnb`, etc.  Internally the XNA pipeline would add a new asset when it found a new combination of importer/processor settings for the same asset.

In the new Builder it was changed so that it would output the dependent assets with the name of the parent asset that built it.  So you would see `mymodel_0.xnb`. mymodel_1.xnb`, etc.  But in this case the 0 one was actually the Effect and the 1 asset was the texture.  This design is very confusing, but worse causes duplicate assets as two models using the same texture would have their own copies.  With a large game with high resolution assets this could be GBs of duplicate content.

The changes here instead revert to how XNA worked... keeping the original asset name, but instead of an index you get a hash of the used importer/processor settings.  So you get assets like: `mytexture.e9216cd.xnb`, `mytexture.7b9fd52.xnb` .. where each hash represents the same source asset processed a different way.

The benefits of this method:

 - Makes clear what the source asset was.
 - Clearly shows all assets built with the same processing settings (same hash).
 - Reduces time building the same asset multiple times.
 - Reduces duplicate assets on disk.

There is more improvements that can be done here.

For example you can end up with `mytexture.xnb` and `mytexture.7b9fd52.xnb` if you have a model that references a texture, but you also include the same texture with the same settings directly via the builder.