### PR TITLE
Increasing descriptor pool size and uniform ringbuffer size.

### DIFF
--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1953,7 +1953,7 @@ mgint MGG_GraphicsDevice_BeginFrame(MGG_GraphicsDevice* device)
 	frame.uniformOffset = 0;
 	if (frame.uniforms == NULL)
 	{
-		frame.uniforms = MGVK_Buffer_Create(device, MGBufferType::Constant, 4 * 1024 * 1024, true);
+		frame.uniforms = MGVK_Buffer_Create(device, MGBufferType::Constant, 32 * 1024 * 1024, true);
 		VK_SET_OBJECT_NAME(device->device, frame.uniforms->buffer, VK_OBJECT_TYPE_BUFFER, "MGVK_FrameState.uniforms->buffer");
 	}
 
@@ -2914,7 +2914,7 @@ static void MGVK_UpdateRenderPass(MGG_GraphicsDevice* device, FrameCounter curre
 	device->deferredOcclusionQueries.clear();
 }
 
-static const int DefaultPoolSize = 1024;
+static const int DefaultPoolSize = 16384;
 
 static void MGVK_FillDescriptorSetCache(MGG_GraphicsDevice* device, MGG_Shader* shader)
 {


### PR DESCRIPTION
This increases the supported draw calls per frame, with more complex shaders in place.

Fixes #9269 and #9270.

### Description of Change
We have 2 similar but separate issues:

1. The uniform ringbuffer size is set too low in the native Vulkan backend. We currently set this at 4MiB, but this seems much too low for any modern system, and it causes issues or crashes that don't appear on the native DX12 backend.
2. The shader descriptor pool size is set too low in the native Vulkan backend. Again, the 1024 descriptor limit seems too low for any modern system.

The ringbuffer size issue is very easy to run into, and the descriptor pool issue depends somewhat on the custom shaders being used. But both are dependent on how crowded the scene is. Which also means it particularly becomes an issue when the game is rendering against VR targets.
This changeset fixes both.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

