### PR TITLE
Fixing memcpy Bug in MGG_Buffer_GetData

### DIFF
--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -1332,11 +1332,13 @@ void MGG_Buffer_GetData(MGG_GraphicsDevice* device, MGG_Buffer* buffer, mgint of
 	ComPtr<D3D12MA::Allocation> intermediateAlloc;
 	CD3DX12_RESOURCE_DESC resourceDesc = CD3DX12_RESOURCE_DESC::Buffer(dataStride * dataCount);
 	D3D12MA::ALLOCATION_DESC allocDesc = { D3D12MA::ALLOCATION_FLAG_NONE, D3D12_HEAP_TYPE_READBACK };
-	device->resources->GetAllocator()->CreateResource(
-		&allocDesc, &resourceDesc,
-		D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
+	DX::ThrowIfFailed(device->resources->GetAllocator()->CreateResource(
+		&allocDesc,
+		&resourceDesc,
+		D3D12_RESOURCE_STATE_COPY_DEST,
+		nullptr,
 		intermediateAlloc.ReleaseAndGetAddressOf(),
-		IID_GRAPHICS_PPV_ARGS(intermediateBuffer.ReleaseAndGetAddressOf()));
+		IID_GRAPHICS_PPV_ARGS(intermediateBuffer.ReleaseAndGetAddressOf())));
 
 	auto cmd = device->resources->BeginCommandList();
 	auto cmdList = cmd->Get();
@@ -1361,13 +1363,24 @@ void MGG_Buffer_GetData(MGG_GraphicsDevice* device, MGG_Buffer* buffer, mgint of
 
 	UINT8* pSourceDataBegin;
 	DX::ThrowIfFailed(intermediateBuffer->Map(0, nullptr, reinterpret_cast<void**>(&pSourceDataBegin)));
-	if (dataStride == dataStride)
+	if (dataBytes == dataStride)
+	{
 		memcpy(data, pSourceDataBegin, dataStride * dataCount);
-	else {
-		for (auto i = 0; i < dataCount; i++)
-			memcpy(data + (i * dataStride), (void*)(pSourceDataBegin + (i * dataStride)), dataStride);
 	}
-	CD3DX12_RANGE writeRange(0, 0); // We haven't write to the buffer
+	else
+	{
+		// TODO: Is it stupid to consider this possibility, or is it better safe than sorry?
+		// I simply don't know the use-cases.
+		auto bytesToCopy = dataBytes < dataStride ? dataBytes : dataStride;
+		for (auto i = 0; i < dataCount; i++)
+		{
+			// TODO: What exactly happens here? Is this about padding?
+			// Assuming it is, how do we know where it is?
+			// Is it standard practice to have padding only at the end?
+			memcpy(data + (i * dataBytes), (void*)(pSourceDataBegin + (i * dataStride)), bytesToCopy);
+		}
+	}
+	CD3DX12_RANGE writeRange(0, 0); // We haven't written to the buffer
 	intermediateBuffer->Unmap(0, &writeRange);
 }
 

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -1369,14 +1369,9 @@ void MGG_Buffer_GetData(MGG_GraphicsDevice* device, MGG_Buffer* buffer, mgint of
 	}
 	else
 	{
-		// TODO: Is it stupid to consider this possibility, or is it better safe than sorry?
-		// I simply don't know the use-cases.
 		auto bytesToCopy = dataBytes < dataStride ? dataBytes : dataStride;
 		for (auto i = 0; i < dataCount; i++)
 		{
-			// TODO: What exactly happens here? Is this about padding?
-			// Assuming it is, how do we know where it is?
-			// Is it standard practice to have padding only at the end?
 			memcpy(data + (i * dataBytes), (void*)(pSourceDataBegin + (i * dataStride)), bytesToCopy);
 		}
 	}

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -1363,7 +1363,7 @@ void MGG_Buffer_GetData(MGG_GraphicsDevice* device, MGG_Buffer* buffer, mgint of
 
 	UINT8* pSourceDataBegin;
 	DX::ThrowIfFailed(intermediateBuffer->Map(0, nullptr, reinterpret_cast<void**>(&pSourceDataBegin)));
-	if (dataBytes == dataStride)
+	if (dataStride == dataBytes)
 	{
 		memcpy(data, pSourceDataBegin, dataStride * dataCount);
 	}

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -4635,9 +4635,10 @@ void MGG_Buffer_GetData(MGG_GraphicsDevice* device, MGG_Buffer* buffer, mgint of
     }
     else
     {
+		auto bytesToCopy = dataBytes < dataStride ? dataBytes : dataStride;
         for (mgint i = 0; i < dataCount; ++i)
         {
-            memcpy(data + i * dataBytes, src_ptr + i * dataStride, dataBytes);
+            memcpy(data + i * dataBytes, src_ptr + i * dataStride, bytesToCopy);
         }
     }
 }


### PR DESCRIPTION
We have a check that compares `dataStride` against itself where it should be comparing it against `dataBytes`.

Fixes #9277

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

1. We replace the `if (dataStride == dataStride)` check with `if (dataBytes == dataStride)` to fix the bug.
2. I've also added a `dataBytes < dataStride` check, but I'm not sure if it makes sense. As in whether I'm being paranoid, or it's better safe than sorry. I simply don't know the use-cases, so I'm not sure if it could possibly be the target that has padding.
3. I've added the same check to the Vulkan backend too, so let me know if it makes sense to keep them or not.
4. I've also added a `DX::ThrowIfFailed` check since `Allocator::CreateResource` returns `HRESULT`, but I'm not sure whether it's actually useful or not.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

