### PR TITLE
Stencil Handling in RenderTarget2D

### DIFF
--- a/native/monogame/directx12/GraphicsEnums.h
+++ b/native/monogame/directx12/GraphicsEnums.h
@@ -56,8 +56,8 @@ static constexpr DXGI_FORMAT DepthFormatToDXGI_FORMAT[] = {
 static constexpr DXGI_FORMAT DepthFormatToSRV[] = {
     DXGI_FORMAT_UNKNOWN,
     DXGI_FORMAT_R16_UNORM,
-    DXGI_FORMAT_R24_UNORM_X8_TYPELESS,  // For Depth24: Depth only. Stencil is typeless. ("stencil typeless, not readable in shader since it shouldn't be here in the first place")
-    DXGI_FORMAT_R24_UNORM_X8_TYPELESS   // For Depth24Stencil8: There is stencil, but SRV reads only depth. Stencil is typeless, and not accessible by shader via this view. (I'm not sure what the original comment means: "stencil accessed by G channel")
+    DXGI_FORMAT_R24_UNORM_X8_TYPELESS,  // There is no 24bit only format for depth.
+    DXGI_FORMAT_R24_UNORM_X8_TYPELESS,
 };
 
 static constexpr D3D_PRIMITIVE_TOPOLOGY PrimitiveTypeToD3D_PRIMITIVE_TOPOLOGY[] = {

--- a/native/monogame/directx12/GraphicsEnums.h
+++ b/native/monogame/directx12/GraphicsEnums.h
@@ -56,8 +56,15 @@ static constexpr DXGI_FORMAT DepthFormatToDXGI_FORMAT[] = {
 static constexpr DXGI_FORMAT DepthFormatToSRV[] = {
     DXGI_FORMAT_UNKNOWN,
     DXGI_FORMAT_R16_UNORM,
-    DXGI_FORMAT_R24_UNORM_X8_TYPELESS, // stencil typeless, not readable in shader since it shouldn't be here in the first place
-    DXGI_FORMAT_R24G8_TYPELESS // stencil accessed by G channel
+    DXGI_FORMAT_R24_UNORM_X8_TYPELESS,  // For Depth24: Depth only. Stencil is typeless. ("stencil typeless, not readable in shader since it shouldn't be here in the first place")
+    DXGI_FORMAT_R24_UNORM_X8_TYPELESS   // For Depth24Stencil8: There is stencil, but SRV reads only depth. Stencil is typeless, and not accessible by shader via this view. (I'm not sure what the original comment means: "stencil accessed by G channel")
+};
+
+static constexpr DXGI_FORMAT DepthFormatToStencilSRV[] = {
+    DXGI_FORMAT_UNKNOWN,
+    DXGI_FORMAT_UNKNOWN,                // For Depth16: Ignored.
+    DXGI_FORMAT_UNKNOWN,                // For Depth24: Ignored.
+    DXGI_FORMAT_X24_TYPELESS_G8_UINT    // For Depth24Stencil8: Depth is typeless and ignored, stencil is G8_UINT.
 };
 
 static constexpr D3D_PRIMITIVE_TOPOLOGY PrimitiveTypeToD3D_PRIMITIVE_TOPOLOGY[] = {

--- a/native/monogame/directx12/GraphicsEnums.h
+++ b/native/monogame/directx12/GraphicsEnums.h
@@ -60,13 +60,6 @@ static constexpr DXGI_FORMAT DepthFormatToSRV[] = {
     DXGI_FORMAT_R24_UNORM_X8_TYPELESS   // For Depth24Stencil8: There is stencil, but SRV reads only depth. Stencil is typeless, and not accessible by shader via this view. (I'm not sure what the original comment means: "stencil accessed by G channel")
 };
 
-static constexpr DXGI_FORMAT DepthFormatToStencilSRV[] = {
-    DXGI_FORMAT_UNKNOWN,
-    DXGI_FORMAT_UNKNOWN,                // For Depth16: Ignored.
-    DXGI_FORMAT_UNKNOWN,                // For Depth24: Ignored.
-    DXGI_FORMAT_X24_TYPELESS_G8_UINT    // For Depth24Stencil8: Depth is typeless and ignored, stencil is G8_UINT.
-};
-
 static constexpr D3D_PRIMITIVE_TOPOLOGY PrimitiveTypeToD3D_PRIMITIVE_TOPOLOGY[] = {
     D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST,
     D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -148,6 +148,7 @@ struct MGG_BlendState
 struct MGG_DepthStencilState
 {
 	D3D12_DEPTH_STENCIL_DESC desc;
+	mgint referenceStencil;
 };
 
 struct MGG_RasterizerState
@@ -1051,6 +1052,7 @@ MGG_DepthStencilState* MGG_DepthStencilState_Create(MGG_GraphicsDevice* device, 
 	state->desc.BackFace.StencilPassOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->stencilPass];
 	state->desc.BackFace.StencilFailOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->stencilFail];
 	state->desc.BackFace.StencilDepthFailOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->stencilDepthBufferFail];
+	state->referenceStencil = info->referenceStencil;
 
 	return state;
 }

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -605,6 +605,10 @@ void MGG_GraphicsDevice_SetDepthStencilState(MGG_GraphicsDevice* device, MGG_Dep
 
 	auto& depthStencilState = device->pipelineManager->impl->m_currentPSODesc.DepthStencilState;
 	depthStencilState = state->desc;
+	
+	// Set stencil reference on every frame.
+	auto commandList = device->context->GetCommandList();
+	commandList->OMSetStencilRef(state->referenceStencil);
 }
 
 void MGG_GraphicsDevice_SetRasterizerState(MGG_GraphicsDevice* device, MGG_RasterizerState* state)


### PR DESCRIPTION
Attempting to fix a DX12 bug that turned into 2 bugs during my testing:

1. `DepthFormat.Depth24Stencil8` handling was wrong in `Texture::Create()`. This causes `RenderTarget2D` ctor to throw and crash the game.
2. `ReferenceStencil` value was being ignored, which prevented stencil masks from working.

Fixes #9279



### Description of Change

- Changing `DepthFormatToSRV` mapping to return `DXGI_FORMAT_R24_UNORM_X8_TYPELESS` instead of `DXGI_FORMAT_R24G8_TYPELESS` for `Depth24Stencil8`.
- We store `ReferenceStencil` in `MGG_DepthStencilState`.
- We make sure `ReferenceStencil` is set for each frame in `MGG_GraphicsDevice_SetDepthStencilState`.


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

