### PR TITLE
Waiting for Device Idle Before Destroying Graphics Device on Shutdown

### DIFF
--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1478,6 +1478,10 @@ void MGG_GraphicsDevice_Destroy(MGG_GraphicsDevice* device)
 {
 	assert(device != nullptr);
 
+	// Be sure we're done drawing.
+	// Prevents some exceptions while shutting down.
+	vkDeviceWaitIdle(device->device);
+
 	cleanupSwapChain(device);
 
 	for (auto pair : device->shader_programs)


### PR DESCRIPTION
This will hopefully prevent some sporadic exceptions when the game shuts down.
`MGG_GraphicsDevice_Destroy` begins cleaning up the swapchain without ensuring we're not in the middle of a draw.
This can sporadically cause exceptions when we're shutting down the game.

Fixes #9282

### Description of Change

We wait for the GPU to idle before we start the cleanup, like we do in `MGVK_RecreateSwapChain`.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

