### PR TITLE
Add Homebrew update step for macOS environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,11 @@ jobs:
         run: |
           dotnet workload install android
 
+      - name: Update Homebrew
+        if: runner.environment == 'github-hosted' && runner.os == 'macos'
+        run: |
+          brew update
+
       - name: Setup DotNet on MacOS
         if: runner.environment == 'github-hosted' && runner.os == 'macos'
         run: |


### PR DESCRIPTION
Add step to update Homebrew for macOS runners.
This should fix the wine install errors we are seeing.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

