### PR TITLE
Added additional Color.FromNonPremultiplied overloads with new argument types

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1874,6 +1874,16 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Translate a non-premultipled alpha <see cref="Color"/> to a <see cref="Color"/> that contains premultiplied alpha.
         /// </summary>
+        /// <param name="color">A <see cref="Color"/> representing a non-premultiplied color.</param>
+        /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
+        public static Color FromNonPremultiplied(Color color)
+        {
+            return FromNonPremultiplied(color.R, color.G, color.B, color.A);
+        }
+
+        /// <summary>
+        /// Translate a non-premultipled alpha <see cref="Color"/> to a <see cref="Color"/> that contains premultiplied alpha.
+        /// </summary>
         /// <param name="vector">A <see cref="Vector4"/> representing color.</param>
         /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
         public static Color FromNonPremultiplied(Vector4 vector)
@@ -1884,10 +1894,23 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Translate a non-premultipled alpha <see cref="Color"/> to a <see cref="Color"/> that contains premultiplied alpha.
         /// </summary>
-        /// <param name="r">Red component value.</param>
-        /// <param name="g">Green component value.</param>
-        /// <param name="b">Blue component value.</param>
-        /// <param name="a">Alpha component value.</param>
+        /// <param name="r">Red component value from 0.0f to 1.0f.</param>
+        /// <param name="g">Green component value from 0.0f to 1.0f.</param>
+        /// <param name="b">Blue component value from 0.0f to 1.0f.</param>
+        /// <param name="a">Alpha component value from 0.0f to 1.0f.</param>
+        /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
+        public static Color FromNonPremultiplied(float r, float g, float b, float a)
+        {
+            return new Color(r * a, g * a, b * a, a);
+        }
+
+        /// <summary>
+        /// Translate a non-premultipled alpha <see cref="Color"/> to a <see cref="Color"/> that contains premultiplied alpha.
+        /// </summary>
+        /// <param name="r">Red component value from 0 to 255.</param>
+        /// <param name="g">Green component value from 0 to 255.</param>
+        /// <param name="b">Blue component value from 0 to 255.</param>
+        /// <param name="a">Alpha component value from 0 to 255.</param>
         /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
         public static Color FromNonPremultiplied(int r, int g, int b, int a)
         {


### PR DESCRIPTION
Fixes #9300 

### Description of Change

Added different method overloads for the Color.FromNonPremultiplied method. Added overloads for another Color instance and float values.

Also updated the documentation comments for Color.FromNonPremultiplied's arguments to reference their expected numerical value.

### Contributor Declaration

- [X] I certify that no LLM's were used to generate any code or documentation in this contribution.