### PR TITLE
Refactor GitHub Actions for Wine and Fonts installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -315,18 +315,11 @@ jobs:
         if: runner.environment == 'github-hosted'
         uses: monogame/monogame-actions/install-fonts@v1
 
-      - name: install wine64 on linux
-        if: runner.environment == 'github-hosted' && runner.os == 'Linux'
-        run: |
-          wget -qO- https://monogame.net/downloads/net9_mgfxc_wine_setup.sh | bash
-
-      - name: install wine64 on MacOS
+      - name: Pin xcode to 26.3
+        uses: maxim-lobanov/setup-xcode@v1
         if: runner.environment == 'github-hosted' && runner.os == 'macos'
-        run: |
-          sudo mkdir -p /usr/local/lib
-          ls -n /Applications/ | grep Xcode*
-          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
-          wget -qO- https://monogame.net/downloads/net9_mgfxc_wine_setup.sh | bash
+        with:
+          xcode-version: '26.3'
 
       - name: Download Nuget
         uses: actions/download-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -302,33 +302,31 @@ jobs:
           dotnet-version: '${{ env.DotnetVersion }}'
           global-json-file: "./global.json"
 
+      - name: Update Homebrew
+        if: runner.environment == 'github-hosted' && runner.os == 'macos'
+        run: |
+          brew update
+
+      - name: Setup Wine
+        if: runner.environment == 'github-hosted'
+        uses: monogame/monogame-actions/install-wine@v1
+
+      - name: Install Fonts
+        if: runner.environment == 'github-hosted'
+        uses: monogame/monogame-actions/install-fonts@v1
+
       - name: install wine64 on linux
         if: runner.environment == 'github-hosted' && runner.os == 'Linux'
         run: |
-          sudo apt install p7zip-full curl
-          sudo dpkg --add-architecture i386 
-          sudo mkdir -pm755 /etc/apt/keyrings
-          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources
-          sudo apt update && sudo apt install --install-recommends winehq-stable
           wget -qO- https://monogame.net/downloads/net9_mgfxc_wine_setup.sh | bash
 
       - name: install wine64 on MacOS
         if: runner.environment == 'github-hosted' && runner.os == 'macos'
         run: |
-          brew install wine-stable p7zip
           sudo mkdir -p /usr/local/lib
           ls -n /Applications/ | grep Xcode*
           sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
           wget -qO- https://monogame.net/downloads/net9_mgfxc_wine_setup.sh | bash
-
-      - name: Install Arial Font
-        if: runner.os == 'Linux' && runner.environment == 'github-hosted'
-        run: |
-          echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | sudo debconf-set-selections
-          sudo apt install -y ttf-mscorefonts-installer
-          sudo fc-cache
-          fc-match Arial
 
       - name: Download Nuget
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Added steps to update Homebrew, setup Wine, and install Fonts on macOS using the monogame-actions



### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

