### PR TITLE
Enabling GPU instancing in DX12

### DIFF
--- a/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
@@ -307,7 +307,7 @@ public partial class GraphicsDevice
         }
 
         if (_vertexBuffersDirty)
-       {
+        {
             for (var slot = 0; slot < _vertexBuffers.Count; slot++)
             {
                 var vertexBufferBinding = _vertexBuffers.Get(slot);

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -832,6 +832,15 @@ void MGDX_ApplyState(MGG_GraphicsDevice* device)
 			if (!buffer)
 				continue;
 
+
+			if (i >= device->layout->streamStrides.size())
+			{
+				// Vertex buffer and stream slides are out of sync.
+				// Clean up leftover vertex buffer slot.
+				device->vertexBuffers[i] = nullptr;
+				continue;
+			}
+
 			vbv.BufferLocation = buffer->GpuAddress() + device->vertexOffsets[i];
 			vbv.StrideInBytes = device->layout->streamStrides[i];
 			vbv.SizeInBytes = buffer->dataSize;
@@ -979,8 +988,6 @@ void MGG_GraphicsDevice_DrawIndexedInstanced(MGG_GraphicsDevice* device, MGPrimi
 	auto indexCount = MGDX_GetIndexCount(primitiveType, primitiveCount);
 
 	cl->DrawIndexedInstanced(indexCount, instanceCount, indexStart, vertexStart, 0);
-
-	MG_NOT_IMPLEMEMTED;
 }
 
 
@@ -1403,6 +1410,8 @@ MGG_Texture* MGG_Texture_Create(
 	assert(mipmaps > 0);
 	assert(slices > 0);
 	assert(type != MGTextureType::Cube || (slices % 6) == 0);
+	// TODO: Pass slices down into texture ctor and implement handling.
+	// We already use it in Vulkan to define array layers.
 
 	auto texture = new MGG_Texture();
 
@@ -1669,7 +1678,14 @@ MGG_InputLayout* MGG_InputLayout_Create(
 		elem.SemanticIndex = elements[i].SemanticIndex;
 		elem.AlignedByteOffset = elements[i].AlignedByteOffset;
 		elem.InputSlot = elements[i].VertexBufferSlot;
-		elem.InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA; // TODO: instancing!
+
+		// instanceFrequency is set on InstanceDataStepRate at:
+		// AsInputElement() in VertexInputLayout.GenerateInputElements()
+		// We can use MGG_InputElement.InstanceDataStepRate to identify GPU instancing.
+		elem.InputSlotClass = elements[i].InstanceDataStepRate > 0
+			? D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA
+			: D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
+
 		elem.InstanceDataStepRate = elements[i].InstanceDataStepRate;
 		elem.Format = MGVertexElementFormatToDXGI_FORMAT[(int)elements[i].Format];
 		layout->elements.push_back(elem);

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -835,7 +835,7 @@ void MGDX_ApplyState(MGG_GraphicsDevice* device)
 
 			if (i >= device->layout->streamStrides.size())
 			{
-				// Vertex buffer and stream slides are out of sync.
+				// Vertex buffer is out of sync with current layout.
 				// Clean up leftover vertex buffer slot.
 				device->vertexBuffers[i] = nullptr;
 				continue;

--- a/native/monogame/directx12/Texture.cpp
+++ b/native/monogame/directx12/Texture.cpp
@@ -230,10 +230,13 @@ void Texture::SetData(DeviceResources* device, uint32_t subResId, uint8_t* data,
     const UINT64 uploadSize = GetRequiredIntermediateSize(impl->m_res.Get(), subResId, 1);
     CD3DX12_RESOURCE_DESC resourceDesc = CD3DX12_RESOURCE_DESC::Buffer(uploadSize);
     D3D12MA::ALLOCATION_DESC allocDesc = { D3D12MA::ALLOCATION_FLAG_COMMITTED, D3D12_HEAP_TYPE_UPLOAD };
-    device->GetAllocator()->CreateResource(
-        &allocDesc, &resourceDesc,
-        D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
-        uploadAlloc.ReleaseAndGetAddressOf(), IID_GRAPHICS_PPV_ARGS(uploadBuffer.ReleaseAndGetAddressOf()));
+    ThrowIfFailed(device->GetAllocator()->CreateResource(
+        &allocDesc,
+        &resourceDesc,
+        D3D12_RESOURCE_STATE_GENERIC_READ,
+        nullptr,
+        uploadAlloc.ReleaseAndGetAddressOf(),
+        IID_GRAPHICS_PPV_ARGS(uploadBuffer.ReleaseAndGetAddressOf())));
 
     auto cmd = device->BeginCommandList();
     auto cmdList = cmd->Get();

--- a/native/monogame/include/mg_common.h
+++ b/native/monogame/include/mg_common.h
@@ -59,7 +59,7 @@ inline void MG_Print_StdOut(const char* file, int line, const char* message)
 #define MG_ERROR_PRINT(msg) \
     MG_Print_StdError(__FILE__, __LINE__, msg)
 
-#define MG_NOT_IMPLEMEMTED	MG_ERROR_PRINT("NOT IMPLEMENTED!"); MG_GENERATE_TRAP()
+#define MG_NOT_IMPLEMENTED	MG_ERROR_PRINT("NOT IMPLEMENTED!"); MG_GENERATE_TRAP()
 
 
 mguint MG_ComputeHash(const mgbyte* value, mgint length);


### PR DESCRIPTION
Fixes #9305

I was initially hoping to use @acarteas' sample app to test this, but apparently they're using a TextureArray, and we still don't have support for that in DX12.

After taking a stab at adding support for that, it seemed a bit beyond me, so I ended up testing this in my own game instead.
I've added a TODO comment for it though, and created a separate ticket for the Texture array support: #9307

### Description of Change

- Fixed typo in the `MG_NOT_IMPLEMEMTED` trap.
- Removed the trap from `MGG_GraphicsDevice_DrawIndexedInstanced` in `MGG_DX12`.
- Added `ThrowIfFailed` check on resource creation in `Texture::SetData`.
- Ensured correct layout is set for instanced draws in `MGG_InputLayout_Create`.
- Ensured vertex buffer stays in sync with stream strides in `MGDX_ApplyState`


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

