### PR TITLE
Dont fallback to GLES2 if we have GLES3

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/OpenGL.Android.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.Android.cs
@@ -48,8 +48,7 @@ namespace MonoGame.OpenGL
 
             if (GL.BoundApi == GL.RenderApi.ES && libES3 != IntPtr.Zero)
                 Library = libES3;
-
-            if (GL.BoundApi == GL.RenderApi.ES && libES2 != IntPtr.Zero)
+            else if (GL.BoundApi == GL.RenderApi.ES && libES2 != IntPtr.Zero)
                 Library = libES2;
             else if (GL.BoundApi == GL.RenderApi.GL && libGL != IntPtr.Zero)
                 Library = libGL;


### PR DESCRIPTION
There was a bug in the logic when detecting the GLES version. If we found GLES3 we never actually used it. We always fell back to GLES2. 

Lets fix that so we can actually use GLES3.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

