### PR TITLE
Update min xCode version to 26.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,11 +83,11 @@ jobs:
         run: |
           dotnet workload install macos ios
 
-      - name: Pin xcode to 26.3
+      - name: Pin xcode version
         uses: maxim-lobanov/setup-xcode@v1
         if: runner.environment == 'github-hosted' && runner.os == 'macos'
         with:
-          xcode-version: '26.3'
+          xcode-version: '26.4'
 
       - name: Add msbuild to PATH
         if: runner.os == 'Windows'
@@ -378,11 +378,11 @@ jobs:
         if: runner.environment == 'github-hosted'
         uses: monogame/monogame-actions/install-fonts@v1
 
-      - name: Pin xcode to 26.3
+      - name: Pin xcode version
         uses: maxim-lobanov/setup-xcode@v1
         if: runner.environment == 'github-hosted' && runner.os == 'macos'
         with:
-          xcode-version: '26.3'
+          xcode-version: '26.4'
 
       - name: Download Nuget
         uses: actions/download-artifact@v4


### PR DESCRIPTION
# Summary

Updating the min version for xCode on Mac builds to 26.4 due to build requirements,

### Contributor Declaration

- [X] I certify that no LLM's were used to generate any code or documentation in this contribution.

