### PR TITLE
Replace obsolete OffsetToStringData usage

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -1589,7 +1589,7 @@ namespace MonoGame.OpenGL
             if (intPtr == IntPtr.Zero) {
                 throw new OutOfMemoryException ();
             }
-            fixed (char* chars = str + RuntimeHelpers.OffsetToStringData / 2) {
+            fixed (char* chars = str) {
                 int bytes = Encoding.ASCII.GetBytes (chars, str.Length, (byte*)((void*)intPtr), num);
                 Marshal.WriteByte (intPtr, bytes, 0);
                 return intPtr;


### PR DESCRIPTION
Summary
Replaces obsolete `RuntimeHelpers.OffsetToStringData` usage in `OpenGL.cs` with direct string pinning.

Testing
- Attempted `dotnet build MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj`
- Build failed due to missing `StbImageSharp` and `StbImageWriteSharp` dependencies, unrelated to this change

Fixes #9293

