### PR TITLE
Replace obsolete OffsetToStringData usage

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Diagnostics;
 using MonoGame.Framework.Utilities;
@@ -1589,7 +1588,7 @@ namespace MonoGame.OpenGL
             if (intPtr == IntPtr.Zero) {
                 throw new OutOfMemoryException ();
             }
-            fixed (char* chars = str + RuntimeHelpers.OffsetToStringData / 2) {
+            fixed (char* chars = str) {
                 int bytes = Encoding.ASCII.GetBytes (chars, str.Length, (byte*)((void*)intPtr), num);
                 Marshal.WriteByte (intPtr, bytes, 0);
                 return intPtr;


### PR DESCRIPTION
This replaces the obsolete 'RuntimeHelpers.OffsetToStringData' usage in 'OpenGL.cs'  with modern string pinning syntax.
The previous implementation:
fixed (char* chars = str + RuntimeHelpers.OffsetToStringData / 2)
was updated to:
fixed (char* chars = str)
This removes the obsolete API warning while preserving existing behavior.
