### PR TITLE
Temp disabling package nuget testing on Mac until MacOS issues are resolved

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,8 +186,9 @@ jobs:
         run: |
           dotnet workload install macos ios
 
+      # Macos NuGet testing disabled until xCode issues are resolved
       - name: Test generated Nuget packages
-        if: runner.os != 'Linux'
+        if: runner.os != 'Linux' && runner.os != 'macos'
         run: dotnet run --project build/Build.csproj -- --target=TestNuGet --framework net9.0
         env:
           ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN }}


### PR DESCRIPTION
# Summary

Temp disabling package nuget testing on Mac until MacOS issues are resolved

### Contributor Declaration

- [X] I certify that no LLM's were used to generate any code or documentation in this contribution.

