### PR TITLE
[Closed in Favor of #9343] Runtime and Dynamic Spritefont Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,9 @@
 [submodule "native/monogame/external/faudio"]
 	path = native/monogame/external/faudio
 	url = https://github.com/FNA-XNA/FAudio.git
+[submodule "ThirdParty/StbTrueTypeSharp"]
+	path = ThirdParty/StbTrueTypeSharp
+	url = https://github.com/StbSharp/StbTrueTypeSharp.git
+[submodule "ThirdParty/StbRectPackSharp"]
+	path = ThirdParty/StbRectPackSharp
+	url = https://github.com/StbSharp/StbRectPackSharp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,9 +31,3 @@
 [submodule "native/monogame/external/faudio"]
 	path = native/monogame/external/faudio
 	url = https://github.com/FNA-XNA/FAudio.git
-[submodule "ThirdParty/StbTrueTypeSharp"]
-	path = ThirdParty/StbTrueTypeSharp
-	url = https://github.com/StbSharp/StbTrueTypeSharp.git
-[submodule "ThirdParty/StbRectPackSharp"]
-	path = ThirdParty/StbRectPackSharp
-	url = https://github.com/StbSharp/StbRectPackSharp.git

--- a/MonoGame.Framework/Graphics/CharacterRegion.cs
+++ b/MonoGame.Framework/Graphics/CharacterRegion.cs
@@ -1,0 +1,60 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Graphics;
+
+/// <summary>
+/// Describes a range of consecutive characters.
+/// </summary>
+public struct CharacterRegion
+{
+    /// <summary>
+    /// The default ASCII character region, U+0020 (space) through U+007E (tilde).
+    /// </summary>
+    public static CharacterRegion Default => new CharacterRegion(' ', '~');
+    /// <summary>
+    /// The first character in the region.
+    /// </summary>
+    public char Start;
+
+    /// <summary>
+    /// The last character in the region.
+    /// </summary>
+    public char End;
+
+    /// <summary>
+    /// Initializes  new instance of the <see cref="CharacterRegion"/> struct.
+    /// </summary>
+    /// <param name="start">The first character in the region.</param>
+    /// <param name="end">The last character in the region.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="start"/> is greater than <paramref name="end"/>.
+    /// </exception>
+    public CharacterRegion(char start, char end)
+    {
+        if (start > end)
+        {
+            throw new ArgumentException(
+                $"The start character '{start}' must not be greater than the end character '{end}'");
+        }
+
+        Start = start;
+        End = end;
+    }
+
+    /// <summary>
+    /// Enumerates all characters in the region.
+    /// </summary>
+    /// <returns>An enumeration of characters from <see cref="Start"/> through <see cref="End"/>.</returns>
+    public readonly IEnumerable<char> Characters()
+    {
+        for (char c = Start; c <= End; c++)
+        {
+            yield return c;
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
         private readonly Glyph[] _glyphs;
-        private readonly CharacterRegion[] _regions;
+        private readonly CharacterMapRegion[] _regions;
         private char? _defaultCharacter;
         private int _defaultGlyphIndex = -1;
 		
@@ -72,7 +72,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			Spacing = spacing;
 
             _glyphs = new Glyph[characters.Count];
-            var regions = new Stack<CharacterRegion>();
+            var regions = new Stack<CharacterMapRegion>();
 
 			for (var i = 0; i < characters.Count; i++) 
             {
@@ -92,7 +92,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 if(regions.Count == 0 || characters[i] > (regions.Peek().End+1))
                 {
                     // Start a new region
-                    regions.Push(new CharacterRegion(characters[i], i));
+                    regions.Push(new CharacterMapRegion(characters[i], i));
                 } 
                 else if(characters[i] == (regions.Peek().End+1))
                 {
@@ -264,7 +264,7 @@ namespace Microsoft.Xna.Framework.Graphics
         
         internal unsafe bool TryGetGlyphIndex(char c, out int index)
         {
-            fixed (CharacterRegion* pRegions = _regions)
+            fixed (CharacterMapRegion* pRegions = _regions)
             {
                 if(!TryGetRegionIdx(c, pRegions, out int regionIdx))
                 {
@@ -284,7 +284,7 @@ namespace Microsoft.Xna.Framework.Graphics
             return true;
         }
 
-        private unsafe bool TryGetRegionIdx(char c, CharacterRegion* pRegions, out int regionIdx)
+        private unsafe bool TryGetRegionIdx(char c, CharacterMapRegion* pRegions, out int regionIdx)
         {
             // Get region Index 
             regionIdx = -1;
@@ -411,13 +411,13 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
-        private struct CharacterRegion
+        private struct CharacterMapRegion
         {
             public char Start;
             public char End;
             public int StartIndex;
 
-            public CharacterRegion(char start, int startIndex)
+            public CharacterMapRegion(char start, int startIndex)
             {
                 this.Start = start;                
                 this.End = start;

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 
 namespace Microsoft.Xna.Framework.Graphics 
@@ -30,6 +31,8 @@ namespace Microsoft.Xna.Framework.Graphics
         private int _defaultGlyphIndex = -1;
 		
 		private readonly Texture2D _texture;
+        
+        // internal SpriteFontState State { get; }
 
 		/// <summary>
 		/// All the glyphs in this SpriteFont.
@@ -65,7 +68,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public SpriteFont (
 			Texture2D texture, List<Rectangle> glyphBounds, List<Rectangle> cropping, List<char> characters,
 			int lineSpacing, float spacing, List<Vector3> kerning, char? defaultCharacter)
-		{
+        {
 			Characters = new ReadOnlyCollection<char>(characters.ToArray());
 			_texture = texture;
 			LineSpacing = lineSpacing;
@@ -170,6 +173,93 @@ namespace Microsoft.Xna.Framework.Graphics
 		/// the font.
 		/// </summary>
 		public float Spacing { get; set; }
+
+        /// <summary>
+        /// Creates a <see cref="SpriteFont"/> from a font file
+        /// </summary>
+        /// <param name="graphicsDevice">The graphics device used to create the font texture.</param>
+        /// <param name="path">The path to a TrueType or OpenType font file.</param>
+        /// <param name="size">The font size, in pixels, used when rasterizing glyphs.</param>
+        /// <param name="characterRegions">The character ranges to include in the created font.</param>
+        /// <returns>A <see cref="SpriteFont"/> created from the supplied font file.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="graphicsDevice"/>, <paramref name="path"/>, or 
+        /// <paramref name="characterRegions"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="size"/> is zero or negative.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="characterRegions"/> does not contain any characters.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the font data cannot be parsed or no glyphs can be created.
+        /// </exception>
+        public static SpriteFont FromFile(GraphicsDevice graphicsDevice, string path, int size, IEnumerable<CharacterRegion> characterRegions)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path), $"{nameof(path)} must not be null.");
+            }
+
+            using(Stream stream = File.OpenRead(path))
+            {
+                return FromStream(graphicsDevice, stream, size, characterRegions);
+            }
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SpriteFont"/> from a font stream.
+        /// </summary>
+        /// <param name="graphicsDevice">The graphics device used to create the font texture.</param>
+        /// <param name="stream">The stream containing TrueType or OpenType font data.</param>
+        /// <param name="size">The font size, in pixels, used when rasterizing glyphs.</param>
+        /// <param name="characterRegions">The character ranges to include in the created font.</param>
+        /// <returns>A <see cref="SpriteFont"/> created from the supplied font file.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="graphicsDevice"/>, <paramref name="stream"/>, or 
+        /// <paramref name="characterRegions"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="size"/> is zero or negative.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="characterRegions"/> does not contain any characters.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the font data cannot be parsed or no glyphs can be created.
+        /// </exception>
+        public static SpriteFont FromStream(GraphicsDevice graphicsDevice, Stream stream, int size, IEnumerable<CharacterRegion> characterRegions)
+        {
+            if (graphicsDevice == null)
+            {
+                throw new ArgumentNullException(nameof(graphicsDevice), $"{nameof(graphicsDevice)} must not be null.");
+            }
+
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream), $"{nameof(stream)} must not be null.");
+            }
+
+            if (size <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(size), $"{nameof(size)} must be greater than zero.");
+            }
+
+            if(characterRegions == null)
+            {
+                throw new ArgumentNullException(nameof(characterRegions), $"{nameof(characterRegions)} must not be null.");
+            }
+
+            byte[] fontData;
+            using(MemoryStream memoryStream = new MemoryStream())
+            {
+                stream.CopyTo(memoryStream);
+                fontData =memoryStream.ToArray();
+            }
+
+            return SpriteFontBaker.Bake(graphicsDevice, fontData, size,characterRegions);
+        }
 
 		/// <summary>
 		/// Returns the size of a string when rendered in this font.

--- a/MonoGame.Framework/Graphics/SpriteFontBaker.cs
+++ b/MonoGame.Framework/Graphics/SpriteFontBaker.cs
@@ -4,12 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using StbRectPackSharp;
-using StbTrueTypeSharp;
-
-using StbTrueTypeFontInfo = StbTrueTypeSharp.StbTrueType.stbtt_fontinfo;
-using StbRectPackRect = StbRectPackSharp.StbRectPack.stbrp_rect;
-using StbRectPackContext = StbRectPackSharp.StbRectPack.stbrp_context;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics;
 
@@ -47,27 +42,28 @@ internal static class SpriteFontBaker
             throw new ArgumentException("At least one character must be supplied.", nameof(characterRegions));
         }
 
-        StbTrueTypeFontInfo fontInfo = StbTrueType.CreateFont(data, 0);
-        if (fontInfo == null)
+        FreeType.FT_LibraryRec* library = null;
+        FreeType.FT_FaceRec* face = null;
+        GCHandle fontDataHandle = default;
+
+        try
         {
-            throw new InvalidOperationException("The supplied font data could not be parsed.");
-        }
+            FreeType.CheckError(FreeType.FT_Init_FreeType(out library));
 
-        using (fontInfo)
-        {
-            float scale = StbTrueType.stbtt_ScaleForMappingEmToPixels(fontInfo, size);
+            fontDataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+            byte* fileBase = (byte*)fontDataHandle.AddrOfPinnedObject();
+            FreeType.CheckError(FreeType.FT_New_Memory_Face(library, fileBase, data.Length, 0, out face));
+            FreeType.CheckError(FreeType.FT_Set_Pixel_Sizes(face, 0, (uint)size));
 
-            int ascent;
-            int descent;
-            int lineGap;
-            StbTrueType.stbtt_GetFontVMetrics(fontInfo, &ascent, &descent, &lineGap);
+            int ascentPixels = FreeTypeHelper.GetAscender(face);
+            int lineSpace = FreeTypeHelper.GetLineSpacing(face);
 
-            int ascentPixels = (int)Math.Ceiling(ascent * scale);
-            int descentPixels = (int)Math.Ceiling(-descent * scale);
-            int lineGapPixels = (int)Math.Ceiling(lineGap * scale);
-            int lineSpacing = ascentPixels + descentPixels + lineGapPixels;
+            if (lineSpace <= 0)
+            {
+                lineSpace = size;
+            }
 
-            List<GlyphBuildInfo> glyphs = BuildGlyphs(fontInfo, characters, scale);
+            List<GlyphBuildInfo> glyphs = BuildGlyphs(face, characters);
             if (glyphs.Count == 0)
             {
                 throw new InvalidOperationException("The supplied character regions do not resolve to any glyphs in this font.");
@@ -85,7 +81,7 @@ internal static class SpriteFontBaker
             }
 
             byte[] atlasPixels = new byte[Math.Max(1, atlasSize * atlasSize)];
-            RasterizeGlyphs(fontInfo, glyphs, atlasPixels, atlasSize, scale);
+            RasterizeGlyphs(glyphs, atlasPixels, atlasSize);
 
             Texture2D texture = new Texture2D(graphicsDevice, atlasSize, atlasSize, false, SurfaceFormat.Color);
             texture.SetData(ConvertAlphaMaskToRgba(atlasPixels));
@@ -99,13 +95,31 @@ internal static class SpriteFontBaker
             {
                 bakedCharacters.Add(glyph.Character);
                 glyphBounds.Add(new Rectangle(glyph.AtlasX, glyph.AtlasY, glyph.Width, glyph.Height));
-                cropping.Add(new Rectangle(0, ascentPixels + glyph.BitmapY0, glyph.Width, lineSpacing));
+                cropping.Add(new Rectangle(0, ascentPixels - glyph.BitmapTop, glyph.Width, lineSpace));
                 kerning.Add(new Vector3(glyph.LeftSideBearing, glyph.WidthValue, glyph.RightSideBearing));
             }
 
-            return new SpriteFont(texture, glyphBounds, cropping, bakedCharacters, lineSpacing, 0.0f, kerning, null);
+            return new SpriteFont(texture, glyphBounds, cropping, bakedCharacters, lineSpace, 0.0f, kerning, null);
+        }
+        finally
+        {
+            if (face != null)
+            {
+                FreeType.FT_Done_Face(face);
+            }
+
+            if (library != null)
+            {
+                FreeType.FT_Done_FreeType(library);
+            }
+
+            if (fontDataHandle.IsAllocated)
+            {
+                fontDataHandle.Free();
+            }
         }
     }
+
 
     private static List<char> CollectCharacters(IEnumerable<CharacterRegion> characterRegions)
     {
@@ -122,47 +136,45 @@ internal static class SpriteFontBaker
         return new List<char>(characters);
     }
 
-    private static unsafe List<GlyphBuildInfo> BuildGlyphs(StbTrueTypeFontInfo fontInfo, List<char> characters, float scale)
+    private static unsafe List<GlyphBuildInfo> BuildGlyphs(FreeType.FT_FaceRec* face, List<char> characters)
     {
         List<GlyphBuildInfo> glyphs = new List<GlyphBuildInfo>(characters.Count);
 
         foreach (char character in characters)
         {
-            int glyphIndex = StbTrueType.stbtt_FindGlyphIndex(fontInfo, character);
+            uint glyphIndex = FreeType.FT_Get_Char_Index(face, character);
             if (glyphIndex == 0)
             {
                 continue;
             }
 
-            int bitmapX0;
-            int bitmapY0;
-            int bitmapX1;
-            int bitmapY1;
-            StbTrueType.stbtt_GetGlyphBitmapBox(fontInfo, glyphIndex, scale, scale, &bitmapX0, &bitmapY0, &bitmapX1, &bitmapY1);
+            FreeType.CheckError(FreeType.FT_Load_Glyph(face, glyphIndex, 0));
 
-            int advanceWidth;
-            int leftSideBearing;
-            StbTrueType.stbtt_GetGlyphHMetrics(fontInfo, glyphIndex, &advanceWidth, &leftSideBearing);
+            FreeType.FT_GlyphSlotRec* glyphSlot = FreeTypeHelper.GetGlyphSlot(face);
+            FreeType.CheckError(FreeType.FT_Render_Glyph(glyphSlot, FreeType.RenderMode.Normal));
 
-            int width = Math.Max(0, bitmapX1 - bitmapX0);
-            int height = Math.Max(0, bitmapY1 - bitmapY0);
-            float advancePixels = advanceWidth * scale;
+            FreeType.FT_Bitmap bitmap = FreeTypeHelper.GetGlyphBitmap(glyphSlot);
+            int width = checked((int)bitmap.width);
+            int height = checked((int)bitmap.rows);
+            int bitmapLeft = FreeTypeHelper.GetGlyphBitmapLeft(glyphSlot);
+            int bitmapTop = FreeTypeHelper.GetGlyphBitmapTop(glyphSlot);
+            float advancePixels = FreeTypeHelper.GetGlyphHorizontalAdvance(glyphSlot);
+
 
             GlyphBuildInfo glyph = new GlyphBuildInfo()
             {
                 Character = character,
-                GlyphIndex = glyphIndex,
-                BitmapX0 = bitmapX0,
-                BitmapY0 = bitmapY0,
                 Width = width,
-                Height = height
+                Height = height,
+                BitmapTop = bitmapTop,
+                Pixels = ExtractBitmap(bitmap)
             };
 
             if (width > 0)
             {
-                glyph.LeftSideBearing = bitmapX0;
+                glyph.LeftSideBearing = bitmapLeft;
                 glyph.WidthValue = width;
-                glyph.RightSideBearing = advancePixels - bitmapX1;
+                glyph.RightSideBearing = advancePixels - (bitmapLeft + width);
             }
             else
             {
@@ -175,6 +187,58 @@ internal static class SpriteFontBaker
         }
 
         return glyphs;
+    }
+
+    private static unsafe byte[] ExtractBitmap(FreeType.FT_Bitmap bitmap)
+    {
+        int width = checked((int)bitmap.width);
+        int rows = checked((int)bitmap.rows);
+
+        if (width == 0 || rows == 0 || bitmap.buffer == null)
+        {
+            return Array.Empty<byte>();
+        }
+
+        byte[] pixels = new byte[width * rows];
+        int sourceRowPitch = Math.Abs(bitmap.pitch);
+        byte[] rowBuffer = new byte[sourceRowPitch];
+
+        for (int row = 0; row < bitmap.rows; row++)
+        {
+            int sourceRow = bitmap.pitch >= 0 ? row : (rows - 1 - row);
+            byte* source = bitmap.buffer + (sourceRow * sourceRowPitch);
+            Marshal.Copy((IntPtr)source, rowBuffer, 0, sourceRowPitch);
+
+            int destinationIndex = row * width;
+            switch ((FreeType.PixelMode)bitmap.pixel_mode)
+            {
+                case FreeType.PixelMode.Gray:
+                    Buffer.BlockCopy(rowBuffer, 0, pixels, destinationIndex, width);
+                    break;
+
+                case FreeType.PixelMode.Mono:
+                    ExpandMonochromeRow(rowBuffer, width, pixels, destinationIndex);
+                    break;
+
+                default:
+                    throw new InvalidOperationException($"Unsupported FreeType pixel mode '{bitmap.pixel_mode}'.");
+            }
+        }
+
+        return pixels;
+    }
+
+    private static void ExpandMonochromeRow(byte[] source, int width, byte[] destination, int destinationIndex)
+    {
+        for (int column = 0; column < width; column++)
+        {
+            int sourceByte = column >> 3;
+            int bitIndex = 7 - (column & 7);
+
+            destination[destinationIndex + column] = (source[sourceByte] & (1 << bitIndex)) != 0 ?
+                                                     byte.MaxValue :
+                                                     byte.MinValue;
+        }
     }
 
     private static int EstimateInitialAtlasSize(List<GlyphBuildInfo> glyphs)
@@ -204,81 +268,81 @@ internal static class SpriteFontBaker
 
     private static unsafe bool TryPackGlyphs(List<GlyphBuildInfo> glyphs, int atlasWidth, int atlasHeight)
     {
-        int packedGlyphCount = 0;
-        foreach (GlyphBuildInfo glyph in glyphs)
-        {
-            if (glyph.Width > 0 && glyph.Height > 0)
-            {
-                packedGlyphCount++;
-            }
-        }
-
-        if (packedGlyphCount == 0)
-        {
-            return true;
-        }
-
-        StbRectPackRect[] rectangles = new StbRectPackRect[packedGlyphCount];
-        int[] glyphIndexes = new int[packedGlyphCount];
-
-        int rectangleIndex = 0;
+        List<int> packOrder = new List<int>(glyphs.Count);
         for (int i = 0; i < glyphs.Count; i++)
         {
-            GlyphBuildInfo glyph = glyphs[i];
-            if (glyph.Width == 0 || glyph.Height == 0)
+            if (glyphs[i].Width > 0 && glyphs[i].Height > 0)
             {
-                continue;
-            }
-
-            StbRectPackRect rectangle = rectangles[rectangleIndex];
-            rectangle.id = rectangleIndex;
-            rectangle.w = glyph.Width + Padding;
-            rectangle.h = glyph.Height + Padding;
-            rectangles[rectangleIndex] = rectangle;
-
-            glyphIndexes[rectangleIndex] = i;
-            rectangleIndex++;
-        }
-
-        using (StbRectPackContext context = new StbRectPackContext(atlasWidth))
-        {
-            StbRectPackContext* contextPtr = &context;
-            fixed (StbRectPackRect* rectanglesPtr = rectangles)
-            {
-                StbRectPack.stbrp_init_target(contextPtr, atlasWidth, atlasHeight, context.all_nodes, atlasWidth);
-                StbRectPack.stbrp_pack_rects(contextPtr, rectanglesPtr, rectangles.Length);
+                packOrder.Add(i);
             }
         }
 
-        for (int i = 0; i < rectangles.Length; i++)
+        packOrder.Sort((left, right) =>
         {
-            if (rectangles[i].was_packed == 0)
+            GlyphBuildInfo leftGlyph = glyphs[left];
+            GlyphBuildInfo rightGlyph = glyphs[right];
+
+            int heightComparison = rightGlyph.Height.CompareTo(leftGlyph.Height);
+            if (heightComparison != 0)
+            {
+                return heightComparison;
+            }
+
+            return rightGlyph.Width.CompareTo(leftGlyph.Width);
+        });
+
+        int x = 0;
+        int y = 0;
+        int rowHeight = 0;
+
+        foreach (int glyphIndex in packOrder)
+        {
+            GlyphBuildInfo glyph = glyphs[glyphIndex];
+            int packedWidth = glyph.Width + Padding;
+            int packedHeight = glyph.Height + Padding;
+
+            if (packedWidth > atlasHeight || packedHeight > atlasHeight)
             {
                 return false;
             }
 
-            GlyphBuildInfo glyph = glyphs[glyphIndexes[i]];
-            glyph.AtlasX = rectangles[i].x;
-            glyph.AtlasY = rectangles[i].y;
-            glyphs[glyphIndexes[i]] = glyph;
+            if (x + packedWidth > atlasWidth)
+            {
+                x = 0;
+                y += rowHeight;
+                rowHeight = 0;
+            }
+
+            if (y + packedHeight > atlasHeight)
+            {
+                return false;
+            }
+
+            glyph.AtlasX = x;
+            glyph.AtlasY = y;
+            glyphs[glyphIndex] = glyph;
+
+            x += packedWidth;
+            rowHeight = Math.Max(rowHeight, packedHeight);
         }
 
         return true;
     }
 
-    private static unsafe void RasterizeGlyphs(StbTrueTypeFontInfo fontInfo, List<GlyphBuildInfo> glyphs, byte[] atlasPixels, int atlasWidth, float scale)
+    private static void RasterizeGlyphs(List<GlyphBuildInfo> glyphs, byte[] atlasPixels, int atlasWidth)
     {
-        fixed (byte* atlasPixelsPtr = atlasPixels)
+        foreach (GlyphBuildInfo glyph in glyphs)
         {
-            foreach (GlyphBuildInfo glyph in glyphs)
+            if (glyph.Width == 0 || glyph.Height == 0 || glyph.Pixels.Length == 0)
             {
-                if (glyph.Width == 0 || glyph.Height == 0)
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                byte* destination = atlasPixelsPtr + (glyph.AtlasY * atlasWidth) + glyph.AtlasX;
-                StbTrueType.stbtt_MakeGlyphBitmap(fontInfo, destination, glyph.Width, glyph.Height, atlasWidth, scale, scale, glyph.GlyphIndex);
+            for (int row = 0; row < glyph.Height; row++)
+            {
+                int sourceIndex = row * glyph.Width;
+                int destinationIndex = ((glyph.AtlasY + row) * atlasWidth) + glyph.AtlasX;
+                Buffer.BlockCopy(glyph.Pixels, sourceIndex, atlasPixels, destinationIndex, glyph.Width);
             }
         }
     }
@@ -303,15 +367,14 @@ internal static class SpriteFontBaker
     private struct GlyphBuildInfo
     {
         public char Character;
-        public int GlyphIndex;
-        public int BitmapX0;
-        public int BitmapY0;
         public int Width;
         public int Height;
+        public int BitmapTop;
         public int AtlasX;
         public int AtlasY;
         public float LeftSideBearing;
         public float WidthValue;
         public float RightSideBearing;
+        public byte[] Pixels;
     }
 }

--- a/MonoGame.Framework/Graphics/SpriteFontBaker.cs
+++ b/MonoGame.Framework/Graphics/SpriteFontBaker.cs
@@ -1,0 +1,317 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+using StbRectPackSharp;
+using StbTrueTypeSharp;
+
+using StbTrueTypeFontInfo = StbTrueTypeSharp.StbTrueType.stbtt_fontinfo;
+using StbRectPackRect = StbRectPackSharp.StbRectPack.stbrp_rect;
+using StbRectPackContext = StbRectPackSharp.StbRectPack.stbrp_context;
+
+namespace Microsoft.Xna.Framework.Graphics;
+
+internal static class SpriteFontBaker
+{
+    private const int Padding = 1;
+    private const int MinimumAtlasSize = 256;
+    private const int MaximumAtlasSize = 4096;
+
+    public static unsafe SpriteFont Bake(GraphicsDevice graphicsDevice, byte[] data, int size, IEnumerable<CharacterRegion> characterRegions)
+    {
+        if (graphicsDevice == null)
+        {
+            throw new ArgumentNullException(nameof(graphicsDevice), $"{nameof(graphicsDevice)} must not be null.");
+        }
+
+        if (data == null)
+        {
+            throw new ArgumentNullException(nameof(data), $"{nameof(data)} must not be null.");
+        }
+
+        if (characterRegions == null)
+        {
+            throw new ArgumentNullException(nameof(characterRegions), $"{nameof(characterRegions)} must not be null.");
+        }
+
+        if (size <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), $"{nameof(size)} must be greater than zero.");
+        }
+
+        List<char> characters = CollectCharacters(characterRegions);
+        if (characters.Count == 0)
+        {
+            throw new ArgumentException("At least one character must be supplied.", nameof(characterRegions));
+        }
+
+        StbTrueTypeFontInfo fontInfo = StbTrueType.CreateFont(data, 0);
+        if (fontInfo == null)
+        {
+            throw new InvalidOperationException("The supplied font data could not be parsed.");
+        }
+
+        using (fontInfo)
+        {
+            float scale = StbTrueType.stbtt_ScaleForMappingEmToPixels(fontInfo, size);
+
+            int ascent;
+            int descent;
+            int lineGap;
+            StbTrueType.stbtt_GetFontVMetrics(fontInfo, &ascent, &descent, &lineGap);
+
+            int ascentPixels = (int)Math.Ceiling(ascent * scale);
+            int descentPixels = (int)Math.Ceiling(-descent * scale);
+            int lineGapPixels = (int)Math.Ceiling(lineGap * scale);
+            int lineSpacing = ascentPixels + descentPixels + lineGapPixels;
+
+            List<GlyphBuildInfo> glyphs = BuildGlyphs(fontInfo, characters, scale);
+            if (glyphs.Count == 0)
+            {
+                throw new InvalidOperationException("The supplied character regions do not resolve to any glyphs in this font.");
+            }
+
+            int atlasSize = EstimateInitialAtlasSize(glyphs);
+            while (!TryPackGlyphs(glyphs, atlasSize, atlasSize))
+            {
+                if (atlasSize >= MaximumAtlasSize)
+                {
+                    throw new InvalidOperationException("The supplied character regions could not be packed into a texture atlas.");
+                }
+
+                atlasSize *= 2;
+            }
+
+            byte[] atlasPixels = new byte[Math.Max(1, atlasSize * atlasSize)];
+            RasterizeGlyphs(fontInfo, glyphs, atlasPixels, atlasSize, scale);
+
+            Texture2D texture = new Texture2D(graphicsDevice, atlasSize, atlasSize, false, SurfaceFormat.Color);
+            texture.SetData(ConvertAlphaMaskToRgba(atlasPixels));
+
+            List<Rectangle> glyphBounds = new List<Rectangle>(glyphs.Count);
+            List<Rectangle> cropping = new List<Rectangle>(glyphs.Count);
+            List<char> bakedCharacters = new List<char>(glyphs.Count);
+            List<Vector3> kerning = new List<Vector3>(glyphs.Count);
+
+            foreach (GlyphBuildInfo glyph in glyphs)
+            {
+                bakedCharacters.Add(glyph.Character);
+                glyphBounds.Add(new Rectangle(glyph.AtlasX, glyph.AtlasY, glyph.Width, glyph.Height));
+                cropping.Add(new Rectangle(0, ascentPixels + glyph.BitmapY0, glyph.Width, lineSpacing));
+                kerning.Add(new Vector3(glyph.LeftSideBearing, glyph.WidthValue, glyph.RightSideBearing));
+            }
+
+            return new SpriteFont(texture, glyphBounds, cropping, bakedCharacters, lineSpacing, 0.0f, kerning, null);
+        }
+    }
+
+    private static List<char> CollectCharacters(IEnumerable<CharacterRegion> characterRegions)
+    {
+        SortedSet<char> characters = new SortedSet<char>();
+
+        foreach (CharacterRegion region in characterRegions)
+        {
+            for (int value = region.Start; value <= region.End; value++)
+            {
+                characters.Add((char)value);
+            }
+        }
+
+        return new List<char>(characters);
+    }
+
+    private static unsafe List<GlyphBuildInfo> BuildGlyphs(StbTrueTypeFontInfo fontInfo, List<char> characters, float scale)
+    {
+        List<GlyphBuildInfo> glyphs = new List<GlyphBuildInfo>(characters.Count);
+
+        foreach (char character in characters)
+        {
+            int glyphIndex = StbTrueType.stbtt_FindGlyphIndex(fontInfo, character);
+            if (glyphIndex == 0)
+            {
+                continue;
+            }
+
+            int bitmapX0;
+            int bitmapY0;
+            int bitmapX1;
+            int bitmapY1;
+            StbTrueType.stbtt_GetGlyphBitmapBox(fontInfo, glyphIndex, scale, scale, &bitmapX0, &bitmapY0, &bitmapX1, &bitmapY1);
+
+            int advanceWidth;
+            int leftSideBearing;
+            StbTrueType.stbtt_GetGlyphHMetrics(fontInfo, glyphIndex, &advanceWidth, &leftSideBearing);
+
+            int width = Math.Max(0, bitmapX1 - bitmapX0);
+            int height = Math.Max(0, bitmapY1 - bitmapY0);
+            float advancePixels = advanceWidth * scale;
+
+            GlyphBuildInfo glyph = new GlyphBuildInfo()
+            {
+                Character = character,
+                GlyphIndex = glyphIndex,
+                BitmapX0 = bitmapX0,
+                BitmapY0 = bitmapY0,
+                Width = width,
+                Height = height
+            };
+
+            if (width > 0)
+            {
+                glyph.LeftSideBearing = bitmapX0;
+                glyph.WidthValue = width;
+                glyph.RightSideBearing = advancePixels - bitmapX1;
+            }
+            else
+            {
+                glyph.LeftSideBearing = 0.0f;
+                glyph.WidthValue = 0.0f;
+                glyph.RightSideBearing = advancePixels;
+            }
+
+            glyphs.Add(glyph);
+        }
+
+        return glyphs;
+    }
+
+    private static int EstimateInitialAtlasSize(List<GlyphBuildInfo> glyphs)
+    {
+        int totalArea = 0;
+
+        foreach (GlyphBuildInfo glyph in glyphs)
+        {
+            if (glyph.Width == 0 || glyph.Height == 0)
+            {
+                continue;
+            }
+
+            totalArea += (glyph.Width + Padding) * (glyph.Height + Padding);
+        }
+
+        if (totalArea == 0)
+        {
+            return 1;
+        }
+
+        int estimated = (int)Math.Ceiling(Math.Sqrt(totalArea * 1.5));
+        estimated = Math.Max(MinimumAtlasSize, estimated);
+        estimated = Math.Min(MaximumAtlasSize, estimated);
+        return MathHelper.NextPowerOfTwo(estimated);
+    }
+
+    private static unsafe bool TryPackGlyphs(List<GlyphBuildInfo> glyphs, int atlasWidth, int atlasHeight)
+    {
+        int packedGlyphCount = 0;
+        foreach (GlyphBuildInfo glyph in glyphs)
+        {
+            if (glyph.Width > 0 && glyph.Height > 0)
+            {
+                packedGlyphCount++;
+            }
+        }
+
+        if (packedGlyphCount == 0)
+        {
+            return true;
+        }
+
+        StbRectPackRect[] rectangles = new StbRectPackRect[packedGlyphCount];
+        int[] glyphIndexes = new int[packedGlyphCount];
+
+        int rectangleIndex = 0;
+        for (int i = 0; i < glyphs.Count; i++)
+        {
+            GlyphBuildInfo glyph = glyphs[i];
+            if (glyph.Width == 0 || glyph.Height == 0)
+            {
+                continue;
+            }
+
+            StbRectPackRect rectangle = rectangles[rectangleIndex];
+            rectangle.id = rectangleIndex;
+            rectangle.w = glyph.Width + Padding;
+            rectangle.h = glyph.Height + Padding;
+            rectangles[rectangleIndex] = rectangle;
+
+            glyphIndexes[rectangleIndex] = i;
+            rectangleIndex++;
+        }
+
+        using (StbRectPackContext context = new StbRectPackContext(atlasWidth))
+        {
+            StbRectPackContext* contextPtr = &context;
+            fixed (StbRectPackRect* rectanglesPtr = rectangles)
+            {
+                StbRectPack.stbrp_init_target(contextPtr, atlasWidth, atlasHeight, context.all_nodes, atlasWidth);
+                StbRectPack.stbrp_pack_rects(contextPtr, rectanglesPtr, rectangles.Length);
+            }
+        }
+
+        for (int i = 0; i < rectangles.Length; i++)
+        {
+            if (rectangles[i].was_packed == 0)
+            {
+                return false;
+            }
+
+            GlyphBuildInfo glyph = glyphs[glyphIndexes[i]];
+            glyph.AtlasX = rectangles[i].x;
+            glyph.AtlasY = rectangles[i].y;
+            glyphs[glyphIndexes[i]] = glyph;
+        }
+
+        return true;
+    }
+
+    private static unsafe void RasterizeGlyphs(StbTrueTypeFontInfo fontInfo, List<GlyphBuildInfo> glyphs, byte[] atlasPixels, int atlasWidth, float scale)
+    {
+        fixed (byte* atlasPixelsPtr = atlasPixels)
+        {
+            foreach (GlyphBuildInfo glyph in glyphs)
+            {
+                if (glyph.Width == 0 || glyph.Height == 0)
+                {
+                    continue;
+                }
+
+                byte* destination = atlasPixelsPtr + (glyph.AtlasY * atlasWidth) + glyph.AtlasX;
+                StbTrueType.stbtt_MakeGlyphBitmap(fontInfo, destination, glyph.Width, glyph.Height, atlasWidth, scale, scale, glyph.GlyphIndex);
+            }
+        }
+    }
+
+    private static byte[] ConvertAlphaMaskToRgba(byte[] atlasPixels)
+    {
+        byte[] texturePixels = new byte[atlasPixels.Length * 4];
+
+        for (int i = 0; i < atlasPixels.Length; i++)
+        {
+            byte alpha = atlasPixels[i];
+            int textureIndex = i * 4;
+            texturePixels[textureIndex + 0] = alpha;
+            texturePixels[textureIndex + 1] = alpha;
+            texturePixels[textureIndex + 2] = alpha;
+            texturePixels[textureIndex + 3] = alpha;
+        }
+
+        return texturePixels;
+    }
+
+    private struct GlyphBuildInfo
+    {
+        public char Character;
+        public int GlyphIndex;
+        public int BitmapX0;
+        public int BitmapY0;
+        public int Width;
+        public int Height;
+        public int AtlasX;
+        public int AtlasY;
+        public float LeftSideBearing;
+        public float WidthValue;
+        public float RightSideBearing;
+    }
+}

--- a/MonoGame.Framework/MathHelper.cs
+++ b/MonoGame.Framework/MathHelper.cs
@@ -11,47 +11,47 @@ namespace Microsoft.Xna.Framework
     /// </summary>
     public static partial class MathHelper
     {
-    	/// <summary>
+        /// <summary>
         /// Represents the mathematical constant e(2.71828175).
         /// </summary>
         public const float E = MathF.E;
-        
+
         /// <summary>
         /// Represents the log base ten of e(0.4342945).
         /// </summary>
         public const float Log10E = 0.4342945f;
-        
+
         /// <summary>
         /// Represents the log base two of e(1.442695).
         /// </summary>
         public const float Log2E = 1.442695f;
-        
+
         /// <summary>
         /// Represents the value of pi(3.14159274).
         /// </summary>
         public const float Pi = MathF.PI;
-        
+
         /// <summary>
         /// Represents the value of pi divided by two(1.57079637).
         /// </summary>
         public const float PiOver2 = (float)(Math.PI / 2.0);
-        
+
         /// <summary>
         /// Represents the value of pi divided by four(0.7853982).
         /// </summary>
         public const float PiOver4 = (float)(Math.PI / 4.0);
-        
+
         /// <summary>
         /// Represents the value of pi times two(6.28318548).
         /// </summary>
         public const float TwoPi = (float)(Math.PI * 2.0);
-        
+
         /// <summary>
         /// Represents the value of pi times two(6.28318548).
         /// This is an alias of TwoPi.
         /// </summary>
         public const float Tau = TwoPi;
-        
+
         /// <summary>
         /// Returns the Cartesian coordinate for one axis of a point that is defined by a given triangle and two normalized barycentric (areal) coordinates.
         /// </summary>
@@ -66,7 +66,7 @@ namespace Microsoft.Xna.Framework
             return value1 + (value2 - value1) * amount1 + (value3 - value1) * amount2;
         }
 
-	/// <summary>
+        /// <summary>
         /// Performs a Catmull-Rom interpolation using the specified positions.
         /// </summary>
         /// <param name="value1">The first position in the interpolation.</param>
@@ -87,7 +87,7 @@ namespace Microsoft.Xna.Framework
                 (3.0 * value2 - value1 - 3.0 * value3 + value4) * amountCubed));
         }
 
- 	/// <summary>
+        /// <summary>
         /// Restricts a value to be within a specified range.
         /// </summary>
         /// <param name="value">The value to clamp.</param>
@@ -105,7 +105,7 @@ namespace Microsoft.Xna.Framework
             // There's no check to see if min > max.
             return value;
         }
-        
+
         /// <summary>
         /// Restricts a value to be within a specified range.
         /// </summary>
@@ -114,12 +114,12 @@ namespace Microsoft.Xna.Framework
         /// <param name="max">The maximum value. If <c>value</c> is greater than <c>max</c>, <c>max</c> will be returned.</param>
         /// <returns>The clamped value.</returns>
         public static int Clamp(int value, int min, int max)
-        { 
-            value = (value > max) ? max : value; 
-            value = (value < min) ? min : value; 
+        {
+            value = (value > max) ? max : value;
+            value = (value < min) ? min : value;
             return value;
         }
-        
+
         /// <summary>
         /// Calculates the absolute value of the difference of two values.
         /// </summary>
@@ -130,7 +130,7 @@ namespace Microsoft.Xna.Framework
         {
             return Math.Abs(value1 - value2);
         }
-        
+
         /// <summary>
         /// Performs a Hermite spline interpolation.
         /// </summary>
@@ -159,8 +159,8 @@ namespace Microsoft.Xna.Framework
                     v1;
             return (float)result;
         }
-        
-        
+
+
         /// <summary>
         /// Linearly interpolates between two values.
         /// </summary>
@@ -225,7 +225,7 @@ namespace Microsoft.Xna.Framework
         {
             return value1 > value2 ? value1 : value2;
         }
-        
+
         /// <summary>
         /// Returns the lesser of two values.
         /// </summary>
@@ -247,7 +247,7 @@ namespace Microsoft.Xna.Framework
         {
             return value1 < value2 ? value1 : value2;
         }
-        
+
         /// <summary>
         /// Interpolates between two values using a cubic equation.
         /// </summary>
@@ -277,7 +277,7 @@ namespace Microsoft.Xna.Framework
         /// Factor = 180 / pi
         /// </remarks>
         public static float ToDegrees(float radians)
-        { 
+        {
             return (float)(radians * 57.295779513082320876798154814105);
         }
 
@@ -292,10 +292,10 @@ namespace Microsoft.Xna.Framework
         /// Factor = pi / 180
         /// </remarks>
         public static float ToRadians(float degrees)
-        { 
+        {
             return (float)(degrees * 0.017453292519943295769236907684886);
         }
-	 
+
         /// <summary>
         /// Reduces a given angle to a value between π and -π.
         /// </summary>
@@ -313,14 +313,39 @@ namespace Microsoft.Xna.Framework
             return angle;
         }
 
- 	    /// <summary>
+        /// <summary>
         /// Determines if value is powered by two.
         /// </summary>
         /// <param name="value">A value.</param>
         /// <returns><c>true</c> if <c>value</c> is powered by two; otherwise <c>false</c>.</returns>
-	    public static bool IsPowerOfTwo(int value)
-	    {
-	         return (value > 0) && ((value & (value - 1)) == 0);
-	    }
+        public static bool IsPowerOfTwo(int value)
+        {
+            return (value > 0) && ((value & (value - 1)) == 0);
+        }
+
+        /// <summary>
+        /// Returns the smallest power of two that is greater than or equal to the specified value.
+        /// </summary>
+        /// <param name="value">The value to round up to a power of two.</param>
+        /// <returns>
+        /// The smallest power of two that is greater than or equal to <paramref name="value"/>.
+        /// if <paramref name="value"/> is less than or equal to <c>1</c>, this method returns <c>1</c>
+        /// </returns>
+        public static int NextPowerOfTwo(int value)
+        {
+            // https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+            if (value <= 1)
+            {
+                return 1;
+            }
+
+            value--;
+            value |= value >> 1;
+            value |= value >> 2;
+            value |= value >> 4;
+            value |= value >> 8;
+            value |= value >> 16;
+            return value + 1;
+        }
     }
 }

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="bin\**\*" />
     <Compile Remove="obj\**\*" />
     <Compile Remove="Platform\**\*" />
@@ -72,11 +76,11 @@
     <Compile Include="Platform\Utilities\FuncLoader.Android.cs" />
     <Compile Include="Platform\Utilities\InteropHelpers.cs" />
     <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
+    <Compile Include="Platform\FreeType\FreeType.cs" />
+    <Compile Include="Platform\FreeType\FreeTypeHelper.cs" />    
 
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
-    <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
-    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -75,6 +75,8 @@
 
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
+    <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
+    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -73,7 +73,9 @@
     <Compile Include="Platform\Utilities\InteropHelpers.cs" />
     <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
 
-    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" 
+             Exclude="..\ThirdParty\StbImageSharp\src\Hebron.Runtime\CRuntime.cs;..\ThirdParty\StbImageSharp\src\Hebron.Runtime\MemoryStats.cs"
+             LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
     <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
     <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />    

--- a/MonoGame.Framework/MonoGame.Framework.Android.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Android.csproj
@@ -73,12 +73,10 @@
     <Compile Include="Platform\Utilities\InteropHelpers.cs" />
     <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
 
-    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" 
-             Exclude="..\ThirdParty\StbImageSharp\src\Hebron.Runtime\CRuntime.cs;..\ThirdParty\StbImageSharp\src\Hebron.Runtime\MemoryStats.cs"
-             LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
     <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
-    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />    
+    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -75,7 +75,9 @@
     <Compile Include="Platform\Desktop\Devices\Sensors\Accelerometer.cs" />
     <Compile Include="Platform\Desktop\Devices\Sensors\Compass.cs" />
 
-    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" 
+             Exclude="..\ThirdParty\StbImageSharp\src\Hebron.Runtime\CRuntime.cs;..\ThirdParty\StbImageSharp\src\Hebron.Runtime\MemoryStats.cs"
+             LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
     <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
     <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -77,6 +77,8 @@
 
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
+    <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
+    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="MonoGame.Library.SDL" Version="2.32.10.2" />
+    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -74,11 +75,11 @@
     <Compile Include="Platform\GraphicsDeviceManager.SDL.cs" />
     <Compile Include="Platform\Desktop\Devices\Sensors\Accelerometer.cs" />
     <Compile Include="Platform\Desktop\Devices\Sensors\Compass.cs" />
+    <Compile Include="Platform\FreeType\FreeType.cs" />
+    <Compile Include="Platform\FreeType\FreeTypeHelper.cs" />
 
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
-    <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
-    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.DesktopGL.csproj
@@ -75,9 +75,7 @@
     <Compile Include="Platform\Desktop\Devices\Sensors\Accelerometer.cs" />
     <Compile Include="Platform\Desktop\Devices\Sensors\Compass.cs" />
 
-    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" 
-             Exclude="..\ThirdParty\StbImageSharp\src\Hebron.Runtime\CRuntime.cs;..\ThirdParty\StbImageSharp\src\Hebron.Runtime\MemoryStats.cs"
-             LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
     <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
     <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />

--- a/MonoGame.Framework/MonoGame.Framework.Native.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Native.csproj
@@ -16,6 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.3" />
+  </ItemGroup>    
+
+  <ItemGroup>
     <Compile Remove="bin\**\*" />
     <Compile Remove="obj\**\*" />
     <Compile Remove="Platform\**\*" />
@@ -38,8 +42,6 @@
   <ItemGroup>
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
 	<Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
-    <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
-    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>
 
   <ItemGroup>
@@ -48,6 +50,8 @@
     <Compile Include="Platform\Threading.cs" />
     <Compile Include="Platform\Desktop\Devices\Sensors\Accelerometer.cs" />
     <Compile Include="Platform\Desktop\Devices\Sensors\Compass.cs" />
+    <Compile Include="Platform\FreeType\FreeType.cs" />
+    <Compile Include="Platform\FreeType\FreeTypeHelper.cs" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.Native.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Native.csproj
@@ -38,6 +38,8 @@
   <ItemGroup>
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
 	<Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
+    <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
+    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.Native.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Native.csproj
@@ -36,7 +36,9 @@
         backend doesn't use it to load or save textures.
   -->
   <ItemGroup>
-    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" 
+             Exclude="..\ThirdParty\StbImageSharp\src\Hebron.Runtime\CRuntime.cs;..\ThirdParty\StbImageSharp\src\Hebron.Runtime\MemoryStats.cs"
+             LinkBase="Utilities\StbImageSharp" />
 	<Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
     <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
     <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />

--- a/MonoGame.Framework/MonoGame.Framework.Native.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.Native.csproj
@@ -30,15 +30,13 @@
     <None Remove="Platform\**\*" />
     <None Remove="Utilities\System.Numerics.Vectors\**\*" />
   </ItemGroup>
-	
+
   <!--
         We leave this because we made it part of the public API, but the native
         backend doesn't use it to load or save textures.
   -->
   <ItemGroup>
-    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" 
-             Exclude="..\ThirdParty\StbImageSharp\src\Hebron.Runtime\CRuntime.cs;..\ThirdParty\StbImageSharp\src\Hebron.Runtime\MemoryStats.cs"
-             LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
 	<Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
     <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
     <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -62,7 +62,8 @@
 
   <ItemGroup>
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
-    <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
+    <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
+    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -61,7 +61,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" 
+             Exclude="..\ThirdParty\StbImageSharp\src\Hebron.Runtime\CRuntime.cs;..\ThirdParty\StbImageSharp\src\Hebron.Runtime\MemoryStats.cs"
+             LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
     <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -61,9 +61,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" 
-             Exclude="..\ThirdParty\StbImageSharp\src\Hebron.Runtime\CRuntime.cs;..\ThirdParty\StbImageSharp\src\Hebron.Runtime\MemoryStats.cs"
-             LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
     <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.WindowsDX.csproj
@@ -58,12 +58,12 @@
     <Compile Include="Platform\Windows\WinFormsGameWindow.cs" />
     <Compile Include="Platform\Desktop\Devices\Sensors\Accelerometer.cs" />
     <Compile Include="Platform\Desktop\Devices\Sensors\Compass.cs" />
+    <Compile Include="Platform\FreeType\FreeType.cs" />
+    <Compile Include="Platform\FreeType\FreeTypeHelper.cs" />    
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
-    <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
-    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>
 
   <ItemGroup>
@@ -80,6 +80,7 @@
     <PackageReference Version="4.0.1" Include="SharpDX.XInput" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.3" />
   </ItemGroup>
 
   <Import Project="Platform\DirectX.targets" />

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -79,6 +79,8 @@
 
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
+    <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
+    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -77,7 +77,9 @@
     <Compile Include="Platform\Utilities\InteropHelpers.cs" />
     <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
 
-    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" 
+             Exclude="..\ThirdParty\StbImageSharp\src\Hebron.Runtime\CRuntime.cs;..\ThirdParty\StbImageSharp\src\Hebron.Runtime\MemoryStats.cs"
+             LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
     <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
     <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -20,6 +20,10 @@
     <None Include="..\README-packages.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MonoGame.Library.FreeType" Version="2.13.2.3" />
+  </ItemGroup>  
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <CreatePackage>false</CreatePackage>
   </PropertyGroup>
@@ -76,11 +80,11 @@
     <Compile Include="Platform\Utilities\FuncLoader.iOS.cs" />
     <Compile Include="Platform\Utilities\InteropHelpers.cs" />
     <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
+    <Compile Include="Platform\FreeType\FreeType.cs" />
+    <Compile Include="Platform\FreeType\FreeTypeHelper.cs" />    
 
     <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
-    <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
-    <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGame.Framework/MonoGame.Framework.iOS.csproj
+++ b/MonoGame.Framework/MonoGame.Framework.iOS.csproj
@@ -77,9 +77,7 @@
     <Compile Include="Platform\Utilities\InteropHelpers.cs" />
     <Compile Include="Platform\Utilities\ReflectionHelpers.Default.cs" />
 
-    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" 
-             Exclude="..\ThirdParty\StbImageSharp\src\Hebron.Runtime\CRuntime.cs;..\ThirdParty\StbImageSharp\src\Hebron.Runtime\MemoryStats.cs"
-             LinkBase="Utilities\StbImageSharp" />
+    <Compile Include="..\ThirdParty\StbImageSharp\src\**\*.cs" LinkBase="Utilities\StbImageSharp" />
     <Compile Include="..\ThirdParty\StbImageWriteSharp\src\**\*.cs" LinkBase="Utilities\StbImageWriteSharp" />
     <Compile Include="..\ThirdParty\StbTrueTypeSharp\src\**\*.cs" LinkBase="Utilities\StbTrueTypeSharp" />
     <Compile Include="..\ThirdParty\StbRectPackSharp\src\**\*.cs" LinkBase="Utilities\StbRectPackSharp" />

--- a/MonoGame.Framework/Platform/FreeType/FreeType.cs
+++ b/MonoGame.Framework/Platform/FreeType/FreeType.cs
@@ -1,0 +1,386 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+
+using System;
+using System.Runtime.InteropServices;
+using MonoGame.Framework.Utilities;
+
+internal unsafe static class FreeType
+{
+    public static readonly IntPtr NativeLibrary = GetNativeLibrary();
+
+    private static IntPtr GetNativeLibrary()
+    {
+        if (CurrentPlatform.OS == OS.Windows)
+        {
+            return FuncLoader.LoadLibraryExt("freetype.dll");
+        }
+        else if (CurrentPlatform.OS == OS.Linux)
+        {
+            return FuncLoader.LoadLibraryExt("libfreetype.so");
+        }
+        else if (CurrentPlatform.OS == OS.MacOSX)
+        {
+            return FuncLoader.LoadLibraryExt("libfreetype.dylib");
+        }
+        else
+        {
+            return FuncLoader.LoadLibraryExt("libfreetype");
+        }
+    }
+
+    internal static readonly int CLongSize = GetCLongSize();
+
+    /// Determines the ABI size of C long for the current target.
+    /// Using this instead of System.Runtime.InteropServices.CLong since we
+    /// need to target netstandard2.1 for MonoGame.Framework.Native
+    private static int GetCLongSize()
+    {
+#if WINDOWS
+        // Windows C Long is always 32-bit (4 bytes)
+        return 4;
+#elif DESKTOPGL || NATIVE
+        // DesktopGL and Native can both target Windows or *Nix systems
+        // So the size depends on which runtime the platform is on
+        return CurrentPlatform.OS == OS.Windows ? 4 : IntPtr.Size;
+#else
+        return IntPtr.Size;
+#endif
+    }
+
+    public enum PixelMode : byte
+    {
+        None = 0,
+        Mono = 1,
+        Gray = 2,
+        Gray2 = 3,
+        Gray4 = 4,
+        Lcd = 5,
+        LcdVertical = 6,
+        Bgra = 7
+    }
+
+    public enum RenderMode
+    {
+        Normal = 0,
+        Light = 1,
+        Mono = 2,
+        Lcd = 3,
+        LcdVertical = 4,
+        Sdf = 5
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct FT_FaceRec { }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct FT_GlyphSlotRec { }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct FT_SizeRec { }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct FT_CharMapRec { }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_Generic
+    {
+        public IntPtr data;
+        public IntPtr finalizer;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_LibraryRec
+    {
+        public IntPtr memory;
+        public int version_major;
+        public int version_minor;
+        public int version_patch;
+        public uint num_modules;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct FT_Bitmap
+    {
+        public uint rows;
+        public uint width;
+        public int pitch;
+        public byte* buffer;
+        public ushort num_grays;
+        public byte pixel_mode;
+        public byte palette_mode;
+        public IntPtr palette;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_Bitmap_Size32
+    {
+        public short height;
+        public short width;
+        public int size;
+        public int x_ppem;
+        public int y_ppem;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_Bitmap_Size64
+    {
+        public short height;
+        public short width;
+        public long size;
+        public long x_ppem;
+        public long y_ppem;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_Size_Metrics32
+    {
+        public ushort x_ppem;
+        public ushort y_ppem;
+        public int x_scale;
+        public int y_scale;
+        public int ascender;
+        public int descender;
+        public int height;
+        public int max_advance;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_Size_Metrics64
+    {
+        public ushort x_ppem;
+        public ushort y_ppem;
+        public long x_scale;
+        public long y_scale;
+        public long ascender;
+        public long descender;
+        public long height;
+        public long max_advance;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct FT_SizeRec32
+    {
+        public FT_FaceRec* face;
+        public FT_Generic generic;
+        public FT_Size_Metrics32 metrics;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct FT_SizeRec64
+    {
+        public FT_FaceRec* face;
+        public FT_Generic generic;
+        public FT_Size_Metrics64 metrics;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_BBox32
+    {
+        public int xMin;
+        public int yMin;
+        public int xMax;
+        public int yMax;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_BBox64
+    {
+        public long xMin;
+        public long yMin;
+        public long xMax;
+        public long yMax;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct FT_FaceRec32
+    {
+        public int num_faces;
+        public int face_index;
+        public int face_flags;
+        public int style_flags;
+        public int num_glyphs;
+        public sbyte* family_name;
+        public sbyte* style_name;
+        public int num_fixed_sizes;
+        public FT_Bitmap_Size32* available_sizes;
+        public int num_charmaps;
+        public FT_CharMapRec** charmaps;
+        public FT_Generic generic;
+        public FT_BBox32 bbox;
+        public ushort units_per_EM;
+        public short ascender;
+        public short descender;
+        public short height;
+        public short max_advance_width;
+        public short max_advance_height;
+        public short underline_position;
+        public short underline_thickness;
+        public FT_GlyphSlotRec* glyph;
+        public FT_SizeRec* size;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct FT_FaceRec64
+    {
+        public long num_faces;
+        public long face_index;
+        public long face_flags;
+        public long style_flags;
+        public long num_glyphs;
+        public sbyte* family_name;
+        public sbyte* style_name;
+        public int num_fixed_sizes;
+        public FT_Bitmap_Size64* available_sizes;
+        public int num_charmaps;
+        public FT_CharMapRec** charmaps;
+        public FT_Generic generic;
+        public FT_BBox64 bbox;
+        public ushort units_per_EM;
+        public short ascender;
+        public short descender;
+        public short height;
+        public short max_advance_width;
+        public short max_advance_height;
+        public short underline_position;
+        public short underline_thickness;
+        public FT_GlyphSlotRec* glyph;
+        public FT_SizeRec* size;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_Glyph_Metrics32
+    {
+        public int width;
+        public int height;
+        public int horiBearingX;
+        public int horiBearingY;
+        public int horiAdvance;
+        public int vertBearingX;
+        public int vertBearingY;
+        public int vertAdvance;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_Glyph_Metrics64
+    {
+        public long width;
+        public long height;
+        public long horiBearingX;
+        public long horiBearingY;
+        public long horiAdvance;
+        public long vertBearingX;
+        public long vertBearingY;
+        public long vertAdvance;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_GlyphSlotRec32
+    {
+        public FT_LibraryRec* library;
+        public FT_FaceRec* face;
+        public FT_GlyphSlotRec* next;
+        public uint glyph_index;
+        public FT_Generic generic;
+        public FT_Glyph_Metrics32 metrics;
+        public int linearHoriAdvance;
+        public int linearVertAdvance;
+        public int advance_x;
+        public int advance_y;
+        public int format;
+        public FT_Bitmap bitmap;
+        public int bitmap_left;
+        public int bitmap_top;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct FT_GlyphSlotRec64
+    {
+        public FT_LibraryRec* library;
+        public FT_FaceRec* face;
+        public FT_GlyphSlotRec* next;
+        public uint glyph_index;
+        public FT_Generic generic;
+        public FT_Glyph_Metrics64 metrics;
+        public long linearHoriAdvance;
+        public long linearVertAdvance;
+        public long advance_x;
+        public long advance_y;
+        public int format;
+        public FT_Bitmap bitmap;
+        public int bitmap_left;
+        public int bitmap_top;
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int d_ft_init_freetype(out FT_LibraryRec* library);
+    public static readonly d_ft_init_freetype FT_Init_FreeType = FuncLoader.LoadFunction<d_ft_init_freetype>(NativeLibrary, "FT_Init_FreeType");
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int d_ft_done_freetype(FT_LibraryRec* library);
+    public static readonly d_ft_done_freetype FT_Done_FreeType = FuncLoader.LoadFunction<d_ft_done_freetype>(NativeLibrary, "FT_Done_FreeType");
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int d_ft_new_memory_face_32(FT_LibraryRec* library, byte* fileBase, int fileSize, int faceIndex, out FT_FaceRec* face);
+    private static readonly d_ft_new_memory_face_32 FT_New_Memory_Face_32 = FuncLoader.LoadFunction<d_ft_new_memory_face_32>(NativeLibrary, "FT_New_Memory_Face");
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int d_ft_new_memory_face_64(FT_LibraryRec* library, byte* fileBase, long fileSize, long faceIndex, out FT_FaceRec* face);
+    private static readonly d_ft_new_memory_face_64 FT_New_Memory_Face_64 = FuncLoader.LoadFunction<d_ft_new_memory_face_64>(NativeLibrary, "FT_New_Memory_Face");
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int d_ft_done_face(FT_FaceRec* face);
+    public static readonly d_ft_done_face FT_Done_Face = FuncLoader.LoadFunction<d_ft_done_face>(NativeLibrary, nameof(FT_Done_Face));
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate uint d_ft_get_char_index_32(FT_FaceRec* face, uint charCode);
+    private static readonly d_ft_get_char_index_32 FT_Get_Char_Index_32 = FuncLoader.LoadFunction<d_ft_get_char_index_32>(NativeLibrary, "FT_Get_Char_Index");
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate uint d_ft_get_char_index_64(FT_FaceRec* face, ulong charCode);
+    private static readonly d_ft_get_char_index_64 FT_Get_Char_Index_64 = FuncLoader.LoadFunction<d_ft_get_char_index_64>(NativeLibrary, "FT_Get_Char_Index");
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int d_ft_set_pixel_sizes(FT_FaceRec* face, uint pixelWidth, uint pixelHeight);
+    public static readonly d_ft_set_pixel_sizes FT_Set_Pixel_Sizes = FuncLoader.LoadFunction<d_ft_set_pixel_sizes>(NativeLibrary, nameof(FT_Set_Pixel_Sizes));
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int d_ft_load_glyph(FT_FaceRec* face, uint glyphIndex, int loadFlags);
+    public static readonly d_ft_load_glyph FT_Load_Glyph = FuncLoader.LoadFunction<d_ft_load_glyph>(NativeLibrary, nameof(FT_Load_Glyph));
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int d_ft_render_glyph(FT_GlyphSlotRec* slot, RenderMode renderMode);
+    public static readonly d_ft_render_glyph FT_Render_Glyph = FuncLoader.LoadFunction<d_ft_render_glyph>(NativeLibrary, nameof(FT_Render_Glyph));
+
+    public static int FT_New_Memory_Face(FT_LibraryRec* library, byte* fileBase, int fileSize, int faceIndex, out FT_FaceRec* face)
+    {
+        if (CLongSize == 4)
+        {
+            return FT_New_Memory_Face_32(library, fileBase, fileSize, faceIndex, out face);
+        }
+
+        return FT_New_Memory_Face_64(library, fileBase, fileSize, faceIndex, out face);
+    }
+
+    public static uint FT_Get_Char_Index(FT_FaceRec* face, uint charCode)
+    {
+        if(CLongSize == 4)
+        {
+            return FT_Get_Char_Index_32(face, charCode);
+        }
+
+        return FT_Get_Char_Index_64(face, charCode);
+    }
+
+    public static void CheckError(int error)
+    {
+        if (error == 0)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"A FreeType call failed with error code {error}");
+    }
+}

--- a/MonoGame.Framework/Platform/FreeType/FreeTypeHelper.cs
+++ b/MonoGame.Framework/Platform/FreeType/FreeTypeHelper.cs
@@ -1,0 +1,88 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+internal static unsafe class FreeTypeHelper
+{
+    public readonly struct Fixed26Dot6
+    {
+        // FT_26Dot6 in fttypes.h is a signed 26.6 fixed-point value.
+        // Shifting by 6 converts form 1/64th pixels to whole pixels.
+        public const int Fixed26Dot6FractionalBits = 6;
+
+        private readonly long _value;
+
+        public Fixed26Dot6(int value) => _value = value;
+        public Fixed26Dot6(long value) => _value = value;
+        public int Floor() => (int)(_value >> Fixed26Dot6FractionalBits);
+    }
+
+    public static unsafe int GetAscender(FreeType.FT_FaceRec* face)
+    {
+        FreeType.FT_SizeRec* size = GetSize(face);
+
+        long ascender = FreeType.CLongSize == 4 ?
+                        ((FreeType.FT_SizeRec32*)size)->metrics.ascender :
+                        ((FreeType.FT_SizeRec64*)size)->metrics.ascender;
+
+        Fixed26Dot6 fixedValue = new Fixed26Dot6(ascender);
+        return fixedValue.Floor();
+    }
+
+    public static unsafe int GetLineSpacing(FreeType.FT_FaceRec* face)
+    {
+        FreeType.FT_SizeRec* size = GetSize(face);
+
+        long height = FreeType.CLongSize == 4 ?
+                      ((FreeType.FT_SizeRec32*)size)->metrics.height :
+                      ((FreeType.FT_SizeRec64*)size)->metrics.height;
+
+        Fixed26Dot6 fixedValue = new Fixed26Dot6(height);
+        return fixedValue.Floor();
+    }
+
+    public static unsafe FreeType.FT_GlyphSlotRec* GetGlyphSlot(FreeType.FT_FaceRec* face)
+    {
+        return FreeType.CLongSize == 4 ?
+               ((FreeType.FT_FaceRec32*)face)->glyph :
+               ((FreeType.FT_FaceRec64*)face)->glyph;
+    }
+
+    public static unsafe FreeType.FT_Bitmap GetGlyphBitmap(FreeType.FT_GlyphSlotRec* glyphSlot)
+    {
+        return FreeType.CLongSize == 4 ?
+               ((FreeType.FT_GlyphSlotRec32*)glyphSlot)->bitmap :
+               ((FreeType.FT_GlyphSlotRec64*)glyphSlot)->bitmap;
+    }
+
+    public static unsafe int GetGlyphBitmapLeft(FreeType.FT_GlyphSlotRec* glyphSlot)
+    {
+        return FreeType.CLongSize == 4 ?
+               ((FreeType.FT_GlyphSlotRec32*)glyphSlot)->bitmap_left :
+               ((FreeType.FT_GlyphSlotRec64*)glyphSlot)->bitmap_left;
+    }
+
+    public static unsafe int GetGlyphBitmapTop(FreeType.FT_GlyphSlotRec* glyphSlot)
+    {
+        return FreeType.CLongSize == 4 ?
+               ((FreeType.FT_GlyphSlotRec32*)glyphSlot)->bitmap_top :
+               ((FreeType.FT_GlyphSlotRec64*)glyphSlot)->bitmap_top;
+    }
+
+    public static unsafe int GetGlyphHorizontalAdvance(FreeType.FT_GlyphSlotRec* glyphSlot)
+    {
+        long horiAdvance = FreeType.CLongSize == 4 ?
+                           ((FreeType.FT_GlyphSlotRec32*)glyphSlot)->metrics.horiAdvance :
+                           ((FreeType.FT_GlyphSlotRec64*)glyphSlot)->metrics.horiAdvance;
+
+        Fixed26Dot6 fixedValue = new Fixed26Dot6(horiAdvance);
+        return fixedValue.Floor();
+    }
+
+    private static unsafe FreeType.FT_SizeRec* GetSize(FreeType.FT_FaceRec* face)
+    {
+        return FreeType.CLongSize == 4 ?
+               ((FreeType.FT_FaceRec32*)face)->size :
+               ((FreeType.FT_FaceRec64*)face)->size;
+    }
+}


### PR DESCRIPTION
> [!CAUTION]
> Closing because the implementation has shifted to using native.  New PR is #9343 

### Description
Add support for creating a `SpriteFont` at runtime directly from a TrueType or OpenType font file, including presetting character ranges as well as dynamically generating glyphs at runtime on first glyph use.

### Related Issues and Discussions

- https://github.com/MonoGame/MonoGame/issues/6812
- https://github.com/MonoGame/MonoGame/issues/2026
- https://github.com/MonoGame/MonoGame/issues/6324


### Description of Changes
- Added `StbTrueTypeSharp` and `StbRectPackSharp` submodules to `/ThirdParty` directory
- Added reference to `StbTrueTypeSharp` and `StbRectPackSharp` to all platform csproj files
- Created new `CharacterRegion` struct and renamed the `SpriteFont.CharacterRegion` nested struct to `SpriteFont.CharacterMapRegion` to avoid confusion
- Added `MathHelper.NextPowerOfTwo` to calculate the next rounded up power of two value from a given integer
- Created `SpriteFontBaker` to generate the texture atlas for `SpriteFont` at runtime
- Added `SpriteFont.FromFile` and `SpriteFont.FromStream` methods
- Updated submodules for `StbImageSharp` and `StbTrueTypeSharp` to resolve the issue where both contained the `Hebron.Runtime` namespace causing "already implemented" exceptions.  This was resolved by submitting the PRs https://github.com/StbSharp/StbImageSharp/pull/30 and https://github.com/StbSharp/StbTrueTypeSharp/pull/8 then updating the submodules in MonoGame

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

