### PR TITLE
Update Vulkan custom border color feature handling

### DIFF
--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1342,7 +1342,7 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 		vkGetPhysicalDeviceFeatures2(device->physicalDevice, &supportedFeatures2);
 		
 		extensions.push_back(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
-		customBorderColorFeatures.customBorderColors             = supportedCbc.customBorderColors;
+		customBorderColorFeatures.customBorderColors = supportedCbc.customBorderColors;
 		customBorderColorFeatures.customBorderColorWithoutFormat = supportedCbc.customBorderColorWithoutFormat;
 		customBorderColorFeatures.pNext = lastFeature;
 		lastFeature = &customBorderColorFeatures;

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -1336,9 +1336,14 @@ MGG_GraphicsDevice* MGG_GraphicsDevice_Create(MGG_GraphicsSystem* system, MGG_Gr
 	VkPhysicalDeviceCustomBorderColorFeaturesEXT customBorderColorFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT };
 	if (device->customBorderColorSupported)
 	{
+		VkPhysicalDeviceCustomBorderColorFeaturesEXT supportedCbc = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT };
+		VkPhysicalDeviceFeatures2 supportedFeatures2 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
+		supportedFeatures2.pNext = &supportedCbc;
+		vkGetPhysicalDeviceFeatures2(device->physicalDevice, &supportedFeatures2);
+		
 		extensions.push_back(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
-		customBorderColorFeatures.customBorderColors = VK_TRUE;
-		customBorderColorFeatures.customBorderColorWithoutFormat = VK_TRUE;
+		customBorderColorFeatures.customBorderColors             = supportedCbc.customBorderColors;
+		customBorderColorFeatures.customBorderColorWithoutFormat = supportedCbc.customBorderColorWithoutFormat;
 		customBorderColorFeatures.pNext = lastFeature;
 		lastFeature = &customBorderColorFeatures;
 	}


### PR DESCRIPTION
Retrieve supported custom border color features and update the Vulkan device configuration accordingly.

This lets us check that the feature is available before tryng to activate it. This allows us to initialise the Vulkan device on lower spec devices like the Pi 5.


Fixes #

#9334 

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

