### PR TITLE
Fix for adding alpha to sRGB in OpenGL

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -528,7 +528,7 @@ namespace Microsoft.Xna.Framework.Graphics
             case SurfaceFormat.ColorSRgb:
                 if (!supportsSRgb)
                     goto case SurfaceFormat.Color;
-                glInternalFormat = PixelInternalFormat.Srgb;
+                glInternalFormat = PixelInternalFormat.Srgb8Alpha8;
                 glFormat = PixelFormat.Rgba;
                 glType = PixelType.UnsignedByte;
                 break;

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -426,6 +426,7 @@ namespace MonoGame.OpenGL
         // ETC1
         Etc1 = 0x8D64,
         Srgb = 0x8C40,
+        Srgb8Alpha8 = 0x8C43,
 
         // ETC2 RGB8A1
         Etc2Rgb8 = 0x9274,


### PR DESCRIPTION
Fixes #6689
Sibling for #1995 

GraphicsExtensions.GetGLFormat mapped SurfaceFormat.ColorSRgb to PixelInternalFormat.Srgb (GL_SRGB, 0x8C40), which is the 3-channel sRGB format with no alpha. RGBA SetData() had their alpha channel discarded, and the sampler returned 1.0 for alpha regardless of source data. 

### Description of Change

Adds PixelInternalFormat.Srgb8Alpha8 (GL_SRGB8, 0x8C43) and uses it for SurfaceFormat.ColorSRgb. This matches the DirectX path (SharpDXHelper maps ColorSRGB to R8G8B8A8_UNorm_SRgb) and the Vulkan backend in develop (VK_FORMAT_R8G8B8A8_SRGB).

Verified locally on Mac with a SurfaceFormat.ColorSRGB texture and a shader returning float(sample.a, sample.a, sample.a, 1) and visually with sprites.

### Contributor Declaration

- [X] I certify that no LLM's were used to generate any code or documentation in this contribution.

