### PR TITLE
Srgb Framebuffer

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -344,6 +344,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
             framebufferHelper = FramebufferHelper.Create(this);
 
+            if (GraphicsCapabilities.SupportsSRgb)
+            {
+                GL.Enable(EnableCap.FramebufferSrgb);
+                GraphicsExtensions.CheckGLError();
+            }
+
             // Force resetting states
             this.PlatformApplyBlend(true);
             this.DepthStencilState.PlatformApplyState(this, true);

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -184,6 +184,7 @@ namespace MonoGame.OpenGL
         SampleCoverage = 0x80A0,
         DebugOutputSynchronous = 0x8242,
         DebugOutput = 0x92E0,
+        FramebufferSrgb = 0x8DB9,
     }
 
     internal enum VertexPointerType

--- a/MonoGame.Framework/Platform/GraphicsDeviceManager.SDL.cs
+++ b/MonoGame.Framework/Platform/GraphicsDeviceManager.SDL.cs
@@ -20,11 +20,7 @@ namespace Microsoft.Xna.Framework
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.BlueSize, surfaceFormat.B);
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.AlphaSize, surfaceFormat.A);
 
-            if (
-                backBufferFormat == SurfaceFormat.ColorSRgb
-                || backBufferFormat == SurfaceFormat.Bgr32SRgb
-                || backBufferFormat == SurfaceFormat.Bgra32SRgb
-            )
+            if (backBufferFormat == SurfaceFormat.ColorSRgb || backBufferFormat == SurfaceFormat.Bgr32SRgb || backBufferFormat == SurfaceFormat.Bgra32SRgb)
             {
                 Sdl.GL.SetAttribute(Sdl.GL.Attribute.FramebufferSRGBCapable, 1);
             }
@@ -56,10 +52,7 @@ namespace Microsoft.Xna.Framework
             if (presentationParameters.MultiSampleCount > 0)
             {
                 Sdl.GL.SetAttribute(Sdl.GL.Attribute.MultiSampleBuffers, 1);
-                Sdl.GL.SetAttribute(
-                    Sdl.GL.Attribute.MultiSampleSamples,
-                    presentationParameters.MultiSampleCount
-                );
+                Sdl.GL.SetAttribute(Sdl.GL.Attribute.MultiSampleSamples, presentationParameters.MultiSampleCount);
             }
 
             ((SdlGameWindow)SdlGameWindow.Instance).CreateWindow();

--- a/MonoGame.Framework/Platform/GraphicsDeviceManager.SDL.cs
+++ b/MonoGame.Framework/Platform/GraphicsDeviceManager.SDL.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Xna.Framework
     {
         partial void PlatformInitialize(PresentationParameters presentationParameters)
         {
-            var surfaceFormat = _game.graphicsDeviceManager.PreferredBackBufferFormat.GetColorFormat();
+            var backBufferFormat = _game.graphicsDeviceManager.PreferredBackBufferFormat;
+            var surfaceFormat = backBufferFormat.GetColorFormat();
             var depthStencilFormat = _game.graphicsDeviceManager.PreferredDepthStencilFormat;
 
             // TODO Need to get this data from the Presentation Parameters
@@ -18,12 +19,12 @@ namespace Microsoft.Xna.Framework
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.GreenSize, surfaceFormat.G);
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.BlueSize, surfaceFormat.B);
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.AlphaSize, surfaceFormat.A);
-            
-            SurfaceFormat backBufferFormat = _game.graphicsDeviceManager.PreferredBackBufferFormat;
 
-            if (backBufferFormat == SurfaceFormat.ColorSRgb
+            if (
+                backBufferFormat == SurfaceFormat.ColorSRgb
                 || backBufferFormat == SurfaceFormat.Bgr32SRgb
-                || backBufferFormat == SurfaceFormat.Bgra32SRgb)
+                || backBufferFormat == SurfaceFormat.Bgra32SRgb
+            )
             {
                 Sdl.GL.SetAttribute(Sdl.GL.Attribute.FramebufferSRGBCapable, 1);
             }
@@ -55,7 +56,10 @@ namespace Microsoft.Xna.Framework
             if (presentationParameters.MultiSampleCount > 0)
             {
                 Sdl.GL.SetAttribute(Sdl.GL.Attribute.MultiSampleBuffers, 1);
-                Sdl.GL.SetAttribute(Sdl.GL.Attribute.MultiSampleSamples, presentationParameters.MultiSampleCount);
+                Sdl.GL.SetAttribute(
+                    Sdl.GL.Attribute.MultiSampleSamples,
+                    presentationParameters.MultiSampleCount
+                );
             }
 
             ((SdlGameWindow)SdlGameWindow.Instance).CreateWindow();

--- a/MonoGame.Framework/Platform/GraphicsDeviceManager.SDL.cs
+++ b/MonoGame.Framework/Platform/GraphicsDeviceManager.SDL.cs
@@ -18,6 +18,15 @@ namespace Microsoft.Xna.Framework
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.GreenSize, surfaceFormat.G);
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.BlueSize, surfaceFormat.B);
             Sdl.GL.SetAttribute(Sdl.GL.Attribute.AlphaSize, surfaceFormat.A);
+            
+            SurfaceFormat backBufferFormat = _game.graphicsDeviceManager.PreferredBackBufferFormat;
+
+            if (backBufferFormat == SurfaceFormat.ColorSRgb
+                || backBufferFormat == SurfaceFormat.Bgr32SRgb
+                || backBufferFormat == SurfaceFormat.Bgra32SRgb)
+            {
+                Sdl.GL.SetAttribute(Sdl.GL.Attribute.FramebufferSRGBCapable, 1);
+            }
 
             switch (depthStencilFormat)
             {


### PR DESCRIPTION
Fixes #9337 
Sibling to #1995 

### Description of Change

The OpenGL backend was never enabling `GL_FRAMEBUFFER_SRGB`, so the GPU did the sRGB to linear decode but skipped the linear to sRGB encode. Output was way too dark.

1. Added EnableCap.FramebufferSrgb (0x8DB9) to the enum to reference it.
2. In GraphicsDeviceManager.SDL.PlatformInitialize, requested FramebufferSRGBCapable from SDL when the requested backbuffer format is one of the sRGB variants; otherwise, SDL hands us a non-sRGB-capable default framebuffer.
3. In GraphicsDevice.PlatformInitialize, call GL.Enable(EnableCap.FramebufferSrgb) once, gated on GraphicsCapabilities.SupportsSRgb.

Tested on Mac.

### Contributor Declaration

- [X] I certify that no LLM's were used to generate any code or documentation in this contribution.

