### PR TITLE
Adding missing layout transition.

### DIFF
--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -2663,6 +2663,13 @@ void MGVK_GetTransition(	VkImageLayout oldLayout,
 		sourceStage |= VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 		destinationStage |= VK_PIPELINE_STAGE_TRANSFER_BIT;
 	}
+	else if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+	{
+		srcAccessMask = 0;
+		dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+		sourceStage |= VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+		destinationStage |= VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+	}
 	else if (oldLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
 	{
 		srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;


### PR DESCRIPTION
Fixes #9341

### Description of Change

Added the missing mapping for the `VK_IMAGE_LAYOUT_UNDEFINED` to `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL` layout transition in: `MGG_Vulkan.cpp`

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

