### PR TITLE
Fixing GPU Instancing on Vulkan

### DIFF
--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -5149,17 +5149,25 @@ MGG_InputLayout* MGG_InputLayout_Create(
 	{
 		bindings[i].binding = i;
 		bindings[i].stride = strides[i];
-		bindings[i].inputRate = VK_VERTEX_INPUT_RATE_VERTEX; // Support instance rates.
+		bindings[i].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
 	}
 
 	layout->attributeCount = elementCount;
 	auto attrs = layout->attributes = new VkVertexInputAttributeDescription[elementCount];
 	for (int i = 0; i < elementCount; i++)
 	{
+		const auto element = elements[i];
+
 		attrs[i].location = i;
-		attrs[i].binding = elements[i].VertexBufferSlot;
-		attrs[i].format = ToVkFormat(elements[i].Format);
-		attrs[i].offset = elements[i].AlignedByteOffset;
+		attrs[i].binding = element.VertexBufferSlot;
+		attrs[i].format = ToVkFormat(element.Format);
+		attrs[i].offset = element.AlignedByteOffset;
+
+		if (element.InstanceDataStepRate > 0)
+		{
+			// Override input rate for instanced elements.
+			bindings[element.VertexBufferSlot].inputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
+		}
 	}
 
 	return layout;


### PR DESCRIPTION
Fixes #9299

### Description of Change

Overriding `inputRate` with `VK_VERTEX_INPUT_RATE_INSTANCE` for **instanced** elements when creating layout.
This seems to fix the issue reproduced in the example repo.
([There is an updated fork of that](https://github.com/uygary/mg-vulkan-gpu-instancing-bug/tree/test/uygary/dx12) specifically for testing this here.)

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

