### PR TITLE
Fix NativeLib path for DirectX12 and DesktopVK tests to use NativePlatform variable

### DIFF
--- a/Tests/MonoGame.Tests.DesktopVK.csproj
+++ b/Tests/MonoGame.Tests.DesktopVK.csproj
@@ -53,7 +53,7 @@
     <ItemGroup>
 		<ProjectReference Include="..\MonoGame.Framework\MonoGame.Framework.Native.csproj" />
 	
-		<NativeLib Include="..\Artifacts\native\mgruntime\desktopvk\windows\$(Configuration)\mgruntime.dll" Condition="Exists('..\Artifacts\native\mgruntime\desktopvk\windows\$(Configuration)\mgruntime.dll')" PackagePath="runtimes\win-$(NativePlatform)\native" />
+		<NativeLib Include="..\Artifacts\native\mgruntime\desktopvk\windows\$(NativePlatform)\$(Configuration)\mgruntime.dll" Condition="Exists('..\Artifacts\native\mgruntime\desktopvk\windows\$(NativePlatform)\$(Configuration)\mgruntime.dll')" PackagePath="runtimes\win-$(NativePlatform)\native" />
 	    <NativeLib Include="..\Artifacts\native\mgruntime\desktopvk\linux\$(Configuration)\libmgruntime.so" Condition="Exists('..\Artifacts\native\mgruntime\desktopvk\linux\$(Configuration)\libmgruntime.so')" PackagePath="runtimes\linux-x64\native" />
 	    <NativeLib Include="..\Artifacts\native\mgruntime\desktopvk\macos\$(Configuration)\libmgruntime.dylib" Condition="Exists('..\Artifacts\native\mgruntime\desktopvk\macos\$(Configuration)\libmgruntime.dylib')" PackagePath="runtimes\osx\native" />
     </ItemGroup>

--- a/Tests/MonoGame.Tests.DesktopVK.csproj
+++ b/Tests/MonoGame.Tests.DesktopVK.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -45,8 +45,9 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <NativePlatform Condition="'$(Platform)' == 'ARM64' or '$(Platform)' == 'x64'">$(Platform)</NativePlatform>
-    <NativePlatform Condition="'$(NativePlatform)' == '' And '$(PROCESSOR_ARCHITECTURE)' == 'ARM64'">ARM64</NativePlatform>
+    <_OSArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant())</_OSArch>
+    <NativePlatform Condition="'$(_OSArch)' != ''">$(_OSArch)</NativePlatform>
+    <NativePlatform Condition="'$(NativePlatform)' == '' And '$(PROCESSOR_ARCHITECTURE)' == 'ARM64'">arm64</NativePlatform>
     <NativePlatform Condition="'$(NativePlatform)' == ''">x64</NativePlatform>
   </PropertyGroup>
 
@@ -54,7 +55,7 @@
 		<ProjectReference Include="..\MonoGame.Framework\MonoGame.Framework.Native.csproj" />
 	
 		<NativeLib Include="..\Artifacts\native\mgruntime\desktopvk\windows\$(NativePlatform)\$(Configuration)\mgruntime.dll" Condition="Exists('..\Artifacts\native\mgruntime\desktopvk\windows\$(NativePlatform)\$(Configuration)\mgruntime.dll')" PackagePath="runtimes\win-$(NativePlatform)\native" />
-	    <NativeLib Include="..\Artifacts\native\mgruntime\desktopvk\linux\$(Configuration)\libmgruntime.so" Condition="Exists('..\Artifacts\native\mgruntime\desktopvk\linux\$(Configuration)\libmgruntime.so')" PackagePath="runtimes\linux-x64\native" />
+	    <NativeLib Include="..\Artifacts\native\mgruntime\desktopvk\linux\$(NativePlatform)\$(Configuration)\libmgruntime.so" Condition="Exists('..\Artifacts\native\mgruntime\desktopvk\linux\$(NativePlatform)\$(Configuration)\libmgruntime.so')" PackagePath="runtimes\linux-$(NativePlatform)\native" />
 	    <NativeLib Include="..\Artifacts\native\mgruntime\desktopvk\macos\$(Configuration)\libmgruntime.dylib" Condition="Exists('..\Artifacts\native\mgruntime\desktopvk\macos\$(Configuration)\libmgruntime.dylib')" PackagePath="runtimes\osx\native" />
     </ItemGroup>
 	

--- a/Tests/MonoGame.Tests.WindowsDX12.csproj
+++ b/Tests/MonoGame.Tests.WindowsDX12.csproj
@@ -53,7 +53,7 @@
     <ItemGroup>
 		<ProjectReference Include="..\MonoGame.Framework\MonoGame.Framework.Native.csproj" />
 	
-		<NativeLib Include="..\Artifacts\native\mgruntime\windowsdx\windows\$(Configuration)\mgruntime.dll" Condition="Exists('..\Artifacts\native\mgruntime\windowsdx\windows\$(Configuration)\mgruntime.dll')" PackagePath="runtimes\win-$(NativePlatform)\native" />
+		<NativeLib Include="..\Artifacts\native\mgruntime\windowsdx\windows\$(NativePlatform)\$(Configuration)\mgruntime.dll" Condition="Exists('..\Artifacts\native\mgruntime\windowsdx\windows\$(NativePlatform)\$(Configuration)\mgruntime.dll')" PackagePath="runtimes\win-$(NativePlatform)\native" />
     </ItemGroup>
 	
 	<ItemGroup>


### PR DESCRIPTION
Fixes 
- #9347 

### Description of Change

Update the `MonoGame.Tests.DesktopVK.csproj` and `MonoGame.Tests.WindowsDX12.csproj` file to include the `$(NativePlatform)` variable in the path resolution for the `<NativeLib>` include.  

This was needed due to the `<NativeLib>` being include in  commit 0c7c3b543a411af24acada37c86be118b881cdbd that was part of PR #9224.  Without this, running the tests fail with the error that it cannot find the `mgruntime` dll

> [!WARNING]
> Note that this fixes the tests so that they can run. Running the tests show three tests failing that should be reviewed and resolved in a separate PR

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

