### PR TITLE
Add GPU instancing regression test

### DIFF
--- a/Tests/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceTest.cs
@@ -470,6 +470,92 @@ namespace MonoGame.Tests.Graphics
         }
 #endif
 
+#if XNA || DIRECTX || DIRECTX12 || VULKAN
+        [Test]
+        [RunOnUI]
+        public void DrawInstancedPrimitivesUsesInstanceData()
+        {
+            var renderTarget = new RenderTarget2D(gd, 64, 32, false, SurfaceFormat.Color, DepthFormat.None);
+            VertexBuffer vertexBuffer = null;
+            IndexBuffer indexBuffer = null;
+            VertexBuffer instanceVertexBuffer = null;
+            Effect effect = null;
+
+            try
+            {
+                var vertices = new[]
+                {
+                    new VertexPositionTexture(new Vector3(-6,  6, 0), new Vector2(0, 0)),
+                    new VertexPositionTexture(new Vector3( 6,  6, 0), new Vector2(1, 0)),
+                    new VertexPositionTexture(new Vector3(-6, -6, 0), new Vector2(0, 1)),
+                    new VertexPositionTexture(new Vector3( 6, -6, 0), new Vector2(1, 1)),
+                };
+                vertexBuffer = new VertexBuffer(gd, VertexPositionTexture.VertexDeclaration, vertices.Length, BufferUsage.None);
+                vertexBuffer.SetData(vertices);
+
+                var indices = new ushort[] { 0, 1, 2, 1, 3, 2 };
+                indexBuffer = new IndexBuffer(gd, IndexElementSize.SixteenBits, indices.Length, BufferUsage.None);
+                indexBuffer.SetData(indices);
+
+                var instanceTransforms = new[]
+                {
+                    Matrix.CreateTranslation(-16, 0, 0),
+                    Matrix.CreateTranslation(16, 0, 0),
+                };
+                var instanceVertexDeclaration = new VertexDeclaration
+                (
+                    new VertexElement(0, VertexElementFormat.Vector4, VertexElementUsage.BlendWeight, 0),
+                    new VertexElement(16, VertexElementFormat.Vector4, VertexElementUsage.BlendWeight, 1),
+                    new VertexElement(32, VertexElementFormat.Vector4, VertexElementUsage.BlendWeight, 2),
+                    new VertexElement(48, VertexElementFormat.Vector4, VertexElementUsage.BlendWeight, 3)
+                );
+                instanceVertexBuffer = new VertexBuffer(gd, instanceVertexDeclaration, instanceTransforms.Length, BufferUsage.None);
+                instanceVertexBuffer.SetData(instanceTransforms);
+
+                effect = AssetTestUtility.LoadEffect(content, "Instancing");
+                effect.Parameters["View"].SetValue(Matrix.Identity);
+                effect.Parameters["Projection"].SetValue(Matrix.CreateOrthographic(64, 32, 0, 1));
+
+                gd.SetRenderTarget(renderTarget);
+                gd.Clear(Color.CornflowerBlue);
+                gd.BlendState = BlendState.Opaque;
+                gd.DepthStencilState = DepthStencilState.None;
+                gd.RasterizerState = RasterizerState.CullNone;
+                gd.SetVertexBuffers(
+                    new VertexBufferBinding(vertexBuffer, 0, 0),
+                    new VertexBufferBinding(instanceVertexBuffer, 0, 1));
+                gd.Indices = indexBuffer;
+
+                effect.Techniques[0].Passes[0].Apply();
+                gd.DrawInstancedPrimitives(PrimitiveType.TriangleList, 0, 0, indices.Length, 0, 2, instanceTransforms.Length);
+
+                gd.SetRenderTarget(null);
+
+                var pixels = new Color[renderTarget.Width * renderTarget.Height];
+                renderTarget.GetData(pixels);
+
+                Assert.That(pixels[16 + 16 * renderTarget.Width], Is.Not.EqualTo(Color.CornflowerBlue));
+                Assert.That(pixels[48 + 16 * renderTarget.Width], Is.Not.EqualTo(Color.CornflowerBlue));
+                Assert.That(pixels[32 + 16 * renderTarget.Width], Is.EqualTo(Color.CornflowerBlue));
+            }
+            finally
+            {
+                gd.SetRenderTarget(null);
+
+                if (effect != null)
+                    effect.Dispose();
+                if (vertexBuffer != null)
+                    vertexBuffer.Dispose();
+                if (instanceVertexBuffer != null)
+                    instanceVertexBuffer.Dispose();
+                if (indexBuffer != null)
+                    indexBuffer.Dispose();
+
+                renderTarget.Dispose();
+            }
+        }
+#endif
+
         [Test]
         [RunOnUI]
         public void DrawUserPrimitivesParameterValidation()


### PR DESCRIPTION
Fixes #9346

### Description of Change

Adds a GPU instancing regression test that renders two instances using per-instance transform data.

The test uses a separate instance vertex buffer with an instance frequency of `1`, then reads back the render target to check that both instances rendered while the gap between them stayed clear.

### Testing

* `dotnet test Tests\MonoGame.Tests.WindowsDX.csproj --filter "FullyQualifiedName~DrawInstancedPrimitivesUsesInstanceData"`
* `dotnet test Tests\MonoGame.Tests.WindowsDX.csproj --filter "FullyQualifiedName~DrawInstancedPrimitives"`

Couldn't run DesktopVK test locally because of my environment the native `mgruntime` dependency was missing but DesktopVK project compiled before the runtime load failure.



### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

