### PR TITLE
Fix Issue #8065. MultiSampling on RenderTargets for DesktopGL/Vulkan

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -645,6 +645,12 @@ namespace Microsoft.Xna.Framework.Graphics
             var stencil = 0;
             
             var sampleCount = GetClampedMultisampleCount(preferredFormat, preferredMultiSampleCount);
+            if (sampleCount > 0 && preferredDepthFormat != DepthFormat.None)
+            {
+                GL.GetInteger(GetPName.MaxSamples, out int maxDepthMultiSampleCount);
+                GraphicsExtensions.CheckGLError();
+                sampleCount = Math.Min(sampleCount, maxDepthMultiSampleCount);
+            }
             
             if (sampleCount > 0 && this.framebufferHelper.SupportsBlitFramebuffer)
             {
@@ -713,11 +719,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
                 }
             }
-
-            if (color != 0)
-                renderTarget.GLColorBuffer = color;
-            else
-                renderTarget.GLColorBuffer = renderTarget.GLTexture;
+            
+            renderTarget.GLColorBuffer = color;
             renderTarget.GLDepthBuffer = depth;
             renderTarget.GLStencilBuffer = stencil;
         }
@@ -732,7 +735,7 @@ namespace Microsoft.Xna.Framework.Graphics
             color = renderTarget.GLColorBuffer;
             depth = renderTarget.GLDepthBuffer;
             stencil = renderTarget.GLStencilBuffer;
-            colorIsRenderbuffer = color != renderTarget.GLTexture;
+            colorIsRenderbuffer = color != 0;
 
             if (color != 0)
             {
@@ -842,14 +845,16 @@ namespace Microsoft.Xna.Framework.Graphics
                 this.framebufferHelper.BindFramebuffer(glFramebuffer);
                 var renderTargetBinding = this._currentRenderTargetBindings[0];
                 var renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
-                this.framebufferHelper.FramebufferRenderbuffer((int)FramebufferAttachment.DepthAttachment, renderTarget.GLDepthBuffer, 0);
-                this.framebufferHelper.FramebufferRenderbuffer((int)FramebufferAttachment.StencilAttachment, renderTarget.GLStencilBuffer, 0);
+                if (renderTarget.GLDepthBuffer != 0)
+                    this.framebufferHelper.FramebufferRenderbuffer((int)FramebufferAttachment.DepthAttachment, renderTarget.GLDepthBuffer, 0);
+                if (renderTarget.GLStencilBuffer != 0)
+                    this.framebufferHelper.FramebufferRenderbuffer((int)FramebufferAttachment.StencilAttachment, renderTarget.GLStencilBuffer, 0);
                 for (var i = 0; i < this._currentRenderTargetCount; ++i)
                 {
                     renderTargetBinding = this._currentRenderTargetBindings[i];
                     renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
                     var attachement = (int)(FramebufferAttachment.ColorAttachment0 + i);
-                    if (renderTarget.GLColorBuffer != renderTarget.GLTexture)
+                    if (renderTarget.GLColorBuffer != 0)
                         this.framebufferHelper.FramebufferRenderbuffer(attachement, renderTarget.GLColorBuffer, 0);
                     else
                         this.framebufferHelper.FramebufferTexture2D(attachement, (int)renderTarget.GetFramebufferTarget(renderTargetBinding), renderTarget.GLTexture, 0, renderTarget.MultiSampleCount);
@@ -1278,7 +1283,6 @@ namespace Microsoft.Xna.Framework.Graphics
         internal int PlatformGetMaxMultiSampleCount(SurfaceFormat sformat)
         {
             // For OpenGL we don't seem to check the correct setting per-format.
-
             int maxMultiSampleCount;
             GL.GetInteger(GetPName.MaxSamples, out maxMultiSampleCount);
             return maxMultiSampleCount;

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -644,11 +644,13 @@ namespace Microsoft.Xna.Framework.Graphics
             var depth = 0;
             var stencil = 0;
             
-            if (preferredMultiSampleCount > 0 && this.framebufferHelper.SupportsBlitFramebuffer)
+            var sampleCount = GetClampedMultisampleCount(preferredFormat, preferredMultiSampleCount);
+            
+            if (sampleCount > 0 && this.framebufferHelper.SupportsBlitFramebuffer)
             {
                 this.framebufferHelper.GenRenderbuffer(out color);
                 this.framebufferHelper.BindRenderbuffer(color);
-                this.framebufferHelper.RenderbufferStorageMultisample(preferredMultiSampleCount, (int)RenderbufferStorage.Rgba8, width, height);
+                this.framebufferHelper.RenderbufferStorageMultisample(sampleCount, (int)RenderbufferStorage.Rgba8, width, height);
             }
 
             if (preferredDepthFormat != DepthFormat.None)
@@ -698,7 +700,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 {
                     this.framebufferHelper.GenRenderbuffer(out depth);
                     this.framebufferHelper.BindRenderbuffer(depth);
-                    this.framebufferHelper.RenderbufferStorageMultisample(preferredMultiSampleCount, (int)depthInternalFormat, width, height);
+                    this.framebufferHelper.RenderbufferStorageMultisample(sampleCount, (int)depthInternalFormat, width, height);
                     if (preferredDepthFormat == DepthFormat.Depth24Stencil8)
                     {
                         stencil = depth;
@@ -706,7 +708,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         {
                             this.framebufferHelper.GenRenderbuffer(out stencil);
                             this.framebufferHelper.BindRenderbuffer(stencil);
-                            this.framebufferHelper.RenderbufferStorageMultisample(preferredMultiSampleCount, (int)stencilInternalFormat, width, height);
+                            this.framebufferHelper.RenderbufferStorageMultisample(sampleCount, (int)stencilInternalFormat, width, height);
                         }
                     }
                 }

--- a/Tests/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Tests/Framework/Graphics/RenderTarget2DTest.cs
@@ -184,5 +184,44 @@ namespace MonoGame.Tests.Graphics
             rt.Dispose();
         }
 #endif
+
+        [Test]
+        [TestCase(DepthFormat.None, 0)]
+        [TestCase(DepthFormat.None, 1)]
+        [TestCase(DepthFormat.None, 2)]
+        [TestCase(DepthFormat.Depth16, 0)]
+        [TestCase(DepthFormat.Depth16, 1)]
+        [TestCase(DepthFormat.Depth16, 2)]
+        [TestCase(DepthFormat.Depth24, 0)]
+        [TestCase(DepthFormat.Depth24, 1)]
+        [TestCase(DepthFormat.Depth24, 2)]
+        [TestCase(DepthFormat.Depth24Stencil8, 0)]
+        [TestCase(DepthFormat.Depth24Stencil8, 1)]
+        [TestCase(DepthFormat.Depth24Stencil8, 2)]
+        [RunOnUI]
+        public void ClearAndGetDataWithMultiSample(DepthFormat depthFormat, int multiSampleCount)
+        {
+            const int size = 16;
+            var rt = new RenderTarget2D(gd, size, size, mipMap: false, SurfaceFormat.Color, depthFormat, multiSampleCount, RenderTargetUsage.DiscardContents);
+            try
+            {
+                var previousTargets = gd.GetRenderTargets();
+                gd.SetRenderTarget(rt);
+                gd.Clear(Color.MonoGameOrange);
+                gd.SetRenderTargets(previousTargets);
+
+                var pixels = new Color[size * size];
+                rt.GetData(pixels);
+
+                for (int i=0; i < pixels.Length; i++)
+                {
+                    Assert.AreEqual(Color.MonoGameOrange, pixels[i], $"Pixel {i} should be {Color.MonoGameOrange} but was {pixels[i]}");
+                }
+            }
+            finally
+            {
+               rt.Dispose(); 
+            }
+        }
     }
 }

--- a/Tests/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Tests/Framework/Graphics/RenderTarget2DTest.cs
@@ -198,7 +198,6 @@ namespace MonoGame.Tests.Graphics
         [TestCase(DepthFormat.Depth24Stencil8, 0)]
         [TestCase(DepthFormat.Depth24Stencil8, 1)]
         [TestCase(DepthFormat.Depth24Stencil8, 4)]
-        [RunOnUI]
         public void ClearAndGetDataWithMultiSample(DepthFormat depthFormat, int multiSampleCount)
         {
             const int size = 16;

--- a/Tests/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Tests/Framework/Graphics/RenderTarget2DTest.cs
@@ -188,16 +188,12 @@ namespace MonoGame.Tests.Graphics
         [Test]
         [TestCase(DepthFormat.None, 0)]
         [TestCase(DepthFormat.None, 1)]
-        [TestCase(DepthFormat.None, 2)]
         [TestCase(DepthFormat.Depth16, 0)]
         [TestCase(DepthFormat.Depth16, 1)]
-        [TestCase(DepthFormat.Depth16, 2)]
         [TestCase(DepthFormat.Depth24, 0)]
         [TestCase(DepthFormat.Depth24, 1)]
-        [TestCase(DepthFormat.Depth24, 2)]
         [TestCase(DepthFormat.Depth24Stencil8, 0)]
         [TestCase(DepthFormat.Depth24Stencil8, 1)]
-        [TestCase(DepthFormat.Depth24Stencil8, 2)]
         [RunOnUI]
         public void ClearAndGetDataWithMultiSample(DepthFormat depthFormat, int multiSampleCount)
         {

--- a/Tests/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Tests/Framework/Graphics/RenderTarget2DTest.cs
@@ -188,12 +188,16 @@ namespace MonoGame.Tests.Graphics
         [Test]
         [TestCase(DepthFormat.None, 0)]
         [TestCase(DepthFormat.None, 1)]
+        [TestCase(DepthFormat.None, 4)]
         [TestCase(DepthFormat.Depth16, 0)]
         [TestCase(DepthFormat.Depth16, 1)]
+        [TestCase(DepthFormat.Depth16, 4)]
         [TestCase(DepthFormat.Depth24, 0)]
         [TestCase(DepthFormat.Depth24, 1)]
+        [TestCase(DepthFormat.Depth24, 4)]
         [TestCase(DepthFormat.Depth24Stencil8, 0)]
         [TestCase(DepthFormat.Depth24Stencil8, 1)]
+        [TestCase(DepthFormat.Depth24Stencil8, 4)]
         [RunOnUI]
         public void ClearAndGetDataWithMultiSample(DepthFormat depthFormat, int multiSampleCount)
         {

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -2446,6 +2446,12 @@ static void MGVK_DestroyFrameResources(MGG_GraphicsDevice* device, FrameCounter 
 			if (texture->view != VK_NULL_HANDLE)
 				vkDestroyImageView(device->device, texture->view, nullptr);
 
+			if (texture->msImage != VK_NULL_HANDLE)
+			{
+				vkDestroyImageView(device->device, texture->resolve_view, nullptr);
+				vmaDestroyImage(device->allocator, texture->msImage, texture->msAllocation);
+			}
+
 			vmaDestroyImage(device->allocator, texture->image, texture->allocation);
 			mg_remove(device->all_textures, texture);
 			delete texture;
@@ -3259,7 +3265,7 @@ static void MGVK_UpdateRenderPass(MGG_GraphicsDevice* device, FrameCounter curre
 			desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 			desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 			desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-			desc.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+			desc.finalLayout = firstTarget->isSwapchain ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
 			num_attachments++;
 		}
@@ -5185,7 +5191,7 @@ MGG_Texture* MGG_RenderTarget_Create(
 		create_info.extent.depth = depth;
 		create_info.mipLevels = mipmaps;
 		create_info.arrayLayers = slices;
-        create_info.samples = ToVkSampleCount(multiSampleCount);
+        create_info.samples = VK_SAMPLE_COUNT_1_BIT;
 		create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
 		create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | 
                         VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | 
@@ -5200,6 +5206,37 @@ MGG_Texture* MGG_RenderTarget_Create(
 
 		texture->view = CreateImageView(device, texture, create_info.mipLevels);
 		VK_SET_OBJECT_NAME(device->device, texture->view, VK_OBJECT_TYPE_IMAGE_VIEW, "MGG_Texture.view (RenderTarget id: %llu)", texture->id);
+		
+		if (multiSampleCount > 1)
+		{
+			auto ms_create_info = create_info;
+			ms_create_info.samples = ToVkSampleCount(multiSampleCount);
+			ms_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+			VmaAllocationCreateInfo allocInfo = {};
+			allocInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+			VkResult res = vmaCreateImage(device->allocator, &ms_create_info, &allocInfo,
+				&texture->msImage, &texture->msAllocation, nullptr);
+			VK_CHECK_RESULT(res);
+			VK_SET_OBJECT_NAME(device->device, texture->msImage, VK_OBJECT_TYPE_IMAGE,
+				"MGG_Texture.msImage (RenderTarget id: %llu)", texture->id);
+
+			VkImageViewCreateInfo image_view_create_info = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
+			image_view_create_info.image = texture->image;
+			image_view_create_info.viewType = ToVkImageViewType(texture->type);
+			image_view_create_info.format = texture->info.format;
+			image_view_create_info.subresourceRange.aspectMask = DetermineAspectMask(texture->info.format);
+			image_view_create_info.subresourceRange.baseMipLevel = 0;
+			image_view_create_info.subresourceRange.levelCount = 1;
+			image_view_create_info.subresourceRange.baseArrayLayer = 0;
+			image_view_create_info.subresourceRange.layerCount = texture->info.arrayLayers;
+
+			res = vkCreateImageView(device->device, &image_view_create_info, NULL, &texture->resolve_view);
+			VK_CHECK_RESULT(res);
+			VK_SET_OBJECT_NAME(device->device, texture->resolve_view, VK_OBJECT_TYPE_IMAGE_VIEW,
+				"MGG_Texture.resolve_view (RenderTarget id: %llu)", texture->id);
+
+		}
+
 		texture->target_view = CreateImageView(device, texture, create_info.mipLevels);
 		VK_SET_OBJECT_NAME(device->device, texture->target_view, VK_OBJECT_TYPE_IMAGE_VIEW, "MGG_Texture.target_view (RenderTarget id: %llu)", texture->id);
 


### PR DESCRIPTION
Fixes #8065 

There is an error in the logic we use to create Render Targets with Multi Sampling. This can cause the entire RenderTarget2D to produce just black output no matter what is drawn to it.

There were also some problems with the Vulkan implementation of multi sampling. When running the new test it would cause a seg fault trying to access some non existent memory. 


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

