### PR TITLE
Patch builder.targets to recognise VK/DX12

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -41,19 +41,21 @@
         <Output TaskParameter="Output" ItemName="ContentReferences"/>
     </CollectContentReferences>
 
-    <Error Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, , MacOSX, iOS, Linux, DesktopGL, RaspberryPi, Android, NativeClient, PlayStation4, PSVita, XboxOne or PlayStationMobile."
+    <Error Text="The MonoGamePlatform property was not defined in the project!  It must be set to Windows, WindowsGL, WindowsDX12, MacOSX, iOS, Linux, DesktopGL, DesktopVK, RaspberryPi, Android, NativeClient, PlayStation4, PSVita, XboxOne or PlayStationMobile."
        Condition="	'$(MonoGamePlatform)' != 'Windows' And
-			'$(MonoGamePlatform)' != 'iOS' And       
-			'$(MonoGamePlatform)' != 'Android' And       
-			'$(MonoGamePlatform)' != 'Linux' And           
-			'$(MonoGamePlatform)' != 'DesktopGL' And           
-			'$(MonoGamePlatform)' != 'MacOSX' And       
-			'$(MonoGamePlatform)' != 'NativeClient' And       
-			'$(MonoGamePlatform)' != 'RaspberryPi' And       
-			'$(MonoGamePlatform)' != 'PlayStation4' And       
-			'$(MonoGamePlatform)' != 'PlayStation5' And       
+			'$(MonoGamePlatform)' != 'iOS' And 
+			'$(MonoGamePlatform)' != 'Android' And 
+			'$(MonoGamePlatform)' != 'Linux' And 
+			'$(MonoGamePlatform)' != 'DesktopGL' And 
+			'$(MonoGamePlatform)' != 'DesktopVK' And 
+			'$(MonoGamePlatform)' != 'MacOSX' And 
+			'$(MonoGamePlatform)' != 'NativeClient' And 
+			'$(MonoGamePlatform)' != 'RaspberryPi' And 
+			'$(MonoGamePlatform)' != 'PlayStation4' And 
+			'$(MonoGamePlatform)' != 'PlayStation5' And 
 			'$(MonoGamePlatform)' != 'XboxOne' And 
-			'$(MonoGamePlatform)' != 'WindowsGL'" />
+			'$(MonoGamePlatform)' != 'WindowsGL' And 
+			'$(MonoGamePlatform)' != 'WindowsDX12'" />
 
     <Error
         Text="The MonoGame content builder executable could not be located at '$(MonoGameContentBuilderExe)'!"


### PR DESCRIPTION
# Summary

In `3.8.5-Preview.6` the MGCB build reports that the MonoGamePlatform is missing when building for Vulkan or DX12, likely because it is not in the validation list.

## Resolution

Patching the Builder.Targets to recognise DesktopVK and WindowsDX12 as valid MonoGamePlatform definitions

> [!NOTE]
> Needs testing from built packages to ensure it resolves the issue

### Contributor Declaration

- [X] I certify that no LLM's were used to generate any code or documentation in this contribution.

