### PR TITLE
Update Windows runner from 'windows-latest' to 'windows-2022'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2022
             platform: windows
             shell: pwsh
           - os: macos-26


### PR DESCRIPTION
TRy to pin to window-2022 to fix 

```
C:\Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Microsoft\VC\v180\Microsoft.CppBuild.targets(473,5): error MSB8020: The build tools for Visual Studio 2022 (Platform Toolset = 'v143') cannot be found. To build using the v143 build tools, please install Visual Studio 2022 build tools.  Alternatively, you may upgrade to the current Visual Studio tools by selecting the Project menu or right-click the solution, and then selecting "Retarget solution". [D:\a\MonoGame\MonoGame\native\monogame\desktopvk.vcxproj]
```


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

