### PR TITLE
Escape SDL include directory for faduio

### DIFF
--- a/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
+++ b/build/BuildFrameworksTasks/BuildNativeDependenciesTask.cs
@@ -64,8 +64,8 @@ public sealed class BuildNativeDependenciesTask : FrostingTask<BuildContext>
             .Append("-S").AppendQuoted(context.MakeAbsolute(new DirectoryPath(faudioSourceDir)).FullPath)
             .Append("-B").AppendQuoted(context.MakeAbsolute(new DirectoryPath(faudioBuildDir)).FullPath)
             .Append("-DBUILD_SHARED_LIBS=OFF")
-            .Append($"-DCMAKE_C_STANDARD_INCLUDE_DIRECTORIES={context.MakeAbsolute(new DirectoryPath(sdlIncludeDir))}")
-            .Append($"-DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES={context.MakeAbsolute(new DirectoryPath(sdlIncludeDir))}")
+            .Append($"-DCMAKE_C_STANDARD_INCLUDE_DIRECTORIES=\"{context.MakeAbsolute(new DirectoryPath(sdlIncludeDir))}\"")
+            .Append($"-DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES=\"{context.MakeAbsolute(new DirectoryPath(sdlIncludeDir))}\"")
             .Append("-DBUILD_SDL3=OFF");
 
         AppendPlatformCMakeArgs(configureArgs, context, isSDL: false, targetArch);


### PR DESCRIPTION
### Description of Change
Simply fixes an issue where the SDL include for Faudio needed to be quoted to allow a project directory with spaces.



### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

