### PR TITLE
DX12: Fixes invalid render target state after requesting texture data on an active render target

### DIFF
--- a/native/monogame/directx12/CommandContext.cpp
+++ b/native/monogame/directx12/CommandContext.cpp
@@ -67,9 +67,8 @@ CommandContext::~CommandContext() {
     }
 }
 
-void CommandContext::Reset(unsigned int currentFrame) {
-    m_backBufferIndex = currentFrame;
-
+void CommandContext::Reset()
+{
     for (auto t : m_tempTextures[m_backBufferIndex]) {
         t->FreeDescriptors(m_deviceRes);
         delete t;
@@ -87,10 +86,16 @@ void CommandContext::Reset(unsigned int currentFrame) {
     };
     cmdList->SetDescriptorHeaps(_countof(descriptorHeaps), descriptorHeaps);
 
+    m_cbOffset = 0;
+}
+
+void CommandContext::Reset(unsigned int currentFrame) {
+    m_backBufferIndex = currentFrame;
+
+    Reset();
+
     m_currentRT.clear();
     m_currentDepthStencil = nullptr;
-
-    m_cbOffset = 0;
 }
 
 uint64_t CommandContext::Close() {

--- a/native/monogame/directx12/CommandContext.h
+++ b/native/monogame/directx12/CommandContext.h
@@ -51,6 +51,7 @@ public:
     CommandContext(DeviceResources* deviceResources); // CommandContext cannot be constructed from C#
     ~CommandContext();
 
+    void Reset();
     void Reset(unsigned int backBufferIndex);
     uint64_t Close();
 
@@ -72,6 +73,5 @@ public:
 
     void CreateDefaultRootSignature();
     void CreateGenerateMipPipelineResources();
-
 };
 }

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -742,7 +742,7 @@ void MGG_GraphicsDevice_GetBackBufferData(MGG_GraphicsDevice* device, mgint x, m
 	if (restart_cmdlist)
 	{
 		auto context = device->resources->GetCommandContext();
-		context->Reset(context->m_backBufferIndex);
+		context->Reset();
 
 		device->pipelineManager->Prepare();
 		device->indexBufferDirty = true;
@@ -1778,7 +1778,7 @@ void MGG_Texture_GetData(MGG_GraphicsDevice* device, MGG_Texture* texture, mgint
 	if (restart_cmdlist)
 	{
 		auto context = device->resources->GetCommandContext();
-		context->Reset(context->m_backBufferIndex);
+		context->Reset();
 
 		device->pipelineManager->Prepare();
 		device->indexBufferDirty = true;


### PR DESCRIPTION
Fixes #9368

### Description of Change
Fixes a bug where state of a render target is not transitioned back to `D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE` if you request `MGG_Texture_GetData` while the render target is active.

This was producing a warning on Windows and a crash on Xbox.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

