### PR TITLE
Only enable sRGB flag if the back buffer is compatible

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -344,7 +344,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
             framebufferHelper = FramebufferHelper.Create(this);
 
-            if (GraphicsCapabilities.SupportsSRgb)
+            var backBufferFormat = PresentationParameters.BackBufferFormat;
+            if (
+                GraphicsCapabilities.SupportsSRgb &&
+                (backBufferFormat == SurfaceFormat.ColorSRgb || backBufferFormat == SurfaceFormat.Bgr32SRgb || backBufferFormat == SurfaceFormat.Bgra32SRgb))
             {
                 GL.Enable(EnableCap.FramebufferSrgb);
                 GraphicsExtensions.CheckGLError();

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -345,8 +345,7 @@ namespace Microsoft.Xna.Framework.Graphics
             framebufferHelper = FramebufferHelper.Create(this);
 
             var backBufferFormat = PresentationParameters.BackBufferFormat;
-            if (
-                GraphicsCapabilities.SupportsSRgb &&
+            if (GraphicsCapabilities.SupportsSRgb &&
                 (backBufferFormat == SurfaceFormat.ColorSRgb || backBufferFormat == SurfaceFormat.Bgr32SRgb || backBufferFormat == SurfaceFormat.Bgra32SRgb))
             {
                 GL.Enable(EnableCap.FramebufferSrgb);


### PR DESCRIPTION
Fixes #9370

### Description of Change

`GL.Enable(EnableCap.FramebufferSrgb);` should only be enabled if a compatible back buffer was requested. Right now its being enabled just if the device supports it.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

