### PR TITLE
DX12: Allow changing back buffer size followed by setting a custom render target

### DIFF
--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -443,6 +443,9 @@ void MGG_GraphicsDevice_ResolveRenderTargets(MGG_GraphicsDevice* device)
 {
 	assert(device != nullptr);
 
+	if (!device->is_recording)
+		return;
+
 	auto& currentRT = device->context->m_currentRT;
 	if (currentRT.size() == 0)
 		return;


### PR DESCRIPTION
Fixes #9377

### Description of Change

This fixes a bug where the game would crash if you try resize the back buffer during an `Update()` call, and then set a custom render target in a `Draw()` call.

Inside the `Update()` call the current back buffer gets destroyed when a resize is requested.
```
    protected override void Update(GameTime gameTime)
    {
        ...
        _graphics.PreferredBackBufferWidth = 1920;
        _graphics.PreferredBackBufferHeight = 1080;
        _graphics.ApplyChanges();
        ...
    }
```
https://github.com/MonoGame/MonoGame/blob/5585348b3c8dce7ccc3ee1d3946239b583300bb3/native/monogame/directx12/DeviceResources.cpp#L229-L235

Inside the `Draw()` call `MGG_GraphicsDevice_ResolveRenderTargets` attempts to get the current render target so it can resolve the mipmaps. The reference it holds (`m_currentRT`) was the destroyed back buffer texture and the game crashes.
```
    protected override void Draw(GameTime gameTime)
    {
        GraphicsDevice.SetRenderTarget(_rt);
	...
    }
```
https://github.com/MonoGame/MonoGame/blob/5585348b3c8dce7ccc3ee1d3946239b583300bb3/native/monogame/directx12/MGG_DX12.cpp#L442-L460

If `!device.is_recording` there is no reason to resolve the current render targets.
- It's set to false once `EndDraw()` is called. At this point all mipmaps should of been already generated.

There is other ways to solve this as well possibly such as
- Deferring destroying back buffer textures
- Resetting `m_currentRT` if it matches to be destroyed back buffer texture.

Let me know thoughts.

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

