### PR TITLE
Fix the RasterizerStateTest to only ignore the problem tests , NOT all of them

### DIFF
--- a/Tests/Framework/Graphics/RasterizerStateTest.cs
+++ b/Tests/Framework/Graphics/RasterizerStateTest.cs
@@ -17,7 +17,7 @@ namespace MonoGame.Tests.Graphics
         [TestCase(-1f)]
 #if DESKTOPGL
         [TestCase(1f, Ignore = "fails similarity test. Needs Investigating")]
-#elif VULKAN
+#elif VULKAN && MACOS
         [TestCase(1f, Ignore = "Constant depth bias has no effect on float-depth polygons at z=0; not supported on MoltenVK. See https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#primsrast-depthbias")]  
 #else
         [TestCase(1f)]

--- a/Tests/Framework/Graphics/RasterizerStateTest.cs
+++ b/Tests/Framework/Graphics/RasterizerStateTest.cs
@@ -16,7 +16,9 @@ namespace MonoGame.Tests.Graphics
     {
         [TestCase(-1f)]
 #if DESKTOPGL
-        [TestCase(1f), Ignore ("fails similarity test. Needs Investigating")]
+        [TestCase(1f, Ignore = "fails similarity test. Needs Investigating")]
+#elif VULKAN
+        [TestCase(1f, Ignore = "Constant depth bias has no effect on float-depth polygons at z=0; not supported on MoltenVK. See https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#primsrast-depthbias")]  
 #else
         [TestCase(1f)]
 #endif
@@ -24,14 +26,6 @@ namespace MonoGame.Tests.Graphics
         [RunOnUI]
         public void DepthBiasVisualTest(float depthBias)
         {
-#if VULKAN
-            if (OperatingSystem.IsMacOS())
-            {
-                Assert.Ignore("TODO: Fix on macOS");
-                return;
-            }
-#endif
-
             var effect = new BasicEffect(gd)
             {
                 VertexColorEnabled = true,

--- a/Tests/MonoGame.Tests.DesktopVK.csproj
+++ b/Tests/MonoGame.Tests.DesktopVK.csproj
@@ -8,6 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateProgramFile>false</GenerateProgramFile>
     <DefineConstants>VULKAN;DESKTOP</DefineConstants>
+    <DefineConstants Condition="$([MSBuild]::IsOSPlatform('MacOS'))">$(DefineConstants);MACOS</DefineConstants>
     <Platforms>AnyCPU;ARM64;x64</Platforms>
   </PropertyGroup>
 


### PR DESCRIPTION
The way the Ignore attribute was being used ment that ALL the test cases were being ignored. 
Lets fix that so only the broken ones are ignored. 

Also found we don't seem to be able to support depthBias on MoltenVK

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

