### PR TITLE
Fix `SoundEffect.FromStream` parsing for oversided WAV `fmt` chunks

### DIFF
--- a/MonoGame.Framework/Platform/Audio/AudioLoader.cs
+++ b/MonoGame.Framework/Platform/Audio/AudioLoader.cs
@@ -131,6 +131,7 @@ namespace Microsoft.Xna.Framework.Audio
                 {
                     case "fmt ":
                         {
+                            int formatChunkBytesRead = 16;
                             audioFormat = reader.ReadInt16(); // 2
                             channels = reader.ReadInt16(); // 4
                             frequency = reader.ReadInt32();  // 8
@@ -142,10 +143,12 @@ namespace Microsoft.Xna.Framework.Audio
                             if (chunkSize > 16)
                             {
                                 int extraDataSize = reader.ReadInt16();
+                                formatChunkBytesRead += 2;
                                 if (audioFormat == FormatIma4)
                                 {
                                     samplesPerBlock = reader.ReadInt16();
                                     extraDataSize -= 2;
+                                    formatChunkBytesRead += 2;
                                 }
                                 if (extraDataSize > 0)
                                 {
@@ -156,6 +159,19 @@ namespace Microsoft.Xna.Framework.Audio
                                         for (int i = 0; i < extraDataSize; ++i)
                                             reader.ReadByte();
                                     }
+                                }
+                                formatChunkBytesRead += extraDataSize;
+                            }
+
+                            int remainingFormatChunkBytes = chunkSize - formatChunkBytesRead;
+                            if (remainingFormatChunkBytes > 0)
+                            {
+                                if (reader.BaseStream.CanSeek)
+                                    reader.BaseStream.Seek(remainingFormatChunkBytes, SeekOrigin.Current);
+                                else
+                                {
+                                    for (int i = 0; i < remainingFormatChunkBytes; ++i)
+                                        reader.ReadByte();
                                 }
                             }
                         }

--- a/Tests/Framework/Audio/SoundEffectTest.cs
+++ b/Tests/Framework/Audio/SoundEffectTest.cs
@@ -393,6 +393,18 @@ namespace MonoGame.Tests.Audio
             Assert.Throws<ArgumentNullException>(() => SoundEffect.FromStream(null));
         }
 
+#if !XNA
+        [Test]
+        public void SoundEffectFromStream_PcmFmtChunkWithTrailingBytes_Loads()
+        {
+            using (FileStream stream = File.OpenRead(@"Assets/Audio/pcm-fmt40-cb0.wav"))
+            using (SoundEffect sound = SoundEffect.FromStream(stream))
+            {
+                Assert.AreEqual(84014 / 10, (int)sound.Duration.TotalMilliseconds / 10);
+            }
+        }
+#endif
+
         [TestCase(@"Assets/Audio/blast_mono.wav", 7165)]
         [TestCase(@"Assets/Audio/blast_mono_22hz.wav", 7165)]
         [TestCase(@"Assets/Audio/blast_mono_11hz.wav", 7165)]


### PR DESCRIPTION
Fixes #9388

### Description of Change

Fixes a WAV parsing issue in `SoundEffect.FromStream()` when the `fmt` chunk is larger than the standard PCM header size.

MonoGame's OpenAL `AudioLoader` reads the PCM format fields and optionally consumes extra format data based on `cbSize`, but it did not ensure the stream advanced to the end of the `fmt ` chunk before continuing to the next RIFF chunk. For WAV files with oversized PCM `fmt ` chunks, this could leave unread bytes behind and cause the parser to become misaligned, eventually resulting in an `EndOfStreamException`.

This change keeps the existing format parsing behavior intact and only adds a final step to consume any unread bytes remaining in the `fmt ` chunk before moving on. That keeps the reader aligned with the next chunk without changing how supported formats are interpreted.

A regression test was added using the repro file from the issue report to verify that `SoundEffect.FromStream()` can successfully load a WAV file with a 40-byte PCM `fmt ` chunk.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.