### PR TITLE
Fix native SoundEffect duration overflow for large WAV files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -381,13 +381,6 @@ jobs:
         run: |
           brew update
 
-      - name: Install Full Vulkan SDK
-        if: runner.os == 'macos'
-        uses: humbletim/install-vulkan-sdk@v1.2
-        with:
-          version: 1.4.309.0
-          cache: true          
-
       - name: Check Vulkan
         if: runner.environment != 'github-hosted' && runner.os == 'macos'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -384,7 +384,14 @@ jobs:
       - name: Check Vulkan
         if: runner.environment != 'github-hosted' && runner.os == 'macos'
         run: |
-          vulkaninfo
+          echo "VULKAN_SDK: $VULKAN_SDK"
+          echo "VK_ICD_FILENAMES: $VK_ICD_FILENAMES"
+          which vulkaninfo
+          vulkaninfo --summary
+          ls -l /usr/local/lib/libvulkan.1.dylib
+          file /usr/local/lib/libvulkan.1.dylib
+          echo $DYLD_LIBRARY_PATH
+        working-directory: tests-desktopvk          
 
       - name: Disable Annotations
         run: echo "::remove-matcher owner=csc::"
@@ -428,14 +435,6 @@ jobs:
         with:
           name: tests-desktopvk-${{ matrix.platform }}
           path: tests-desktopvk
-
-      - name: Check Vulkan SDK
-        if: runner.environment != 'github-hosted' && runner.os == 'macos'
-        run: |
-           ls -l /usr/local/lib/libvulkan.1.dylib
-           file /usr/local/lib/libvulkan.1.dylib
-           echo $DYLD_LIBRARY_PATH
-        working-directory: tests-desktopvk
 
       # Run the DirectX 11 tests in two steps: first the audio, then the rest.
       # This is because the audio tests has some incompatibilities within the runner with ContentManagerTests.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -391,7 +391,6 @@ jobs:
           ls -l /usr/local/lib/libvulkan.1.dylib
           file /usr/local/lib/libvulkan.1.dylib
           echo $DYLD_LIBRARY_PATH
-        working-directory: tests-desktopvk          
 
       - name: Disable Annotations
         run: echo "::remove-matcher owner=csc::"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -381,6 +381,13 @@ jobs:
         run: |
           brew update
 
+      - name: Install Full Vulkan SDK
+        if: runner.os == 'macos'
+        uses: humbletim/install-vulkan-sdk@v1.2
+        with:
+          version: 1.4.309.0
+          cache: true          
+
       - name: Check Vulkan
         if: runner.environment != 'github-hosted' && runner.os == 'macos'
         run: |

--- a/native/monogame/faudio/MGA_faudio.cpp
+++ b/native/monogame/faudio/MGA_faudio.cpp
@@ -323,7 +323,7 @@ void MGA_Buffer_InitializeFormat(MGA_Buffer* buffer, mgbyte* waveHeader, mgbyte*
 		assert((length % wformat.nBlockAlign) == 0);
 
 		// Calculate duration
-		buffer->duration = (mgulong)((length * 1000) / buffer->format->nAvgBytesPerSec);
+		buffer->duration = ((mgulong)length * 1000) / buffer->format->nAvgBytesPerSec;
 
 		buffer->length = length;
 		buffer->data = (uint8_t*)malloc(length);
@@ -433,7 +433,7 @@ void MGA_Buffer_InitializePCM(MGA_Buffer* buffer, mgbyte* waveData, mgint offset
 		memcpy(buffer->data, waveData + offset, length);
 
 	// Calculate duration
-	buffer->duration = (mgulong)((length * 1000) / buffer->format->nAvgBytesPerSec);
+	buffer->duration = ((mgulong)length * 1000) / buffer->format->nAvgBytesPerSec;
 
 	// Set the buffer structure passed to SubmitSourceBuffer.
 	memset(&buffer->buffer, 0, sizeof(buffer->buffer));
@@ -469,11 +469,11 @@ void MGA_Buffer_InitializeXact(MGA_Buffer* buffer, mguint codec, mgbyte* waveDat
 	// Calculate duration (approximate for compressed formats)
 	if (codec == 0x166) // WMA
 	{
-		buffer->duration = (mgulong)((length * 1000) / (sampleRate * channels * 2));
+		buffer->duration = ((mgulong)length * 1000) / (sampleRate * channels * 2);
 	}
 	else
 	{
-		buffer->duration = (mgulong)((length * 1000) / buffer->format->nAvgBytesPerSec);
+		buffer->duration = ((mgulong)length * 1000) / buffer->format->nAvgBytesPerSec;
 	}
 }
 

--- a/native/monogame/xaudio/MGA_xaudio2.cpp
+++ b/native/monogame/xaudio/MGA_xaudio2.cpp
@@ -285,7 +285,7 @@ void MGA_Buffer_InitializeFormat(MGA_Buffer* buffer, mgbyte* waveHeader, mgbyte*
 		assert((length % wformat->nBlockAlign) == 0);
 
 		// Calculate duration
-		buffer->duration = (mgulong)((length * 1000) / buffer->format->nAvgBytesPerSec);
+		buffer->duration = ((mgulong)length * 1000) / buffer->format->nAvgBytesPerSec;
 
 		buffer->length = length;
 		buffer->data = (uint8_t*)malloc(length);
@@ -396,7 +396,7 @@ void MGA_Buffer_InitializePCM(MGA_Buffer* buffer, mgbyte* waveData, mgint offset
 		memcpy(buffer->data, waveData + offset, length);
 
 	// Calculate duration
-	buffer->duration = (mgulong)((length * 1000) / buffer->format->nAvgBytesPerSec);
+	buffer->duration = ((mgulong)length * 1000) / buffer->format->nAvgBytesPerSec;
 
 	// Set the buffer structure passed to SubmitSourceBuffer.
 	memset(&buffer->buffer, 0, sizeof(buffer->buffer));


### PR DESCRIPTION
Discovered while working on #9388 when tests failed in #9389

### Description of Change

The native duration calculation multiplied the WAV data length by `1000` using 32-bit integer math before converting the result to `mgulong`. For longer durations, that intermediate multiplication could overflow and produce a much smaller duration than expected.

This changes it so that the multiplication is done as a `mgulong` before dividing so there is no potential overflow.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

