### PR TITLE
Removing OffsetToStringData Use and Fixing Pointer Arithmetic Bug

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -1583,15 +1583,19 @@ namespace MonoGame.OpenGL
 
         protected unsafe static IntPtr MarshalStringToPtr (string str)
         {
-            if (string.IsNullOrEmpty (str)) {
+            if (string.IsNullOrEmpty (str))
+            {
                 return IntPtr.Zero;
             }
             int num = Encoding.ASCII.GetMaxByteCount (str.Length) + 1;
             IntPtr intPtr = Marshal.AllocHGlobal (num);
-            if (intPtr == IntPtr.Zero) {
+            if (intPtr == IntPtr.Zero)
+            {
                 throw new OutOfMemoryException ();
             }
-            fixed (char* chars = str + RuntimeHelpers.OffsetToStringData / 2) {
+            
+            fixed (char* chars = str)
+            {
                 int bytes = Encoding.ASCII.GetBytes (chars, str.Length, (byte*)((void*)intPtr), num);
                 Marshal.WriteByte (intPtr, bytes, 0);
                 return intPtr;


### PR DESCRIPTION
Fixes #9293

> [!IMPORTANT]
> Note that this code actually had a bug that was accidentally not surfacing:
> It attempted to do pointer arithmetic, but it was actually performing string concatenation.
> This meant we have been redundantly allocating strings in OpenGL.
> 
> Although, this is likely not that big a deal, because I think it's called just once per shader.

<details><summary>To clarify, when we compile this example:</summary>

```cs
using System;
using System.Runtime.CompilerServices;

public class Program
{
	public static unsafe void Main()
	{
		var str = "Hello World";

		fixed (char* chars = str + RuntimeHelpers.OffsetToStringData / 2)
		{
			fixed (char* charsNew = str)
			{
				var isNewEqual = charsNew == chars;
				Console.WriteLine(isNewEqual);
			}
		}
	}
}
```

</details>

<details><summary>This is the IL that's generated:</summary>

```msil
IL_0000 | nop |
IL_0001 | ldstr | "Hello World"
IL_0006 | stloc.0 | // str
IL_0007 | ldloc.0 | // str
IL_0008 | call | RuntimeHelpers.get_OffsetToStringData ()
IL_000D | ldc.i4.2 |  
IL_000E | div |  
IL_000F | stloc.3 |  
IL_0010 | ldloca.s | 03
IL_0012 | call | Int32.ToString ()
IL_0017 | call | String.Concat (String, String)
IL_001C | dup |  
IL_001D | brtrue.s | IL_0024
IL_001F | pop |  
IL_0020 | ldc.i4.0 |  
IL_0021 | conv.u |  
IL_0022 | br.s | IL_002C
IL_0024 | call | String.GetPinnableReference ()
IL_0029 | stloc.2 |  
IL_002A | ldloc.2 |  
IL_002B | conv.u |  
IL_002C | stloc.1 | // chars
IL_002D | nop |  
IL_002E | ldloc.0 | // str
IL_002F | brtrue.s | IL_0035
IL_0031 | ldc.i4.0 |  
IL_0032 | conv.u |  
IL_0033 | br.s | IL_0040
IL_0035 | ldloc.0 | // str
IL_0036 | call | String.GetPinnableReference ()
IL_003B | stloc.s | 05
IL_003D | ldloc.s | 05
IL_003F | conv.u |  
IL_0040 | stloc.s | 04    // charsNew
IL_0042 | nop |  
IL_0043 | ldloc.s | 04    // charsNew
IL_0045 | ldloc.1 | // chars
IL_0046 | ceq |  
IL_0048 | stloc.s | 06    // isNewEqual
IL_004A | ldloc.s | 06    // isNewEqual
IL_004C | call | Console.WriteLine (Boolean)
IL_0051 | nop |  
IL_0052 | nop |  
IL_0053 | ldc.i4.0 |  
IL_0054 | conv.u |  
IL_0055 | stloc.s | 05
IL_0057 | nop |  
IL_0058 | ldc.i4.0 |  
IL_0059 | conv.u |  
IL_005A | stloc.2 |  
IL_005B | ret |  
```

</details>

<details><summary>And this is what that decompiles to:</summary>

```cs
   string str = "Hello World";
   string text = string.Concat (str, (RuntimeHelpers.OffsetToStringData / 2).ToString ());
   fixed (char* chars = &(text != null ? ref text.GetPinnableReference () : ref *(char*)null))
   {
        char* intPtr;
        if (str == null)
        {
             char* charsNew;
             intPtr = (charsNew = null);
             bool isNewEqual = charsNew == chars;
             Console.WriteLine (isNewEqual);
             return;
        }
        fixed (char* ptr = &str.GetPinnableReference ())
        {
             char* charsNew;
             intPtr = (charsNew = ptr);
             bool isNewEqual = charsNew == chars;
             Console.WriteLine (isNewEqual);
        }
   }
```

</details>

---

So what happens in the existing code is this:
This:  `str + RuntimeHelpers.OffsetToStringData / 2`
Translates to this: `str + 6.ToString()`
Which means this: `fixed (char* chars = "OriginalString" + RuntimeHelpers.OffsetToStringData / 2)`
Translates to this: `fixed (char* chars = "OriginalString6")`
But this doesn't become an issue, since we use `str.Length` down the line, and the first `str.Length` characters of the new string is the same.
Which is why we don't notice the bug.

More context is on this PR: #9323 
Unfortunately I couldn't get the author of that PR to update their description to include the LLM declaration, which is why I'm sending this PR.

---

### Description of Change

- Removed `RuntimeHelpers.OffsetToStringData` usage in `MarshalStringToPtr()`.


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

