### PR TITLE
fix: remove deprecated RuntimeHelpers.OffsetToStringData usage

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Diagnostics;
 using MonoGame.Framework.Utilities;
@@ -1591,7 +1590,7 @@ namespace MonoGame.OpenGL
             if (intPtr == IntPtr.Zero) {
                 throw new OutOfMemoryException ();
             }
-            fixed (char* chars = str + RuntimeHelpers.OffsetToStringData / 2) {
+            fixed (char* chars = str) {
                 int bytes = Encoding.ASCII.GetBytes (chars, str.Length, (byte*)((void*)intPtr), num);
                 Marshal.WriteByte (intPtr, bytes, 0);
                 return intPtr;


### PR DESCRIPTION
## Summary

Replaced `str + RuntimeHelpers.OffsetToStringData / 2` with `str` in OpenGL.cs. Modern .NET handles string pinning correctly without manual offset calculation.

Also removed unused `using System.Runtime.CompilerServices;` import.

## Changes

- **File:** `MonoGame.Framework/Platform/Graphics/OpenGL.cs`
- **Line 1594:** `fixed (char* chars = str + RuntimeHelpers.OffsetToStringData / 2)` → `fixed (char* chars = str)`
- **Line 8:** Removed `using System.Runtime.CompilerServices;`

## Why

`RuntimeHelpers.OffsetToStringData` has been deprecated in .NET 9+. In modern .NET, the `fixed` statement with a string directly pins the string and gives you a pointer to the first character. The manual offset calculation is no longer necessary.

This fix only affects the OpenGL path, which is not used on consoles (as noted in the issue).

## Testing

- The fix aligns with modern .NET string pinning behavior
- No functional changes, only removes deprecated API usage

Fixes #9293