### PR TITLE
Repacking native dependencies for MGCB Editor.

### DIFF
--- a/build/DeployTasks/RepackForDeployTask.cs
+++ b/build/DeployTasks/RepackForDeployTask.cs
@@ -19,6 +19,11 @@ public sealed class RepackForDeployTask : FrostingTask<BuildContext>
         // mgcb
         context.DotNetPack(context.GetProjectPath(ProjectType.Tools, "MonoGame.Content.Builder"), context.DotNetPackSettings);
 
+        // Repack mgcb-editor-linux with all existing architectures.
+        // This ensures libmgpipeline.so is shipped for both linux-x64 and linux-arm64.
+        context.DotNetPublish(context.GetProjectPath(ProjectType.MGCBEditor, "Linux"), context.DotNetPublishSettings);
+        context.DotNetPack(context.GetProjectPath(ProjectType.MGCBEditorLauncher, "Linux"), context.DotNetPackSettings);
+
         context.DotNetPackSettings.MSBuildSettings.Properties.Remove("DisableNativeBuild");
     }
 }


### PR DESCRIPTION
Fixes #9410

### Description of Change

- Repacking `MGCBEditor` to include `linux-arm64` dependencies as well.
   - This will run in `RepackForDeployTask` task during the `Deploy` job in the CI/CD pipeline.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

