### PR TITLE
Bumped MessagePack to 2.5.301 due to vulnerability

### DIFF
--- a/Templates/MonoGame.Templates.VSExtension/MonoGame.Templates.VSExtension.csproj
+++ b/Templates/MonoGame.Templates.VSExtension/MonoGame.Templates.VSExtension.csproj
@@ -26,7 +26,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.5.187" />
+    <PackageReference Include="MessagePack" Version="2.5.301" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.11.40262" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.12.2069">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Fixes #

Fixes DependABot vulnerability in MessagePack nugets.


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

