### PR TITLE
Add better error information for the WineHelper

### DIFF
--- a/Tools/MonoGame.Effect.Compiler/Effect/WineHelper.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/WineHelper.cs
@@ -14,6 +14,7 @@ namespace MonoGame.Effect.Compiler
     static class WineHelper
     {
         static string _wineExecutable = "wine";
+        static string _winePathExecutable = "winepath";
 
         static WineHelper()
         {
@@ -22,7 +23,7 @@ namespace MonoGame.Effect.Compiler
                 throw new PlatformNotSupportedException("WineHelper is only supported on Unix platforms.");
             }
 
-            if (!DetectWine() || !SetupWine())
+            if (!DetectWine() || !SetupWine() || !DetectWinePath())
             {
                 var os = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "macos" : "linux";
                 var errMessage = $"Error: MGFXC0001: MGFXC effect compiler requires a valid Wine installation to be able to compile shaders. Please visit https://docs.monogame.net/errors/mgfx0001?tab={os} for more details.";
@@ -31,18 +32,14 @@ namespace MonoGame.Effect.Compiler
             }
         }
 
-        static bool DetectWine()
+        static string Which(params string[] exes)
         {
-            string[] wineCommands = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
-                ["wine64", "wine"] :
-                ["wine", "wine64"];
             var proc = new Process();
-            proc.StartInfo.Arguments = "--version";
             proc.StartInfo.UseShellExecute = false;
             proc.StartInfo.CreateNoWindow = true;
             proc.StartInfo.RedirectStandardOutput = true;
 
-            foreach (var wine in wineCommands)
+            foreach (var wine in exes)
             {
                 proc.StartInfo.FileName = "which";
                 proc.StartInfo.Arguments = wine;
@@ -50,12 +47,25 @@ namespace MonoGame.Effect.Compiler
                 proc.WaitForExit();
                 if (proc.ExitCode == 0)
                 {
-                    _wineExecutable = wine;
-                    return true;
+                    return wine;
                 }
             }
+            return string.Empty;
+        }
 
-            return false;
+        static bool DetectWinePath()
+        {
+            _winePathExecutable =Which("winepath");
+            return !string.IsNullOrEmpty(_winePathExecutable);
+        }
+
+        static bool DetectWine()
+        {
+            string[] wineCommands = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
+                ["wine64", "wine"] :
+                ["wine", "wine64"];
+            _wineExecutable = Which(wineCommands);
+            return !string.IsNullOrEmpty(_wineExecutable);
         }
 
         static bool SetupWine()
@@ -74,16 +84,21 @@ namespace MonoGame.Effect.Compiler
             return true;
         }
 
-        static int RunInWine(string cmd)
+        static int RunInWine(string cmd, out string output)
         {
+            Console.WriteLine($"Running in Wine: {_wineExecutable} {cmd}");
             var proc = new Process();
             proc.StartInfo.FileName = _wineExecutable;
             proc.StartInfo.Arguments = cmd;
             proc.StartInfo.CreateNoWindow = true;
-            proc.StartInfo.UseShellExecute = true;
+            proc.StartInfo.UseShellExecute = false;
+            proc.StartInfo.RedirectStandardOutput = true;
+            proc.StartInfo.RedirectStandardError = true;
 
             proc.Start();
             proc.WaitForExit();
+
+            output = proc.StandardOutput.ReadToEnd() + proc.StandardError.ReadToEnd();
 
             return proc.ExitCode;
         }
@@ -91,7 +106,7 @@ namespace MonoGame.Effect.Compiler
         static string GetWinePath(string path)
         {
             var proc = new Process();
-            proc.StartInfo.FileName = "winepath";
+            proc.StartInfo.FileName = _winePathExecutable;
             proc.StartInfo.Arguments = $"-w \"{path}\"";
             proc.StartInfo.UseShellExecute = false;
             proc.StartInfo.RedirectStandardOutput = true;
@@ -113,20 +128,27 @@ namespace MonoGame.Effect.Compiler
                 File.WriteAllText(srcPath, fileContents);
 
                 var cmd = $"dotnet c:\\fxccs.dll {GetWinePath(srcPath)} {shaderFunction} {shaderProfile} {(int)shaderFlags} {displayPath} {GetWinePath(dstPath)}";
-                var result = RunInWine(cmd);
+                var result = RunInWine(cmd, out string output);
                 if (result == 0)
                 {
                     ret = new CompilationResult(new ShaderBytecode(File.ReadAllBytes(dstPath)), Result.Ok, "");
                 }
+                else
+                {
+                    ret = new CompilationResult(null, Result.Fail, $"\nWine returned exit code {result}.\nOutput:\n{output}");
+                }
             }
-            catch { }
+            catch (Exception e)
+            {
+                ret = new CompilationResult(null, Result.Fail, $"\n{e.Message}");
+            }
 
             File.Delete(srcPath);
             File.Delete(dstPath);
 
-            if (ret == null)
+            if (ret.ResultCode != Result.Ok)
             {
-                throw new Exception("Failed to compile shader!");
+                throw new Exception($"Failed to compile shader!\n{ret.Message}");
             }
 
             return ret;

--- a/Tools/MonoGame.Effect.Compiler/Effect/WineHelper.cs
+++ b/Tools/MonoGame.Effect.Compiler/Effect/WineHelper.cs
@@ -39,15 +39,15 @@ namespace MonoGame.Effect.Compiler
             proc.StartInfo.CreateNoWindow = true;
             proc.StartInfo.RedirectStandardOutput = true;
 
-            foreach (var wine in exes)
+            foreach (var exe in exes)
             {
                 proc.StartInfo.FileName = "which";
-                proc.StartInfo.Arguments = wine;
+                proc.StartInfo.Arguments = exe;
                 proc.Start();
                 proc.WaitForExit();
                 if (proc.ExitCode == 0)
                 {
-                    return wine;
+                    return exe;
                 }
             }
             return string.Empty;


### PR DESCRIPTION
If there is a problem with your wine setup or
the mgfxc fails for any reason all we currently
get is a "Failed to compile shader!" error.

Very helpful.

So lets add some more error handling to print
the actual errors or exceptions that we are getting.

Also add a check for both wine/wine64 AND winepath.
This is because some wine installs do not also symlink
`winepath` into the PATH environment.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

