### PR TITLE
Native GraphicsDevice Cleanup

### DIFF
--- a/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
@@ -162,6 +162,24 @@ public partial class GraphicsDevice
 
     private unsafe void PlatformDispose()
     {
+        foreach (var vb in _userVertexBuffers.Values)
+            vb.Dispose();
+        _userVertexBuffers.Clear();
+
+        if (_userIndexBuffer16 != null)
+        {
+            _userIndexBuffer16.Dispose();
+            _userIndexBuffer16 = null;
+        }
+
+        if (_userIndexBuffer32 != null)
+        {
+            _userIndexBuffer32.Dispose();
+            _userIndexBuffer32 = null;
+        }
+
+        DefaultTexture.Dispose();
+
         if (Handle != null)
         {
             MGG.GraphicsDevice_Destroy(Handle);


### PR DESCRIPTION
A few graphics objects were not freeing themselves before shutting down the GraphicsDevice.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

