### PR TITLE
#9426 Fixed summaries for AlphaDestinationBlend and ColorDestinationBlend

### DIFF
--- a/MonoGame.Framework/Graphics/States/BlendState.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <summary>
         /// Gets or sets the blend factor for the destination alpha, which is the
         /// percentage of the destination alpha included in the blended result.
-        /// The default is <see cref="Blend.One"/>.
+        /// The default is <see cref="Blend.Zero"/>.
         /// </summary>
         /// <value>
         /// A value from the <see cref="Blend"/> enumeration.
@@ -119,7 +119,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         /// <summary>
         /// Gets or sets the blend factor for the destination color.
-        /// The default is <see cref="Blend.One"/>.
+        /// The default is <see cref="Blend.Zero"/>.
         /// </summary>
         /// <value>
         /// A value from the <see cref="Blend"/> enumeration.


### PR DESCRIPTION
Fixes #9426

### Description of Change

This fixes issue #9426. The BlendState class is showing a wrong summary on the AlphaDestinationBlend and ColorDestinationBlend properties, saying that they default to Blend.One, when they in fact default to Blend.Zero.


### Contributor Declaration

- [X] I certify that no LLM's were used to generate any code or documentation in this contribution.

