### PR TITLE
Cleaning up DX12 CommandListPool on dtor

### DIFF
--- a/native/monogame/directx12/CommandQueue.cpp
+++ b/native/monogame/directx12/CommandQueue.cpp
@@ -113,8 +113,7 @@ void CommandQueue::ResumeX() {
 
 CommandListPool::~CommandListPool()
 {
-    auto iter = m_freeContexts.begin();
-    for (; iter != m_freeContexts.end(); iter++)
+    for (auto iter = m_allContexts.begin(); iter != m_allContexts.end(); iter++)
         delete (*iter);
 }
 
@@ -144,6 +143,7 @@ CommandList* CommandListPool::Begin()
     ThrowIfFailed(m_device->CreateCommandAllocator(m_queue->GetType(), IID_GRAPHICS_PPV_ARGS(ctx->m_allocator.GetAddressOf())));
     ThrowIfFailed(m_device->CreateCommandList(0, m_queue->GetType(), ctx->m_allocator.Get(), nullptr, IID_GRAPHICS_PPV_ARGS(ctx->m_list.ReleaseAndGetAddressOf())));
     ctx->m_list->SetName((m_name + L" CommandList").c_str());
+    m_allContexts.push_back(ctx);
 
     return ctx;
 }

--- a/native/monogame/directx12/CommandQueue.h
+++ b/native/monogame/directx12/CommandQueue.h
@@ -57,6 +57,7 @@ class CommandListPool {
     std::wstring m_name;
 
     std::vector<CommandList*> m_freeContexts;
+    std::vector<CommandList*> m_allContexts;
 
 public:
     CommandListPool(ID3D12Device* device, CommandQueue* queue)


### PR DESCRIPTION
Fixes #9443

### Description of Change

- Cleaning up CommandListPool in dtor.


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

