### PR TITLE
added missing state changes in video player

### DIFF
--- a/MonoGame.Framework/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.cs
@@ -202,6 +202,7 @@ namespace Microsoft.Xna.Framework.Media
                 if (state == MediaState.Paused)
                 {
                     PlatformResume();
+                    _state = MediaState.Playing;
                     return;
                 }
             }
@@ -251,10 +252,11 @@ namespace Microsoft.Xna.Framework.Media
             if (state == MediaState.Stopped)
             {
                 PlatformPlay();
-                return;
             }
-
-            PlatformResume();
+            else 
+            {
+                PlatformResume();
+            }
 
             _state = MediaState.Playing;
         }


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes #

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

adding missing state changes in VideoPlayer. Without them, Play() while state is paused resumes playing, but state still says paused, and Resume() from stopped plays, but state still says stopped

### Contributor Declaration

- [X] I certify that no LLM's were used to generate any code or documentation in this contribution.

