### PR TITLE
Fix backbuffer resizing on native

### DIFF
--- a/MonoGame.Framework/Platform/Native/GameWindow.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GameWindow.Native.cs
@@ -185,6 +185,10 @@ internal class NativeGameWindow : GameWindow
 
         MGP.Window_SetClientSize(_handle, width, height);
 
+        _platform.Game.GraphicsDevice.PresentationParameters.BackBufferWidth = width;
+        _platform.Game.GraphicsDevice.PresentationParameters.BackBufferHeight = height;
+        _platform.Game.GraphicsDevice.Viewport = new Viewport(0, 0, width, height);
+
         OnClientSizeChanged();
     }
 

--- a/Tests/Framework/Graphics/GraphicsDeviceManagerTest.cs
+++ b/Tests/Framework/Graphics/GraphicsDeviceManagerTest.cs
@@ -394,6 +394,22 @@ namespace MonoGame.Tests.Graphics
             Assert.AreEqual(0, count);
         }
 
+#if VULKAN || DIRECTX12
+        [Test]
+        public void BackBufferAndViewportUpdateOnResize()
+        {
+            int width = 100;
+            int height = 50;
+
+            ((NativeGameWindow)game.Window).ClientResize(width, height);
+
+            Assert.AreEqual(width, gd.PresentationParameters.BackBufferWidth);
+            Assert.AreEqual(height, gd.PresentationParameters.BackBufferHeight);
+            Assert.AreEqual(width, gd.Viewport.Width);
+            Assert.AreEqual(height, gd.Viewport.Height);
+        }
+#endif
+
         [Test]
 #if DESKTOPGL
         [Ignore("Expected 2 but got 3. Needs Investigating")]


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes #9468

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

Fixes an issue where the `BackBufferWidth` and `BackBufferHeight` were not being updated on the native backends (Vulkan/DX12).

This just does the same thing DesktopGL does and updates the `BackBufferWidth`, `BackBufferHeight` and `Viewport` directly without modifying the PreferredBackBufferWidth/Height

I'm not sure if the PreferredBackBufferHeight/Width should be updated and `ApplyChanges()` called instead, but that would be different from the current DesktopGL implementation.

<!-- 
Enter description of the fix in this section.
Please be as descriptive as possible, future contributors will need to know *why* these changes are being made.
For inspiration review the commit/PR history in the MonoGame repository.
-->


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

