### PR TITLE
Added [Pure] Annotations to functions

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 ﻿
 using System;
+using System.Diagnostics.Contracts;
 using System.IO;
 
 namespace Microsoft.Xna.Framework.Audio
@@ -293,6 +294,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// <param name="sampleRate">Sample rate, in Hertz (Hz). Must be between 8000 Hz and 48000 Hz</param>
         /// <param name="channels">Number of channels in the audio data.</param>
         /// <returns>The duration of the audio data.</returns>
+        [Pure]
         public static TimeSpan GetSampleDuration(int sizeInBytes, int sampleRate, AudioChannels channels)
         {
             if (sizeInBytes < 0)
@@ -324,6 +326,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// <param name="sampleRate">Sample rate, in Hertz (Hz), of audio data. Must be between 8,000 and 48,000 Hz.</param>
         /// <param name="channels">Number of channels in the audio data.</param>
         /// <returns>The size in bytes of a single sample of audio data.</returns>
+        [Pure]
         public static int GetSampleSizeInBytes(TimeSpan duration, int sampleRate, AudioChannels channels)
         {
             if (duration < TimeSpan.Zero || duration > TimeSpan.FromMilliseconds(0x7FFFFFF))

--- a/MonoGame.Framework/Audio/Xact/AudioCategory.cs
+++ b/MonoGame.Framework/Audio/Xact/AudioCategory.cs
@@ -3,9 +3,10 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.Diagnostics;
-using System.IO;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.IO;
 
 namespace Microsoft.Xna.Framework.Audio
 {
@@ -151,6 +152,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// <param name="first">First AudioCategory instance to compare.</param>
         /// <param name="second">Second AudioCategory instance to compare.</param>
         /// <returns>true if the objects are equal or false if they aren't.</returns>
+        [Pure]
         public static bool operator ==(AudioCategory first, AudioCategory second)
         {
             return first._engine == second._engine && first._name.Equals(second._name, StringComparison.Ordinal);
@@ -162,6 +164,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// <param name="first">First AudioCategory instance to compare.</param>
         /// <param name="second">Second AudioCategory instance to compare.</param>
         /// <returns>true if the objects are not equal or false if they are.</returns>
+        [Pure]
         public static bool operator !=(AudioCategory first, AudioCategory second)
         {
             return first._engine != second._engine || !first._name.Equals(second._name, StringComparison.Ordinal);

--- a/MonoGame.Framework/Audio/Xact/XactHelpers.cs
+++ b/MonoGame.Framework/Audio/Xact/XactHelpers.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Audio
 {
@@ -10,6 +11,7 @@ namespace Microsoft.Xna.Framework.Audio
 	{
         static internal readonly Random Random = new Random();
 
+        [Pure]
         public static float ParseDecibels(byte decibles)
         {
             //lazy 4-param fitting:
@@ -30,6 +32,7 @@ namespace Microsoft.Xna.Framework.Audio
             return dB;
         }
 
+        [Pure]
         public static float ParseVolumeFromDecibels(byte decibles)
         {
             //lazy 4-param fitting:
@@ -50,6 +53,7 @@ namespace Microsoft.Xna.Framework.Audio
             return ParseVolumeFromDecibels(dB);
         }
 
+        [Pure]
         public static float ParseVolumeFromDecibels(float decibles)
         {
             // Convert from decibles to linear volume.

--- a/MonoGame.Framework/BoundingBox.cs
+++ b/MonoGame.Framework/BoundingBox.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -389,6 +390,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="count">The number of points to iterate</param>
         /// <returns>A bounding box that encapsulates the given point cloud.</returns>
         /// <exception cref="System.ArgumentException">Thrown if the given array is null or has no points.</exception>
+        [Pure]
         public static BoundingBox CreateFromPoints(Vector3[] points, int index = 0, int count = -1)
         {
             if (points == null || points.Length == 0)
@@ -422,6 +424,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="count">The number of points to iterate</param>
         /// <returns>A bounding box that encapsulates the given point cloud.</returns>
         /// <exception cref="System.ArgumentException">Thrown if the given list is null or has no points.</exception>
+        [Pure]
         public static BoundingBox CreateFromPoints(List<Vector3> points, int index = 0, int count = -1)
         {
             if (points == null || points.Count == 0)
@@ -453,6 +456,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="points">The list of <see cref="Vector3"/> instances defining the point cloud to bound.</param>
         /// <returns>A <see cref="BoundingBox"/> that encloses the given point cloud.</returns>
         /// <exception cref="System.ArgumentException">Thrown if the given list has no points.</exception>
+        [Pure]
         public static BoundingBox CreateFromPoints(IEnumerable<Vector3> points)
         {
             if (points == null)
@@ -484,6 +488,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="sphere">The <see cref="BoundingSphere"/> to enclose.</param>
         /// <returns>A <see cref="BoundingBox"/> enclosing <paramref name="sphere"/>.</returns>
+        [Pure]
         public static BoundingBox CreateFromSphere(BoundingSphere sphere)
         {
             BoundingBox result;
@@ -511,6 +516,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>
         ///   The <see cref="BoundingBox"/> enclosing <paramref name="original"/> and <paramref name="additional"/>.
         /// </returns>
+        [Pure]
         public static BoundingBox CreateMerged(BoundingBox original, BoundingBox additional)
         {
             BoundingBox result;
@@ -841,6 +847,7 @@ namespace Microsoft.Xna.Framework
         ///   <code>true</code> if <paramref name="a"/> is equal to this <paramref name="b"/>,
         ///   <code>false</code> if it is not.
         /// </returns>
+        [Pure]
         public static bool operator ==(BoundingBox a, BoundingBox b)
         {
             return a.Equals(b);
@@ -855,6 +862,7 @@ namespace Microsoft.Xna.Framework
         ///   <code>true</code> if <paramref name="a"/> is not equal to this <paramref name="b"/>,
         ///   <code>false</code> if it is.
         /// </returns>
+        [Pure]
         public static bool operator !=(BoundingBox a, BoundingBox b)
         {
             return !a.Equals(b);

--- a/MonoGame.Framework/BoundingFrustum.cs
+++ b/MonoGame.Framework/BoundingFrustum.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework
 {
@@ -143,6 +144,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a"><see cref="BoundingFrustum"/> instance on the left of the equal sign.</param>
         /// <param name="b"><see cref="BoundingFrustum"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator ==(BoundingFrustum a, BoundingFrustum b)
         {
             if (Equals(a, null))
@@ -160,6 +162,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a"><see cref="BoundingFrustum"/> instance on the left of the not equal sign.</param>
         /// <param name="b"><see cref="BoundingFrustum"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator !=(BoundingFrustum a, BoundingFrustum b)
         {
             return !(a == b);

--- a/MonoGame.Framework/BoundingSphere.cs
+++ b/MonoGame.Framework/BoundingSphere.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -242,6 +243,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="box">The box to create the sphere from.</param>
         /// <returns>The new <see cref="BoundingSphere"/>.</returns>
+        [Pure]
         public static BoundingSphere CreateFromBoundingBox(BoundingBox box)
         {
             BoundingSphere result;
@@ -274,6 +276,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="frustum">The frustum to create the sphere from.</param>
         /// <returns>The new <see cref="BoundingSphere"/>.</returns>
+        [Pure]
         public static BoundingSphere CreateFromFrustum(BoundingFrustum frustum)
         {
             return CreateFromPoints(frustum.GetCorners());
@@ -284,6 +287,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="points">List of point to create the sphere from.</param>
         /// <returns>The new <see cref="BoundingSphere"/>.</returns>
+        [Pure]
         public static BoundingSphere CreateFromPoints(IEnumerable<Vector3> points)
         {
             if (points == null )
@@ -371,6 +375,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="original">First sphere.</param>
         /// <param name="additional">Second sphere.</param>
         /// <returns>The new <see cref="BoundingSphere"/>.</returns>
+        [Pure]
         public static BoundingSphere CreateMerged(BoundingSphere original, BoundingSphere additional)
         {
             BoundingSphere result;
@@ -618,6 +623,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a"><see cref="BoundingSphere"/> instance on the left of the equal sign.</param>
         /// <param name="b"><see cref="BoundingSphere"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator == (BoundingSphere a, BoundingSphere b)
         {
             return a.Equals(b);
@@ -629,6 +635,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a"><see cref="BoundingSphere"/> instance on the left of the not equal sign.</param>
         /// <param name="b"><see cref="BoundingSphere"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator != (BoundingSphere a, BoundingSphere b)
         {
             return !a.Equals(b);

--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -3,9 +3,10 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.Text;
-using System.Runtime.Serialization;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Runtime.Serialization;
+using System.Text;
 
 namespace Microsoft.Xna.Framework
 {
@@ -392,6 +393,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">The converted value.</param>
         /// <returns></returns>
+        [Pure]
         public static implicit operator Color(System.Numerics.Vector4 value)
         {
             return new Color(value.X, value.Y, value.Z, value.W);
@@ -403,6 +405,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a"><see cref="Color"/> instance on the left of the equal sign.</param>
         /// <param name="b"><see cref="Color"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator ==(Color a, Color b)
         {
             return (a._packedValue == b._packedValue);
@@ -414,6 +417,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a"><see cref="Color"/> instance on the left of the not equal sign.</param>
         /// <param name="b"><see cref="Color"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
+        [Pure]
         public static bool operator !=(Color a, Color b)
         {
             return (a._packedValue != b._packedValue);
@@ -1724,6 +1728,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">Destination <see cref="Color"/>.</param>
         /// <param name="amount">Interpolation factor.</param>
         /// <returns>Interpolated <see cref="Color"/>.</returns>
+        [Pure]
         public static Color Lerp(Color value1, Color value2, Single amount)
         {
             amount = MathHelper.Clamp(amount, 0, 1);
@@ -1755,6 +1760,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">The source color value to multiply.</param>
         /// <param name="scale">The value to multiply the RGBA component values by.</param>
         /// <returns>The new color value created as a result of the multiplication.</returns>
+        [Pure]
         public static Color Multiply(Color value, float scale)
         {
             return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
@@ -1766,6 +1772,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">The source color value to multiply.</param>
         /// <param name="scale">The value to multiply the Alpha component value by.</param>
         /// <returns>The new color value created as a result of the multiplication.</returns>
+        [Pure]
         public static Color MultiplyAlpha(Color value, float scale)
         {
             return new Color(value.R, value.G, value.B, (int)(value.A * scale));
@@ -1777,6 +1784,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">The source color value to multiply.</param>
         /// <param name="scale">The value to multiply the RGBA component values by.</param>
         /// <returns>The new color value created as a result of the multiplication.</returns>
+        [Pure]
         public static Color operator *(Color value, float scale)
         {
             return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
@@ -1788,6 +1796,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="scale">The value to multiply the RGBA component values by.</param>
         /// <param name="value">The source color value to multiply.</param>
         /// <returns>The new color value created as a result of the multiplication.</returns>
+        [Pure]
         public static Color operator *(float scale, Color value)
         {
             return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
@@ -1799,6 +1808,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="color1">The first color to be multiplied.</param>
         /// <param name="color2">The second color to be multiplied.</param>
         /// <returns>The new color value created as a result of the multiplication.</returns>
+        [Pure]
         public static Color operator *(Color color1, Color color2)
         {
             return new Color(
@@ -1813,6 +1823,7 @@ namespace Microsoft.Xna.Framework
         /// Gets a <see cref="Vector3"/> representation for this object.
         /// </summary>
         /// <returns>A <see cref="Vector3"/> representation for this object.</returns>
+        [Pure]
         public Vector3 ToVector3()
         {
             return new Vector3(R / 255.0f, G / 255.0f, B / 255.0f);
@@ -1822,6 +1833,7 @@ namespace Microsoft.Xna.Framework
         /// Gets a <see cref="Vector4"/> representation for this object.
         /// </summary>
         /// <returns>A <see cref="Vector4"/> representation for this object.</returns>
+        [Pure]
         public Vector4 ToVector4()
         {
             return new Vector4(R / 255.0f, G / 255.0f, B / 255.0f, A / 255.0f);
@@ -1876,6 +1888,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="color">A <see cref="Color"/> representing a non-premultiplied color.</param>
         /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
+        [Pure]
         public static Color FromNonPremultiplied(Color color)
         {
             return FromNonPremultiplied(color.R, color.G, color.B, color.A);
@@ -1886,6 +1899,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="vector">A <see cref="Vector4"/> representing color.</param>
         /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
+        [Pure]
         public static Color FromNonPremultiplied(Vector4 vector)
         {
             return new Color(vector.X * vector.W, vector.Y * vector.W, vector.Z * vector.W, vector.W);
@@ -1899,6 +1913,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="b">Blue component value from 0.0f to 1.0f.</param>
         /// <param name="a">Alpha component value from 0.0f to 1.0f.</param>
         /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
+        [Pure]
         public static Color FromNonPremultiplied(float r, float g, float b, float a)
         {
             return new Color(r * a, g * a, b * a, a);
@@ -1912,6 +1927,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="b">Blue component value from 0 to 255.</param>
         /// <param name="a">Alpha component value from 0 to 255.</param>
         /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
+        [Pure]
         public static Color FromNonPremultiplied(int r, int g, int b, int a)
         {
             return new Color(r * a / 255, g * a / 255, b * a / 255, a);
@@ -2071,7 +2087,7 @@ namespace Microsoft.Xna.Framework
             else
                 return c;
         }
-        
+
         /// <summary>
         /// Creates a <see cref="Color"/> from HSL values
         /// </summary>
@@ -2079,6 +2095,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="s">Saturation component value, from 0.0f to 100.0f</param>
         /// <param name="l">Luminosity (brightness) component value, from 0.0f to 100.0f</param>
         /// <returns><see cref="Color"/> with the HSL values</returns>
+        [Pure]
         public static Color FromHSL(float h, float s, float l)
         {
             s /= 100;
@@ -2110,7 +2127,7 @@ namespace Microsoft.Xna.Framework
             return new Color(r, g, b);
 
         }
-        
+
         /// <summary>
         /// Creates a <see cref="Color"/> from HSV values. 
         /// </summary>
@@ -2118,6 +2135,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="s">Saturation component value, ranging from 0.0f to 1.0f</param>
         /// <param name="v">Value component value, ranging from 0.0f to 1.0f</param>
         /// <returns><see cref="Color"/> with the HSV values</returns>
+        [Pure]
         public static Color FromHSV(float h, float s, float v)
         {
             //defining values for easier colour conversion at end

--- a/MonoGame.Framework/CurveKey.cs
+++ b/MonoGame.Framework/CurveKey.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -137,6 +138,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1"><see cref="CurveKey"/> instance on the left of the not equal sign.</param>
         /// <param name="value2"><see cref="CurveKey"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
+        [Pure]
         public static bool operator !=(CurveKey value1, CurveKey value2)
         {
             return !(value1 == value2);
@@ -148,6 +150,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1"><see cref="CurveKey"/> instance on the left of the equal sign.</param>
         /// <param name="value2"><see cref="CurveKey"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator ==(CurveKey value1, CurveKey value2)
         {
             if (object.Equals(value1, null))

--- a/MonoGame.Framework/Design/VectorConversion.cs
+++ b/MonoGame.Framework/Design/VectorConversion.cs
@@ -1,13 +1,15 @@
-﻿using System;
+﻿using Microsoft.Xna.Framework.Graphics.PackedVector;
+using System;
 using System.ComponentModel;
-using System.Globalization;
-using Microsoft.Xna.Framework.Graphics.PackedVector;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
+using System.Globalization;
 
 namespace Microsoft.Xna.Framework.Design
 {
     internal static class VectorConversion
     {
+        [Pure]
         public static bool CanConvertTo(ITypeDescriptorContext context, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type destinationType)
         {
             if (destinationType == typeof(float))
@@ -24,6 +26,7 @@ namespace Microsoft.Xna.Framework.Design
             return false;
         }
 
+        [Pure]
         public static object ConvertToFromVector4(ITypeDescriptorContext context, CultureInfo culture, Vector4 value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type destinationType)
         {
             if (destinationType == typeof(float))

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
@@ -1176,6 +1177,7 @@ namespace Microsoft.Xna.Framework
                 Item = item;
             }
 
+            [Pure]
             public static AddJournalEntry<T> CreateKey(T item)
             {
                 return new AddJournalEntry<T>(-1, item);

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -29,6 +29,7 @@ SOFTWARE.
 #endregion License
 
 using System;
+using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Runtime.Serialization;
 
@@ -107,6 +108,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="left">The DisplayMode object on the left of the inequality operator.</param>
         /// <param name="right">The DisplayMode object on the right of the inequality operator.</param>
         /// <returns>true if the objects are different; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(DisplayMode left, DisplayMode right)
         {
             return !(left == right);
@@ -119,6 +121,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="left">The DisplayMode object on the left of the equality operator.</param>
         /// <param name="right">The DisplayMode object on the right of the equality operator.</param>
         /// <returns>true if the objects are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(DisplayMode left, DisplayMode right)
         {
             if (ReferenceEquals(left, right)) //Same object or both are null

--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
+
 
 #if OPENGL
 #if DESKTOPGL || GLES
@@ -20,6 +22,7 @@ namespace Microsoft.Xna.Framework.Graphics
     static class GraphicsExtensions
     {
 #if OPENGL
+        [Pure]
         public static int OpenGLNumberOfElements(this VertexElementFormat elementFormat)
         {
             switch (elementFormat)
@@ -64,6 +67,7 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new ArgumentException();
         }
 
+        [Pure]
         public static VertexPointerType OpenGLVertexPointerType(this VertexElementFormat elementFormat)
         {
             switch (elementFormat)
@@ -108,7 +112,8 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new ArgumentException();
         }
 
-		public static VertexAttribPointerType OpenGLVertexAttribPointerType(this VertexElementFormat elementFormat)
+        [Pure]
+        public static VertexAttribPointerType OpenGLVertexAttribPointerType(this VertexElementFormat elementFormat)
         {
             switch (elementFormat)
             {
@@ -154,6 +159,7 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new ArgumentException();
         }
 
+        [Pure]
         public static bool OpenGLVertexAttribNormalized(this VertexElement element)
         {
             // TODO: This may or may not be the right behavor.  
@@ -178,6 +184,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        [Pure]
         public static ColorPointerType OpenGLColorPointerType(this VertexElementFormat elementFormat)
         {
             switch (elementFormat)
@@ -224,7 +231,8 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new ArgumentException();
         }
 
-       public static NormalPointerType OpenGLNormalPointerType(this VertexElementFormat elementFormat)
+        [Pure]
+        public static NormalPointerType OpenGLNormalPointerType(this VertexElementFormat elementFormat)
         {
             switch (elementFormat)
             {
@@ -270,7 +278,8 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new ArgumentException();
         }
 
-       public static TexCoordPointerType OpenGLTexCoordPointerType(this VertexElementFormat elementFormat)
+        [Pure]
+        public static TexCoordPointerType OpenGLTexCoordPointerType(this VertexElementFormat elementFormat)
         {
             switch (elementFormat)
             {
@@ -316,8 +325,9 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new ArgumentException();
         }
 
-		
-		public static BlendEquationMode GetBlendEquationMode (this BlendFunction function)
+
+        [Pure]
+        public static BlendEquationMode GetBlendEquationMode (this BlendFunction function)
 		{
 			switch (function) {
 			case BlendFunction.Add:
@@ -338,7 +348,8 @@ namespace Microsoft.Xna.Framework.Graphics
 			}
 		}
 
-		public static BlendingFactorSrc GetBlendFactorSrc (this Blend blend)
+        [Pure]
+        public static BlendingFactorSrc GetBlendFactorSrc (this Blend blend)
 		{
 			switch (blend) {
             case Blend.BlendFactor:
@@ -373,7 +384,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		}
 
-		public static BlendingFactorDest GetBlendFactorDest (this Blend blend)
+        [Pure]
+        public static BlendingFactorDest GetBlendFactorDest (this Blend blend)
 		{
 			switch (blend) {
             case Blend.BlendFactor:
@@ -408,6 +420,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		}
 
+        [Pure]
         public static DepthFunction GetDepthFunction(this CompareFunction compare)
         {
             switch (compare)
@@ -439,6 +452,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         /// <returns>An OpenTK.Graphics.ColorFormat instance.</returns>
         /// <param name="format">The <see cref="SurfaceFormat"/> to convert.</param>
+        [Pure]
         internal static ColorFormat GetColorFormat(this SurfaceFormat format)
         {
             switch (format)
@@ -472,6 +486,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         /// <returns>A value according to EXT_swap_control</returns>
         /// <param name="interval">The <see cref="PresentInterval"/> to convert.</param>
+        [Pure]
         internal static int GetSwapInterval(this PresentInterval interval)
         {
             // See http://www.opengl.org/registry/specs/EXT/swap_control.txt
@@ -497,7 +512,9 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
 
         const SurfaceFormat InvalidFormat = (SurfaceFormat)int.MaxValue;
-		internal static void GetGLFormat (this SurfaceFormat format,
+
+        [Pure]
+        internal static void GetGLFormat (this SurfaceFormat format,
             GraphicsDevice graphicsDevice,
             out PixelInternalFormat glInternalFormat,
             out PixelFormat glFormat,
@@ -919,6 +936,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        [Pure]
         public static int GetSize(this VertexElementFormat elementFormat)
         {
             switch (elementFormat)
@@ -962,6 +980,7 @@ namespace Microsoft.Xna.Framework.Graphics
             return 0;
         }
 
+        [Pure]
         public static void GetBlockSize(this SurfaceFormat surfaceFormat, out int width, out int height)
         {
             switch (surfaceFormat)

--- a/MonoGame.Framework/Graphics/GraphicsMetrics.cs
+++ b/MonoGame.Framework/Graphics/GraphicsMetrics.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Diagnostics.Contracts;
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
@@ -64,6 +66,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="value1">Source <see cref="GraphicsMetrics"/> on the left of the sub sign.</param>
         /// <param name="value2">Source <see cref="GraphicsMetrics"/> on the right of the sub sign.</param>
         /// <returns>Difference between two sets of metrics.</returns>
+        [Pure]
         public static GraphicsMetrics operator -(GraphicsMetrics value1, GraphicsMetrics value2)
         {
             return new GraphicsMetrics()
@@ -85,6 +88,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="value1">Source <see cref="GraphicsMetrics"/> on the left of the add sign.</param>
         /// <param name="value2">Source <see cref="GraphicsMetrics"/> on the right of the add sign.</param>
         /// <returns>Combination of two sets of metrics.</returns>
+        [Pure]
         public static GraphicsMetrics operator +(GraphicsMetrics value1, GraphicsMetrics value2)
         {
             return new GraphicsMetrics()

--- a/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -95,6 +96,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the equality operator.</param>
         /// <param name="rhs">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(Alpha8 lhs, Alpha8 rhs)
         {
             return lhs.packedValue == rhs.packedValue;
@@ -106,6 +108,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the inequality operator.</param>
         /// <param name="rhs">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(Alpha8 lhs, Alpha8 rhs)
         {
             return lhs.packedValue != rhs.packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -117,6 +118,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the equality operator.</param>
         /// <param name="rhs">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(Bgr565 lhs, Bgr565 rhs)
         {
             return lhs._packedValue == rhs._packedValue;
@@ -128,6 +130,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the inequality operator.</param>
         /// <param name="rhs">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(Bgr565 lhs, Bgr565 rhs)
         {
             return lhs._packedValue != rhs._packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -110,6 +111,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the equality operator.</param>
         /// <param name="rhs">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(Bgra4444 lhs, Bgra4444 rhs)
         {
             return lhs._packedValue == rhs._packedValue;
@@ -121,6 +123,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the inequality operator.</param>
         /// <param name="rhs">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(Bgra4444 lhs, Bgra4444 rhs)
         {
             return lhs._packedValue != rhs._packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -101,6 +102,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the equality operator.</param>
         /// <param name="rhs">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(Bgra5551 lhs, Bgra5551 rhs)
         {
             return lhs.packedValue == rhs.packedValue;
@@ -112,6 +114,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the inequality operator.</param>
         /// <param name="rhs">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(Bgra5551 lhs, Bgra5551 rhs)
         {
             return lhs.packedValue != rhs.packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -56,6 +57,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the inequality operator.</param>
         /// <param name="b">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(Byte4 a, Byte4 b)
         {
             return a.PackedValue != b.PackedValue;
@@ -67,6 +69,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the equality operator.</param>
         /// <param name="b">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(Byte4 a, Byte4 b)
         {
             return a.PackedValue == b.PackedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -95,6 +96,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the equality operator.</param>
         /// <param name="rhs">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(HalfSingle lhs, HalfSingle rhs)
         {
             return lhs.packedValue == rhs.packedValue;
@@ -106,6 +108,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the inequality operator.</param>
         /// <param name="rhs">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(HalfSingle lhs, HalfSingle rhs)
         {
             return lhs.packedValue != rhs.packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -109,6 +110,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the equality operator.</param>
         /// <param name="b">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(HalfVector4 a, HalfVector4 b)
         {
             return a.Equals(b);
@@ -120,6 +122,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the inequality operator.</param>
         /// <param name="b">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(HalfVector4 a, HalfVector4 b)
         {
             return !a.Equals(b);

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -45,6 +46,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the inequality operator.</param>
         /// <param name="b">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(NormalizedByte2 a, NormalizedByte2 b)
         {
             return a._packed != b._packed;
@@ -56,6 +58,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the equality operator.</param>
         /// <param name="b">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(NormalizedByte2 a, NormalizedByte2 b)
         {
             return a._packed == b._packed;

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -47,6 +48,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the inequality operator.</param>
         /// <param name="b">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(NormalizedByte4 a, NormalizedByte4 b)
         {
             return a._packed != b._packed;
@@ -58,6 +60,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the equality operator.</param>
         /// <param name="b">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(NormalizedByte4 a, NormalizedByte4 b)
         {
             return a._packed == b._packed;

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -46,6 +47,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the inequality operator.</param>
         /// <param name="b">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(NormalizedShort2 a, NormalizedShort2 b)
 		{
 			return !a.Equals (b);
@@ -57,6 +59,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the equality operator.</param>
         /// <param name="b">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(NormalizedShort2 a, NormalizedShort2 b)
 		{
 			return a.Equals (b);

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -47,6 +48,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the inequality operator.</param>
         /// <param name="b">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(NormalizedShort4 a, NormalizedShort4 b)
 		{
 			return !a.Equals (b);
@@ -58,6 +60,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the equality operator.</param>
         /// <param name="b">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(NormalizedShort4 a, NormalizedShort4 b)
 		{
 			return a.Equals (b);

--- a/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -105,6 +106,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the equality operator.</param>
         /// <param name="rhs">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(Rg32 lhs, Rg32 rhs)
         {
             return lhs.packedValue == rhs.packedValue;
@@ -116,6 +118,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the inequality operator.</param>
         /// <param name="rhs">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(Rg32 lhs, Rg32 rhs)
         {
             return lhs.packedValue != rhs.packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -101,6 +102,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the equality operator.</param>
         /// <param name="rhs">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(Rgba1010102 lhs, Rgba1010102 rhs)
         {
             return lhs.packedValue == rhs.packedValue;
@@ -112,6 +114,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the inequality operator.</param>
         /// <param name="rhs">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(Rgba1010102 lhs, Rgba1010102 rhs)
         {
             return lhs.packedValue != rhs.packedValue;

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -100,7 +101,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the equality operator.</param>
         /// <param name="rhs">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
-		public static bool operator ==(Rgba64 lhs, Rgba64 rhs)
+		[Pure]
+        public static bool operator ==(Rgba64 lhs, Rgba64 rhs)
 		{
 			return lhs.packedValue == rhs.packedValue;
 		}
@@ -111,7 +113,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="lhs">The value on the left of the inequality operator.</param>
         /// <param name="rhs">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
-		public static bool operator !=(Rgba64 lhs, Rgba64 rhs)
+		[Pure]
+        public static bool operator !=(Rgba64 lhs, Rgba64 rhs)
 		{
 			return lhs.packedValue != rhs.packedValue;
 		}

--- a/MonoGame.Framework/Graphics/PackedVector/Short2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short2.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -46,7 +47,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the inequality operator.</param>
         /// <param name="b">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
-		public static bool operator !=(Short2 a, Short2 b)
+		[Pure]
+        public static bool operator !=(Short2 a, Short2 b)
 		{
 			return a.PackedValue != b.PackedValue;
 		}
@@ -57,7 +59,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the equality operator.</param>
         /// <param name="b">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
-		public static bool operator ==(Short2 a, Short2 b)
+		[Pure]
+        public static bool operator ==(Short2 a, Short2 b)
 		{
 			return a.PackedValue == b.PackedValue;
 		}

--- a/MonoGame.Framework/Graphics/PackedVector/Short4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short4.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
@@ -47,6 +48,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the inequality operator.</param>
         /// <param name="b">The value on the right of the inequality operator.</param>
         /// <returns>true if the two value are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(Short4 a, Short4 b)
         {
             return a.PackedValue != b.PackedValue;
@@ -58,6 +60,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <param name="a">The value on the left of the equality operator.</param>
         /// <param name="b">The value on the right of the equality operator.</param>
         /// <returns>true if the two values are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(Short4 a, Short4 b)
         {
             return a.PackedValue == b.PackedValue;

--- a/MonoGame.Framework/Graphics/RenderTargetBinding.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetBinding.cs
@@ -5,6 +5,7 @@
 // Author: Kenneth James Pouncey
 
 using System;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -91,6 +92,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// The <paramref name="arraySlice" /> is less than zero or greater than the array size of the render target
         /// </exception>
         /// <exception cref="InvalidOperationException">Texture arrays are not supported by the current graphics device.</exception>
+        [Pure]
         public RenderTargetBinding(RenderTarget2D renderTarget, int arraySlice)
         {
             if (renderTarget == null)
@@ -148,6 +150,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         /// <param name="renderTarget">The render target to convert.</param>
         /// <returns>A new <b>RenderTargetBinding</b> instance bound to the specified render target.</returns>
+        [Pure]
         public static implicit operator RenderTargetBinding(RenderTarget2D renderTarget)
         {
             return new RenderTargetBinding(renderTarget);
@@ -160,11 +163,12 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         /// <param name="renderTarget">The render target to convert.</param>
         /// <returns>A new <b>RenderTargetBinding</b> instance bound to the specified render target.</returns>
+        [Pure]
         public static implicit operator RenderTargetBinding(RenderTarget3D renderTarget)
         {
             return new RenderTargetBinding(renderTarget);
         }
 
 #endif
-	}
+    }
 }

--- a/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.cs
@@ -2,10 +2,11 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using MonoGame.Framework.Utilities;
 using System;
 using System.Collections.Generic;
-using MonoGame.Framework.Utilities;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -294,6 +295,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <see langword="true"/> if the <paramref name="left"/> and <paramref name="right"/> are
         /// the same; otherwise, <see langword="false"/>.
         /// </returns>
+        [Pure]
         public static bool operator ==(VertexDeclaration left, VertexDeclaration right)
         {
             return Equals(left, right);
@@ -309,6 +311,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <see langword="true"/> if the <paramref name="left"/> and <paramref name="right"/> are
         /// the different; otherwise, <see langword="false"/>.
         /// </returns>
+        [Pure]
         public static bool operator !=(VertexDeclaration left, VertexDeclaration right)
         {
             return !Equals(left, right);

--- a/MonoGame.Framework/Graphics/Vertices/VertexElement.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexElement.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -156,6 +157,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <see langword="true"/> if the <paramref name="left"/> and <paramref name="right"/> are
         /// the same; otherwise, <see langword="false"/>.
         /// </returns>
+        [Pure]
         public static bool operator ==(VertexElement left, VertexElement right)
         {
             return left.Equals(right);
@@ -171,6 +173,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <see langword="true"/> if the <paramref name="left"/> and <paramref name="right"/> are
         /// the different; otherwise, <see langword="false"/>.
         /// </returns>
+        [Pure]
         public static bool operator !=(VertexElement left, VertexElement right)
         {
             return !left.Equals(right);

--- a/MonoGame.Framework/Graphics/Vertices/VertexInputLayout.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexInputLayout.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -142,6 +143,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <see langword="true"/> if the <paramref name="left"/> and <paramref name="right"/> are
         /// the same; otherwise, <see langword="false"/>.
         /// </returns>
+        [Pure]
         public static bool operator ==(VertexInputLayout left, VertexInputLayout right)
         {
             return Equals(left, right);
@@ -157,6 +159,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <see langword="true"/> if the <paramref name="left"/> and <paramref name="right"/> are
         /// the different; otherwise, <see langword="false"/>.
         /// </returns>
+        [Pure]
         public static bool operator !=(VertexInputLayout left, VertexInputLayout right)
         {
             return !Equals(left, right);

--- a/MonoGame.Framework/Graphics/Vertices/VertexPosition.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPosition.cs
@@ -2,8 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System.Runtime.Serialization;
+using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -59,6 +60,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the vertices are the same; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator == (VertexPosition left, VertexPosition right)
 		{
 			return left.Position == right.Position;
@@ -72,6 +74,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the vertices are different; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator != (VertexPosition left, VertexPosition right)
 		{
 			return !(left == right);

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColor.cs
@@ -1,6 +1,7 @@
 using System;
-using System.Runtime.Serialization;
+using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -66,6 +67,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator == (VertexPositionColor left, VertexPositionColor right)
 		{
 			return ((left.Color == right.Color) && (left.Position == right.Position));
@@ -79,6 +81,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator != (VertexPositionColor left, VertexPositionColor right)
 		{
 			return !(left == right);

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormal.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormal.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -65,6 +66,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator ==(VertexPositionColorNormal left, VertexPositionColorNormal right)
         {
             return (((left.Position == right.Position) && (left.Color == right.Color)) && (left.Normal == right.Normal));
@@ -78,6 +80,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator !=(VertexPositionColorNormal left, VertexPositionColorNormal right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormalTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorNormalTexture.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -70,6 +71,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator ==(VertexPositionColorNormalTexture left, VertexPositionColorNormalTexture right)
         {
             return (((left.Position == right.Position) && (left.Color == right.Color)) && (left.Normal == right.Normal) && (left.TextureCoordinate == right.TextureCoordinate));
@@ -83,6 +85,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator !=(VertexPositionColorNormalTexture left, VertexPositionColorNormalTexture right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionColorTexture.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -65,6 +66,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator ==(VertexPositionColorTexture left, VertexPositionColorTexture right)
         {
             return (((left.Position == right.Position) && (left.Color == right.Color)) && (left.TextureCoordinate == right.TextureCoordinate));
@@ -78,6 +80,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator !=(VertexPositionColorTexture left, VertexPositionColorTexture right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionNormalTexture.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -67,6 +68,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator ==(VertexPositionNormalTexture left, VertexPositionNormalTexture right)
         {
             return (((left.Position == right.Position) && (left.Normal == right.Normal)) && (left.TextureCoordinate == right.TextureCoordinate));
@@ -80,6 +82,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator !=(VertexPositionNormalTexture left, VertexPositionNormalTexture right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexPositionTexture.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Diagnostics.Contracts;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -59,6 +60,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the vertices are the same; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator ==(VertexPositionTexture left, VertexPositionTexture right)
         {
             return ((left.Position == right.Position) && (left.TextureCoordinate == right.TextureCoordinate));
@@ -72,6 +74,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <returns>
         /// <see langword="true"/> if the vertices are different; <see langword="false"/> otherwise.
         /// </returns>
+        [Pure]
         public static bool operator !=(VertexPositionTexture left, VertexPositionTexture right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Input/GamePadButtons.cs
+++ b/MonoGame.Framework/Input/GamePadButtons.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Diagnostics.Contracts;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
@@ -170,6 +172,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(GamePadButtons left, GamePadButtons right)
         {
             return left._buttons == right._buttons;
@@ -181,6 +184,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(GamePadButtons left, GamePadButtons right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Input/GamePadCapabilities.cs
+++ b/MonoGame.Framework/Input/GamePadCapabilities.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Diagnostics.Contracts;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
@@ -188,6 +190,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first <see cref="Microsoft.Xna.Framework.Input.GamePadCapabilities"/> to compare.</param>
         /// <param name="right">The second <see cref="Microsoft.Xna.Framework.Input.GamePadCapabilities"/> to compare.</param>
         /// <returns><c>true</c> if <c>left</c> and <c>right</c> are equal; otherwise, <c>false</c>.</returns>
+        [Pure]
         public static bool operator ==(GamePadCapabilities left, GamePadCapabilities right)
         {
             var eq = true;
@@ -231,6 +234,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first <see cref="Microsoft.Xna.Framework.Input.GamePadCapabilities"/> to compare.</param>
         /// <param name="right">The second <see cref="Microsoft.Xna.Framework.Input.GamePadCapabilities"/> to compare.</param>
         /// <returns><c>true</c> if <c>left</c> and <c>right</c> are not equal; otherwise, <c>false</c>.</returns>
+        [Pure]
         public static bool operator !=(GamePadCapabilities left, GamePadCapabilities right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Input/GamePadDPad.cs
+++ b/MonoGame.Framework/Input/GamePadDPad.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Diagnostics.Contracts;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
@@ -67,6 +69,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(GamePadDPad left, GamePadDPad right)
         {
             return (left.Down == right.Down)
@@ -81,6 +84,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(GamePadDPad left, GamePadDPad right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Input/GamePadState.cs
+++ b/MonoGame.Framework/Input/GamePadState.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Diagnostics.Contracts;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
@@ -156,6 +158,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first <see cref="Microsoft.Xna.Framework.Input.GamePadState"/> to compare.</param>
         /// <param name="right">The second <see cref="Microsoft.Xna.Framework.Input.GamePadState"/> to compare.</param>
         /// <returns><c>true</c> if <c>left</c> and <c>right</c> are equal; otherwise, <c>false</c>.</returns>
+        [Pure]
         public static bool operator ==(GamePadState left, GamePadState right)
         {
             return (left.IsConnected == right.IsConnected) &&
@@ -173,6 +176,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first <see cref="Microsoft.Xna.Framework.Input.GamePadState"/> to compare.</param>
         /// <param name="right">The second <see cref="Microsoft.Xna.Framework.Input.GamePadState"/> to compare.</param>
         /// <returns><c>true</c> if <c>left</c> and <c>right</c> are not equal; otherwise, <c>false</c>.</returns>
+        [Pure]
         public static bool operator !=(GamePadState left, GamePadState right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Input/GamePadThumbSticks.cs
+++ b/MonoGame.Framework/Input/GamePadThumbSticks.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Diagnostics.Contracts;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
@@ -147,6 +149,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(GamePadThumbSticks left, GamePadThumbSticks right)
         {
             return (left.Left == right.Left) && (left.Right == right.Right);
@@ -158,6 +161,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(GamePadThumbSticks left, GamePadThumbSticks right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Input/GamePadTriggers.cs
+++ b/MonoGame.Framework/Input/GamePadTriggers.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Diagnostics.Contracts;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
@@ -38,6 +40,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator ==(GamePadTriggers left, GamePadTriggers right)
         {
             return (left.Left == right.Left) && (left.Right == right.Right);
@@ -49,6 +52,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns>true if <paramref name="left"/> and <paramref name="right"/> are not equal; otherwise, false.</returns>
+        [Pure]
         public static bool operator !=(GamePadTriggers left, GamePadTriggers right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Input/JoystickCapabilities.cs
+++ b/MonoGame.Framework/Input/JoystickCapabilities.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Diagnostics.Contracts;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
@@ -58,6 +60,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first <see cref="Microsoft.Xna.Framework.Input.JoystickCapabilities"/> to compare.</param>
         /// <param name="right">The second <see cref="Microsoft.Xna.Framework.Input.JoystickCapabilities"/> to compare.</param>
         /// <returns><c>true</c> if <c>left</c> and <c>right</c> are equal; otherwise, <c>false</c>.</returns>
+        [Pure]
         public static bool operator ==(JoystickCapabilities left, JoystickCapabilities right)
         {
             return left.IsConnected == right.IsConnected &&
@@ -75,6 +78,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first <see cref="Microsoft.Xna.Framework.Input.JoystickCapabilities"/> to compare.</param>
         /// <param name="right">The second <see cref="Microsoft.Xna.Framework.Input.JoystickCapabilities"/> to compare.</param>
         /// <returns><c>true</c> if <c>left</c> and <c>right</c> are not equal; otherwise, <c>false</c>.</returns>
+        [Pure]
         public static bool operator !=(JoystickCapabilities left, JoystickCapabilities right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Input/JoystickHat.cs
+++ b/MonoGame.Framework/Input/JoystickHat.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Diagnostics.Contracts;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
@@ -40,6 +42,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first <see cref="Microsoft.Xna.Framework.Input.JoystickHat"/> to compare.</param>
         /// <param name="right">The second <see cref="Microsoft.Xna.Framework.Input.JoystickHat"/> to compare.</param>
         /// <returns><c>true</c> if <c>left</c> and <c>right</c> are equal; otherwise, <c>false</c>.</returns>
+        [Pure]
         public static bool operator ==(JoystickHat left, JoystickHat right)
         {
             return (left.Down == right.Down) &&
@@ -55,6 +58,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first <see cref="Microsoft.Xna.Framework.Input.JoystickHat"/> to compare.</param>
         /// <param name="right">The second <see cref="Microsoft.Xna.Framework.Input.JoystickHat"/> to compare.</param>
         /// <returns><c>true</c> if <c>left</c> and <c>right</c> are not equal; otherwise, <c>false</c>.</returns>
+        [Pure]
         public static bool operator !=(JoystickHat left, JoystickHat right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Input/JoystickState.cs
+++ b/MonoGame.Framework/Input/JoystickState.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text;
 
@@ -43,6 +44,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first <see cref="Microsoft.Xna.Framework.Input.JoystickState"/> to compare.</param>
         /// <param name="right">The second <see cref="Microsoft.Xna.Framework.Input.JoystickState"/> to compare.</param>
         /// <returns><c>true</c> if <c>left</c> and <c>right</c> are equal; otherwise, <c>false</c>.</returns>
+        [Pure]
         public static bool operator ==(JoystickState left, JoystickState right)
         {
             return left.IsConnected == right.IsConnected &&
@@ -58,6 +60,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">The first <see cref="Microsoft.Xna.Framework.Input.JoystickState"/> to compare.</param>
         /// <param name="right">The second <see cref="Microsoft.Xna.Framework.Input.JoystickState"/> to compare.</param>
         /// <returns><c>true</c> if <c>left</c> and <c>right</c> are not equal; otherwise, <c>false</c>.</returns>
+        [Pure]
         public static bool operator !=(JoystickState left, JoystickState right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Input/KeyboardState.cs
+++ b/MonoGame.Framework/Input/KeyboardState.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework.Input
 {
@@ -289,6 +290,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="a"><see cref="KeyboardState"/> instance to the left of the equality operator.</param>
         /// <param name="b"><see cref="KeyboardState"/> instance to the right of the equality operator.</param>
         /// <returns>true if the instances are equal; false otherwise.</returns>
+        [Pure]
         public static bool operator ==(KeyboardState a, KeyboardState b)
         {
             return a._keys0 == b._keys0
@@ -307,6 +309,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="a"><see cref="KeyboardState"/> instance to the left of the inequality operator.</param>
         /// <param name="b"><see cref="KeyboardState"/> instance to the right of the inequality operator.</param>
         /// <returns>true if the instances are different; false otherwise.</returns>
+        [Pure]
         public static bool operator !=(KeyboardState a, KeyboardState b)
         {
             return !(a == b);

--- a/MonoGame.Framework/Input/MouseState.cs
+++ b/MonoGame.Framework/Input/MouseState.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.Diagnostics.Contracts;
+
 namespace Microsoft.Xna.Framework.Input
 {
     /// <summary>
@@ -99,6 +101,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">MouseState instance on the left of the equal sign.</param>
         /// <param name="right">MouseState instance  on the right of the equal sign.</param>
         /// <returns>true if the instances are equal; false otherwise.</returns>
+        [Pure]
         public static bool operator ==(MouseState left, MouseState right)
         {
             return left._x == right._x &&
@@ -114,6 +117,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="left">MouseState instance on the left of the equal sign.</param>
         /// <param name="right">MouseState instance  on the right of the equal sign.</param>
         /// <returns>true if the objects are not equal; false otherwise.</returns>
+        [Pure]
         public static bool operator !=(MouseState left, MouseState right)
         {
             return !(left == right);

--- a/MonoGame.Framework/Input/Touch/TouchLocation.cs
+++ b/MonoGame.Framework/Input/Touch/TouchLocation.cs
@@ -5,6 +5,7 @@
 #region Using clause
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 #endregion Using clause
 
 
@@ -337,6 +338,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <param name="value1">The value on the left of the inequality operator.</param>
         /// <param name="value2">The value on the right of the inequality operator.</param>
         /// <returns><see langword="true"/> if the two values are not equal; otherwise, <see langword="false"/>.</returns>
+        [Pure]
         public static bool operator !=(TouchLocation value1, TouchLocation value2)
         {
 			return  value1._id != value2._id || 
@@ -352,6 +354,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
         /// <param name="value1">The value on the left of the equality operator.</param>
         /// <param name="value2">The value on the right of the equality operator.</param>
         /// <returns><see langword="true"/> if the two values are equal; otherwise, <see langword="false"/>.</returns>
+        [Pure]
         public static bool operator ==(TouchLocation value1, TouchLocation value2)
         {
             return  value1._id == value2._id && 

--- a/MonoGame.Framework/MathF.cs
+++ b/MonoGame.Framework/MathF.cs
@@ -5,61 +5,75 @@
 namespace System
 {
 #if (!NETCOREAPP && !NETSTANDARD2_1) || NETCOREAPP1_0 || NETCOREAPP1_1
+
+    using System.Diagnostics.Contracts;
+
     internal static class MathF
     {
         public const float E = (float)Math.E;
         public const float PI = (float)Math.PI;
 
+        [Pure]
         public static float Sqrt(float f)
         {
             return (float)Math.Sqrt(f);
         }
 
+        [Pure]
         public static float Pow(float x, float y)
         {
             return (float)Math.Pow(x, y);
         }
 
+        [Pure]
         public static float Sin(float f)
         {
             return (float)Math.Sin(f);
         }
 
+        [Pure]
         public static float Cos(float f)
         {
             return (float)Math.Cos(f);
         }
 
+        [Pure]
         public static float Tan(float f)
         {
             return (float)Math.Tan(f);
         }
 
+        [Pure]
         public static float Asin(float f)
         {
             return (float)Math.Asin(f);
         }
 
+        [Pure]
         public static float Acos(float f)
         {
             return (float)Math.Acos(f);
         }
 
+        [Pure]
         public static float Atan(float f)
         {
             return (float)Math.Atan(f);
         }
 
+        [Pure]
         public static float Round(float f)
         {
             return (float)Math.Round(f);
         }
 
+        [Pure]
         public static float Ceiling(float f)
         {
             return (float)Math.Ceiling(f);
         }
 
+        [Pure]
         public static float Floor(float f)
         {
             return (float)Math.Floor(f);

--- a/MonoGame.Framework/MathHelper.cs
+++ b/MonoGame.Framework/MathHelper.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.Contracts;
 
 namespace Microsoft.Xna.Framework
 {
@@ -51,7 +52,7 @@ namespace Microsoft.Xna.Framework
         /// This is an alias of TwoPi.
         /// </summary>
         public const float Tau = TwoPi;
-        
+
         /// <summary>
         /// Returns the Cartesian coordinate for one axis of a point that is defined by a given triangle and two normalized barycentric (areal) coordinates.
         /// </summary>
@@ -61,12 +62,13 @@ namespace Microsoft.Xna.Framework
         /// <param name="amount1">The normalized barycentric (areal) coordinate b2, equal to the weighting factor for vertex 2, the coordinate of which is specified in value2.</param>
         /// <param name="amount2">The normalized barycentric (areal) coordinate b3, equal to the weighting factor for vertex 3, the coordinate of which is specified in value3.</param>
         /// <returns>Cartesian coordinate of the specified point with respect to the axis being used.</returns>
+        [Pure]
         public static float Barycentric(float value1, float value2, float value3, float amount1, float amount2)
         {
             return value1 + (value2 - value1) * amount1 + (value3 - value1) * amount2;
         }
 
-	/// <summary>
+        /// <summary>
         /// Performs a Catmull-Rom interpolation using the specified positions.
         /// </summary>
         /// <param name="value1">The first position in the interpolation.</param>
@@ -75,6 +77,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value4">The fourth position in the interpolation.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <returns>A position that is the result of the Catmull-Rom interpolation.</returns>
+        [Pure]
         public static float CatmullRom(float value1, float value2, float value3, float value4, float amount)
         {
             // Using formula from http://www.mvps.org/directx/articles/catmull/
@@ -87,13 +90,14 @@ namespace Microsoft.Xna.Framework
                 (3.0 * value2 - value1 - 3.0 * value3 + value4) * amountCubed));
         }
 
- 	/// <summary>
+        /// <summary>
         /// Restricts a value to be within a specified range.
         /// </summary>
         /// <param name="value">The value to clamp.</param>
         /// <param name="min">The minimum value. If <c>value</c> is less than <c>min</c>, <c>min</c> will be returned.</param>
         /// <param name="max">The maximum value. If <c>value</c> is greater than <c>max</c>, <c>max</c> will be returned.</param>
         /// <returns>The clamped value.</returns>
+        [Pure]
         public static float Clamp(float value, float min, float max)
         {
             // First we check to see if we're greater than the max
@@ -105,7 +109,7 @@ namespace Microsoft.Xna.Framework
             // There's no check to see if min > max.
             return value;
         }
-        
+
         /// <summary>
         /// Restricts a value to be within a specified range.
         /// </summary>
@@ -113,24 +117,26 @@ namespace Microsoft.Xna.Framework
         /// <param name="min">The minimum value. If <c>value</c> is less than <c>min</c>, <c>min</c> will be returned.</param>
         /// <param name="max">The maximum value. If <c>value</c> is greater than <c>max</c>, <c>max</c> will be returned.</param>
         /// <returns>The clamped value.</returns>
+        [Pure]
         public static int Clamp(int value, int min, int max)
         { 
             value = (value > max) ? max : value; 
             value = (value < min) ? min : value; 
             return value;
         }
-        
+
         /// <summary>
         /// Calculates the absolute value of the difference of two values.
         /// </summary>
         /// <param name="value1">Source value.</param>
         /// <param name="value2">Source value.</param>
         /// <returns>Distance between the two values.</returns>
+        [Pure]
         public static float Distance(float value1, float value2)
         {
             return Math.Abs(value1 - value2);
         }
-        
+
         /// <summary>
         /// Performs a Hermite spline interpolation.
         /// </summary>
@@ -140,6 +146,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="tangent2">Source tangent.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <returns>The result of the Hermite spline interpolation.</returns>
+        [Pure]
         public static float Hermite(float value1, float tangent1, float value2, float tangent2, float amount)
         {
             // All transformed to double not to lose precision
@@ -159,8 +166,8 @@ namespace Microsoft.Xna.Framework
                     v1;
             return (float)result;
         }
-        
-        
+
+
         /// <summary>
         /// Linearly interpolates between two values.
         /// </summary>
@@ -173,6 +180,7 @@ namespace Microsoft.Xna.Framework
         /// Passing amount a value of 0 will cause value1 to be returned, a value of 1 will cause value2 to be returned.
         /// See <see cref="MathHelper.LerpPrecise"/> for a less efficient version with more precision around edge cases.
         /// </remarks>
+        [Pure]
         public static float Lerp(float value1, float value2, float amount)
         {
             return value1 + (value2 - value1) * amount;
@@ -199,6 +207,7 @@ namespace Microsoft.Xna.Framework
         /// Relevant Wikipedia Article: https://en.wikipedia.org/wiki/Linear_interpolation#Programming_language_support
         /// Relevant StackOverflow Answer: http://stackoverflow.com/questions/4353525/floating-point-linear-interpolation#answer-23716956
         /// </remarks>
+        [Pure]
         public static float LerpPrecise(float value1, float value2, float amount)
         {
             return ((1 - amount) * value1) + (value2 * amount);
@@ -210,6 +219,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source value.</param>
         /// <param name="value2">Source value.</param>
         /// <returns>The greater value.</returns>
+        [Pure]
         public static float Max(float value1, float value2)
         {
             return value1 > value2 ? value1 : value2;
@@ -221,17 +231,19 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source value.</param>
         /// <param name="value2">Source value.</param>
         /// <returns>The greater value.</returns>
+        [Pure]
         public static int Max(int value1, int value2)
         {
             return value1 > value2 ? value1 : value2;
         }
-        
+
         /// <summary>
         /// Returns the lesser of two values.
         /// </summary>
         /// <param name="value1">Source value.</param>
         /// <param name="value2">Source value.</param>
         /// <returns>The lesser value.</returns>
+        [Pure]
         public static float Min(float value1, float value2)
         {
             return value1 < value2 ? value1 : value2;
@@ -243,11 +255,12 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source value.</param>
         /// <param name="value2">Source value.</param>
         /// <returns>The lesser value.</returns>
+        [Pure]
         public static int Min(int value1, int value2)
         {
             return value1 < value2 ? value1 : value2;
         }
-        
+
         /// <summary>
         /// Interpolates between two values using a cubic equation.
         /// </summary>
@@ -255,6 +268,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">Source value.</param>
         /// <param name="amount">Weighting value.</param>
         /// <returns>Interpolated value.</returns>
+        [Pure]
         public static float SmoothStep(float value1, float value2, float amount)
         {
             // It is expected that 0 < amount < 1
@@ -276,6 +290,7 @@ namespace Microsoft.Xna.Framework
         /// though it returns single float
         /// Factor = 180 / pi
         /// </remarks>
+        [Pure]
         public static float ToDegrees(float radians)
         { 
             return (float)(radians * 57.295779513082320876798154814105);
@@ -291,16 +306,18 @@ namespace Microsoft.Xna.Framework
         /// though it returns single float
         /// Factor = pi / 180
         /// </remarks>
+        [Pure]
         public static float ToRadians(float degrees)
         { 
             return (float)(degrees * 0.017453292519943295769236907684886);
         }
-	 
+
         /// <summary>
         /// Reduces a given angle to a value between π and -π.
         /// </summary>
         /// <param name="angle">The angle to reduce, in radians.</param>
         /// <returns>The new angle, in radians.</returns>
+        [Pure]
         public static float WrapAngle(float angle)
         {
             if ((angle > -Pi) && (angle <= Pi))
@@ -313,12 +330,13 @@ namespace Microsoft.Xna.Framework
             return angle;
         }
 
- 	    /// <summary>
+        /// <summary>
         /// Determines if value is powered by two.
         /// </summary>
         /// <param name="value">A value.</param>
         /// <returns><c>true</c> if <c>value</c> is powered by two; otherwise <c>false</c>.</returns>
-	    public static bool IsPowerOfTwo(int value)
+        [Pure]
+        public static bool IsPowerOfTwo(int value)
 	    {
 	         return (value > 0) && ((value & (value - 1)) == 0);
 	    }

--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -414,6 +415,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">The first matrix to add.</param>
         /// <param name="matrix2">The second matrix to add.</param>
         /// <returns>The result of the matrix addition.</returns>
+        [Pure]
         public static Matrix Add(Matrix matrix1, Matrix matrix2)
         {
             matrix1.M11 += matrix2.M11;
@@ -441,6 +443,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">The first matrix to add.</param>
         /// <param name="matrix2">The second matrix to add.</param>
         /// <param name="result">The result of the matrix addition as an output parameter.</param>
+        [Pure]
         public static void Add(ref Matrix matrix1, ref Matrix matrix2, out Matrix result)
         {
             result.M11 = matrix1.M11 + matrix2.M11;
@@ -470,6 +473,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="cameraUpVector">The camera up vector.</param>
         /// <param name="cameraForwardVector">Optional camera forward vector.</param>
         /// <returns>The <see cref="Matrix"/> for spherical billboarding.</returns>
+        [Pure]
         public static Matrix CreateBillboard(Vector3 objectPosition, Vector3 cameraPosition,
             Vector3 cameraUpVector, Nullable<Vector3> cameraForwardVector)
         {
@@ -533,6 +537,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="cameraForwardVector">Optional camera forward vector.</param>
         /// <param name="objectForwardVector">Optional object forward vector.</param>
         /// <returns>The <see cref="Matrix"/> for cylindrical billboarding.</returns>
+        [Pure]
         public static Matrix CreateConstrainedBillboard(Vector3 objectPosition, Vector3 cameraPosition,
             Vector3 rotateAxis, Nullable<Vector3> cameraForwardVector, Nullable<Vector3> objectForwardVector)
         {
@@ -626,6 +631,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="axis">The axis of rotation.</param>
         /// <param name="angle">The angle of rotation in radians.</param>
         /// <returns>The rotation <see cref="Matrix"/>.</returns>
+        [Pure]
         public static Matrix CreateFromAxisAngle(Vector3 axis, float angle)
         {
             Matrix result;
@@ -675,6 +681,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="quaternion"><see cref="Quaternion"/> of rotation moment.</param>
         /// <returns>The rotation <see cref="Matrix"/>.</returns>
+        [Pure]
         public static Matrix CreateFromQuaternion(Quaternion quaternion)
         {
             Matrix result;
@@ -725,7 +732,8 @@ namespace Microsoft.Xna.Framework
         /// <returns>The rotation <see cref="Matrix"/>.</returns>
         /// <remarks>For more information about yaw, pitch and roll visit http://en.wikipedia.org/wiki/Euler_angles.
         /// </remarks>
-		public static Matrix CreateFromYawPitchRoll(float yaw, float pitch, float roll)
+		[Pure]
+        public static Matrix CreateFromYawPitchRoll(float yaw, float pitch, float roll)
 		{
 			Matrix matrix;
             CreateFromYawPitchRoll(yaw, pitch, roll, out matrix);
@@ -755,6 +763,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="cameraTarget">Lookup vector of the camera.</param>
         /// <param name="cameraUpVector">The direction of the upper edge of the camera.</param>
         /// <returns>The viewing <see cref="Matrix"/>.</returns>
+        [Pure]
         public static Matrix CreateLookAt(Vector3 cameraPosition, Vector3 cameraTarget, Vector3 cameraUpVector)
         {
             Matrix matrix;
@@ -800,6 +809,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="zNearPlane">Depth of the near plane.</param>
         /// <param name="zFarPlane">Depth of the far plane.</param>
         /// <returns>The new projection <see cref="Matrix"/> for orthographic view.</returns>
+        [Pure]
         public static Matrix CreateOrthographic(float width, float height, float zNearPlane, float zFarPlane)
         {
             Matrix matrix;
@@ -838,6 +848,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="zNearPlane">Depth of the near plane.</param>
         /// <param name="zFarPlane">Depth of the far plane.</param>
         /// <returns>The new projection <see cref="Matrix"/> for customized orthographic view.</returns>
+        [Pure]
         public static Matrix CreateOrthographicOffCenter(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane)
         {
 			Matrix matrix;
@@ -852,6 +863,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="zNearPlane">Depth of the near plane.</param>
         /// <param name="zFarPlane">Depth of the far plane.</param>
         /// <returns>The new projection <see cref="Matrix"/> for customized orthographic view.</returns>
+        [Pure]
         public static Matrix CreateOrthographicOffCenter(Rectangle viewingVolume, float zNearPlane, float zFarPlane)
         {
             Matrix matrix;
@@ -897,6 +909,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="nearPlaneDistance">Distance to the near plane.</param>
         /// <param name="farPlaneDistance">Distance to the far plane.</param>
         /// <returns>The new projection <see cref="Matrix"/> for perspective view.</returns>
+        [Pure]
         public static Matrix CreatePerspective(float width, float height, float nearPlaneDistance, float farPlaneDistance)
         {
             Matrix matrix;
@@ -948,6 +961,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="nearPlaneDistance">Distance to the near plane.</param>
         /// <param name="farPlaneDistance">Distance to the far plane, or <see cref="float.PositiveInfinity"/>.</param>
         /// <returns>The new projection <see cref="Matrix"/> for perspective view with FOV.</returns>
+        [Pure]
         public static Matrix CreatePerspectiveFieldOfView(float fieldOfView, float aspectRatio, float nearPlaneDistance, float farPlaneDistance)
         {
             Matrix result;
@@ -1007,6 +1021,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="nearPlaneDistance">Distance to the near plane.</param>
         /// <param name="farPlaneDistance">Distance to the far plane.</param>
         /// <returns>The new <see cref="Matrix"/> for customized perspective view.</returns>
+        [Pure]
         public static Matrix CreatePerspectiveOffCenter(float left, float right, float bottom, float top, float nearPlaneDistance, float farPlaneDistance)
         {
             Matrix result;
@@ -1021,6 +1036,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="nearPlaneDistance">Distance to the near plane.</param>
         /// <param name="farPlaneDistance">Distance to the far plane.</param>
         /// <returns>The new <see cref="Matrix"/> for customized perspective view.</returns>
+        [Pure]
         public static Matrix CreatePerspectiveOffCenter(Rectangle viewingVolume, float nearPlaneDistance, float farPlaneDistance)
         {
             Matrix result;
@@ -1069,6 +1085,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="radians">Angle in radians.</param>
         /// <returns>The rotation <see cref="Matrix"/> around X axis.</returns>
+        [Pure]
         public static Matrix CreateRotationX(float radians)
         {
             Matrix result;
@@ -1099,6 +1116,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="radians">Angle in radians.</param>
         /// <returns>The rotation <see cref="Matrix"/> around Y axis.</returns>
+        [Pure]
         public static Matrix CreateRotationY(float radians)
         {
             Matrix result;
@@ -1129,6 +1147,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="radians">Angle in radians.</param>
         /// <returns>The rotation <see cref="Matrix"/> around Z axis.</returns>
+        [Pure]
         public static Matrix CreateRotationZ(float radians)
         {
             Matrix result;
@@ -1159,6 +1178,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="scale">Scale value for all three axises.</param>
         /// <returns>The scaling <see cref="Matrix"/>.</returns>
+        [Pure]
         public static Matrix CreateScale(float scale)
         {
             Matrix result;
@@ -1183,6 +1203,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="yScale">Scale value for Y axis.</param>
         /// <param name="zScale">Scale value for Z axis.</param>
         /// <returns>The scaling <see cref="Matrix"/>.</returns>
+        [Pure]
         public static Matrix CreateScale(float xScale, float yScale, float zScale)
         {
             Matrix result;
@@ -1222,6 +1243,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="scales"><see cref="Vector3"/> representing x,y and z scale values.</param>
         /// <returns>The scaling <see cref="Matrix"/>.</returns>
+        [Pure]
         public static Matrix CreateScale(Vector3 scales)
         {
             Matrix result;
@@ -1261,6 +1283,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="lightDirection">A vector specifying the direction from which the light that will cast the shadow is coming.</param>
         /// <param name="plane">The plane onto which the new matrix should flatten geometry so as to cast a shadow.</param>
         /// <returns>A <see cref="Matrix"/> that can be used to flatten geometry onto the specified plane from the specified direction. </returns>
+        [Pure]
         public static Matrix CreateShadow(Vector3 lightDirection, Plane plane)
         {
             Matrix result;
@@ -1300,7 +1323,7 @@ namespace Microsoft.Xna.Framework
             result.M43 = d * lightDirection.Z;
             result.M44 = dot;
         }
-        
+
         /// <summary>
         /// Creates a new translation <see cref="Matrix"/>.
         /// </summary>
@@ -1308,6 +1331,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="yPosition">Y coordinate of translation.</param>
         /// <param name="zPosition">Z coordinate of translation.</param>
         /// <returns>The translation <see cref="Matrix"/>.</returns>
+        [Pure]
         public static Matrix CreateTranslation(float xPosition, float yPosition, float zPosition)
         {
             Matrix result;
@@ -1345,6 +1369,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="position">X,Y and Z coordinates of translation.</param>
         /// <returns>The translation <see cref="Matrix"/>.</returns>
+        [Pure]
         public static Matrix CreateTranslation(Vector3 position)
         {
 			Matrix result;
@@ -1378,12 +1403,13 @@ namespace Microsoft.Xna.Framework
 			result.M43 = zPosition;
 			result.M44 = 1;
         }
-        
+
         /// <summary>
         /// Creates a new reflection <see cref="Matrix"/>.
         /// </summary>
         /// <param name="value">The plane that used for reflection calculation.</param>
         /// <returns>The reflection <see cref="Matrix"/>.</returns>
+        [Pure]
         public static Matrix CreateReflection(Plane value)
         {
             Matrix result;
@@ -1431,6 +1457,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="forward">The forward direction vector.</param>
         /// <param name="up">The upward direction vector. Usually <see cref="Vector3.Up"/>.</param>
         /// <returns>The world <see cref="Matrix"/>.</returns>
+        [Pure]
         public static Matrix CreateWorld(Vector3 position, Vector3 forward, Vector3 up)
         {
             Matrix ret;
@@ -1537,6 +1564,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">Source <see cref="Matrix"/>.</param>
         /// <param name="matrix2">Divisor <see cref="Matrix"/>.</param>
         /// <returns>The result of dividing the matrix.</returns>
+        [Pure]
         public static Matrix Divide(Matrix matrix1, Matrix matrix2)
         {
 		    matrix1.M11 = matrix1.M11 / matrix2.M11;
@@ -1590,6 +1618,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">Source <see cref="Matrix"/>.</param>
         /// <param name="divider">Divisor scalar.</param>
         /// <returns>The result of dividing a matrix by a scalar.</returns>
+        [Pure]
         public static Matrix Divide(Matrix matrix1, float divider)
         {
 		    float num = 1f / divider;
@@ -1678,6 +1707,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="matrix">Source <see cref="Matrix"/>.</param>
         /// <returns>The inverted matrix.</returns>
+        [Pure]
         public static Matrix Invert(Matrix matrix)
         {
             Matrix result;
@@ -1797,6 +1827,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix2">The second <see cref="Vector2"/>.</param>
         /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
         /// <returns>>The result of linear interpolation of the specified matrixes.</returns>
+        [Pure]
         public static Matrix Lerp(Matrix matrix1, Matrix matrix2, float amount)
         {
 		    matrix1.M11 = matrix1.M11 + ((matrix2.M11 - matrix1.M11) * amount);
@@ -1851,6 +1882,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">Source <see cref="Matrix"/>.</param>
         /// <param name="matrix2">Source <see cref="Matrix"/>.</param>
         /// <returns>Result of the matrix multiplication.</returns>
+        [Pure]
         public static Matrix Multiply(Matrix matrix1, Matrix matrix2)
         {
             var m11 = (((matrix1.M11 * matrix2.M11) + (matrix1.M12 * matrix2.M21)) + (matrix1.M13 * matrix2.M31)) + (matrix1.M14 * matrix2.M41);
@@ -1936,6 +1968,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">Source <see cref="Matrix"/>.</param>
         /// <param name="scaleFactor">Scalar value.</param>
         /// <returns>Result of the matrix multiplication with a scalar.</returns>
+        [Pure]
         public static Matrix Multiply(Matrix matrix1, float scaleFactor)
         {
             matrix1.M11 *= scaleFactor;
@@ -1992,6 +2025,7 @@ namespace Microsoft.Xna.Framework
         /// <remarks>
         /// Required for OpenGL 2.0 projection matrix stuff.
         /// </remarks>
+        [Pure]
         public static float[] ToFloatArray(Matrix matrix)
         {
             float[] matarray = {
@@ -2008,6 +2042,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="matrix">Source <see cref="Matrix"/>.</param>
         /// <returns>Result of the matrix negation.</returns>
+        [Pure]
         public static Matrix Negate(Matrix matrix)
         {
 		    matrix.M11 = -matrix.M11;
@@ -2058,6 +2093,7 @@ namespace Microsoft.Xna.Framework
         /// Converts a <see cref="System.Numerics.Matrix4x4"/> to a <see cref="Matrix"/>.
         /// </summary>
         /// <param name="value">The converted value.</param>
+        [Pure]
         public static implicit operator Matrix(System.Numerics.Matrix4x4 value)
         {
             return new Matrix(
@@ -2073,6 +2109,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">Source <see cref="Matrix"/> on the left of the add sign.</param>
         /// <param name="matrix2">Source <see cref="Matrix"/> on the right of the add sign.</param>
         /// <returns>Sum of the matrixes.</returns>
+        [Pure]
         public static Matrix operator +(Matrix matrix1, Matrix matrix2)
         {
             matrix1.M11 = matrix1.M11 + matrix2.M11;
@@ -2100,6 +2137,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">Source <see cref="Matrix"/> on the left of the div sign.</param>
         /// <param name="matrix2">Divisor <see cref="Matrix"/> on the right of the div sign.</param>
         /// <returns>The result of dividing the matrixes.</returns>
+        [Pure]
         public static Matrix operator /(Matrix matrix1, Matrix matrix2)
         {
 		    matrix1.M11 = matrix1.M11 / matrix2.M11;
@@ -2127,6 +2165,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix">Source <see cref="Matrix"/> on the left of the div sign.</param>
         /// <param name="divider">Divisor scalar on the right of the div sign.</param>
         /// <returns>The result of dividing a matrix by a scalar.</returns>
+        [Pure]
         public static Matrix operator /(Matrix matrix, float divider)
         {
 		    float num = 1f / divider;
@@ -2155,6 +2194,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">Source <see cref="Matrix"/> on the left of the equal sign.</param>
         /// <param name="matrix2">Source <see cref="Matrix"/> on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator ==(Matrix matrix1, Matrix matrix2)
         {
             return (
@@ -2183,6 +2223,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">Source <see cref="Matrix"/> on the left of the not equal sign.</param>
         /// <param name="matrix2">Source <see cref="Matrix"/> on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator !=(Matrix matrix1, Matrix matrix2)
         {
             return (
@@ -2214,6 +2255,7 @@ namespace Microsoft.Xna.Framework
         /// <remarks>
         /// Using matrix multiplication algorithm - see http://en.wikipedia.org/wiki/Matrix_multiplication.
         /// </remarks>
+        [Pure]
         public static Matrix operator *(Matrix matrix1, Matrix matrix2)
         {
             var m11 = (((matrix1.M11 * matrix2.M11) + (matrix1.M12 * matrix2.M21)) + (matrix1.M13 * matrix2.M31)) + (matrix1.M14 * matrix2.M41);
@@ -2257,6 +2299,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix">Source <see cref="Matrix"/> on the left of the mul sign.</param>
         /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
         /// <returns>Result of the matrix multiplication with a scalar.</returns>
+        [Pure]
         public static Matrix operator *(Matrix matrix, float scaleFactor)
         {
 		    matrix.M11 = matrix.M11 * scaleFactor;
@@ -2284,6 +2327,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="scaleFactor">Scalar value on the left of the mul sign.</param>
         /// <param name="matrix">Source <see cref="Matrix"/> on the right of the mul sign.</param>
         /// <returns>Result of the matrix multiplication with a scalar.</returns>
+        [Pure]
         public static Matrix operator *(float scaleFactor, Matrix matrix)
         {
 		    matrix.M11 = matrix.M11 * scaleFactor;
@@ -2311,6 +2355,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">Source <see cref="Matrix"/> on the left of the sub sign.</param>
         /// <param name="matrix2">Source <see cref="Matrix"/> on the right of the sub sign.</param>
         /// <returns>Result of the matrix subtraction.</returns>
+        [Pure]
         public static Matrix operator -(Matrix matrix1, Matrix matrix2)
         {
 		    matrix1.M11 = matrix1.M11 - matrix2.M11;
@@ -2337,6 +2382,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="matrix">Source <see cref="Matrix"/> on the right of the sub sign.</param>
         /// <returns>Result of the inversion.</returns>
+        [Pure]
         public static Matrix operator -(Matrix matrix)
         {
 		    matrix.M11 = -matrix.M11;
@@ -2364,6 +2410,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">The first <see cref="Matrix"/>.</param>
         /// <param name="matrix2">The second <see cref="Matrix"/>.</param>
         /// <returns>The result of the matrix subtraction.</returns>
+        [Pure]
         public static Matrix Subtract(Matrix matrix1, Matrix matrix2)
         {
 		    matrix1.M11 = matrix1.M11 - matrix2.M11;
@@ -2391,6 +2438,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="matrix1">The first <see cref="Matrix"/>.</param>
         /// <param name="matrix2">The second <see cref="Matrix"/>.</param>
         /// <param name="result">The result of the matrix subtraction as an output parameter.</param>
+        [Pure]
         public static void Subtract(ref Matrix matrix1, ref Matrix matrix2, out Matrix result)
         {
             result.M11 = matrix1.M11 - matrix2.M11;
@@ -2449,6 +2497,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="matrix">The matrix for transposing operation.</param>
         /// <returns>The new <see cref="Matrix"/> which contains the transposing result.</returns>
+        [Pure]
         public static Matrix Transpose(Matrix matrix)
         {
             Matrix ret;
@@ -2461,6 +2510,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="matrix">The matrix for transposing operation.</param>
         /// <param name="result">The new <see cref="Matrix"/> which contains the transposing result as an output parameter.</param>
+        [Pure]
         public static void Transpose(ref Matrix matrix, out Matrix result)
         {
             Matrix ret;

--- a/MonoGame.Framework/Media/Song.cs
+++ b/MonoGame.Framework/Media/Song.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics.Contracts;
 using System.IO;
 
 namespace Microsoft.Xna.Framework.Media
@@ -150,7 +151,8 @@ namespace Microsoft.Xna.Framework.Media
         /// <summary>
         /// Determines whether the specified Song instances are equal.
         /// </summary>
-		public static bool operator ==(Song song1, Song song2)
+		[Pure]
+        public static bool operator ==(Song song1, Song song2)
 		{
 			if((object)song1 == null)
 			{
@@ -163,6 +165,7 @@ namespace Microsoft.Xna.Framework.Media
         /// <summary>
         /// Determines whether the specified Song instances are not equal.
         /// </summary>
+        [Pure]
         public static bool operator !=(Song song1, Song song2)
 		{
 		    return !(song1 == song2);

--- a/MonoGame.Framework/Plane.cs
+++ b/MonoGame.Framework/Plane.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -16,6 +17,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="point">The point to check with</param>
         /// <param name="plane">The plane to check against</param>
         /// <returns>Greater than zero if on the positive side, less than zero if on the negative size, 0 otherwise</returns>
+        [Pure]
         public static float ClassifyPoint(ref Vector3 point, ref Plane plane)
         {
             return point.X * plane.Normal.X + point.Y * plane.Normal.Y + point.Z * plane.Normal.Z + plane.D;
@@ -27,6 +29,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="point">The point to check</param>
         /// <param name="plane">The place to check</param>
         /// <returns>The perpendicular distance from the point to the plane</returns>
+        [Pure]
         public static float PerpendicularDistance(ref Vector3 point, ref Plane plane)
         {
             // dist = (ax + by + cz + d) / sqrt(a*a + b*b + c*c)
@@ -217,6 +220,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="plane">The normalized plane to transform.</param>
         /// <param name="matrix">The transformation matrix.</param>
         /// <returns>The transformed plane.</returns>
+        [Pure]
         public static Plane Transform(Plane plane, Matrix matrix)
         {
             Plane result;
@@ -253,6 +257,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="plane">The normalized plane to transform.</param>
         /// <param name="rotation">The quaternion rotation.</param>
         /// <returns>The transformed plane.</returns>
+        [Pure]
         public static Plane Transform(Plane plane, Quaternion rotation)
         {
             Plane result;
@@ -288,6 +293,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">The <see cref="Plane"/> to normalize.</param>
         /// <returns>A normalized version of the specified <see cref="Plane"/>.</returns>
+        [Pure]
         public static Plane Normalize(Plane value)
         {
 			Plane ret;
@@ -314,6 +320,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="plane1">A <see cref="Plane"/> to check for inequality.</param>
         /// <param name="plane2">A <see cref="Plane"/> to check for inequality.</param>
         /// <returns><code>true</code> if the two planes are not equal, <code>false</code> if they are.</returns>
+        [Pure]
         public static bool operator !=(Plane plane1, Plane plane2)
         {
             return !plane1.Equals(plane2);
@@ -325,6 +332,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="plane1">A <see cref="Plane"/> to check for equality.</param>
         /// <param name="plane2">A <see cref="Plane"/> to check for equality.</param>
         /// <returns><code>true</code> if the two planes are equal, <code>false</code> if they are not.</returns>
+        [Pure]
         public static bool operator ==(Plane plane1, Plane plane2)
         {
             return plane1.Equals(plane2);
@@ -487,6 +495,7 @@ namespace Microsoft.Xna.Framework
         /// Converts a <see cref="System.Numerics.Plane"/> to a <see cref="Plane"/>.
         /// </summary>
         /// <param name="value">The converted value.</param>
+        [Pure]
         public static implicit operator Plane(System.Numerics.Plane value)
         {
             return new Plane(value.Normal, value.D);

--- a/MonoGame.Framework/Platform/Audio/AudioLoader.cs
+++ b/MonoGame.Framework/Platform/Audio/AudioLoader.cs
@@ -2,9 +2,10 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.IO;
 using MonoGame.OpenAL;
+using System;
+using System.Diagnostics.Contracts;
+using System.IO;
 
 namespace Microsoft.Xna.Framework.Audio
 {
@@ -15,6 +16,7 @@ namespace Microsoft.Xna.Framework.Audio
         internal const int FormatIeee = 3;
         internal const int FormatIma4 = 17;
 
+        [Pure]
         public static ALFormat GetSoundFormat(int format, int channels, int bits)
         {
             switch (format)
@@ -58,6 +60,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         // Converts block alignment in bytes to sample alignment, primarily for compressed formats
         // Calculation of sample alignment from http://kcat.strangesoft.net/openal-extensions/SOFT_block_alignment.txt
+        [Pure]
         public static int SampleAlignment(ALFormat format, int blockAlignment)
         {
             switch (format)
@@ -86,6 +89,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// <param name="samplesPerBlock">Gets the number of samples per block.</param>
         /// <param name="sampleCount">Gets the total number of samples.</param>
         /// <returns>The byte buffer containing the waveform data or compressed blocks.</returns>
+        [Pure]
         public static byte[] Load(Stream stream, out ALFormat format, out int frequency, out int channels, out int blockAlignment, out int bitsPerSample, out int samplesPerBlock, out int sampleCount)
         {
             byte[] audioData = null;

--- a/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
@@ -1,11 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.IO;
-using System.Runtime.InteropServices;
 using MonoGame.Framework.Utilities;
 using MonoGame.OpenAL;
 using MonoGame.OpenGL;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 #if ANDROID
 using System.Globalization;
@@ -37,6 +38,7 @@ namespace Microsoft.Xna.Framework.Audio
             }
         }
 
+        [Pure]
         public static bool IsStereoFormat(ALFormat format)
         {
             return (format == ALFormat.Stereo8

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
+
 
 #if ANGLE
 using OpenTK.Graphics;
@@ -40,31 +42,37 @@ namespace Microsoft.Xna.Framework.Graphics
             public ResourceType type;
             public int handle;
 
+            [Pure]
             public static ResourceHandle Texture(int handle)
             {
                 return new ResourceHandle() { type = ResourceType.Texture, handle = handle };
             }
 
+            [Pure]
             public static ResourceHandle Buffer(int handle)
             {
                 return new ResourceHandle() { type = ResourceType.Buffer, handle = handle };
             }
 
+            [Pure]
             public static ResourceHandle Shader(int handle)
             {
                 return new ResourceHandle() { type = ResourceType.Shader, handle = handle };
             }
 
+            [Pure]
             public static ResourceHandle Program(int handle)
             {
                 return new ResourceHandle() { type = ResourceType.Program, handle = handle };
             }
 
+            [Pure]
             public static ResourceHandle Query(int handle)
             {
                 return new ResourceHandle() { type = ResourceType.Query, handle = handle };
             }
 
+            [Pure]
             public static ResourceHandle Framebuffer(int handle)
             {
                 return new ResourceHandle() { type = ResourceType.Framebuffer, handle = handle };

--- a/MonoGame.Framework/Platform/SDL/SDL2.cs
+++ b/MonoGame.Framework/Platform/SDL/SDL2.cs
@@ -2,12 +2,13 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
-using System.IO;
-using System.Text;
-using System.Runtime.InteropServices;
-using System.Diagnostics;
 using MonoGame.Framework.Utilities;
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 
 internal static class Sdl
 {
@@ -142,17 +143,20 @@ internal static class Sdl
         public byte Minor;
         public byte Patch;
 
+        [Pure]
         public static bool operator >(Version version1, Version version2)
         {
             return ConcatenateVersion(version1) > ConcatenateVersion(version2);
         }
 
+        [Pure]
         public static bool operator <(Version version1, Version version2)
         {
             return ConcatenateVersion(version1) < ConcatenateVersion(version2);
         }
 
 
+        [Pure]
         public static bool operator ==(Version version1, Version version2)
         {
             return version1.Major == version2.Major &&
@@ -180,21 +184,25 @@ internal static class Sdl
             }
         }
 
+        [Pure]
         public static bool operator !=(Version version1, Version version2)
         {
             return !(version1 == version2);
         }
 
+        [Pure]
         public static bool operator >=(Version version1, Version version2)
         {
             return version1 == version2 || version1 > version2;
         }
 
+        [Pure]
         public static bool operator <=(Version version1, Version version2)
         {
             return version1 == version2 || version1 < version2;
         }
 
+        [Pure]
         public override string ToString()
         {
             return Major + "." + Minor + "." + Patch;

--- a/MonoGame.Framework/Point.cs
+++ b/MonoGame.Framework/Point.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -98,6 +99,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Point"/> on the left of the add sign.</param>
         /// <param name="value2">Source <see cref="Point"/> on the right of the add sign.</param>
         /// <returns>Sum of the points.</returns>
+        [Pure]
         public static Point operator +(Point value1, Point value2)
         {
             return new Point(value1.X + value2.X, value1.Y + value2.Y);
@@ -109,6 +111,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Point"/> on the left of the sub sign.</param>
         /// <param name="value2">Source <see cref="Point"/> on the right of the sub sign.</param>
         /// <returns>Result of the subtraction.</returns>
+        [Pure]
         public static Point operator -(Point value1, Point value2)
         {
             return new Point(value1.X - value2.X, value1.Y - value2.Y);
@@ -120,6 +123,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Point"/> on the left of the mul sign.</param>
         /// <param name="value2">Source <see cref="Point"/> on the right of the mul sign.</param>
         /// <returns>Result of the multiplication.</returns>
+        [Pure]
         public static Point operator *(Point value1, Point value2)
         {
             return new Point(value1.X * value2.X, value1.Y * value2.Y);
@@ -131,6 +135,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Point"/> on the left of the mul sign.</param>
         /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
         /// <returns>Result of multiplying point with a scalar.</returns>
+        [Pure]
         public static Point operator *(Point value, int scaleFactor)
         {
             value.X *= scaleFactor;
@@ -144,6 +149,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="scaleFactor">Scalar value on the left of the mul sign.</param>
         /// <param name="value">Source <see cref="Point"/> on the right of the mul sign.</param>
         /// <returns>Result of multiplying point with a scalar.</returns>
+        [Pure]
         public static Point operator *(int scaleFactor, Point value)
         {
             value.X *= scaleFactor;
@@ -157,6 +163,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="source">Source <see cref="Point"/> on the left of the div sign.</param>
         /// <param name="divisor">Divisor <see cref="Point"/> on the right of the div sign.</param>
         /// <returns>The result of dividing the points.</returns>
+        [Pure]
         public static Point operator /(Point source, Point divisor)
         {
             return new Point(source.X / divisor.X, source.Y / divisor.Y);
@@ -168,6 +175,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Point"/> on the left of the div sign.</param>
         /// <param name="scaleFactor">Scalar value on the right of the div sign.</param>
         /// <returns>Result of dividing point by a scalar.</returns>
+        [Pure]
         public static Point operator /(Point value, int scaleFactor)
         {
             value.X /= scaleFactor;
@@ -181,6 +189,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a"><see cref="Point"/> instance on the left of the equal sign.</param>
         /// <param name="b"><see cref="Point"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator ==(Point a, Point b)
         {
             return a.Equals(b);
@@ -192,6 +201,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a"><see cref="Point"/> instance on the left of the not equal sign.</param>
         /// <param name="b"><see cref="Point"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator !=(Point a, Point b)
         {
             return !a.Equals(b);

--- a/MonoGame.Framework/Quaternion.cs
+++ b/MonoGame.Framework/Quaternion.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -137,6 +138,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1">Source <see cref="Quaternion"/>.</param>
         /// <param name="quaternion2">Source <see cref="Quaternion"/>.</param>
         /// <returns>The result of the quaternion addition.</returns>
+        [Pure]
         public static Quaternion Add(Quaternion quaternion1, Quaternion quaternion2)
         {
 			Quaternion quaternion;
@@ -171,6 +173,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first <see cref="Quaternion"/> to concatenate.</param>
         /// <param name="value2">The second <see cref="Quaternion"/> to concatenate.</param>
         /// <returns>The result of rotation of <paramref name="value1"/> followed by <paramref name="value2"/> rotation.</returns>
+        [Pure]
         public static Quaternion Concatenate(Quaternion value1, Quaternion value2)
 		{
 			Quaternion quaternion;
@@ -236,6 +239,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">The quaternion which values will be used to create the conjugated version.</param>
         /// <returns>The conjugate version of the specified quaternion.</returns>
+        [Pure]
         public static Quaternion Conjugate(Quaternion value)
 		{
 			return new Quaternion(-value.X,-value.Y,-value.Z,value.W);
@@ -264,6 +268,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="axis">The axis of rotation.</param>
         /// <param name="angle">The angle in radians.</param>
         /// <returns>The new quaternion builded from axis and angle.</returns>
+        [Pure]
         public static Quaternion CreateFromAxisAngle(Vector3 axis, float angle)
         {
 		    float half = angle * 0.5f;
@@ -298,6 +303,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="matrix">The rotation matrix.</param>
         /// <returns>A quaternion composed from the rotation part of the matrix.</returns>
+        [Pure]
         public static Quaternion CreateFromRotationMatrix(Matrix matrix)
         {
             Quaternion quaternion;
@@ -417,6 +423,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="pitch">Pitch around the x axis in radians.</param>
         /// <param name="roll">Roll around the z axis in radians.</param>
         /// <returns>A new quaternion from the concatenated yaw, pitch, and roll angles.</returns>
+        [Pure]
         public static Quaternion CreateFromYawPitchRoll(float yaw, float pitch, float roll)
 		{
             float halfRoll = roll * 0.5f;
@@ -472,6 +479,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1">Source <see cref="Quaternion"/>.</param>
         /// <param name="quaternion2">Divisor <see cref="Quaternion"/>.</param>
         /// <returns>The result of dividing the quaternions.</returns>
+        [Pure]
         public static Quaternion Divide(Quaternion quaternion1, Quaternion quaternion2)
         {
             Quaternion quaternion;
@@ -534,6 +542,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1">The first quaternion.</param>
         /// <param name="quaternion2">The second quaternion.</param>
         /// <returns>The dot product of two quaternions.</returns>
+        [Pure]
         public static float Dot(Quaternion quaternion1, Quaternion quaternion2)
         {
             return ((((quaternion1.X * quaternion2.X) + (quaternion1.Y * quaternion2.Y)) + (quaternion1.Z * quaternion2.Z)) + (quaternion1.W * quaternion2.W));
@@ -597,6 +606,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="quaternion">Source <see cref="Quaternion"/>.</param>
         /// <returns>The inverse quaternion.</returns>
+        [Pure]
         public static Quaternion Inverse(Quaternion quaternion)
         {
             Quaternion quaternion2;
@@ -653,6 +663,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion2">Source <see cref="Quaternion"/>.</param>
         /// <param name="amount">The blend amount where 0 returns <paramref name="quaternion1"/> and 1 <paramref name="quaternion2"/>.</param>
         /// <returns>The result of linear blending between two quaternions.</returns>
+        [Pure]
         public static Quaternion Lerp(Quaternion quaternion1, Quaternion quaternion2, float amount)
         {
             float num = amount;
@@ -728,6 +739,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion2">Source <see cref="Quaternion"/>.</param>
         /// <param name="amount">The blend amount where 0 returns <paramref name="quaternion1"/> and 1 <paramref name="quaternion2"/>.</param>
         /// <returns>The result of spherical linear blending between two quaternions.</returns>
+        [Pure]
         public static Quaternion Slerp(Quaternion quaternion1, Quaternion quaternion2, float amount)
         {
             float num2;
@@ -807,6 +819,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1">Source <see cref="Quaternion"/>.</param>
         /// <param name="quaternion2">Source <see cref="Quaternion"/>.</param>
         /// <returns>The result of the quaternion subtraction.</returns>
+        [Pure]
         public static Quaternion Subtract(Quaternion quaternion1, Quaternion quaternion2)
         {
             Quaternion quaternion;
@@ -841,6 +854,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1">Source <see cref="Quaternion"/>.</param>
         /// <param name="quaternion2">Source <see cref="Quaternion"/>.</param>
         /// <returns>The result of the quaternion multiplication.</returns>
+        [Pure]
         public static Quaternion Multiply(Quaternion quaternion1, Quaternion quaternion2)
         {
             Quaternion quaternion;
@@ -869,6 +883,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1">Source <see cref="Quaternion"/>.</param>
         /// <param name="scaleFactor">Scalar value.</param>
         /// <returns>The result of the quaternion multiplication with a scalar.</returns>
+        [Pure]
         public static Quaternion Multiply(Quaternion quaternion1, float scaleFactor)
         {
             Quaternion quaternion;
@@ -928,6 +943,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="quaternion">Source <see cref="Quaternion"/>.</param>
         /// <returns>The result of the quaternion negation.</returns>
+        [Pure]
         public static Quaternion Negate(Quaternion quaternion)
         {
 		    return new Quaternion(-quaternion.X, -quaternion.Y, -quaternion.Z, -quaternion.W);
@@ -967,6 +983,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="quaternion">Source <see cref="Quaternion"/>.</param>
         /// <returns>The unit length quaternion.</returns>
+        [Pure]
         public static Quaternion Normalize(Quaternion quaternion)
         {
             Quaternion result;
@@ -1044,6 +1061,7 @@ namespace Microsoft.Xna.Framework
         /// Converts a <see cref="System.Numerics.Quaternion"/> to a <see cref="Quaternion"/>.
         /// </summary>
         /// <param name="value">The converted value.</param>
+        [Pure]
         public static implicit operator Quaternion(System.Numerics.Quaternion value)
         {
             return new Quaternion(value.X, value.Y, value.Z, value.W);
@@ -1055,6 +1073,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1">Source <see cref="Quaternion"/> on the left of the add sign.</param>
         /// <param name="quaternion2">Source <see cref="Quaternion"/> on the right of the add sign.</param>
         /// <returns>Sum of the vectors.</returns>
+        [Pure]
         public static Quaternion operator +(Quaternion quaternion1, Quaternion quaternion2)
         {
             Quaternion quaternion;
@@ -1071,6 +1090,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1">Source <see cref="Quaternion"/> on the left of the div sign.</param>
         /// <param name="quaternion2">Divisor <see cref="Quaternion"/> on the right of the div sign.</param>
         /// <returns>The result of dividing the quaternions.</returns>
+        [Pure]
         public static Quaternion operator /(Quaternion quaternion1, Quaternion quaternion2)
         {
             Quaternion quaternion;
@@ -1101,6 +1121,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1"><see cref="Quaternion"/> instance on the left of the equal sign.</param>
         /// <param name="quaternion2"><see cref="Quaternion"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator ==(Quaternion quaternion1, Quaternion quaternion2)
         {
             return ((((quaternion1.X == quaternion2.X) && (quaternion1.Y == quaternion2.Y)) && (quaternion1.Z == quaternion2.Z)) && (quaternion1.W == quaternion2.W));
@@ -1112,6 +1133,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1"><see cref="Quaternion"/> instance on the left of the not equal sign.</param>
         /// <param name="quaternion2"><see cref="Quaternion"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator !=(Quaternion quaternion1, Quaternion quaternion2)
         {
             if (((quaternion1.X == quaternion2.X) && (quaternion1.Y == quaternion2.Y)) && (quaternion1.Z == quaternion2.Z))
@@ -1127,6 +1149,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1">Source <see cref="Quaternion"/> on the left of the mul sign.</param>
         /// <param name="quaternion2">Source <see cref="Quaternion"/> on the right of the mul sign.</param>
         /// <returns>Result of the quaternions multiplication.</returns>
+        [Pure]
         public static Quaternion operator *(Quaternion quaternion1, Quaternion quaternion2)
         {
             Quaternion quaternion;
@@ -1155,6 +1178,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1">Source <see cref="Vector3"/> on the left of the mul sign.</param>
         /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
         /// <returns>Result of the quaternion multiplication with a scalar.</returns>
+        [Pure]
         public static Quaternion operator *(Quaternion quaternion1, float scaleFactor)
         {
             Quaternion quaternion;
@@ -1171,6 +1195,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="quaternion1">Source <see cref="Vector3"/> on the left of the sub sign.</param>
         /// <param name="quaternion2">Source <see cref="Vector3"/> on the right of the sub sign.</param>
         /// <returns>Result of the quaternion subtraction.</returns>
+        [Pure]
         public static Quaternion operator -(Quaternion quaternion1, Quaternion quaternion2)
         {
             Quaternion quaternion;
@@ -1187,6 +1212,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="quaternion">Source <see cref="Quaternion"/> on the right of the sub sign.</param>
         /// <returns>The result of the quaternion negation.</returns>
+        [Pure]
         public static Quaternion operator -(Quaternion quaternion)
         {
             Quaternion quaternion2;

--- a/MonoGame.Framework/Ray.cs
+++ b/MonoGame.Framework/Ray.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -313,6 +314,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a">A ray to check for inequality.</param>
         /// <param name="b">A ray to check for inequality.</param>
         /// <returns><code>true</code> if the two rays are not equal, <code>false</code> if they are.</returns>
+        [Pure]
         public static bool operator !=(Ray a, Ray b)
         {
             return !a.Equals(b);
@@ -324,6 +326,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a">A ray to check for equality.</param>
         /// <param name="b">A ray to check for equality.</param>
         /// <returns><code>true</code> if the two rays are equals, <code>false</code> if they are not.</returns>
+        [Pure]
         public static bool operator ==(Ray a, Ray b)
         {
             return a.Equals(b);

--- a/MonoGame.Framework/Rectangle.cs
+++ b/MonoGame.Framework/Rectangle.cs
@@ -3,8 +3,9 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.Runtime.Serialization;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
 {
@@ -211,6 +212,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a"><see cref="Rectangle"/> instance on the left of the equal sign.</param>
         /// <param name="b"><see cref="Rectangle"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator ==(Rectangle a, Rectangle b)
         {
             return ((a.X == b.X) && (a.Y == b.Y) && (a.Width == b.Width) && (a.Height == b.Height));
@@ -222,6 +224,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="a"><see cref="Rectangle"/> instance on the left of the not equal sign.</param>
         /// <param name="b"><see cref="Rectangle"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator !=(Rectangle a, Rectangle b)
         {
             return !(a == b);
@@ -409,6 +412,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first <see cref="Rectangle"/>.</param>
         /// <param name="value2">The second <see cref="Rectangle"/>.</param>
         /// <returns>Overlapping region of the two rectangles.</returns>
+        [Pure]
         public static Rectangle Intersect(Rectangle value1, Rectangle value2)
         {
             Rectangle rectangle;
@@ -496,6 +500,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first <see cref="Rectangle"/>.</param>
         /// <param name="value2">The second <see cref="Rectangle"/>.</param>
         /// <returns>The union of the two rectangles.</returns>
+        [Pure]
         public static Rectangle Union(Rectangle value1, Rectangle value2)
         {
             int x = Math.Min(value1.X, value2.X);

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -126,6 +127,7 @@ namespace Microsoft.Xna.Framework
         /// Converts a <see cref="System.Numerics.Vector2"/> to a <see cref="Vector2"/>.
         /// </summary>
         /// <param name="value">The converted value.</param>
+        [Pure]
         public static implicit operator Vector2(System.Numerics.Vector2 value)
         {
             return new Vector2(value.X, value.Y);
@@ -136,6 +138,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/> on the right of the sub sign.</param>
         /// <returns>Result of the inversion.</returns>
+        [Pure]
         public static Vector2 operator -(Vector2 value)
         {
             value.X = -value.X;
@@ -149,6 +152,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/> on the left of the add sign.</param>
         /// <param name="value2">Source <see cref="Vector2"/> on the right of the add sign.</param>
         /// <returns>Sum of the vectors.</returns>
+        [Pure]
         public static Vector2 operator +(Vector2 value1, Vector2 value2)
         {
             value1.X += value2.X;
@@ -162,6 +166,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/> on the left of the sub sign.</param>
         /// <param name="value2">Source <see cref="Vector2"/> on the right of the sub sign.</param>
         /// <returns>Result of the vector subtraction.</returns>
+        [Pure]
         public static Vector2 operator -(Vector2 value1, Vector2 value2)
         {
             value1.X -= value2.X;
@@ -175,6 +180,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/> on the left of the mul sign.</param>
         /// <param name="value2">Source <see cref="Vector2"/> on the right of the mul sign.</param>
         /// <returns>Result of the vector multiplication.</returns>
+        [Pure]
         public static Vector2 operator *(Vector2 value1, Vector2 value2)
         {
             value1.X *= value2.X;
@@ -188,6 +194,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Vector2"/> on the left of the mul sign.</param>
         /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
         /// <returns>Result of the vector multiplication with a scalar.</returns>
+        [Pure]
         public static Vector2 operator *(Vector2 value, float scaleFactor)
         {
             value.X *= scaleFactor;
@@ -201,6 +208,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="scaleFactor">Scalar value on the left of the mul sign.</param>
         /// <param name="value">Source <see cref="Vector2"/> on the right of the mul sign.</param>
         /// <returns>Result of the vector multiplication with a scalar.</returns>
+        [Pure]
         public static Vector2 operator *(float scaleFactor, Vector2 value)
         {
             value.X *= scaleFactor;
@@ -214,6 +222,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/> on the left of the div sign.</param>
         /// <param name="value2">Divisor <see cref="Vector2"/> on the right of the div sign.</param>
         /// <returns>The result of dividing the vectors.</returns>
+        [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 operator /(Vector2 value1, Vector2 value2)
         {
@@ -228,6 +237,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/> on the left of the div sign.</param>
         /// <param name="divider">Divisor scalar on the right of the div sign.</param>
         /// <returns>The result of dividing a vector by a scalar.</returns>
+        [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 operator /(Vector2 value1, float divider)
         {
@@ -243,6 +253,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1"><see cref="Vector2"/> instance on the left of the equal sign.</param>
         /// <param name="value2"><see cref="Vector2"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator ==(Vector2 value1, Vector2 value2)
         {
             return value1.X == value2.X && value1.Y == value2.Y;
@@ -254,6 +265,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1"><see cref="Vector2"/> instance on the left of the not equal sign.</param>
         /// <param name="value2"><see cref="Vector2"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
+        [Pure]
         public static bool operator !=(Vector2 value1, Vector2 value2)
         {
             return value1.X != value2.X || value1.Y != value2.Y;
@@ -269,6 +281,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector to add.</param>
         /// <param name="value2">The second vector to add.</param>
         /// <returns>The result of the vector addition.</returns>
+        [Pure]
         public static Vector2 Add(Vector2 value1, Vector2 value2)
         {
             value1.X += value2.X;
@@ -299,6 +312,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="amount1">Barycentric scalar <c>b2</c> which represents a weighting factor towards second vector of 2d-triangle.</param>
         /// <param name="amount2">Barycentric scalar <c>b3</c> which represents a weighting factor towards third vector of 2d-triangle.</param>
         /// <returns>The cartesian translation of barycentric coordinates.</returns>
+        [Pure]
         public static Vector2 Barycentric(Vector2 value1, Vector2 value2, Vector2 value3, float amount1, float amount2)
         {
             return new Vector2(
@@ -330,6 +344,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value4">The fourth vector in interpolation.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <returns>The result of CatmullRom interpolation.</returns>
+        [Pure]
         public static Vector2 CatmullRom(Vector2 value1, Vector2 value2, Vector2 value3, Vector2 value4, float amount)
         {
             return new Vector2(
@@ -366,6 +381,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/>.</param>
         /// <returns>The rounded <see cref="Vector2"/>.</returns>
+        [Pure]
         public static Vector2 Ceiling(Vector2 value)
         {
             value.X = MathF.Ceiling(value.X);
@@ -391,6 +407,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="min">The min value.</param>
         /// <param name="max">The max value.</param>
         /// <returns>The clamped value.</returns>
+        [Pure]
         public static Vector2 Clamp(Vector2 value1, Vector2 min, Vector2 max)
         {
             return new Vector2(
@@ -417,6 +434,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The distance between two vectors.</returns>
+        [Pure]
         public static float Distance(Vector2 value1, Vector2 value2)
         {
             float v1 = value1.X - value2.X, v2 = value1.Y - value2.Y;
@@ -441,6 +459,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The squared distance between two vectors.</returns>
+        [Pure]
         public static float DistanceSquared(Vector2 value1, Vector2 value2)
         {
             float v1 = value1.X - value2.X, v2 = value1.Y - value2.Y;
@@ -465,6 +484,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/>.</param>
         /// <param name="value2">Divisor <see cref="Vector2"/>.</param>
         /// <returns>The result of dividing the vectors.</returns>
+        [Pure]
         public static Vector2 Divide(Vector2 value1, Vector2 value2)
         {
             value1.X /= value2.X;
@@ -490,6 +510,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/>.</param>
         /// <param name="divider">Divisor scalar.</param>
         /// <returns>The result of dividing a vector by a scalar.</returns>
+        [Pure]
         public static Vector2 Divide(Vector2 value1, float divider)
         {
             float factor = 1 / divider;
@@ -517,6 +538,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The dot product of two vectors.</returns>
+        [Pure]
         public static float Dot(Vector2 value1, Vector2 value2)
         {
             return (value1.X * value2.X) + (value1.Y * value2.Y);
@@ -572,6 +594,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/>.</param>
         /// <returns>The rounded <see cref="Vector2"/>.</returns>
+        [Pure]
         public static Vector2 Floor(Vector2 value)
         {
             value.X = MathF.Floor(value.X);
@@ -611,6 +634,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="tangent2">The second tangent vector.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <returns>The hermite spline interpolation vector.</returns>
+        [Pure]
         public static Vector2 Hermite(Vector2 value1, Vector2 tangent1, Vector2 value2, Vector2 tangent2, float amount)
         {
             return new Vector2(MathHelper.Hermite(value1.X, tangent1.X, value2.X, tangent2.X, amount), MathHelper.Hermite(value1.Y, tangent1.Y, value2.Y, tangent2.Y, amount));
@@ -656,6 +680,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">The second vector.</param>
         /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
         /// <returns>The result of linear interpolation of the specified vectors.</returns>
+        [Pure]
         public static Vector2 Lerp(Vector2 value1, Vector2 value2, float amount)
         {
             return new Vector2(
@@ -686,6 +711,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">The second vector.</param>
         /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
         /// <returns>The result of linear interpolation of the specified vectors.</returns>
+        [Pure]
         public static Vector2 LerpPrecise(Vector2 value1, Vector2 value2, float amount)
         {
             return new Vector2(
@@ -715,6 +741,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The <see cref="Vector2"/> with maximal values from the two vectors.</returns>
+        [Pure]
         public static Vector2 Max(Vector2 value1, Vector2 value2)
         {
             return new Vector2(value1.X > value2.X ? value1.X : value2.X,
@@ -739,6 +766,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The <see cref="Vector2"/> with minimal values from the two vectors.</returns>
+        [Pure]
         public static Vector2 Min(Vector2 value1, Vector2 value2)
         {
             return new Vector2(value1.X < value2.X ? value1.X : value2.X,
@@ -763,6 +791,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/>.</param>
         /// <param name="value2">Source <see cref="Vector2"/>.</param>
         /// <returns>The result of the vector multiplication.</returns>
+        [Pure]
         public static Vector2 Multiply(Vector2 value1, Vector2 value2)
         {
             value1.X *= value2.X;
@@ -788,6 +817,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/>.</param>
         /// <param name="scaleFactor">Scalar value.</param>
         /// <returns>The result of the vector multiplication with a scalar.</returns>
+        [Pure]
         public static Vector2 Multiply(Vector2 value1, float scaleFactor)
         {
             value1.X *= scaleFactor;
@@ -812,6 +842,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/>.</param>
         /// <returns>The result of the vector inversion.</returns>
+        [Pure]
         public static Vector2 Negate(Vector2 value)
         {
             value.X = -value.X;
@@ -845,6 +876,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/>.</param>
         /// <returns>Unit vector.</returns>
+        [Pure]
         public static Vector2 Normalize(Vector2 value)
         {
             float val = 1.0f / MathF.Sqrt((value.X * value.X) + (value.Y * value.Y));
@@ -871,6 +903,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="vector">Source <see cref="Vector2"/>.</param>
         /// <param name="normal">Reflection normal.</param>
         /// <returns>Reflected vector.</returns>
+        [Pure]
         public static Vector2 Reflect(Vector2 vector, Vector2 normal)
         {
             Vector2 result;
@@ -907,6 +940,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector2"/>.</param>
         /// <returns>The rounded <see cref="Vector2"/>.</returns>
+        [Pure]
         public static Vector2 Round(Vector2 value)
         {
             value.X = MathF.Round(value.X);
@@ -932,6 +966,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">Source <see cref="Vector2"/>.</param>
         /// <param name="amount">Weighting value.</param>
         /// <returns>Cubic interpolation of the specified vectors.</returns>
+        [Pure]
         public static Vector2 SmoothStep(Vector2 value1, Vector2 value2, float amount)
         {
             return new Vector2(
@@ -958,6 +993,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector2"/>.</param>
         /// <param name="value2">Source <see cref="Vector2"/>.</param>
         /// <returns>The result of the vector subtraction.</returns>
+        [Pure]
         public static Vector2 Subtract(Vector2 value1, Vector2 value2)
         {
             value1.X -= value2.X;
@@ -1002,6 +1038,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="position">Source <see cref="Vector2"/>.</param>
         /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
         /// <returns>Transformed <see cref="Vector2"/>.</returns>
+        [Pure]
         public static Vector2 Transform(Vector2 position, Matrix matrix)
         {
             return new Vector2((position.X * matrix.M11) + (position.Y * matrix.M21) + matrix.M41, (position.X * matrix.M12) + (position.Y * matrix.M22) + matrix.M42);
@@ -1027,6 +1064,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Vector2"/>.</param>
         /// <param name="rotation">The <see cref="Quaternion"/> which contains rotation transformation.</param>
         /// <returns>Transformed <see cref="Vector2"/>.</returns>
+        [Pure]
         public static Vector2 Transform(Vector2 value, Quaternion rotation)
         {
             Transform(ref value, ref rotation, out value);
@@ -1169,6 +1207,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="normal">Source <see cref="Vector2"/> which represents a normal vector.</param>
         /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
         /// <returns>Transformed normal.</returns>
+        [Pure]
         public static Vector2 TransformNormal(Vector2 normal, Matrix matrix)
         {
             return new Vector2((normal.X * matrix.M11) + (normal.Y * matrix.M21),(normal.X * matrix.M12) + (normal.Y * matrix.M22));
@@ -1265,6 +1304,7 @@ namespace Microsoft.Xna.Framework
         /// would rotate counterclockwise and clockwise,
         /// respectively
         /// </remarks>
+        [Pure]
         public static Vector2 Rotate(Vector2 value, float radians)
         {
             float cos = MathF.Cos(radians);
@@ -1305,6 +1345,7 @@ namespace Microsoft.Xna.Framework
         /// would rotate counterclockwise and clockwise,
         /// respectively
         /// </remarks>
+        [Pure]
         public static Vector2 RotateAround(Vector2 value, Vector2 origin, float radians)
         {
             return Rotate(value - origin, radians) + origin;

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -4,8 +4,9 @@
 
 using System;
 using System.Diagnostics;
-using System.Text;
+using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
+using System.Text;
 
 namespace Microsoft.Xna.Framework
 {
@@ -202,9 +203,9 @@ namespace Microsoft.Xna.Framework
             this.Y = value.Y;
             this.Z = z;
         }
-        
+
         #endregion
-        
+
         #region Public Methods
 
         /// <summary>
@@ -213,6 +214,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector to add.</param>
         /// <param name="value2">The second vector to add.</param>
         /// <returns>The result of the vector addition.</returns>
+        [Pure]
         public static Vector3 Add(Vector3 value1, Vector3 value2)
         {
             value1.X += value2.X;
@@ -245,6 +247,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="amount1">Barycentric scalar <c>b2</c> which represents a weighting factor towards second vector of 3d-triangle.</param>
         /// <param name="amount2">Barycentric scalar <c>b3</c> which represents a weighting factor towards third vector of 3d-triangle.</param>
         /// <returns>The cartesian translation of barycentric coordinates.</returns>
+        [Pure]
         public static Vector3 Barycentric(Vector3 value1, Vector3 value2, Vector3 value3, float amount1, float amount2)
         {
             return new Vector3(
@@ -278,6 +281,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value4">The fourth vector in interpolation.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <returns>The result of CatmullRom interpolation.</returns>
+        [Pure]
         public static Vector3 CatmullRom(Vector3 value1, Vector3 value2, Vector3 value3, Vector3 value4, float amount)
         {
             return new Vector3(
@@ -317,6 +321,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/>.</param>
         /// <returns>The rounded <see cref="Vector3"/>.</returns>
+        [Pure]
         public static Vector3 Ceiling(Vector3 value)
         {
             value.X = MathF.Ceiling(value.X);
@@ -344,6 +349,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="min">The min value.</param>
         /// <param name="max">The max value.</param>
         /// <returns>The clamped value.</returns>
+        [Pure]
         public static Vector3 Clamp(Vector3 value1, Vector3 min, Vector3 max)
         {
             return new Vector3(
@@ -372,6 +378,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="vector1">The first vector.</param>
         /// <param name="vector2">The second vector.</param>
         /// <returns>The cross product of two vectors.</returns>
+        [Pure]
         public static Vector3 Cross(Vector3 vector1, Vector3 vector2)
         {
             Cross(ref vector1, ref vector2, out vector1);
@@ -400,6 +407,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The distance between two vectors.</returns>
+        [Pure]
         public static float Distance(Vector3 value1, Vector3 value2)
         {
             float result;
@@ -425,6 +433,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The squared distance between two vectors.</returns>
+        [Pure]
         public static float DistanceSquared(Vector3 value1, Vector3 value2)
         {
             return  (value1.X - value2.X) * (value1.X - value2.X) +
@@ -451,6 +460,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector3"/>.</param>
         /// <param name="value2">Divisor <see cref="Vector3"/>.</param>
         /// <returns>The result of dividing the vectors.</returns>
+        [Pure]
         public static Vector3 Divide(Vector3 value1, Vector3 value2)
         {
             value1.X /= value2.X;
@@ -465,6 +475,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector3"/>.</param>
         /// <param name="divider">Divisor scalar.</param>
         /// <returns>The result of dividing a vector by a scalar.</returns>
+        [Pure]
         public static Vector3 Divide(Vector3 value1, float divider)
         {
             float factor = 1 / divider;
@@ -507,6 +518,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The dot product of two vectors.</returns>
+        [Pure]
         public static float Dot(Vector3 value1, Vector3 value2)
         {
             return value1.X * value2.X + value1.Y * value2.Y + value1.Z * value2.Z;
@@ -566,6 +578,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/>.</param>
         /// <returns>The rounded <see cref="Vector3"/>.</returns>
+        [Pure]
         public static Vector3 Floor(Vector3 value)
         {
             value.X = MathF.Floor(value.X);
@@ -609,6 +622,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="tangent2">The second tangent vector.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <returns>The hermite spline interpolation vector.</returns>
+        [Pure]
         public static Vector3 Hermite(Vector3 value1, Vector3 tangent1, Vector3 value2, Vector3 tangent2, float amount)
         {
             return new Vector3(MathHelper.Hermite(value1.X, tangent1.X, value2.X, tangent2.X, amount),
@@ -657,6 +671,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">The second vector.</param>
         /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
         /// <returns>The result of linear interpolation of the specified vectors.</returns>
+        [Pure]
         public static Vector3 Lerp(Vector3 value1, Vector3 value2, float amount)
         {
             return new Vector3(
@@ -689,6 +704,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">The second vector.</param>
         /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
         /// <returns>The result of linear interpolation of the specified vectors.</returns>
+        [Pure]
         public static Vector3 LerpPrecise(Vector3 value1, Vector3 value2, float amount)
         {
             return new Vector3(
@@ -720,6 +736,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The <see cref="Vector3"/> with maximal values from the two vectors.</returns>
+        [Pure]
         public static Vector3 Max(Vector3 value1, Vector3 value2)
         {
             return new Vector3(
@@ -747,6 +764,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The <see cref="Vector3"/> with minimal values from the two vectors.</returns>
+        [Pure]
         public static Vector3 Min(Vector3 value1, Vector3 value2)
         {
             return new Vector3(
@@ -774,6 +792,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector3"/>.</param>
         /// <param name="value2">Source <see cref="Vector3"/>.</param>
         /// <returns>The result of the vector multiplication.</returns>
+        [Pure]
         public static Vector3 Multiply(Vector3 value1, Vector3 value2)
         {
             value1.X *= value2.X;
@@ -788,6 +807,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector3"/>.</param>
         /// <param name="scaleFactor">Scalar value.</param>
         /// <returns>The result of the vector multiplication with a scalar.</returns>
+        [Pure]
         public static Vector3 Multiply(Vector3 value1, float scaleFactor)
         {
             value1.X *= scaleFactor;
@@ -827,6 +847,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/>.</param>
         /// <returns>The result of the vector inversion.</returns>
+        [Pure]
         public static Vector3 Negate(Vector3 value)
         {
             value = new Vector3(-value.X, -value.Y, -value.Z);
@@ -862,6 +883,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/>.</param>
         /// <returns>Unit vector.</returns>
+        [Pure]
         public static Vector3 Normalize(Vector3 value)
         {
             float factor = MathF.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z));
@@ -889,6 +911,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="vector">Source <see cref="Vector3"/>.</param>
         /// <param name="normal">Reflection normal.</param>
         /// <returns>Reflected vector.</returns>
+        [Pure]
         public static Vector3 Reflect(Vector3 vector, Vector3 normal)
         {
             // I is the original array
@@ -938,6 +961,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/>.</param>
         /// <returns>The rounded <see cref="Vector3"/>.</returns>
+        [Pure]
         public static Vector3 Round(Vector3 value)
         {
             value.X = MathF.Round(value.X);
@@ -965,6 +989,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">Source <see cref="Vector3"/>.</param>
         /// <param name="amount">Weighting value.</param>
         /// <returns>Cubic interpolation of the specified vectors.</returns>
+        [Pure]
         public static Vector3 SmoothStep(Vector3 value1, Vector3 value2, float amount)
         {
             return new Vector3(
@@ -993,6 +1018,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector3"/>.</param>
         /// <param name="value2">Source <see cref="Vector3"/>.</param>
         /// <returns>The result of the vector subtraction.</returns>
+        [Pure]
         public static Vector3 Subtract(Vector3 value1, Vector3 value2)
         {
             value1.X -= value2.X;
@@ -1040,6 +1066,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="position">Source <see cref="Vector3"/>.</param>
         /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
         /// <returns>Transformed <see cref="Vector3"/>.</returns>
+        [Pure]
         public static Vector3 Transform(Vector3 position, Matrix matrix)
         {
             Transform(ref position, ref matrix, out position);
@@ -1068,6 +1095,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Vector3"/>.</param>
         /// <param name="rotation">The <see cref="Quaternion"/> which contains rotation transformation.</param>
         /// <returns>Transformed <see cref="Vector3"/>.</returns>
+        [Pure]
         public static Vector3 Transform(Vector3 value, Quaternion rotation)
         {
             Vector3 result;
@@ -1234,6 +1262,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="normal">Source <see cref="Vector3"/> which represents a normal vector.</param>
         /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
         /// <returns>Transformed normal.</returns>
+        [Pure]
         public static Vector3 TransformNormal(Vector3 normal, Matrix matrix)
         {
             TransformNormal(ref normal, ref matrix, out normal);
@@ -1351,6 +1380,7 @@ namespace Microsoft.Xna.Framework
         /// Converts a <see cref="System.Numerics.Vector3"/> to a <see cref="Vector3"/>.
         /// </summary>
         /// <param name="value">The converted value.</param>
+        [Pure]
         public static implicit operator Vector3(System.Numerics.Vector3 value)
         {
             return new Vector3(value.X, value.Y, value.Z);
@@ -1362,6 +1392,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1"><see cref="Vector3"/> instance on the left of the equal sign.</param>
         /// <param name="value2"><see cref="Vector3"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator ==(Vector3 value1, Vector3 value2)
         {
             return value1.X == value2.X
@@ -1375,6 +1406,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1"><see cref="Vector3"/> instance on the left of the not equal sign.</param>
         /// <param name="value2"><see cref="Vector3"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
+        [Pure]
         public static bool operator !=(Vector3 value1, Vector3 value2)
         {
             return !(value1 == value2);
@@ -1386,6 +1418,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector3"/> on the left of the add sign.</param>
         /// <param name="value2">Source <see cref="Vector3"/> on the right of the add sign.</param>
         /// <returns>Sum of the vectors.</returns>
+        [Pure]
         public static Vector3 operator +(Vector3 value1, Vector3 value2)
         {
             value1.X += value2.X;
@@ -1399,6 +1432,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector3"/> on the right of the sub sign.</param>
         /// <returns>Result of the inversion.</returns>
+        [Pure]
         public static Vector3 operator -(Vector3 value)
         {
             value = new Vector3(-value.X, -value.Y, -value.Z);
@@ -1411,6 +1445,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector3"/> on the left of the sub sign.</param>
         /// <param name="value2">Source <see cref="Vector3"/> on the right of the sub sign.</param>
         /// <returns>Result of the vector subtraction.</returns>
+        [Pure]
         public static Vector3 operator -(Vector3 value1, Vector3 value2)
         {
             value1.X -= value2.X;
@@ -1425,6 +1460,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector3"/> on the left of the mul sign.</param>
         /// <param name="value2">Source <see cref="Vector3"/> on the right of the mul sign.</param>
         /// <returns>Result of the vector multiplication.</returns>
+        [Pure]
         public static Vector3 operator *(Vector3 value1, Vector3 value2)
         {
             value1.X *= value2.X;
@@ -1439,6 +1475,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Vector3"/> on the left of the mul sign.</param>
         /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
         /// <returns>Result of the vector multiplication with a scalar.</returns>
+        [Pure]
         public static Vector3 operator *(Vector3 value, float scaleFactor)
         {
             value.X *= scaleFactor;
@@ -1453,6 +1490,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="scaleFactor">Scalar value on the left of the mul sign.</param>
         /// <param name="value">Source <see cref="Vector3"/> on the right of the mul sign.</param>
         /// <returns>Result of the vector multiplication with a scalar.</returns>
+        [Pure]
         public static Vector3 operator *(float scaleFactor, Vector3 value)
         {
             value.X *= scaleFactor;
@@ -1467,6 +1505,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector3"/> on the left of the div sign.</param>
         /// <param name="value2">Divisor <see cref="Vector3"/> on the right of the div sign.</param>
         /// <returns>The result of dividing the vectors.</returns>
+        [Pure]
         public static Vector3 operator /(Vector3 value1, Vector3 value2)
         {
             value1.X /= value2.X;
@@ -1481,6 +1520,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector3"/> on the left of the div sign.</param>
         /// <param name="divider">Divisor scalar on the right of the div sign.</param>
         /// <returns>The result of dividing a vector by a scalar.</returns>
+        [Pure]
         public static Vector3 operator /(Vector3 value1, float divider)
         {
             float factor = 1 / divider;

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -3,8 +3,9 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.Runtime.Serialization;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
 {
@@ -192,6 +193,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector to add.</param>
         /// <param name="value2">The second vector to add.</param>
         /// <returns>The result of the vector addition.</returns>
+        [Pure]
         public static Vector4 Add(Vector4 value1, Vector4 value2)
         {
             value1.X += value2.X;
@@ -226,6 +228,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="amount1">Barycentric scalar <c>b2</c> which represents a weighting factor towards second vector of 4d-triangle.</param>
         /// <param name="amount2">Barycentric scalar <c>b3</c> which represents a weighting factor towards third vector of 4d-triangle.</param>
         /// <returns>The cartesian translation of barycentric coordinates.</returns>
+        [Pure]
         public static Vector4 Barycentric(Vector4 value1, Vector4 value2, Vector4 value3, float amount1, float amount2)
         {
             return new Vector4(
@@ -261,6 +264,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value4">The fourth vector in interpolation.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <returns>The result of CatmullRom interpolation.</returns>
+        [Pure]
         public static Vector4 CatmullRom(Vector4 value1, Vector4 value2, Vector4 value3, Vector4 value4, float amount)
         {
             return new Vector4(
@@ -303,6 +307,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/>.</param>
         /// <returns>The rounded <see cref="Vector4"/>.</returns>
+        [Pure]
         public static Vector4 Ceiling(Vector4 value)
         {
             value.X = MathF.Ceiling(value.X);
@@ -332,6 +337,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="min">The min value.</param>
         /// <param name="max">The max value.</param>
         /// <returns>The clamped value.</returns>
+        [Pure]
         public static Vector4 Clamp(Vector4 value1, Vector4 min, Vector4 max)
         {
             return new Vector4(
@@ -362,6 +368,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The distance between two vectors.</returns>
+        [Pure]
         public static float Distance(Vector4 value1, Vector4 value2)
         {
             return MathF.Sqrt(DistanceSquared(value1, value2));
@@ -384,6 +391,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The squared distance between two vectors.</returns>
+        [Pure]
         public static float DistanceSquared(Vector4 value1, Vector4 value2)
         {
               return (value1.W - value2.W) * (value1.W - value2.W) +
@@ -412,6 +420,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector4"/>.</param>
         /// <param name="value2">Divisor <see cref="Vector4"/>.</param>
         /// <returns>The result of dividing the vectors.</returns>
+        [Pure]
         public static Vector4 Divide(Vector4 value1, Vector4 value2)
         {
             value1.W /= value2.W;
@@ -427,6 +436,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector4"/>.</param>
         /// <param name="divider">Divisor scalar.</param>
         /// <returns>The result of dividing a vector by a scalar.</returns>
+        [Pure]
         public static Vector4 Divide(Vector4 value1, float divider)
         {
             float factor = 1f / divider;
@@ -472,6 +482,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The dot product of two vectors.</returns>
+        [Pure]
         public static float Dot(Vector4 value1, Vector4 value2)
         {
             return value1.X * value2.X + value1.Y * value2.Y + value1.Z * value2.Z + value1.W * value2.W;
@@ -527,6 +538,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/>.</param>
         /// <returns>The rounded <see cref="Vector4"/>.</returns>
+        [Pure]
         public static Vector4 Floor(Vector4 value)
         {
             value.X = MathF.Floor(value.X);
@@ -574,6 +586,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="tangent2">The second tangent vector.</param>
         /// <param name="amount">Weighting factor.</param>
         /// <returns>The hermite spline interpolation vector.</returns>
+        [Pure]
         public static Vector4 Hermite(Vector4 value1, Vector4 tangent1, Vector4 value2, Vector4 tangent2, float amount)
         {
             return new Vector4(MathHelper.Hermite(value1.X, tangent1.X, value2.X, tangent2.X, amount),
@@ -624,6 +637,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">The second vector.</param>
         /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
         /// <returns>The result of linear interpolation of the specified vectors.</returns>
+        [Pure]
         public static Vector4 Lerp(Vector4 value1, Vector4 value2, float amount)
         {
             return new Vector4(
@@ -658,6 +672,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">The second vector.</param>
         /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
         /// <returns>The result of linear interpolation of the specified vectors.</returns>
+        [Pure]
         public static Vector4 LerpPrecise(Vector4 value1, Vector4 value2, float amount)
         {
             return new Vector4(
@@ -691,6 +706,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The <see cref="Vector4"/> with maximal values from the two vectors.</returns>
+        [Pure]
         public static Vector4 Max(Vector4 value1, Vector4 value2)
         {
             return new Vector4(
@@ -720,6 +736,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">The first vector.</param>
         /// <param name="value2">The second vector.</param>
         /// <returns>The <see cref="Vector4"/> with minimal values from the two vectors.</returns>
+        [Pure]
         public static Vector4 Min(Vector4 value1, Vector4 value2)
         {
             return new Vector4(
@@ -749,6 +766,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector4"/>.</param>
         /// <param name="value2">Source <see cref="Vector4"/>.</param>
         /// <returns>The result of the vector multiplication.</returns>
+        [Pure]
         public static Vector4 Multiply(Vector4 value1, Vector4 value2)
         {
             value1.W *= value2.W;
@@ -764,6 +782,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector4"/>.</param>
         /// <param name="scaleFactor">Scalar value.</param>
         /// <returns>The result of the vector multiplication with a scalar.</returns>
+        [Pure]
         public static Vector4 Multiply(Vector4 value1, float scaleFactor)
         {
             value1.W *= scaleFactor;
@@ -806,6 +825,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/>.</param>
         /// <returns>The result of the vector inversion.</returns>
+        [Pure]
         public static Vector4 Negate(Vector4 value)
         {
             value = new Vector4(-value.X, -value.Y, -value.Z, -value.W);
@@ -843,6 +863,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/>.</param>
         /// <returns>Unit vector.</returns>
+        [Pure]
         public static Vector4 Normalize(Vector4 value)
         {
             float factor = MathF.Sqrt((value.X * value.X) + (value.Y * value.Y) + (value.Z * value.Z) + (value.W * value.W));
@@ -881,6 +902,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/>.</param>
         /// <returns>The rounded <see cref="Vector4"/>.</returns>
+        [Pure]
         public static Vector4 Round(Vector4 value)
         {
             value.X = MathF.Round(value.X);
@@ -910,6 +932,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">Source <see cref="Vector4"/>.</param>
         /// <param name="amount">Weighting value.</param>
         /// <returns>Cubic interpolation of the specified vectors.</returns>
+        [Pure]
         public static Vector4 SmoothStep(Vector4 value1, Vector4 value2, float amount)
         {
             return new Vector4(
@@ -940,6 +963,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector4"/>.</param>
         /// <param name="value2">Source <see cref="Vector4"/>.</param>
         /// <returns>The result of the vector subtraction.</returns>
+        [Pure]
         public static Vector4 Subtract(Vector4 value1, Vector4 value2)
         {
             value1.W -= value2.W;
@@ -971,6 +995,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Vector2"/>.</param>
         /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
         /// <returns>Transformed <see cref="Vector4"/>.</returns>
+        [Pure]
         public static Vector4 Transform(Vector2 value, Matrix matrix)
         {
             Vector4 result;
@@ -984,6 +1009,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Vector2"/>.</param>
         /// <param name="rotation">The <see cref="Quaternion"/> which contains rotation transformation.</param>
         /// <returns>Transformed <see cref="Vector4"/>.</returns>
+        [Pure]
         public static Vector4 Transform(Vector2 value, Quaternion rotation)
         {
             Vector4 result;
@@ -997,6 +1023,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Vector3"/>.</param>
         /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
         /// <returns>Transformed <see cref="Vector4"/>.</returns>
+        [Pure]
         public static Vector4 Transform(Vector3 value, Matrix matrix)
         {
             Vector4 result;
@@ -1010,6 +1037,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Vector3"/>.</param>
         /// <param name="rotation">The <see cref="Quaternion"/> which contains rotation transformation.</param>
         /// <returns>Transformed <see cref="Vector4"/>.</returns>
+        [Pure]
         public static Vector4 Transform(Vector3 value, Quaternion rotation)
         {
             Vector4 result;
@@ -1023,6 +1051,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Vector4"/>.</param>
         /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
         /// <returns>Transformed <see cref="Vector4"/>.</returns>
+        [Pure]
         public static Vector4 Transform(Vector4 value, Matrix matrix)
         {
             Transform(ref value, ref matrix, out value);
@@ -1035,6 +1064,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Vector4"/>.</param>
         /// <param name="rotation">The <see cref="Quaternion"/> which contains rotation transformation.</param>
         /// <returns>Transformed <see cref="Vector4"/>.</returns>
+        [Pure]
         public static Vector4 Transform(Vector4 value, Quaternion rotation)
         {
             Vector4 result;
@@ -1277,6 +1307,7 @@ namespace Microsoft.Xna.Framework
         /// Converts a <see cref="System.Numerics.Vector4"/> to a <see cref="Vector4"/>.
         /// </summary>
         /// <param name="value">The converted value.</param>
+        [Pure]
         public static implicit operator Vector4(System.Numerics.Vector4 value)
         {
             return new Vector4(value.X, value.Y, value.Z, value.W);
@@ -1287,6 +1318,7 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         /// <param name="value">Source <see cref="Vector4"/> on the right of the sub sign.</param>
         /// <returns>Result of the inversion.</returns>
+        [Pure]
         public static Vector4 operator -(Vector4 value)
         {
             return new Vector4(-value.X, -value.Y, -value.Z, -value.W);
@@ -1298,6 +1330,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1"><see cref="Vector4"/> instance on the left of the equal sign.</param>
         /// <param name="value2"><see cref="Vector4"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator ==(Vector4 value1, Vector4 value2)
         {
             return value1.W == value2.W
@@ -1312,6 +1345,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1"><see cref="Vector4"/> instance on the left of the not equal sign.</param>
         /// <param name="value2"><see cref="Vector4"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
+        [Pure]
         public static bool operator !=(Vector4 value1, Vector4 value2)
         {
             return !(value1 == value2);
@@ -1323,6 +1357,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector4"/> on the left of the add sign.</param>
         /// <param name="value2">Source <see cref="Vector4"/> on the right of the add sign.</param>
         /// <returns>Sum of the vectors.</returns>
+        [Pure]
         public static Vector4 operator +(Vector4 value1, Vector4 value2)
         {
             value1.W += value2.W;
@@ -1338,6 +1373,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector4"/> on the left of the sub sign.</param>
         /// <param name="value2">Source <see cref="Vector4"/> on the right of the sub sign.</param>
         /// <returns>Result of the vector subtraction.</returns>
+        [Pure]
         public static Vector4 operator -(Vector4 value1, Vector4 value2)
         {
             value1.W -= value2.W;
@@ -1353,6 +1389,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector4"/> on the left of the mul sign.</param>
         /// <param name="value2">Source <see cref="Vector4"/> on the right of the mul sign.</param>
         /// <returns>Result of the vector multiplication.</returns>
+        [Pure]
         public static Vector4 operator *(Vector4 value1, Vector4 value2)
         {
             value1.W *= value2.W;
@@ -1368,6 +1405,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value">Source <see cref="Vector4"/> on the left of the mul sign.</param>
         /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
         /// <returns>Result of the vector multiplication with a scalar.</returns>
+        [Pure]
         public static Vector4 operator *(Vector4 value, float scaleFactor)
         {
             value.W *= scaleFactor;
@@ -1383,6 +1421,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="scaleFactor">Scalar value on the left of the mul sign.</param>
         /// <param name="value">Source <see cref="Vector4"/> on the right of the mul sign.</param>
         /// <returns>Result of the vector multiplication with a scalar.</returns>
+        [Pure]
         public static Vector4 operator *(float scaleFactor, Vector4 value)
         {
             value.W *= scaleFactor;
@@ -1398,6 +1437,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector4"/> on the left of the div sign.</param>
         /// <param name="value2">Divisor <see cref="Vector4"/> on the right of the div sign.</param>
         /// <returns>The result of dividing the vectors.</returns>
+        [Pure]
         public static Vector4 operator /(Vector4 value1, Vector4 value2)
         {
             value1.W /= value2.W;
@@ -1413,6 +1453,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="value1">Source <see cref="Vector4"/> on the left of the div sign.</param>
         /// <param name="divider">Divisor scalar on the right of the div sign.</param>
         /// <returns>The result of dividing a vector by a scalar.</returns>
+        [Pure]
         public static Vector4 operator /(Vector4 value1, float divider)
         {
             float factor = 1f / divider;


### PR DESCRIPTION
Implementation of https://github.com/MonoGame/MonoGame/issues/9474

### Description of Change

People can make mistakes while programming; 
```csharp
var stringValue = "abc";
stringValue.ToUpper(); // invokes CA1806 warning
Console.Write(stringValue); // "abc", not "ABC"
```
In this case, the programmer assumed `stringValue` would be altered; it isn't, a new string is returned instead.

In MonoGame these mistakes can be made as well
```csharp

var newVector = new Vector2(1.8f, 1.6f);
Vector2.Floor(newVector);  // invokes CA1806 due to this PR
Console.Write(newVector); // "{X: 1.8 Y: 1.6}", not  "{X: 1 Y: 1}"
```
CA1806 compiler warning was invented to work around this; one way is that if a method is marked `[Pure]`, it promises not to alter input or global state, that it will return an output (or `out`) that should be used, and that it will always return the same output. (e.g. `int Add(int x, int y)` , when invoked `Add(2,2)` will always return `4`)

Therefore, if the programmer invokes the method yet does nothing with the output, a warning will be given out at compile-time.

This PR does nothing more than label a bunch of methods and operators as `[Pure]`, which doesn't affect runtime but only hands out warnings at compile time to help the user. `[Pure]` is (AFAIK) the only remaining "survivor" of the contract attributes still in use for .NET 10, but it has existed since at least _.NET Framework 4.0_ and _.NET Standard 2.0_ - so Framework compatibility isn't affected.

#### Why are the operators labelled `[Pure]`? 

Operators don't promise not to alter state; it's _expected_, but not enforced that you only perform stateless pure operations here.

#### Why aren't non-static methods on structs labelled `[Pure]`? 

Because the values they carry are not immutable; 
```csharp
var newVector = new Vector2(2.5f, 2.2f);
var vectorAsString = newVector.ToString();
newVector.X = 0;
vectorAsString = newVector.ToString(); // different result, despite the fact the method is called in the same fashion
```
Now, if vectors, packed vectors and other datatypes _did_ have immutable fields, we could mark their non-static methods as `[Pure]`

#### Why aren't many SDL/OpenGL/DirectX static methods marked `[Pure]`?

Because they do two things:
- Perform a "startup creation" for a global state variable, which is not what a pure function does
- Invoke DLL's or perform I/O operations, which are also impure operations. 

### Contributor Declaration

- [X] I certify that no LLM's were used to generate any code or documentation in this contribution.

