### PR TITLE
Changed SpriteBatch.Draw doc comments to indicate rotation is in radians

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="position">The drawing location on screen.</param>
         /// <param name="sourceRectangle">An optional region on the texture which will be rendered. If null - draws full texture.</param>
         /// <param name="color">A color mask.</param>
-        /// <param name="rotation">A rotation of this sprite.</param>
+        /// <param name="rotation">A rotation of this sprite, in radians.</param>
         /// <param name="origin">Center of the rotation. 0,0 by default.</param>
         /// <param name="scale">A scaling of this sprite.</param>
         /// <param name="effects">Modificators for drawing. Can be combined.</param>
@@ -279,7 +279,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="position">The drawing location on screen.</param>
         /// <param name="sourceRectangle">An optional region on the texture which will be rendered. If null - draws full texture.</param>
         /// <param name="color">A color mask.</param>
-        /// <param name="rotation">A rotation of this sprite.</param>
+        /// <param name="rotation">A rotation of this sprite, in radians.</param>
         /// <param name="origin">Center of the rotation. 0,0 by default.</param>
         /// <param name="scale">A scaling of this sprite.</param>
         /// <param name="effects">Modificators for drawing. Can be combined.</param>
@@ -305,7 +305,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="destinationRectangle">The drawing bounds on screen.</param>
         /// <param name="sourceRectangle">An optional region on the texture which will be rendered. If null - draws full texture.</param>
         /// <param name="color">A color mask.</param>
-        /// <param name="rotation">A rotation of this sprite.</param>
+        /// <param name="rotation">A rotation of this sprite, in radians.</param>
         /// <param name="origin">Center of the rotation. 0,0 by default.</param>
         /// <param name="effects">Modificators for drawing. Can be combined.</param>
         /// <param name="layerDepth">A depth of the layer of this sprite.</param>


### PR DESCRIPTION
<!--
Are you targeting develop? All PRs should target the develop branch unless otherwise noted.
-->

Fixes #9476 

<!--
Please try to make sure that there is a bug logged for the issue being fixed if one is not present.
Especially for issues which are complex. 
The bug should describe the problem and how to reproduce it.
-->

### Description of Change

Adds a short piece of text to the `SpriteBatch.Draw` overload doc comments to make it clear that `rotation` is expected in radians.

<!-- 
Enter description of the fix in this section.
Please be as descriptive as possible, future contributors will need to know *why* these changes are being made.
For inspiration review the commit/PR history in the MonoGame repository.
-->


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

