### PR TITLE
Fix render target retention after dispose

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -926,7 +926,25 @@ namespace Microsoft.Xna.Framework.Graphics
 			else
 			{
 				_tempRenderTargetBinding[0] = new RenderTargetBinding(renderTarget);
-				SetRenderTargets(_tempRenderTargetBinding);
+				
+                try
+                {
+				    SetRenderTargets(_tempRenderTargetBinding);
+                }
+                finally
+                {
+                    /*
+                     * This is only temporary storage for the single render target overload.
+                     * If we  do not clear this and the ser disposes the render target before
+                     * a new one i set, the graphics device will keep a strong reference to
+                     * the render target, preventing the garbage collector fom collecting it.
+                     *
+                     * See issue: https://github.com/MonoGame/MonoGame/issues/9485
+                     *
+                     * - Chris <aristurtledev>
+                     */
+                    _tempRenderTargetBinding[0] = default;
+                }
 			}
 		}
 
@@ -947,7 +965,25 @@ namespace Microsoft.Xna.Framework.Graphics
             else
             {
                 _tempRenderTargetBinding[0] = new RenderTargetBinding(renderTarget, cubeMapFace);
-                SetRenderTargets(_tempRenderTargetBinding);
+                
+                try
+                {
+				    SetRenderTargets(_tempRenderTargetBinding);
+                }
+                finally
+                {
+                    /*
+                     * This is only temporary storage for the single render target overload.
+                     * If we  do not clear this and the ser disposes the render target before
+                     * a new one i set, the graphics device will keep a strong reference to
+                     * the render target, preventing the garbage collector fom collecting it.
+                     *
+                     * See issue: https://github.com/MonoGame/MonoGame/issues/9485
+                     *
+                     * - Chris <aristurtledev>
+                     */
+                    _tempRenderTargetBinding[0] = default;
+                }
             }
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -933,16 +933,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
                 finally
                 {
-                    /*
-                     * This is only temporary storage for the single render target overload.
-                     * If we  do not clear this and the ser disposes the render target before
-                     * a new one i set, the graphics device will keep a strong reference to
-                     * the render target, preventing the garbage collector fom collecting it.
-                     *
-                     * See issue: https://github.com/MonoGame/MonoGame/issues/9485
-                     *
-                     * - Chris <aristurtledev>
-                     */
+                    // Clear temporary strong reference.
                     _tempRenderTargetBinding[0] = default;
                 }
 			}
@@ -972,16 +963,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
                 finally
                 {
-                    /*
-                     * This is only temporary storage for the single render target overload.
-                     * If we  do not clear this and the ser disposes the render target before
-                     * a new one i set, the graphics device will keep a strong reference to
-                     * the render target, preventing the garbage collector fom collecting it.
-                     *
-                     * See issue: https://github.com/MonoGame/MonoGame/issues/9485
-                     *
-                     * - Chris <aristurtledev>
-                     */
+                    // Clear temporary strong reference.
                     _tempRenderTargetBinding[0] = default;
                 }
             }

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
@@ -611,7 +611,25 @@ namespace Microsoft.Xna.Framework.Graphics
             else
             {
                 _tempRenderTargetBinding[0] = new RenderTargetBinding(renderTarget, arraySlice);
-                SetRenderTargets(_tempRenderTargetBinding);
+                
+                try
+                {
+				    SetRenderTargets(_tempRenderTargetBinding);
+                }
+                finally
+                {
+                    /*
+                     * This is only temporary storage for the single render target overload.
+                     * If we  do not clear this and the ser disposes the render target before
+                     * a new one i set, the graphics device will keep a strong reference to
+                     * the render target, preventing the garbage collector fom collecting it.
+                     *
+                     * See issue: https://github.com/MonoGame/MonoGame/issues/9485
+                     *
+                     * - Chris <aristurtledev>
+                     */
+                    _tempRenderTargetBinding[0] = default;
+                }
             }
         }
 
@@ -623,7 +641,25 @@ namespace Microsoft.Xna.Framework.Graphics
             else
             {
                 _tempRenderTargetBinding[0] = new RenderTargetBinding(renderTarget, arraySlice);
-                SetRenderTargets(_tempRenderTargetBinding);
+                
+                try
+                {
+				    SetRenderTargets(_tempRenderTargetBinding);
+                }
+                finally
+                {
+                    /*
+                     * This is only temporary storage for the single render target overload.
+                     * If we  do not clear this and the ser disposes the render target before
+                     * a new one i set, the graphics device will keep a strong reference to
+                     * the render target, preventing the garbage collector fom collecting it.
+                     *
+                     * See issue: https://github.com/MonoGame/MonoGame/issues/9485
+                     *
+                     * - Chris <aristurtledev>
+                     */
+                    _tempRenderTargetBinding[0] = default;
+                }
             }
         }
 

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
@@ -618,16 +618,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
                 finally
                 {
-                    /*
-                     * This is only temporary storage for the single render target overload.
-                     * If we  do not clear this and the ser disposes the render target before
-                     * a new one i set, the graphics device will keep a strong reference to
-                     * the render target, preventing the garbage collector fom collecting it.
-                     *
-                     * See issue: https://github.com/MonoGame/MonoGame/issues/9485
-                     *
-                     * - Chris <aristurtledev>
-                     */
+                    // Clear temporary strong reference.
                     _tempRenderTargetBinding[0] = default;
                 }
             }
@@ -648,16 +639,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
                 finally
                 {
-                    /*
-                     * This is only temporary storage for the single render target overload.
-                     * If we  do not clear this and the ser disposes the render target before
-                     * a new one i set, the graphics device will keep a strong reference to
-                     * the render target, preventing the garbage collector fom collecting it.
-                     *
-                     * See issue: https://github.com/MonoGame/MonoGame/issues/9485
-                     *
-                     * - Chris <aristurtledev>
-                     */
+                    // Clear temporary strong reference.
                     _tempRenderTargetBinding[0] = default;
                 }
             }

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -742,16 +742,7 @@ namespace Microsoft.Xna.Framework.Graphics
             if (depth != 0)
                 this.framebufferHelper.DeleteRenderbuffer(depth);
 
-            /*
-             * The framebuffer cache holds render target bindings which keep a strong
-             * reference to the render target.  If w do not remove these when the render
-             * target is disposed, the graphics device will prevent the garbage collector
-             * from collecting it.
-             *
-             * See issue: https://github.com/MonoGame/MonoGame/issues/9485
-             *
-             * - Chris <aristurtledev>
-             */
+            // Remove cached framebuffer bindings that still reference this render target.
             var bindingsToDelete = new List<RenderTargetBinding[]>();
             foreach (var bindings in this.glFramebuffers.Keys)
             {

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -730,48 +730,53 @@ namespace Microsoft.Xna.Framework.Graphics
             var color = 0;
             var depth = 0;
             var stencil = 0;
-            var colorIsRenderbuffer = false;
 
             color = renderTarget.GLColorBuffer;
             depth = renderTarget.GLDepthBuffer;
             stencil = renderTarget.GLStencilBuffer;
-            colorIsRenderbuffer = color != 0;
 
             if (color != 0)
-            {
-                if (colorIsRenderbuffer)
-                    this.framebufferHelper.DeleteRenderbuffer(color);
-                if (stencil != 0 && stencil != depth)
-                    this.framebufferHelper.DeleteRenderbuffer(stencil);
-                if (depth != 0)
-                    this.framebufferHelper.DeleteRenderbuffer(depth);
+                this.framebufferHelper.DeleteRenderbuffer(color);
+            if (stencil != 0 && stencil != depth)
+                this.framebufferHelper.DeleteRenderbuffer(stencil);
+            if (depth != 0)
+                this.framebufferHelper.DeleteRenderbuffer(depth);
 
-                var bindingsToDelete = new List<RenderTargetBinding[]>();
-                foreach (var bindings in this.glFramebuffers.Keys)
+            /*
+             * The framebuffer cache holds render target bindings which keep a strong
+             * reference to the render target.  If w do not remove these when the render
+             * target is disposed, the graphics device will prevent the garbage collector
+             * from collecting it.
+             *
+             * See issue: https://github.com/MonoGame/MonoGame/issues/9485
+             *
+             * - Chris <aristurtledev>
+             */
+            var bindingsToDelete = new List<RenderTargetBinding[]>();
+            foreach (var bindings in this.glFramebuffers.Keys)
+            {
+                foreach (var binding in bindings)
                 {
-                    foreach (var binding in bindings)
+                    if (binding.RenderTarget == renderTarget)
                     {
-                        if (binding.RenderTarget == renderTarget)
-                        {
-                            bindingsToDelete.Add(bindings);
-                            break;
-                        }
+                        bindingsToDelete.Add(bindings);
+                        break;
                     }
                 }
+            }
 
-                foreach (var bindings in bindingsToDelete)
+            foreach (var bindings in bindingsToDelete)
+            {
+                var fbo = 0;
+                if (this.glFramebuffers.TryGetValue(bindings, out fbo))
                 {
-                    var fbo = 0;
-                    if (this.glFramebuffers.TryGetValue(bindings, out fbo))
-                    {
-                        this.framebufferHelper.DeleteFramebuffer(fbo);
-                        this.glFramebuffers.Remove(bindings);
-                    }
-                    if (this.glResolveFramebuffers.TryGetValue(bindings, out fbo))
-                    {
-                        this.framebufferHelper.DeleteFramebuffer(fbo);
-                        this.glResolveFramebuffers.Remove(bindings);
-                    }
+                    this.framebufferHelper.DeleteFramebuffer(fbo);
+                    this.glFramebuffers.Remove(bindings);
+                }
+                if (this.glResolveFramebuffers.TryGetValue(bindings, out fbo))
+                {
+                    this.framebufferHelper.DeleteFramebuffer(fbo);
+                    this.glResolveFramebuffers.Remove(bindings);
                 }
             }
         }

--- a/Tests/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Tests/Framework/Graphics/RenderTarget2DTest.cs
@@ -234,9 +234,17 @@ namespace MonoGame.Tests.Graphics
          * - Chris <aristurtledev>
          */
         [Test]
-        public void DisposeAfterUse_NonMsaaRenderTarget_DoesNotRemainReferencedByGraphicsDevice()
+        [TestCase(DepthFormat.None, 0)]
+        [TestCase(DepthFormat.None, 4)]
+        [TestCase(DepthFormat.Depth16, 0)]
+        [TestCase(DepthFormat.Depth16, 4)]
+        [TestCase(DepthFormat.Depth24, 0)]
+        [TestCase(DepthFormat.Depth24, 4)]
+        [TestCase(DepthFormat.Depth24Stencil8, 0)]
+        [TestCase(DepthFormat.Depth24Stencil8, 4)]
+        public void DisposeAfterUse_NonMsaaRenderTarget_DoesNotRemainReferencedByGraphicsDevice(DepthFormat depthFormat, int preferredMultiSampleCount)
         {
-            WeakReference weakRef = CreateAndDisposeRenderTarget();
+            WeakReference weakRef = CreateAndDisposeRenderTarget(depthFormat, preferredMultiSampleCount);
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -256,7 +264,7 @@ namespace MonoGame.Tests.Graphics
          * - Chris <aristurtledev>
          */
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private WeakReference CreateAndDisposeRenderTarget()
+        private WeakReference CreateAndDisposeRenderTarget(DepthFormat depthFormat, int preferredMultiSampleCount)
         {
             RenderTarget2D renderTarget = new RenderTarget2D(
                 gd,
@@ -264,7 +272,9 @@ namespace MonoGame.Tests.Graphics
                 16,
                 false,
                 SurfaceFormat.Color,
-                DepthFormat.None);
+                depthFormat,
+                preferredMultiSampleCount,
+                RenderTargetUsage.DiscardContents);
 
             gd.SetRenderTarget(renderTarget);
             gd.Clear(Color.CornflowerBlue);

--- a/Tests/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Tests/Framework/Graphics/RenderTarget2DTest.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Runtime.CompilerServices;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using NUnit.Framework;
@@ -221,6 +222,57 @@ namespace MonoGame.Tests.Graphics
             {
                rt.Dispose(); 
             }
+        }
+
+        /*
+         * A disposed render target should not be kept alive by references held by the
+         * graphics device.  This verifies that once the render target has been unbound
+         * and disposed, the garbage collector is able to collect it.
+         *
+         * See issue: https://github.com/MonoGame/MonoGame/issues/9485
+         *
+         * - Chris <aristurtledev>
+         */
+        [Test]
+        public void DisposeAfterUse_NonMsaaRenderTarget_DoesNotRemainReferencedByGraphicsDevice()
+        {
+            WeakReference weakRef = CreateAndDisposeRenderTarget();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.False(
+                weakRef.IsAlive,
+                "Disposed RenderTarget2D was still strongly referenced by the GraphicsDevice.");
+        }
+
+        /*
+         * The render target creation and disposal need to be in a separate non-inlined method.
+         * If these were done in the actual test method above, the JIT could keep the local reference
+         * alive, causing the test to fail even though the graphics device is no longer holding
+         * a strong reference to the render target.
+         *
+         * - Chris <aristurtledev>
+         */
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private WeakReference CreateAndDisposeRenderTarget()
+        {
+            RenderTarget2D renderTarget = new RenderTarget2D(
+                gd,
+                16,
+                16,
+                false,
+                SurfaceFormat.Color,
+                DepthFormat.None);
+
+            gd.SetRenderTarget(renderTarget);
+            gd.Clear(Color.CornflowerBlue);
+            gd.SetRenderTarget(null);
+
+            renderTarget.Dispose();
+
+            return new WeakReference(renderTarget);
         }
     }
 }

--- a/Tests/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Tests/Framework/Graphics/RenderTarget2DTest.cs
@@ -284,6 +284,8 @@ namespace MonoGame.Tests.Graphics
             renderTarget.Dispose();
 
             return new WeakReference(renderTarget);
+        }
+
         [Test]
         public void TestRenderTargetSync()
         {

--- a/Tests/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Tests/Framework/Graphics/RenderTarget2DTest.cs
@@ -225,15 +225,9 @@ namespace MonoGame.Tests.Graphics
             }
         }
 
-        /*
-         * A disposed render target should not be kept alive by references held by the
-         * graphics device.  This verifies that once the render target has been unbound
-         * and disposed, the garbage collector is able to collect it.
-         *
-         * See issue: https://github.com/MonoGame/MonoGame/issues/9485
-         *
-         * - Chris <aristurtledev>
-         */
+        
+        // Disposed render targets should not stay referenced by the GraphicsDevice.
+        // See issue: https://github.com/MonoGame/MonoGame/issues/9485
         [Test]
         [TestCase(DepthFormat.None, 0)]
         [TestCase(DepthFormat.None, 4)]
@@ -256,14 +250,7 @@ namespace MonoGame.Tests.Graphics
                 "Disposed RenderTarget2D was still strongly referenced by the GraphicsDevice.");
         }
 
-        /*
-         * The render target creation and disposal need to be in a separate non-inlined method.
-         * If these were done in the actual test method above, the JIT could keep the local reference
-         * alive, causing the test to fail even though the graphics device is no longer holding
-         * a strong reference to the render target.
-         *
-         * - Chris <aristurtledev>
-         */
+        // Keep creation and disposal out of the test method so the JIT does not extend the local lifetime.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private WeakReference CreateAndDisposeRenderTarget(DepthFormat depthFormat, int preferredMultiSampleCount)
         {

--- a/Tests/Framework/Graphics/RenderTargetCubeTest.cs
+++ b/Tests/Framework/Graphics/RenderTargetCubeTest.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Runtime.CompilerServices;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using NUnit.Framework;
@@ -89,6 +90,66 @@ namespace MonoGame.Tests.Graphics
             var renderTarget = new RenderTargetCube(gd, 16, false, preferredSurfaceFormat, DepthFormat.None);
                     
             Assert.AreEqual(renderTarget.Format, expectedSurfaceFormat);
+        }
+
+        /*
+         * A disposed render target cube should not be kept alive by references held by the
+         * graphics device. This verifies that once a face has been used and the render target
+         * has been unbound and disposed, the garbage collector is able to collect it.
+         *
+         * See issue: https://github.com/MonoGame/MonoGame/issues/9485
+         *
+         * - Chris <aristurtledev>
+         */
+        [Test]
+        [TestCase(DepthFormat.None, 0)]
+        [TestCase(DepthFormat.None, 4)]
+        [TestCase(DepthFormat.Depth16, 0)]
+        [TestCase(DepthFormat.Depth16, 4)]
+        [TestCase(DepthFormat.Depth24, 0)]
+        [TestCase(DepthFormat.Depth24, 4)]
+        [TestCase(DepthFormat.Depth24Stencil8, 0)]
+        [TestCase(DepthFormat.Depth24Stencil8, 4)]
+        public void DisposeAfterUse_RenderTargetCube_DoesNotRemainReferencedByGraphicsDevice(DepthFormat depthFormat, int preferredMultiSampleCount)
+        {
+            WeakReference weakRef = CreateAndDisposeRenderTargetCube(depthFormat, preferredMultiSampleCount);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.False(
+                weakRef.IsAlive,
+                "Disposed RenderTargetCube was still strongly referenced by the GraphicsDevice.");
+        }
+
+        /*
+         * The render target cube creation and disposal need to be in a separate non-inlined method.
+         * If these were done in the actual test method above, the JIT could keep the local reference
+         * alive, causing the test to fail even though the graphics device is no longer holding
+         * a strong reference to the render target cube.
+         *
+         * - Chris <aristurtledev>
+         */
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private WeakReference CreateAndDisposeRenderTargetCube(DepthFormat depthFormat, int preferredMultiSampleCount)
+        {
+            RenderTargetCube renderTarget = new RenderTargetCube(
+                gd,
+                16,
+                false,
+                SurfaceFormat.Color,
+                depthFormat,
+                preferredMultiSampleCount,
+                RenderTargetUsage.DiscardContents);
+
+            gd.SetRenderTarget(renderTarget, CubeMapFace.PositiveX);
+            gd.Clear(Color.CornflowerBlue);
+            gd.SetRenderTarget(null, CubeMapFace.PositiveX);
+
+            renderTarget.Dispose();
+
+            return new WeakReference(renderTarget);
         }
     }
 }

--- a/Tests/Framework/Graphics/RenderTargetCubeTest.cs
+++ b/Tests/Framework/Graphics/RenderTargetCubeTest.cs
@@ -92,15 +92,8 @@ namespace MonoGame.Tests.Graphics
             Assert.AreEqual(renderTarget.Format, expectedSurfaceFormat);
         }
 
-        /*
-         * A disposed render target cube should not be kept alive by references held by the
-         * graphics device. This verifies that once a face has been used and the render target
-         * has been unbound and disposed, the garbage collector is able to collect it.
-         *
-         * See issue: https://github.com/MonoGame/MonoGame/issues/9485
-         *
-         * - Chris <aristurtledev>
-         */
+        // Disposed render target cubes should not stay referenced by the GraphicsDevice.
+        // See issue: https://github.com/MonoGame/MonoGame/issues/9485
         [Test]
         [TestCase(DepthFormat.None, 0)]
         [TestCase(DepthFormat.None, 4)]
@@ -123,14 +116,7 @@ namespace MonoGame.Tests.Graphics
                 "Disposed RenderTargetCube was still strongly referenced by the GraphicsDevice.");
         }
 
-        /*
-         * The render target cube creation and disposal need to be in a separate non-inlined method.
-         * If these were done in the actual test method above, the JIT could keep the local reference
-         * alive, causing the test to fail even though the graphics device is no longer holding
-         * a strong reference to the render target cube.
-         *
-         * - Chris <aristurtledev>
-         */
+        // Keep creation and disposal out of the test method so the JIT does not extend the local lifetime.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private WeakReference CreateAndDisposeRenderTargetCube(DepthFormat depthFormat, int preferredMultiSampleCount)
         {


### PR DESCRIPTION
Closes #9485 

### Description of Change
Fixes two places where the `GraphicsDevice` could keep strong references to a disposed `RenderTarget2D` instance, preventing it from being collected by the garbage collector.

- On DesktopGL, `PlatformDeleteRenderTarget` would only clean up entries from the framebuffer cache when `GLColorBuffer` was not `0`
- When calling either of the `SetRenderTarget` overloads, the `_tempRenderTargetBinding` field is used as a temporary storage but is never cleared after calling `SetRenderTargets`

The first one occurred because non-MSAA render targets could still be added to the framebuffer cache even though they did not have a color renderbuffer.  This meant that if a non-MSAA render target was created, set, used, unset, and then disposed, the internal bindings would still hold a reference keeping the instance alive and preventing the garbage collector from collecting it.

The second one was found during testing the first issue.  I found that when `SetRenderTarget` is called, the `GraphicsDevice` uses a `_tempRenderTargetBinding` storage as temporary storage to call into `SetRenderTargets`, but after the call, the storage was not cleared.  So if the user disposed of a render target before a different `RenderTarget2D` instance was set, the `_tempRenderTargetBinding` would continue to hold the reference keeping the instance alive and preventing the garbage collector from collecting it.  This temporary binding is now cleared in a `finally` block after `SetRenderTargets` is called.

Update: Per @dellis1972, I have added the same test for each variation of `DepthFormat` with and without MSAA, as well as extended the tests to cover `RenderTargetCube`

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

