### PR TITLE
Fix WindowsDX RenderTargetCube MSAA depth rendering

### DIFF
--- a/MonoGame.Framework/Graphics/RenderTargetCube.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Xna.Framework.Graphics
             : base(graphicsDevice, size, mipMap, QuerySelectedFormat(graphicsDevice, preferredFormat), true)
         {
             DepthStencilFormat = preferredDepthFormat;
-            MultiSampleCount = preferredMultiSampleCount;
+            MultiSampleCount = graphicsDevice.GetClampedMultisampleCount(Format, preferredMultiSampleCount);
             RenderTargetUsage = usage;
 
             PlatformConstruct(graphicsDevice, mipMap, preferredDepthFormat, preferredMultiSampleCount, usage);

--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.DirectX.cs
@@ -644,10 +644,21 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 var renderTargetBinding = _currentRenderTargetBindings[i];
 
-                // Resolve MSAA render targets
-                var renderTarget = renderTargetBinding.RenderTarget as RenderTarget2D;
-                if (renderTarget != null && renderTarget.MultiSampleCount > 1)
-                    renderTarget.ResolveSubresource();
+                // Need to resolve the individual face that was just rendered.
+                // If not handled separately here, multisampled cube render targets
+                // will not be resolved with they are unbound.
+                var renderTargetCube = renderTargetBinding.RenderTarget as RenderTargetCube;
+                if (renderTargetCube != null && renderTargetCube.MultiSampleCount > 1)
+                {
+                    renderTargetCube.ResolveSubresource(renderTargetBinding.ArraySlice);
+                }
+                else
+                {
+                    // Resolve MSAA render targets
+                    var renderTarget = renderTargetBinding.RenderTarget as RenderTarget2D;
+                    if (renderTarget != null && renderTarget.MultiSampleCount > 1)
+                        renderTarget.ResolveSubresource();
+                }
 
                 // Generate mipmaps.
                 if (renderTargetBinding.RenderTarget.LevelCount > 1)

--- a/MonoGame.Framework/Platform/Graphics/RenderTargetCube.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTargetCube.DirectX.cs
@@ -2,7 +2,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-using System;
 using SharpDX.DXGI;
 using SharpDX.Direct3D11;
 
@@ -12,58 +11,74 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         private RenderTargetView[] _renderTargetViews;
         private DepthStencilView _depthStencilView;
+        private SharpDX.Direct3D11.Texture2D _msTexture;
+        private SampleDescription _msSampleDescription;
 
         private void PlatformConstruct(GraphicsDevice graphicsDevice, bool mipMap, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
         {
+            _msSampleDescription = graphicsDevice.GetSupportedSampleDescription(SharpDXHelper.ToFormat(this.Format), this.MultiSampleCount);
+        }
+
+        private void GenerateIfRequired()
+        {
+            if (_renderTargetViews != null)
+                return;
+
             // Create one render target view per cube map face.
             _renderTargetViews = new RenderTargetView[6];
             for (int i = 0; i < _renderTargetViews.Length; i++)
             {
                 var renderTargetViewDescription = new RenderTargetViewDescription
                 {
-                    Dimension = RenderTargetViewDimension.Texture2DArray,
                     Format = SharpDXHelper.ToFormat(this.Format),
-                    Texture2DArray =
-                    {
-                        ArraySize = 1,
-                        FirstArraySlice = i,
-                        MipSlice = 0
-                    }
                 };
 
-                _renderTargetViews[i] = new RenderTargetView(graphicsDevice._d3dDevice, GetTexture(), renderTargetViewDescription);
+                SharpDX.Direct3D11.Texture2D viewTexture;
+                if (MultiSampleCount > 1)
+                {
+                    // MSAA cubes still resolve back into the actual cube texture face on unbind.
+                    renderTargetViewDescription.Dimension = RenderTargetViewDimension.Texture2DMultisampled;
+                    viewTexture = GetMSTexture();
+                }
+                else
+                {
+                    renderTargetViewDescription.Dimension = RenderTargetViewDimension.Texture2DArray;
+                    renderTargetViewDescription.Texture2DArray.ArraySize = 1;
+                    renderTargetViewDescription.Texture2DArray.FirstArraySlice = i;
+                    renderTargetViewDescription.Texture2DArray.MipSlice = 0;
+                    viewTexture = (SharpDX.Direct3D11.Texture2D)GetTexture();
+                }
+
+                _renderTargetViews[i] = new RenderTargetView(
+                    GraphicsDevice._d3dDevice,
+                    viewTexture,
+                    renderTargetViewDescription);
             }
 
             // If we don't need a depth buffer then we're done.
-            if (preferredDepthFormat == DepthFormat.None)
+            if (DepthStencilFormat == DepthFormat.None)
                 return;
-
-            var sampleDescription = new SampleDescription(1, 0);
-            if (preferredMultiSampleCount > 1)
-            {
-                sampleDescription.Count = preferredMultiSampleCount;
-                sampleDescription.Quality = (int)StandardMultisampleQualityLevels.StandardMultisamplePattern;
-            }
 
             var depthStencilDescription = new Texture2DDescription
             {
-                Format = SharpDXHelper.ToFormat(preferredDepthFormat),
+                Format = SharpDXHelper.ToFormat(DepthStencilFormat),
                 ArraySize = 1,
                 MipLevels = 1,
                 Width = size,
                 Height = size,
-                SampleDescription = sampleDescription,
+                SampleDescription = _msSampleDescription,
                 BindFlags = BindFlags.DepthStencil,
             };
 
-            using (var depthBuffer = new SharpDX.Direct3D11.Texture2D(graphicsDevice._d3dDevice, depthStencilDescription))
+            using (var depthBuffer = new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, depthStencilDescription))
             {
                 var depthStencilViewDescription = new DepthStencilViewDescription
                 {
-                    Dimension = DepthStencilViewDimension.Texture2D,
-                    Format = SharpDXHelper.ToFormat(preferredDepthFormat),
+                    Dimension = MultiSampleCount > 1 ? DepthStencilViewDimension.Texture2DMultisampled : DepthStencilViewDimension.Texture2D,
+                    Format = SharpDXHelper.ToFormat(DepthStencilFormat),
                 };
-                _depthStencilView = new DepthStencilView(graphicsDevice._d3dDevice, depthBuffer, depthStencilViewDescription);
+
+                _depthStencilView = new DepthStencilView(GraphicsDevice._d3dDevice, depthBuffer, depthStencilViewDescription);
             }
         }
 
@@ -77,8 +92,10 @@ namespace Microsoft.Xna.Framework.Graphics
                         _renderTargetViews[i].Dispose();
 
                     _renderTargetViews = null;
-                    SharpDX.Utilities.Dispose(ref _depthStencilView);
                 }
+
+                SharpDX.Utilities.Dispose(ref _depthStencilView);
+                SharpDX.Utilities.Dispose(ref _msTexture);
             }
 
             base.Dispose(disposing);
@@ -87,13 +104,60 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <inheritdoc/>
         public RenderTargetView GetRenderTargetView(int arraySlice)
         {
+            GenerateIfRequired();
             return _renderTargetViews[arraySlice];
         }
 
         /// <inheritdoc/>
         public DepthStencilView GetDepthStencilView()
         {
+            GenerateIfRequired();
             return _depthStencilView;
+        }
+
+        internal void ResolveSubresource(int arraySlice)
+        {
+            lock (GraphicsDevice._d3dContext)
+            {
+                GraphicsDevice._d3dContext.ResolveSubresource(
+                    GetMSTexture(),
+                    0,
+                    GetTexture(),
+                    CalculateSubresourceIndex(arraySlice, 0),
+                    SharpDXHelper.ToFormat(_format));
+            }
+        }
+
+        private SharpDX.Direct3D11.Texture2D GetMSTexture()
+        {
+            if (_msTexture == null)
+                _msTexture = CreateMSTexture();
+
+            return _msTexture;
+        }
+
+        private SharpDX.Direct3D11.Texture2D CreateMSTexture()
+        {
+            Texture2DDescription description = new Texture2DDescription
+            {
+                Width = size,
+                Height = size,
+                MipLevels = 1,
+                ArraySize = 1,
+                Format = SharpDXHelper.ToFormat(_format),
+                BindFlags = BindFlags.RenderTarget,
+                CpuAccessFlags = CpuAccessFlags.None,
+                SampleDescription = _msSampleDescription,
+                Usage = ResourceUsage.Default,
+                OptionFlags = ResourceOptionFlags.None
+            };
+
+            return new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, description);
+        }
+
+        private int CalculateSubresourceIndex(int arraySlice, int level)
+        {
+            return arraySlice * _levelCount + level;
         }
     }
 }

--- a/Tests/Framework/Graphics/RenderTargetCubeTest.cs
+++ b/Tests/Framework/Graphics/RenderTargetCubeTest.cs
@@ -90,5 +90,46 @@ namespace MonoGame.Tests.Graphics
                     
             Assert.AreEqual(renderTarget.Format, expectedSurfaceFormat);
         }
+
+         // Creating a RenderTargetCube on the WindowsDX backend with MSAA enabled and a depth format
+         // other than DepthFormat.None failed during construction with an exception
+         // See: https://github.com/MonoGame/MonoGame/issues/9489
+#if DIRECTX
+        [Test]
+        [TestCase(DepthFormat.Depth16)]
+        [TestCase(DepthFormat.Depth24)]
+        [TestCase(DepthFormat.Depth24Stencil8)]
+        public void RenderedMultisampledRenderTargetCubeFaceWithDepthBuffer_CanBeReadBack(DepthFormat depthFormat)
+        {
+            RenderTargetCube rt = null;
+
+            try
+            {
+                rt = new RenderTargetCube(
+                    gd,
+                    16,
+                    false,
+                    SurfaceFormat.Color,
+                    depthFormat,
+                    4,
+                    RenderTargetUsage.DiscardContents);
+
+                gd.SetRenderTarget(rt, CubeMapFace.PositiveX);
+                gd.Clear(ClearOptions.Target | ClearOptions.DepthBuffer, Color.CornflowerBlue, 1.0f, 0);
+                gd.SetRenderTarget(null, CubeMapFace.PositiveX);
+
+                Color[] readData = new Color[16 * 16];
+                rt.GetData(CubeMapFace.PositiveX, readData);
+
+                for (int i = 0; i < readData.Length; i++)
+                    Assert.AreEqual(Color.CornflowerBlue, readData[i]);
+            }
+            finally
+            {
+                if (rt != null)
+                    rt.Dispose();
+            }
+        }
+#endif
     }
 }


### PR DESCRIPTION
Closes #9489 

### Description of Change

Fixes the WindowsDX `RenderTargetCube` path when using MSAA together with a depth buffer.

- `RenderTargetCube` was storing the requested multisample count directly instead of clamping it the way `RenderTarget2D` does
- The WindowsDX `RenderTargetCube` path did not have the same MSAA render/resolve flow that `RenderTarget2D` uses
- Each cube face needed to resolve back into the actual texture cube after rendering before things like `GetData` or mip generation could work correctly

A DirectX regression test was also added to cover creating, rendering to, resolving, and reading back a multisampled `RenderTargetCube` with a depth buffer.