### PR TITLE
Fix SpriteFont whitespace advance when kerning is disabled

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -110,7 +110,16 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                     }
                     else
                     {
-                        output.Kerning.Add(new Vector3(0, texRect.Width, 0));
+                        float width = texRect.Width;
+
+                        // Whitespace glyphs can carry advance entirely in their metrics.
+                        // Preserve that advance when kerning is disabled so spacing matches XNA.
+                        if (glyph.Data.CharacterWidths.B <= 0 && glyph.Data.XAdvance > width)
+                        {
+                            width = glyph.Data.XAdvance;
+                        }
+
+                        output.Kerning.Add(new Vector3(0, width, 0));
                     }
                 }
 

--- a/Tools/MonoGame.Tools.Tests/FontDescriptionProcessorTests.cs
+++ b/Tools/MonoGame.Tools.Tests/FontDescriptionProcessorTests.cs
@@ -163,6 +163,45 @@ namespace MonoGame.Tests.ContentPipeline
             }
         }
 
+        // When kerning is disabled, the space character's advance width should be preserved in the kerning array.
+        // See: https://github.com/monogame/monogame/issues/4027
+        [Test]
+        public void BuildFontFromDescription_WhenKerningDisabled_PreservesSpaceAdvance()
+        {
+
+            FontDescription withKerning = null;
+            using (var input = XmlReader.Create(new StringReader(ArialFont)))
+                withKerning = IntermediateSerializer.Deserialize<FontDescription>(input, "");
+
+
+            FontDescription withoutKerning = null;
+            using (var input = XmlReader.Create(new StringReader(ArialFontWithoutKerning)))
+                withoutKerning = IntermediateSerializer.Deserialize<FontDescription>(input, "");
+
+            using TestProcessorContext context = new TestProcessorContext(TargetPlatform.Windows, "Arial.xnb");
+            var processor = new FontDescriptionProcessor();
+            SpriteFontContent withKerningContnet = processor.Process(withKerning, context);
+            SpriteFontContent withoutKerningContent = processor.Process(withoutKerning, context);
+
+            int spaceIndex = withKerningContnet.CharacterMap.IndexOf(' ');
+
+            Vector3 spaceWithKerning = withKerningContnet.Kerning[spaceIndex];
+            Vector3 spaceWithoutKerning = withoutKerningContent.Kerning[spaceIndex];
+
+            // Kerning stores the glyph advance as three parts:
+            // X = left side bearing
+            // Y = glyph width
+            // Z = right side bearing
+            //
+            // With kerning enabled, space can be split across those components,
+            // for example (1, 8, 0). With kerning disabled, MonoGame flattens the
+            // full advance into Y, so the equivalent result becomes (0, 9, 0).
+            float expectedSpaceWidth = spaceWithKerning.X + spaceWithKerning.Y + spaceWithKerning.Z;
+
+            Assert.That(spaceWithoutKerning.Y, Is.EqualTo(expectedSpaceWidth));
+
+        }
+
         static string ArialFont = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <XnaContent xmlns:Graphics=""Microsoft.Xna.Framework.Content.Pipeline.Graphics"">
   <Asset Type=""Graphics:FontDescription"">
@@ -170,6 +209,24 @@ namespace MonoGame.Tests.ContentPipeline
     <Size>20</Size>
     <Spacing>0</Spacing>
     <UseKerning>true</UseKerning>
+    <Style>Bold</Style>
+    <CharacterRegions>
+      <CharacterRegion>
+        <Start>&#32;</Start>
+        <End>&#126;</End>
+      </CharacterRegion>
+    </CharacterRegions>
+  </Asset>
+</XnaContent>
+";
+
+        static string ArialFontWithoutKerning = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<XnaContent xmlns:Graphics=""Microsoft.Xna.Framework.Content.Pipeline.Graphics"">
+  <Asset Type=""Graphics:FontDescription"">
+    <FontName>Arial</FontName>
+    <Size>20</Size>
+    <Spacing>0</Spacing>
+    <UseKerning>false</UseKerning>
     <Style>Bold</Style>
     <CharacterRegions>
       <CharacterRegion>


### PR DESCRIPTION
Closes #4027 

### Description of Change

Updates `SpriteFont` processing so whtiespace glyphs keep their intended advance when kerning is disabled.  Output compared to XNA4.0


<img width="1560" height="606" alt="image" src="https://github.com/user-attachments/assets/ab6affe5-9a10-429e-a793-771440476db3" />


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

