### PR TITLE
Nintendo Switch 2 Suppprt

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -136,8 +136,8 @@
     <Exec Command="premake5 vs2022" WorkingDirectory="../native/pipeline/" />
     <!-- Build x64 -->
     <Exec Command="&quot;$(MGMSBuild)&quot; pipeline.sln /p:Configuration=$(Configuration) /p:Platform=x64" WorkingDirectory="../native/pipeline/" />
-    <!-- Build arm64 (cross-compile on same host) -->
-    <Exec Command="&quot;$(MGMSBuild)&quot; pipeline.sln /p:Configuration=$(Configuration) /p:Platform=ARM64" WorkingDirectory="../native/pipeline/" />
+    <!-- Build arm64 (cross-compile on same host) when building from CI -->
+    <Exec Command="&quot;$(MGMSBuild)&quot; pipeline.sln /p:Configuration=$(Configuration) /p:Platform=ARM64" WorkingDirectory="../native/pipeline/" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
   </Target>
 
   <Target Name="BuildMGCPU" Condition="'$(DisableNativeBuild)' != 'True' and '$(OS)' != 'Windows_NT'" BeforeTargets="CollectPackageReferences">

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -113,6 +113,7 @@
   
   <Import Project="..\external\CppNet\CppNet.targets" />
 
+  <Import Project="..\Switch2\MonoGame.Framework.Content.Pipeline.targets" Condition="exists('..\Switch2\MonoGame.Framework.Content.Pipeline.targets')" />
   <Import Project="..\Switch\MonoGame.Framework.Content.Pipeline.targets" Condition="exists('..\Switch\MonoGame.Framework.Content.Pipeline.targets')" />
   <Import Project="..\XBoxOne\MonoGame.Framework.Content.Pipeline.targets" Condition="exists('..\XBoxOne\MonoGame.Framework.Content.Pipeline.targets')" />
   <Import Project="..\PlayStation4\MonoGame.Framework.Content.Pipeline.targets" Condition="exists('..\PlayStation4\MonoGame.Framework.Content.Pipeline.targets')" />
@@ -120,6 +121,7 @@
   <Import Project="..\PSVita\MonoGame.Framework.Content.Pipeline.targets" Condition="exists('..\PSVita\MonoGame.Framework.Content.Pipeline.targets')" />
   <Import Project="..\GDKX\MonoGame.Framework.Content.Pipeline.targets" Condition="exists('..\GDKX\MonoGame.Framework.Content.Pipeline.targets')" />
 
+  <Import Project="..\Switch2\MonoGame.Effect.Compiler.targets" Condition="exists('..\Switch2\MonoGame.Effect.Compiler.targets')" />
   <Import Project="..\Switch\MonoGame.Effect.Compiler.targets" Condition="exists('..\Switch\MonoGame.Effect.Compiler.targets')" />
   <Import Project="..\XBoxOne\MonoGame.Effect.Compiler.targets" Condition="exists('..\XBoxOne\MonoGame.Effect.Compiler.targets')" />
   <Import Project="..\PlayStation4\MonoGame.Effect.Compiler.targets" Condition="exists('..\PlayStation4\MonoGame.Effect.Compiler.targets')" />

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
             'V', // DesktopVK (Vulkan)
             'G', // Windows GDK
             's', // Xbox Series
+            'U', // Nintendo Switch 2
         ];
 
         /// <summary>

--- a/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
+++ b/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
@@ -99,7 +99,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// <summary>
         /// Xbox Series S|X
         /// </summary>
-        XboxSeries
+        XboxSeries,
+
+        /// <summary>
+        /// Nintendo Switch 2
+        /// </summary>
+        Switch2,
     }
 
     /// <summary>

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -50,8 +50,9 @@ namespace Microsoft.Xna.Framework.Content
             'S', // Nintendo Switch
             'b', // WebAssembly and Bridge.NET
             'V', // DesktopVK
-            'G', // Windows GDK
+            'G', // Windows DirectX 12
             's', // Xbox Series
+            'U', // Nintendo Switch 2
 
             // NOTE: There are additional identifiers for consoles that
             // are not defined in this repository.  Be sure to ask the

--- a/MonoGame.Framework/Utilities/MonoGamePlatform.cs
+++ b/MonoGame.Framework/Utilities/MonoGamePlatform.cs
@@ -73,5 +73,10 @@ namespace MonoGame.Framework.Utilities
         /// Cross platform desktop using Vulkan.
         /// </summary>
         DesktopVK,
+
+        /// <summary>
+        /// Nintendo Switch 2 platform.
+        /// </summary>
+        NintendoSwitch2,
     }
 }

--- a/MonoGame.Framework/Utilities/PlatformInfo.cs
+++ b/MonoGame.Framework/Utilities/PlatformInfo.cs
@@ -30,6 +30,8 @@ namespace MonoGame.Framework.Utilities
                 return MonoGamePlatform.Windows;
 #elif SWITCH
                 return MonoGamePlatform.NintendoSwitch;
+#elif SWITCH2
+                return MonoGamePlatform.NintendoSwitch2;
 #elif XB1
                 return MonoGamePlatform.XboxOne;
 #elif PLAYSTATION4

--- a/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
+++ b/Tools/MonoGame.Effect.Compiler/MonoGame.Effect.Compiler.csproj
@@ -49,6 +49,7 @@
   
   <Import Project="..\..\external\CppNet\CppNet.targets" />
 
+  <Import Project="..\..\Switch2\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\Switch2\MonoGame.Effect.Compiler.targets')" />
   <Import Project="..\..\Switch\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\Switch\MonoGame.Effect.Compiler.targets')" />
   <Import Project="..\..\XBoxOne\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\XBoxOne\MonoGame.Effect.Compiler.targets')" />
   <Import Project="..\..\PlayStation4\MonoGame.Effect.Compiler.targets" Condition="exists('..\..\PlayStation4\MonoGame.Effect.Compiler.targets')" />

--- a/native/monogame/include/api_enums.h
+++ b/native/monogame/include/api_enums.h
@@ -521,6 +521,7 @@ enum class MGMonoGamePlatform : mgint
     PlayStation5 = 10,
     NintendoSwitch = 11,
     DesktopVK = 12,
+    NintendoSwitch2 = 13,
 };
 
 enum class MGGraphicsBackend : mgint


### PR DESCRIPTION
This adds the bits needed to support the Nintendo Switch 2 console submodule.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

