### PR TITLE
Fix relative OutputDirectory in ContentBuilderProcessorContext

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderProcessorContext.cs
@@ -21,7 +21,7 @@ class ContentBuilderProcessorContext(ContentBuilder builder, string relativePath
 
     public override ContentIdentity SourceIdentity => new(sourceFilename: relativePath);
 
-    public override string OutputDirectory => builder.Parameters.OutputDirectory;
+    public override string OutputDirectory => PathHelper.NormalizeDirectory(builder.Parameters.RootedOutputDirectory);
 
     public override string OutputFilename { get; } = outputFilename;
 

--- a/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/ContentBuilderProcessorContext.cs
@@ -21,7 +21,7 @@ class ContentBuilderProcessorContext(ContentBuilder builder, string relativePath
 
     public override ContentIdentity SourceIdentity => new(sourceFilename: relativePath);
 
-    public override string OutputDirectory => PathHelper.NormalizeDirectory(builder.Parameters.RootedOutputDirectory);
+    public override string OutputDirectory => builder.Parameters.RootedOutputDirectory;
 
     public override string OutputFilename { get; } = outputFilename;
 


### PR DESCRIPTION
Closes #9497 

### Description of Change

`ContentBuilderProcessorContext.OutputDirectory` was returning `builder.Parameters.OutputDirectory`, which can be a relative path such as `bin/Content`.  `VideoProcessor` uses `context.OutputDirectory` as the base path for the `PathHelper.GetRelativePath` call and that helper currently constructs a `Uri` from the base path.  Whenthe `OutputFilename` is absolute but `OutputDirectory` is relative, video builds fail with System.UriFormatException`

This change returnst eh rooted, normalized output directory from `ContentBuilderProcessorContext` so the processor context says consistent with the absolute `OutputFilename` used during content builds.


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

