### PR TITLE
DesktopGL: Temporarily disable scissor test during clear to match XNA clear behavior

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -380,16 +380,23 @@ namespace Microsoft.Xna.Framework.Graphics
             // So overwrite these states with what is needed to perform
             // the clear correctly and restore it afterwards.
             //
-		    var prevScissorRect = ScissorRectangle;
+            var prevScissorTestEnable = _lastRasterizerState.ScissorTestEnable;
 		    var prevDepthStencilState = DepthStencilState;
             var prevBlendState = BlendState;
-            ScissorRectangle = _viewport.Bounds;
             // DepthStencilState.Default has the Stencil Test disabled; 
             // make sure stencil test is enabled before we clear since
             // some drivers won't clear with stencil test disabled
             DepthStencilState = this.clearDepthStencilState;
 		    BlendState = BlendState.Opaque;
             ApplyState(false);
+
+            // Clear should affect the whole active target, not only the
+            // current viewport-sized scissor rectangle, to match XNA behavior
+            if (prevScissorTestEnable)
+            {
+                GL.Disable(EnableCap.ScissorTest);
+                GraphicsExtensions.CheckGLError();
+            }
 
             ClearBufferMask bufferMask = 0;
             if ((options & ClearOptions.Target) == ClearOptions.Target)
@@ -435,7 +442,12 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
            		
             // Restore the previous render state.
-		    ScissorRectangle = prevScissorRect;
+            if (prevScissorTestEnable)
+            {
+                GL.Enable(EnableCap.ScissorTest);
+                GraphicsExtensions.CheckGLError();
+            }
+
 		    DepthStencilState = prevDepthStencilState;
 		    BlendState = prevBlendState;
         }

--- a/Tests/Framework/Graphics/ViewportTest.cs
+++ b/Tests/Framework/Graphics/ViewportTest.cs
@@ -48,6 +48,44 @@ namespace MonoGame.Tests.Graphics
             CheckFrames();
         }
 
+        // Ensure that when a device clear operation is performed, it clears the entire target
+        // instead of just the viewport/scissor region
+        // See: https://github.com/monogame/monogame/issues/9500
+        [Test]
+        public void Does_not_clip_device_clear_after_scissor_test_draw()
+        {
+            using SpriteBatch sb = new SpriteBatch(gd);
+            using Texture2D swatch = content.Load<Texture2D>(Paths.Texture("white-64"));
+            using RasterizerState scissorEnabled = new RasterizerState {ScissorTestEnable = true };
+
+            // Clear to cornflower blue first to set precedent
+            gd.Clear(Color.CornflowerBlue);
+
+            // Set viewport to a smaller size to test if the clear is obeying hte viewport
+            // which it should not!
+            gd.Viewport = new Viewport(100, 100, 100, 100);
+            gd.ScissorRectangle = new Rectangle(110, 110, 110, 110);
+
+            // Draw random stuff to dirty the pre-clear state
+            // Ensure scissor raster state is applied to test if it affects the clear operation
+            sb.Begin(SpriteSortMode.Immediate, BlendState.Opaque, SamplerState.PointClamp, DepthStencilState.Default, scissorEnabled);
+            sb.Draw(swatch, Vector2.Zero, Color.White);
+            sb.End();
+
+            // Perform clear
+            gd.Clear(ClearOptions.Target, Color.Red.ToVector4(), 0, 0);
+
+            // Test single pixel in top-left corner, should be red from the clear
+            var cornerPixel = new Color[1];
+            gd.GetBackBufferData(new Rectangle(0, 0, 1, 1), cornerPixel, 0, 1);
+            Assert.That(cornerPixel[0], Is.EqualTo(Color.Red));
+
+            // Test pixel within the viewport scissor region, shoudl also be red from clear
+            var viewportPixel = new Color[1];
+            gd.GetBackBufferData(new Rectangle(120, 120, 1, 1), viewportPixel, 0, 1);
+            Assert.That(viewportPixel[0], Is.EqualTo(Color.Red));
+        }
+
         [Test]
         public void Clips_SpriteBatch_draws()
         {


### PR DESCRIPTION
Closes #9500 

### Description of Change

Scissor test is temporarily disabled during clear so that entire target is cleared to match XNA behavior.  Scissor test is restored after clear operation

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

