### PR TITLE
Implement two sided stencil state for vulkan and dx12 backends

### DIFF
--- a/MonoGame.Framework/Platform/Native/DepthStencilState.Native.cs
+++ b/MonoGame.Framework/Platform/Native/DepthStencilState.Native.cs
@@ -25,6 +25,11 @@ public partial class DepthStencilState
             info.stencilDepthBufferFail = StencilDepthBufferFail;
             info.stencilFail = StencilFail;
             info.stencilPass = StencilPass;
+            info.twoSidedStencilMode = TwoSidedStencilMode;
+            info.counterClockwiseStencilFunction = CounterClockwiseStencilFunction;
+            info.counterClockwiseStencilDepthBufferFail = CounterClockwiseStencilDepthBufferFail;
+            info.counterClockwiseStencilFail = CounterClockwiseStencilFail;
+            info.counterClockwiseStencilPass = CounterClockwiseStencilPass;
 
             Handle = MGG.DepthStencilState_Create(device.Handle, &info);
         }

--- a/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
@@ -90,6 +90,11 @@ internal struct MGG_DepthStencilState_Info
     public StencilOperation stencilDepthBufferFail;
     public StencilOperation stencilFail;
     public StencilOperation stencilPass;
+    public bool twoSidedStencilMode;
+    public CompareFunction counterClockwiseStencilFunction;
+    public StencilOperation counterClockwiseStencilDepthBufferFail;
+    public StencilOperation counterClockwiseStencilFail;
+    public StencilOperation counterClockwiseStencilPass;
 }
 
 [StructLayout(LayoutKind.Sequential)]

--- a/Tests/Framework/Graphics/DepthStencilStateTest.cs
+++ b/Tests/Framework/Graphics/DepthStencilStateTest.cs
@@ -139,5 +139,105 @@ namespace MonoGame.Tests.Graphics
             depthStencilState.Dispose();
             cube.UnloadContent();
         }
+
+        [Test]
+        public void TwoSidedStencilModeUsesSeparateClockwiseAndCounterClockwiseStencilStates()
+        {
+            VertexPositionColor[] stencilTriangles = new VertexPositionColor[]
+            {
+                // Uses counter clockwise stencil state
+                new VertexPositionColor(new Vector3(-0.95f, -0.75f, 0f), Color.Red),
+                new VertexPositionColor(new Vector3(-0.15f, -0.75f, 0f), Color.Red),
+                new VertexPositionColor(new Vector3(-0.55f, 0.55f, 0f), Color.Red),
+
+                // Flip the winding order so this uses regular stencil state.
+                new VertexPositionColor(new Vector3(0.55f, 0.55f, 0f), Color.Red),
+                new VertexPositionColor(new Vector3(0.95f, -0.75f, 0f), Color.Red),
+                new VertexPositionColor(new Vector3(0.15f, -0.75f, 0f), Color.Red)
+            };
+
+            VertexPositionColor[] fullScreenTriangle = new VertexPositionColor[]
+            {
+                new VertexPositionColor(new Vector3(-1f, -1f, 0f), Color.Green),
+                new VertexPositionColor(new Vector3(3f, -1f, 0f), Color.Green),
+                new VertexPositionColor(new Vector3(-1f, 3f, 0f), Color.Green)
+            };
+
+            using RenderTarget2D renderTarget = new RenderTarget2D(gd, 64, 64, false, SurfaceFormat.Color,DepthFormat.Depth24Stencil8);
+            using BasicEffect effect = new BasicEffect(gd) { VertexColorEnabled = true };
+
+            // Disable color writes for first pass, only modify stencil buffer.
+            using BlendState stencilOnlyBlendState = new BlendState() { ColorWriteChannels = ColorWriteChannels.None };
+
+            // counter-clockwise face writes 3 to the stencil buffer
+            using DepthStencilState twoSidedStencilState = new DepthStencilState()
+            {
+                    DepthBufferEnable = false,
+                    DepthBufferWriteEnable = false,
+                    StencilEnable = true,
+                    StencilFunction = CompareFunction.Always,
+                    StencilPass = StencilOperation.Keep,
+                    StencilFail = StencilOperation.Keep,
+                    StencilDepthBufferFail = StencilOperation.Keep,
+                    TwoSidedStencilMode = true,
+                    CounterClockwiseStencilFunction = CompareFunction.Always,
+                    CounterClockwiseStencilPass = StencilOperation.Replace,
+                    CounterClockwiseStencilFail = StencilOperation.Keep,
+                    CounterClockwiseStencilDepthBufferFail = StencilOperation.Keep,
+                    ReferenceStencil = 3
+            };
+
+            // only draw where the stencil value is 3
+            using DepthStencilState stencilTestState = new DepthStencilState()
+            {
+                    DepthBufferEnable = false,
+                    DepthBufferWriteEnable = false,
+                    StencilEnable = true,
+                    StencilFunction = CompareFunction.Equal,
+                    StencilPass = StencilOperation.Keep,
+                    StencilFail = StencilOperation.Keep,
+                    StencilDepthBufferFail = StencilOperation.Keep,
+                    ReferenceStencil = 3
+            };
+            using RasterizerState rasterizerState = new RasterizerState() { CullMode = CullMode.None };
+
+            gd.SetRenderTarget(renderTarget!);
+            gd.Clear(ClearOptions.Target | ClearOptions.DepthBuffer | ClearOptions.Stencil, Color.Black, 1f, 1);
+
+            gd.BlendState = stencilOnlyBlendState!;
+            gd.DepthStencilState = twoSidedStencilState!;
+            gd.RasterizerState = rasterizerState!;
+
+            // Draw both windings into the stencil buffer
+            foreach (EffectPass pass in effect.CurrentTechnique.Passes)
+            {
+                pass.Apply();
+                gd.DrawUserPrimitives(PrimitiveType.TriangleList, stencilTriangles, 0, 2);
+            }
+
+            gd.BlendState = BlendState.Opaque;
+            gd.DepthStencilState = stencilTestState!;
+
+            // Draw over the entire target.
+            // Only pixels where the stencil value is 3 should be changed to green.
+            foreach (EffectPass pass in effect.CurrentTechnique.Passes)
+            {
+                pass.Apply();
+                gd.DrawUserPrimitives(PrimitiveType.TriangleList, fullScreenTriangle, 0, 1);
+            }
+
+            gd.SetRenderTarget(null);
+
+            Color[] pixels = renderTarget.GetColorData();
+            int leftIndex = (renderTarget.Height / 2) * renderTarget.Width + (renderTarget.Width / 4);
+            int rightIndex = (renderTarget.Height / 2) * renderTarget.Width + ((renderTarget.Width * 3) / 4);
+            int backgroundIndex = (renderTarget.Height / 8) * renderTarget.Width + (renderTarget.Width / 2);
+
+            // counter-clockwise triangle write 3, regular triangle did not
+            // untouched pixels should have remained clear color
+            Assert.AreEqual(Color.Green, pixels[leftIndex]);
+            Assert.AreEqual(Color.Black, pixels[rightIndex]);
+            Assert.AreEqual(Color.Black, pixels[backgroundIndex]);
+        }
     }
 }

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -1400,10 +1400,17 @@ MGG_DepthStencilState* MGG_DepthStencilState_Create(MGG_GraphicsDevice* device, 
 	state->desc.FrontFace.StencilPassOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->stencilPass];
 	state->desc.FrontFace.StencilFailOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->stencilFail];
 	state->desc.FrontFace.StencilDepthFailOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->stencilDepthBufferFail];
-	state->desc.BackFace.StencilFunc = CompareFunctionToD3D12_COMPARISON_FUNC[(int)info->stencilFunction];
-	state->desc.BackFace.StencilPassOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->stencilPass];
-	state->desc.BackFace.StencilFailOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->stencilFail];
-	state->desc.BackFace.StencilDepthFailOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->stencilDepthBufferFail];
+	if (info->twoSidedStencilMode)
+	{
+		state->desc.BackFace.StencilFunc = CompareFunctionToD3D12_COMPARISON_FUNC[(int)info->counterClockwiseStencilFunction];
+		state->desc.BackFace.StencilPassOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->counterClockwiseStencilPass];
+		state->desc.BackFace.StencilFailOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->counterClockwiseStencilFail];
+		state->desc.BackFace.StencilDepthFailOp = StencilOperationToD3D12_D3D12_STENCIL_OP[(int)info->counterClockwiseStencilDepthBufferFail];
+	}
+	else
+	{
+		state->desc.BackFace = state->desc.FrontFace;
+	}
 	state->referenceStencil = info->referenceStencil;
 
 	return state;

--- a/native/monogame/include/api_structs.h
+++ b/native/monogame/include/api_structs.h
@@ -120,6 +120,11 @@ struct MGG_DepthStencilState_Info
     MGStencilOperation stencilDepthBufferFail;
     MGStencilOperation stencilFail;
     MGStencilOperation stencilPass;
+    mgbool twoSidedStencilMode;
+    MGCompareFunction counterClockwiseStencilFunction;
+    MGStencilOperation counterClockwiseStencilDepthBufferFail;
+    MGStencilOperation counterClockwiseStencilFail;
+    MGStencilOperation counterClockwiseStencilPass;
 };
 
 struct MGG_RasterizerState_Info

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -4551,7 +4551,21 @@ MGG_DepthStencilState* MGG_DepthStencilState_Create(MGG_GraphicsDevice* device, 
 	depth.front.compareMask = info->stencilMask;
 	depth.front.writeMask = info->stencilWriteMask;
 	depth.front.reference = info->referenceStencil;
-	depth.back = depth.front;
+	if (info->twoSidedStencilMode)
+	{
+		depth.back.failOp = ToVkStencilOp(info->counterClockwiseStencilFail);
+		depth.back.passOp = ToVkStencilOp(info->counterClockwiseStencilPass);
+		depth.back.depthFailOp = ToVkStencilOp(info->counterClockwiseStencilDepthBufferFail);
+		depth.back.compareOp = ToVkCompareOp(info->counterClockwiseStencilFunction);
+		depth.back.compareMask = info->stencilMask;
+		depth.back.writeMask = info->stencilWriteMask;
+		depth.back.reference = info->referenceStencil;
+	}
+	else
+	{
+		depth.back = depth.front;
+	}
+
 	depth.minDepthBounds = 0.0f;
 	depth.maxDepthBounds = 1.0f;
 


### PR DESCRIPTION
### Description of Change

Extended the `MGG_DespthStencilState_Info` struct to carry two sided stencil mode and counter clockwise functions.  DX12 and VK backends updated to check for two sided mode and set values if true. Unit test added.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

