### PR TITLE
Mask DesktopGL MRT outputs for single output shaders

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/GraphicsDevice.OpenGL.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #if !GLES
         private DrawBuffersEnum[] _drawBuffers;
+        private DrawBuffersEnum[] _maskedDrawBuffers;
 #endif
 
         enum ResourceType
@@ -326,8 +327,12 @@ namespace Microsoft.Xna.Framework.Graphics
             GL.GetInteger(GetPName.MaxDrawBuffers, out maxDrawBuffers);
             GraphicsExtensions.CheckGLError ();
 			_drawBuffers = new DrawBuffersEnum[maxDrawBuffers];
+            _maskedDrawBuffers = new DrawBuffersEnum[maxDrawBuffers];
 			for (int i = 0; i < maxDrawBuffers; i++)
+            {
 				_drawBuffers[i] = (DrawBuffersEnum)(FramebufferAttachment.ColorAttachment0Ext + i);
+                _maskedDrawBuffers[i] = DrawBuffersEnum.None;
+            }
 #endif
         }
 
@@ -844,6 +849,49 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+#if !GLES
+        private static uint GetDrawBufferMask(int drawBufferCount)
+        {
+            if (drawBufferCount <= 0)
+                return 0u;
+
+            if (drawBufferCount >= 32)
+                return uint.MaxValue;
+
+            return (1u << drawBufferCount) - 1u;
+        }
+
+        private void ApplyRenderTargetDrawBuffers(ShaderProgram shaderProgram)
+        {
+            if (_currentRenderTargetCount <= 0)
+                return;
+
+            uint fragmentOutputMask = shaderProgram != null
+                                      ? shaderProgram.FragmentOutputMask
+                                      : 0u;
+            
+            uint activeDrawBufferMask = GetDrawBufferMask(_currentRenderTargetCount);
+            
+            if (fragmentOutputMask == 0u ||
+                (fragmentOutputMask & activeDrawBufferMask) == activeDrawBufferMask)
+            {
+                GL.DrawBuffers(_currentRenderTargetCount, _drawBuffers);
+                GraphicsExtensions.CheckGLError();
+                return;
+            }
+
+            for (int i = 0; i < _currentRenderTargetCount; ++i)
+            {
+                _maskedDrawBuffers[i] = (fragmentOutputMask & (1u << i)) != 0u
+                                        ? _drawBuffers[i]
+                                        : DrawBuffersEnum.None;
+            }
+
+            GL.DrawBuffers(_currentRenderTargetCount, _maskedDrawBuffers);
+            GraphicsExtensions.CheckGLError();
+        }
+#endif
+
         private IRenderTarget PlatformApplyRenderTargets()
         {
             var glFramebuffer = 0;
@@ -878,7 +926,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 this.framebufferHelper.BindFramebuffer(glFramebuffer);
             }
 #if !GLES
-            GL.DrawBuffers(this._currentRenderTargetCount, this._drawBuffers);
+            ApplyRenderTargetDrawBuffers(_shaderProgram);
 #endif
 
             // Reset the raster state because we flip vertices
@@ -926,6 +974,11 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
                 _shaderProgram = shaderProgram;
             }
+
+#if !GLES
+            if (IsRenderTargetBound)
+                ApplyRenderTargetDrawBuffers(shaderProgram);
+#endif
 
             var posFixupLoc = shaderProgram.GetUniformLocation("posFixup");
             if (posFixupLoc == -1)

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -34,6 +34,7 @@ namespace MonoGame.OpenGL
     }
     internal enum DrawBuffersEnum
     {
+        None = 0,
         UnsignedShort,
         UnsignedInt,
     }

--- a/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/Shader/Shader.OpenGL.cs
@@ -17,14 +17,66 @@ namespace Microsoft.Xna.Framework.Graphics
         // We keep this around for recompiling on context lost and debugging.
         private string _glslCode;
 
+        public uint FragmentOutputMask;
+
         private static int PlatformProfile()
         {
             return 0;
         }
 
+        private static uint GetFragmentOutputMask(string glslCode)
+        {
+            uint fragmentOutputMask = 0;
+
+            // gl_FragColor maps to fragment output 0
+            if (glslCode.Contains("gl_FragColor", StringComparison.Ordinal))
+                fragmentOutputMask |= 1u;
+
+            const string fragmentDataToken = "gl_FragData[";
+            int searchIndex = 0;
+
+            // scan for explicit gl_FragData[n] writes and mark each output slot
+            while (searchIndex < glslCode.Length)
+            {
+                int tokenIndex = glslCode.IndexOf(fragmentDataToken, searchIndex, StringComparison.Ordinal);
+                if (tokenIndex < 0)
+                    break;
+
+                int outputIndex = 0;
+                int indexStart = tokenIndex + fragmentDataToken.Length;
+                int indexEnd = indexStart;
+                while (indexEnd < glslCode.Length)
+                {
+                    char character = glslCode[indexEnd];
+                    if (character < '0' || character > '9')
+                        break;
+
+                    outputIndex = (outputIndex * 10) + (character - '0');
+                    ++indexEnd;
+                }
+
+                // The mask stores up to 32 fragment outputs
+                if (indexEnd > indexStart &&
+                    indexEnd < glslCode.Length &&
+                    glslCode[indexEnd] == ']' &&
+                    outputIndex < 32)
+                {
+                    fragmentOutputMask |= 1u << outputIndex;
+                }
+
+                searchIndex = indexEnd + 1;
+            }
+
+            return fragmentOutputMask;
+        }
+
         private void PlatformConstruct(ShaderStage stage, byte[] shaderBytecode)
         {
             _glslCode = System.Text.Encoding.ASCII.GetString(shaderBytecode);
+            
+            FragmentOutputMask = stage == ShaderStage.Pixel
+                                 ? GetFragmentOutputMask(_glslCode)
+                                 : 0u;
 
             HashKey = MonoGame.Framework.Utilities.Hash.ComputeHash(shaderBytecode);
         }

--- a/MonoGame.Framework/Platform/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Platform/Graphics/Shader/ShaderProgramCache.cs
@@ -10,12 +10,14 @@ namespace Microsoft.Xna.Framework.Graphics
     internal class ShaderProgram
     {
         public readonly int Program;
+        public readonly uint FragmentOutputMask;
 
         private readonly Dictionary<string, int> _uniformLocations = new Dictionary<string, int>();
 
-        public ShaderProgram(int program)
+        public ShaderProgram(int program, uint fragmentOutputMask)
         {
             Program = program;
+            FragmentOutputMask = fragmentOutputMask;
         }
 
         public int GetUniformLocation(string name)
@@ -121,7 +123,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new InvalidOperationException("Unable to link effect program");
             }
 
-            return new ShaderProgram(program);
+            return new ShaderProgram(program, pixelShader.FragmentOutputMask);
         }
 
 

--- a/Tests/Framework/Graphics/BlendStateTest.cs
+++ b/Tests/Framework/Graphics/BlendStateTest.cs
@@ -81,6 +81,90 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
+        public void SingleOutputShaderOnlyWritesToFirstRenderTarget()
+        {
+            using Texture2D pixel = new Texture2D(gd, 1, 1, false, SurfaceFormat.Color);
+            pixel.SetData(new Color[] { Color.White });
+
+            using RenderTarget2D rt0 = new RenderTarget2D(gd, 1, 1, false, SurfaceFormat.Color, DepthFormat.None);
+            using RenderTarget2D rt1 = new RenderTarget2D(gd, 1, 1, false, SurfaceFormat.Color, DepthFormat.None);
+            
+            RenderTargetBinding[] rts =
+            {
+                    new RenderTargetBinding(rt0),
+                    new RenderTargetBinding(rt1)
+            };
+
+            gd.SetRenderTargets(rts);
+            gd.Clear(Color.Transparent);
+
+            using SpriteBatch sb = new SpriteBatch(gd);
+            sb.Begin(blendState: BlendState.Opaque);
+            sb.Draw(pixel, Vector2.Zero, Color.White);
+            sb.End();
+
+            gd.SetRenderTarget(null);
+
+            Color[] rt0Pixels = new Color[1];
+            Color[] rt1Pixels = new Color[1];
+
+            rt0.GetData(rt0Pixels);
+            rt1.GetData(rt1Pixels);
+
+            // XNA writes SpriteBatch's single SV_Target0 output only to RT0
+            Assert.That(rt0Pixels[0], Is.EqualTo(Color.White));
+            Assert.That(rt1Pixels[0], Is.EqualTo(Color.Transparent));
+        }
+
+#if !XNA
+        [Test]
+        public void SingleOutputShaderRespectsIndependentBlendColorWriteChannels()
+        {
+            if (!gd.GraphicsCapabilities.SupportsSeparateBlendStates)
+                Assert.Ignore("Separate blend states are unavailable on this device.");
+
+            using BlendState blendState = new BlendState();
+            blendState.IndependentBlendEnable = true;
+            blendState[0].ColorWriteChannels = ColorWriteChannels.Red;
+            blendState[1].ColorWriteChannels = ColorWriteChannels.Green;
+
+            using Texture2D pixel = new Texture2D(gd, 1, 1, false, SurfaceFormat.Color);
+            pixel.SetData(new Color[] { Color.White });
+
+            using RenderTarget2D rt0 = new RenderTarget2D(gd, 1, 1, false, SurfaceFormat.Color, DepthFormat.None);
+            using RenderTarget2D rt1 = new RenderTarget2D(gd, 1, 1, false, SurfaceFormat.Color, DepthFormat.None);
+
+            RenderTargetBinding[] rts = new RenderTargetBinding[]
+            {
+                new RenderTargetBinding(rt0),
+                new RenderTargetBinding(rt1)
+            };
+
+            gd.SetRenderTargets(rts);
+            gd.Clear(Color.Transparent);
+
+            using SpriteBatch sb = new SpriteBatch(gd);
+            sb.Begin(blendState: blendState);
+            sb.Draw(pixel, Vector2.Zero, Color.White);
+            sb.End();
+
+            gd.SetRenderTarget(null);
+
+            Color[] rt0Pixels = new Color[1];
+            Color[] rt1Pixels = new Color[1];
+
+            rt0.GetData(rt0Pixels);
+            rt1.GetData(rt1Pixels);
+            
+            // SpriteBatch writes SV_Target0, so RT0 still uses its configured red write mask
+            Assert.That(rt0Pixels[0], Is.EqualTo(new Color(255, 0, 0, 0)));
+
+            // RT1 has a green write mask, but the shader has no output for this target
+            Assert.That(rt1Pixels[0], Is.EqualTo(Color.Transparent));
+        }
+#endif
+
+        [Test]
 #if DESKTOPGL
         [Ignore("Fails similarity test. Needs Investigating")]
 #endif


### PR DESCRIPTION
Closes #9507

### Description of Change

The OpenGL shader path now checks the GLSL source when the shader/program is created and caches a bitmask for the fragment outputs it writes.  When multiple render targets are bound, `DesktopGL` uses that mask to disable any draw buffers the shader does not have an output for.  This keeps us from relying on the undefined OpenGL behavior and makes `DesktopGL` consistant with XNA and the other backends.

I also added two unit tests or this.  The first verifies that a single output shader only writes to the first render target.  The second verifies that independent blend color write channels still apply correctly for the render targets the shader actually writes to.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

