### PR TITLE
Cleanup Content Builder build outputs to just be en

### DIFF
--- a/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
+++ b/Tools/MonoGame.Content.Builder/MonoGame.Content.Builder.csproj
@@ -13,6 +13,7 @@
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <AssemblyName>mgcb</AssemblyName>
     <UseAppHost>true</UseAppHost>
+	<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #9513 

### Description of Change

Added the tag to MonoGame.Content.Builder.csproj that was discussed in the issue to specify that we do not want System.CommandLine dlls for each culture variant. After some testing it seems to work! This is a screenshot of what it looks like post change for comparison against the one provided by Tom in the issue.

<img width="732" height="881" alt="image" src="https://github.com/user-attachments/assets/b60808d9-8864-44ac-8b1d-a22292f6149d" />


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

