### PR TITLE
Add LLM usage declaration to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -14,6 +14,12 @@ body:
         required: true
       - label: I have searched [open](https://github.com/MonoGame/MonoGame/issues) and [closed](https://github.com/MonoGame/MonoGame/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported.
         required: true
+- type: checkboxes
+  id: llmdeclaration
+  options:
+    - label: I used an LLM to generate the code or fix in this Issue.
+      required: false
+      description: This is so maintainers are aware of the usage of a LLM to generate the code, this is so we do not accidently copy the code into the actual project.
 - type: input
   id: monogame-version
   validations:


### PR DESCRIPTION
Added a checkbox option to indicate LLM usage in bug reports.

This is not so we don't accept issues , more so that maintainers are aware if they can use the code or not. 

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

