### PR TITLE
Fix compilation errors when upgrading to .net 10 for android

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -1053,7 +1053,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
 #if ANDROID
                 // Todo: Add generic MonoGame logging interface
-                Android.Util.Log.Debug("MonoGame", "MonoGameGLException at " + location + " - " + ex.Message);
+                global::Android.Util.Log.Debug("MonoGame", "MonoGameGLException at " + location + " - " + ex.Message);
 #else
                 Debug.WriteLine("MonoGameGLException at " + location + " - " + ex.Message);
 #endif

--- a/MonoGame.Framework/Media/Album.cs
+++ b/MonoGame.Framework/Media/Album.cs
@@ -10,9 +10,10 @@ using CoreGraphics;
 using MediaPlayer;
 using UIKit;
 #elif ANDROID
-using Android.Content;
-using Android.Graphics;
-using Android.Provider;
+using global::Android.Content;
+using global::Android.Graphics;
+using global::Android.Provider;
+using AN = global::Android.Net;
 #endif
 
 namespace Microsoft.Xna.Framework.Media
@@ -40,7 +41,7 @@ namespace Microsoft.Xna.Framework.Media
 #if IOS && !TVOS
         private MPMediaItemArtwork thumbnail;
 #elif ANDROID
-        private Android.Net.Uri thumbnail;
+        private AN.Uri thumbnail;
 #endif
 
         /// <summary>
@@ -144,7 +145,7 @@ namespace Microsoft.Xna.Framework.Media
             this.thumbnail = thumbnail;
         }
 #elif ANDROID
-        internal Album(SongCollection songCollection, string name, Artist artist, Genre genre, Android.Net.Uri thumbnail)
+        internal Album(SongCollection songCollection, string name, Artist artist, Genre genre, AN.Uri thumbnail)
             : this(songCollection, name, artist, genre)
         {
             this.thumbnail = thumbnail;

--- a/MonoGame.Framework/Platform/Android/AndroidGameActivity.cs
+++ b/MonoGame.Framework/Platform/Android/AndroidGameActivity.cs
@@ -3,10 +3,10 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using Android.App;
-using Android.Content;
-using Android.OS;
-using Android.Views;
+using global::Android.App;
+using global::Android.Content;
+using global::Android.OS;
+using global::Android.Views;
 
 namespace Microsoft.Xna.Framework
 {
@@ -47,7 +47,7 @@ namespace Microsoft.Xna.Framework
 
         public static event EventHandler Paused;
 
-		public override void OnConfigurationChanged (Android.Content.Res.Configuration newConfig)
+		public override void OnConfigurationChanged (global::Android.Content.Res.Configuration newConfig)
 		{
 			// we need to refresh the viewport here.
 			base.OnConfigurationChanged (newConfig);

--- a/MonoGame.Framework/Platform/Android/AndroidGamePlatform.cs
+++ b/MonoGame.Framework/Platform/Android/AndroidGamePlatform.cs
@@ -3,7 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using Android.Views;
+using global::Android.Views;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Media;
 
@@ -79,7 +79,7 @@ namespace Microsoft.Xna.Framework
 
             switch (Game.Activity.Resources.Configuration.Orientation)
             {
-                case Android.Content.Res.Orientation.Portrait:
+                case global::Android.Content.Res.Orientation.Portrait:
                     this._gameWindow.SetOrientation(currentOrientation == DisplayOrientation.PortraitDown ? DisplayOrientation.PortraitDown : DisplayOrientation.Portrait, false);
                     break;
                 default:
@@ -154,7 +154,7 @@ namespace Microsoft.Xna.Framework
         public override void Log(string Message)
         {
 #if LOGGING
-            Android.Util.Log.Debug("MonoGameDebug", Message);
+            global::Android.Util.Log.Debug("MonoGameDebug", Message);
 #endif
         }
 
@@ -170,7 +170,7 @@ namespace Microsoft.Xna.Framework
             }
             catch (Exception ex)
             {
-                Android.Util.Log.Error("Error in swap buffers", ex.ToString());
+                global::Android.Util.Log.Error("Error in swap buffers", ex.ToString());
             }
         }
     }

--- a/MonoGame.Framework/Platform/Android/AndroidGameWindow.cs
+++ b/MonoGame.Framework/Platform/Android/AndroidGameWindow.cs
@@ -3,10 +3,10 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using Android.Content;
-using Android.Content.PM;
-using Android.OS;
-using Android.Views;
+using global::Android.Content;
+using global::Android.Content.PM;
+using global::Android.OS;
+using global::Android.Views;
 using Microsoft.Xna.Framework.Input.Touch;
 using MonoGame.OpenGL;
 
@@ -60,7 +60,7 @@ namespace Microsoft.Xna.Framework
             }
             else
             {
-                Android.Graphics.Point p = new Android.Graphics.Point();
+                global::Android.Graphics.Point p = new global::Android.Graphics.Point();
                 activity.WindowManager.DefaultDisplay.GetRealSize(p);
                 size.X = p.X;
                 size.Y = p.Y;
@@ -260,7 +260,7 @@ namespace Microsoft.Xna.Framework
 
                 bool didOrientationChange = false;
                 // Android 2.3 and above support reverse orientations
-                int sdkVer = (int)Android.OS.Build.VERSION.SdkInt;
+                int sdkVer = (int)global::Android.OS.Build.VERSION.SdkInt;
                 if (sdkVer >= 10)
                 {
                     // Check if the requested orientation is supported. Default means all are supported.

--- a/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
+++ b/MonoGame.Framework/Platform/Android/MonoGameAndroidGameView.cs
@@ -6,11 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Android.Content;
-using Android.Media;
-using Android.Runtime;
-using Android.Util;
-using Android.Views;
+using global::Android.Content;
+using global::Android.Media;
+using global::Android.Runtime;
+using global::Android.Util;
+using global::Android.Views;
 using Javax.Microedition.Khronos.Egl;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
@@ -1098,9 +1098,9 @@ namespace Microsoft.Xna.Framework
                     System.Threading.Thread bgThread = new System.Threading.Thread(
                         o =>
                         {
-                            Android.Util.Log.Debug("MonoGame", "Begin reloading graphics content");
+                            global::Android.Util.Log.Debug("MonoGame", "Begin reloading graphics content");
                             Microsoft.Xna.Framework.Content.ContentManager.ReloadGraphicsContent();
-                            Android.Util.Log.Debug("MonoGame", "End reloading graphics content");
+                            global::Android.Util.Log.Debug("MonoGame", "End reloading graphics content");
 
                             // DeviceReset events
                             _game.graphicsDeviceManager.OnDeviceReset(EventArgs.Empty);

--- a/MonoGame.Framework/Platform/Android/ScreenReceiver.cs
+++ b/MonoGame.Framework/Platform/Android/ScreenReceiver.cs
@@ -1,7 +1,7 @@
 using System;
-using Android.Content;
+using global::Android.Content;
 using Microsoft.Xna.Framework.Media;
-using Android.App;
+using global::Android.App;
 
 namespace Microsoft.Xna.Framework
 {
@@ -11,7 +11,7 @@ namespace Microsoft.Xna.Framework
 		
 		public override void OnReceive(Context context, Intent intent)
 		{
-			Android.Util.Log.Info("MonoGame", intent.Action.ToString());
+			global::Android.Util.Log.Info("MonoGame", intent.Action.ToString());
 			if(intent.Action == Intent.ActionScreenOff)
 			{
                 OnLocked();

--- a/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Platform/Audio/OpenALSoundController.cs
@@ -9,9 +9,9 @@ using MonoGame.OpenGL;
 
 #if ANDROID
 using System.Globalization;
-using Android.Content.PM;
-using Android.Content;
-using Android.Media;
+using global::Android.Content.PM;
+using global::Android.Content;
+using global::Android.Media;
 #endif
 
 #if IOS
@@ -194,7 +194,7 @@ namespace Microsoft.Xna.Framework.Audio
                 int updateBuffers = DEFAULT_UPDATE_BUFFER_COUNT;
                 if (OperatingSystem.IsAndroidVersionAtLeast(17))
                 {
-                    Android.Util.Log.Debug("OAL", Game.Activity.PackageManager.HasSystemFeature(PackageManager.FeatureAudioLowLatency) ? "Supports low latency audio playback." : "Does not support low latency audio playback.");
+                    global::Android.Util.Log.Debug("OAL", Game.Activity.PackageManager.HasSystemFeature(PackageManager.FeatureAudioLowLatency) ? "Supports low latency audio playback." : "Does not support low latency audio playback.");
 
                     var audioManager = Game.Activity.GetSystemService(Context.AudioService) as AudioManager;
                     if (audioManager != null)
@@ -216,9 +216,9 @@ namespace Microsoft.Xna.Framework.Audio
                 }
                 else
                 {
-                    Android.Util.Log.Debug("OAL", "Android 4.2 or higher required for low latency audio playback.");
+                    global::Android.Util.Log.Debug("OAL", "Android 4.2 or higher required for low latency audio playback.");
                 }
-                Android.Util.Log.Debug("OAL", "Using sample rate " + frequency + "Hz and " + updateBuffers + " buffers of " + updateSize + " frames.");
+                global::Android.Util.Log.Debug("OAL", "Using sample rate " + frequency + "Hz and " + updateBuffers + " buffers of " + updateSize + " frames.");
 
                 // These are missing and non-standard ALC constants
                 const int AlcFrequency = 0x1007;

--- a/MonoGame.Framework/Platform/GraphicsDeviceManager.Legacy.cs
+++ b/MonoGame.Framework/Platform/GraphicsDeviceManager.Legacy.cs
@@ -7,7 +7,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input.Touch;
 
 #if ANDROID
-using Android.Views;
+using global::Android.Views;
 #endif
 
 namespace Microsoft.Xna.Framework
@@ -380,7 +380,7 @@ namespace Microsoft.Xna.Framework
         {
             if (IsFullScreen)
 			{
-				Game.Activity.Window.ClearFlags(Android.Views.WindowManagerFlags.ForceNotFullscreen);
+				Game.Activity.Window.ClearFlags(global::Android.Views.WindowManagerFlags.ForceNotFullscreen);
                 Game.Activity.Window.SetFlags(WindowManagerFlags.Fullscreen, WindowManagerFlags.Fullscreen);
 			}
             else
@@ -580,7 +580,7 @@ namespace Microsoft.Xna.Framework
             TouchPanel.DisplayWidth = newClientBounds.Width;
             TouchPanel.DisplayHeight = newClientBounds.Height;
 
-            Android.Util.Log.Debug("MonoGame", "GraphicsDeviceManager.ResetClientBounds: newClientBounds=" + newClientBounds.ToString());
+            global::Android.Util.Log.Debug("MonoGame", "GraphicsDeviceManager.ResetClientBounds: newClientBounds=" + newClientBounds.ToString());
 #endif
         }
 

--- a/MonoGame.Framework/Platform/Input/GamePad.Android.cs
+++ b/MonoGame.Framework/Platform/Input/GamePad.Android.cs
@@ -3,8 +3,8 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using Android.OS;
-using Android.Views;
+using global::Android.OS;
+using global::Android.Views;
 
 namespace Microsoft.Xna.Framework.Input
 {
@@ -174,7 +174,7 @@ namespace Microsoft.Xna.Framework.Input
             var dvc = InputDevice.GetDevice(gamePad._deviceId);
             if (dvc == null)
             {
-                Android.Util.Log.Debug("MonoGame", $"Detected controller disconnect [{index}]");
+                global::Android.Util.Log.Debug("MonoGame", $"Detected controller disconnect [{index}]");
                 gamePad._isConnected = false;
                 return GamePadState.Default;
             }
@@ -221,14 +221,14 @@ namespace Microsoft.Xna.Framework.Input
                 }
                 else if (pad != null && !pad._isConnected && pad._descriptor == device.Descriptor)
                 {
-                    Android.Util.Log.Debug("MonoGame", "Found previous controller [" + i + "] " + device.Name);
+                    global::Android.Util.Log.Debug("MonoGame", "Found previous controller [" + i + "] " + device.Name);
                     pad._deviceId = device.Id;
                     pad._isConnected = true;
                     return pad;
                 }
                 else if (pad == null)
                 {
-                    Android.Util.Log.Debug("MonoGame", "Found new controller [" + i + "] " + device.Name);
+                    global::Android.Util.Log.Debug("MonoGame", "Found new controller [" + i + "] " + device.Name);
                     pad = new AndroidGamePad(device);
                     GamePads[i] = pad;
                     return pad;
@@ -243,7 +243,7 @@ namespace Microsoft.Xna.Framework.Input
             // If we're holding onto a disconnected pad, overwrite it with this one
             if (firstDisconnectedPadId >= 0)
             {
-                Android.Util.Log.Debug("MonoGame", "Found new controller in place of disconnected controller [" + firstDisconnectedPadId + "] " + device.Name);
+                global::Android.Util.Log.Debug("MonoGame", "Found new controller in place of disconnected controller [" + firstDisconnectedPadId + "] " + device.Name);
                 var pad = new AndroidGamePad(device);
                 GamePads[firstDisconnectedPadId] = pad;
                 return pad;

--- a/MonoGame.Framework/Platform/Input/KeyboardInput.Android.cs
+++ b/MonoGame.Framework/Platform/Input/KeyboardInput.Android.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Xna.Framework.Input
                     input.SetSelection(defaultText.Length);
 
                 if (usePasswordMode)
-                    input.InputType = Android.Text.InputTypes.ClassText | Android.Text.InputTypes.TextVariationPassword;
+                    input.InputType = global::Android.Text.InputTypes.ClassText | global::Android.Text.InputTypes.TextVariationPassword;
 
                 alert.SetView(input);
 

--- a/MonoGame.Framework/Platform/Media/Song.Android.cs
+++ b/MonoGame.Framework/Platform/Media/Song.Android.cs
@@ -4,32 +4,34 @@
 
 using System;
 using System.IO;
+using AM = global::Android.Media;
+using AN = global::Android.Net;
 
 namespace Microsoft.Xna.Framework.Media
 {
     public sealed partial class Song : IEquatable<Song>, IDisposable
     {
-        static Android.Media.MediaPlayer _androidPlayer;
+        static AM.MediaPlayer _androidPlayer;
         static Song _playingSong;
 
         private Album album;
         private Artist artist;
         private Genre genre;
         private TimeSpan position;
-        private Android.Net.Uri assetUri;
+        private AN.Uri assetUri;
 
-        public Android.Net.Uri AssetUri
+        public AN.Uri AssetUri
         {
             get { return this.assetUri; }
         }
 
         static Song()
         {
-            _androidPlayer = new Android.Media.MediaPlayer();
+            _androidPlayer = new AM.MediaPlayer();
             _androidPlayer.Completion += AndroidPlayer_Completion;
         }
 
-        internal Song(Album album, Artist artist, Genre genre, string name, TimeSpan duration, Android.Net.Uri assetUri)
+        internal Song(Album album, Artist artist, Genre genre, string name, TimeSpan duration, AN.Uri assetUri)
         {
             this.album = album;
             this.artist = artist;

--- a/MonoGame.Framework/Platform/Media/Video.Android.cs
+++ b/MonoGame.Framework/Platform/Media/Video.Android.cs
@@ -5,6 +5,8 @@
 using System;
 using System.IO;
 using System.Linq;
+using AM = global::Android.Media;
+using AN = global::Android.Net;
 
 namespace Microsoft.Xna.Framework.Media
 {
@@ -13,11 +15,11 @@ namespace Microsoft.Xna.Framework.Media
     /// </summary>
     public sealed partial class Video : IDisposable
     {
-        internal Android.Media.MediaPlayer Player;
+        internal AM.MediaPlayer Player;
 
         private void PlatformInitialize()
         {
-            Player = new Android.Media.MediaPlayer();
+            Player = new AM.MediaPlayer();
             if (Player != null)
             {
                 var afd = Game.Activity.Assets.OpenFd(FileName);

--- a/MonoGame.Framework/Platform/TitleContainer.Android.cs
+++ b/MonoGame.Framework/Platform/TitleContainer.Android.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Xna.Framework
         {
             try
             {
-                return Android.App.Application.Context.Assets.Open(safeName);
+                return global::Android.App.Application.Context.Assets.Open(safeName);
             }
             catch
             {


### PR DESCRIPTION
Fixes #9469

In .net 10 a new namespace `Microsoft.Android` was introduced upstream. This causes allot of namespace and type conflicts with our existing code. Since the new namespace is baked into .net android, the only way around it is to make use of namespace aliases and `global::`.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

