### PR TITLE
Implement Vector4 Quaternion Transforms

### DIFF
--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -1064,7 +1064,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed <see cref="Vector4"/> as an output parameter.</param>
         public static void Transform(ref Vector2 value, ref Quaternion rotation, out Vector4 result)
         {
-            float x = 2 * (0 - rotation.Z * value.Y);
+            float x = -2 * rotation.Z * value.Y;
             float y = 2 * rotation.Z * value.X;
             float z = 2 * (rotation.X * value.Y - rotation.Y * value.X);
 

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -1064,7 +1064,14 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed <see cref="Vector4"/> as an output parameter.</param>
         public static void Transform(ref Vector2 value, ref Quaternion rotation, out Vector4 result)
         {
-            throw new NotImplementedException();
+            float x = 2 * (0 - rotation.Z * value.Y);
+            float y = 2 * rotation.Z * value.X;
+            float z = 2 * (rotation.X * value.Y - rotation.Y * value.X);
+
+            result.X = value.X + x * rotation.W + (rotation.Y * z - rotation.Z * y);
+            result.Y = value.Y + y * rotation.W + (rotation.Z * x - rotation.X * z);
+            result.Z = z * rotation.W + (rotation.X * y - rotation.Y * x);
+            result.W = 1f;
         }
 
         /// <summary>
@@ -1089,7 +1096,14 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed <see cref="Vector4"/> as an output parameter.</param>
         public static void Transform(ref Vector3 value, ref Quaternion rotation, out Vector4 result)
         {
-            throw new NotImplementedException();
+            float x = 2 * (rotation.Y * value.Z - rotation.Z * value.Y);
+            float y = 2 * (rotation.Z * value.X - rotation.X * value.Z);
+            float z = 2 * (rotation.X * value.Y - rotation.Y * value.X);
+
+            result.X = value.X + x * rotation.W + (rotation.Y * z - rotation.Z * y);
+            result.Y = value.Y + y * rotation.W + (rotation.Z * x - rotation.X * z);
+            result.Z = value.Z + z * rotation.W + (rotation.X * y - rotation.Y * x);
+            result.W = 1f;
         }
 
         /// <summary>
@@ -1118,7 +1132,14 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed <see cref="Vector4"/> as an output parameter.</param>
         public static void Transform(ref Vector4 value, ref Quaternion rotation, out Vector4 result)
         {
-            throw new NotImplementedException();
+            float x = 2 * (rotation.Y * value.Z - rotation.Z * value.Y);
+            float y = 2 * (rotation.Z * value.X - rotation.X * value.Z);
+            float z = 2 * (rotation.X * value.Y - rotation.Y * value.X);
+
+            result.X = value.X + x * rotation.W + (rotation.Y * z - rotation.Z * y);
+            result.Y = value.Y + y * rotation.W + (rotation.Z * x - rotation.X * z);
+            result.Z = value.Z + z * rotation.W + (rotation.X * y - rotation.Y * x);
+            result.W = value.W;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #9530 


### Description of Change

Implemented the missing Quaternion based Transforms on Vector4. I used the same kind of cross-product style implementation as Vector3 uses in its similar case. Vector2 has some simplified math from using 0 for Z. I went back and forth on matching the format or just using the simplified equation and ended up just using the simpler one.

Draft Note:
I made this change while I was up very late, so I plan to double check the Math again later in the day lol.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

