### PR TITLE
Wrapping External Texture in RenderTarget2D

### DIFF
--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.DirectX.cs
@@ -192,5 +192,55 @@ namespace Microsoft.Xna.Framework.Graphics
 
             return desc;
         }
+
+        /// <summary>
+        /// Creates a <see cref="RenderTarget2D"/> that wraps an externally-owned native graphics handle.
+        /// Such as an DX11 texture <c>ID3D11Texture2D*</c>.
+        /// </summary>
+        /// <param name="graphicsDevice">The MonoGame graphics device.</param>
+        /// <param name="handle">The native image handle. <para>This should be <c>ID3D11Texture2D*</c> cast to <see cref="nint"/>.</para></param>
+        /// <param name="width">Image width in pixels.</param>
+        /// <param name="height">Image height in pixels.</param>
+        /// <param name="format">The surface format of the native image.</param>
+        /// <param name="preferredDepthFormat">The preferred depth format of the render target.<para><see cref="DepthFormat.None"/> by default.</para></param>
+        /// <param name="preferredMultiSampleCount">The preferred number of samples per pixel when multisampling.<para><c>0</c> by default.</para></param>
+        /// <remarks>
+        /// WARNING: The returned render target does not own the underlying native image memory.
+        /// The external caller/runtime is responsible for its lifetime.
+        /// </remarks>
+        /// <returns>A non-owning <see cref="RenderTarget2D"/> backed by the native resource handle.</returns>
+        public static RenderTarget2D FromNativeHandle(
+            GraphicsDevice graphicsDevice,
+            nint handle,
+            int width,
+            int height,
+            SurfaceFormat format = SurfaceFormat.Color,
+            DepthFormat preferredDepthFormat = DepthFormat.None,
+            int preferredMultiSampleCount = 0)
+        {
+            var renderTarget = new RenderTarget2D(
+                graphicsDevice,
+                width,
+                height,
+                false,
+                format,
+                preferredDepthFormat,
+                preferredMultiSampleCount,
+                RenderTargetUsage.DiscardContents,
+                SurfaceType.SwapChainRenderTarget);
+
+            var d3DTexture = new SharpDX.Direct3D11.Texture2D(handle);
+            ((SharpDX.IUnknown)d3DTexture).AddReference();
+
+            renderTarget.SetNativeTexture(d3DTexture);
+            renderTarget._msSampleDescription = graphicsDevice.GetSupportedSampleDescription(
+                SharpDXHelper.ToFormat(format),
+                renderTarget.MultiSampleCount);
+
+            // Creates RenderTargetView, and if requested, MSAA texture and DepthStencilView
+            renderTarget.GenerateIfRequired();
+
+            return renderTarget;
+        }
     }
 }

--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.OpenGL.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Xna.Framework.Graphics
         private static Action<RenderTarget2D> DisposeAction =
             (t) => t.GraphicsDevice.PlatformDeleteRenderTarget(t);
 
+        private bool _isExternal;
+
         int IRenderTarget.GLTexture
         {
             get { return glTexture; }
@@ -43,6 +45,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGraphicsDeviceResetting()
         {
+            if (_isExternal)
+            {
+                glTexture = -1;
+            }
         }
 
         /// <summary/>
@@ -54,9 +60,78 @@ namespace Microsoft.Xna.Framework.Graphics
                 {
                     Threading.BlockOnUIThread(DisposeAction, this);
                 }
+
+                if (_isExternal)
+                {
+                    // Disassociate glTexture.
+                    // This is to prevent base.Dispose() from invoking GraphicsDevice.DisposeTexture() on the external texture.
+                    glTexture = -1;
+                }
             }
 
             base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="RenderTarget2D"/> that wraps an externally-owned native graphics handle.
+        /// Such as an OpenGL texture <c>GLuint</c>.
+        /// </summary>
+        /// <param name="graphicsDevice">The MonoGame graphics device.</param>
+        /// <param name="handle">The native image handle. <para>This should be an OpenGL texture <c>GLuint</c> cast to <see cref="nint"/> for Vulkan, or <c>ID3D12Resource*</c> for DX12.</para></param>
+        /// <param name="width">Image width in pixels.</param>
+        /// <param name="height">Image height in pixels.</param>
+        /// <param name="format">The surface format of the native image.</param>
+        /// <param name="preferredDepthFormat">The preferred depth format of the render target.<para><see cref="DepthFormat.None"/> by default.</para></param>
+        /// <param name="preferredMultiSampleCount">The preferred number of samples per pixel when multisampling.<para><c>0</c> by default.</para></param>
+        /// <remarks>
+        /// WARNING: The returned render target does not own the underlying native image memory.
+        /// The external caller/runtime is responsible for its lifetime.
+        /// </remarks>
+        /// <returns>A non-owning <see cref="RenderTarget2D"/> backed by the native resource handle.</returns>
+        public static RenderTarget2D FromNativeHandle(
+            GraphicsDevice graphicsDevice,
+            nint handle,
+            int width,
+            int height,
+            SurfaceFormat format = SurfaceFormat.Color,
+            DepthFormat preferredDepthFormat = DepthFormat.None,
+            int preferredMultiSampleCount = 0)
+        {
+            var renderTarget = new RenderTarget2D(
+                graphicsDevice,
+                width,
+                height,
+                false,
+                format,
+                preferredDepthFormat,
+                preferredMultiSampleCount,
+                RenderTargetUsage.DiscardContents,
+                SurfaceType.SwapChainRenderTarget)
+            {
+                _isExternal = true,
+                glTexture = (int)handle,
+                glTarget = TextureTarget.Texture2D,
+            };
+
+            format.GetGLFormat(graphicsDevice, out renderTarget.glInternalFormat, out renderTarget.glFormat, out renderTarget.glType);
+
+            if (preferredDepthFormat != DepthFormat.None || renderTarget.MultiSampleCount > 0)
+            {
+                Threading.BlockOnUIThread(() =>
+                {
+                    graphicsDevice.PlatformCreateRenderTarget(
+                        renderTarget,
+                        width,
+                        height,
+                        false,
+                        format,
+                        preferredDepthFormat,
+                        preferredMultiSampleCount,
+                        RenderTargetUsage.DiscardContents);
+                });
+            }
+
+            return renderTarget;
         }
     }
 }

--- a/MonoGame.Framework/Platform/Graphics/RenderTarget2D.Web.cs
+++ b/MonoGame.Framework/Platform/Graphics/RenderTarget2D.Web.cs
@@ -32,5 +32,28 @@ namespace Microsoft.Xna.Framework.Graphics
 
             base.Dispose(disposing);
         }
+
+        /// <summary>
+        /// Creates a <see cref="RenderTarget2D"/> that wraps an externally-owned native graphics handle.
+        /// </summary>
+        /// <param name="graphicsDevice">The MonoGame graphics device.</param>
+        /// <param name="handle">The native image handle.</param>
+        /// <param name="width">Image width in pixels.</param>
+        /// <param name="height">Image height in pixels.</param>
+        /// <param name="format">The surface format of the native image.</param>
+        /// <param name="preferredDepthFormat">The preferred depth format of the render target.<para><see cref="DepthFormat.None"/> by default.</para></param>
+        /// <param name="preferredMultiSampleCount">The preferred number of samples per pixel when multisampling.<para><c>0</c> by default.</para></param>
+        /// <returns>A non-owning <see cref="RenderTarget2D"/> backed by the native resource handle.</returns>
+        public static RenderTarget2D FromNativeHandle(
+            GraphicsDevice graphicsDevice,
+            nint handle,
+            int width,
+            int height,
+            SurfaceFormat format = SurfaceFormat.Color,
+            DepthFormat preferredDepthFormat = DepthFormat.None,
+            int preferredMultiSampleCount = 0)
+        {
+            throw new PlatformNotSupportedException();
+        }
     }
 }

--- a/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Platform/Graphics/Texture2D.DirectX.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private bool _shared;
         private bool _mipmap;
-        private SampleDescription _sampleDescription;
+        private SampleDescription _sampleDescription = new SampleDescription(1, 0);
 
         private SharpDX.Direct3D11.Texture2D _cachedStagingTexture;
 
@@ -33,7 +33,6 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             _shared = shared;
             _mipmap = mipmap;
-            _sampleDescription = new SampleDescription(1, 0);
         }
 
         private void PlatformSetData<T>(int level, T[] data, int startIndex, int elementCount) where T : struct

--- a/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
@@ -372,6 +372,16 @@ internal static unsafe partial class MGG
         int multiSampleCount,
         RenderTargetUsage usage);
 
+    [DllImport(MGP.MonoGameNativeDLL, EntryPoint = "MGG_RenderTarget_WrapNativeHandle", ExactSpelling = true)]
+    public static extern MGG_Texture* RenderTarget_WrapNativeHandle(
+        MGG_GraphicsDevice* device,
+        nint nativeHandle,
+        SurfaceFormat format,
+        int width,
+        int height,
+        DepthFormat depthFormat,
+        int multiSampleCount);
+
     [DllImport(MGP.MonoGameNativeDLL, EntryPoint = "MGG_Texture_Destroy", ExactSpelling = true)]
     public static extern void Texture_Destroy(MGG_GraphicsDevice* device, MGG_Texture* texture);
 

--- a/MonoGame.Framework/Platform/Native/RenderTarget2D.Native.cs
+++ b/MonoGame.Framework/Platform/Native/RenderTarget2D.Native.cs
@@ -31,4 +31,62 @@ public partial class RenderTarget2D
             Handle = null;
         }
     }
+
+    /// <summary>
+    /// Creates a <see cref="RenderTarget2D"/> that wraps an externally-owned native graphics handle.
+    /// Such as an OpenXR swapchain <c>VkImage</c> or <c>ID3D12Resource*</c>.
+    /// </summary>
+    /// <param name="graphicsDevice">The MonoGame graphics device.</param>
+    /// <param name="handle">The native image handle. <para>This should be <c>VkImage</c> cast to <see cref="nint"/> for Vulkan, or <c>ID3D12Resource*</c> for DX12.</para></param>
+    /// <param name="width">Image width in pixels.</param>
+    /// <param name="height">Image height in pixels.</param>
+    /// <param name="format">The surface format of the native image.</param>
+    /// <param name="preferredDepthFormat">The preferred depth format of the render target.<para><see cref="DepthFormat.None"/> by default.</para></param>
+    /// <param name="preferredMultiSampleCount">The preferred number of samples per pixel when multisampling.<para><c>0</c> by default.</para></param>
+    /// <remarks>
+    /// WARNING: The returned render target does not own the underlying native image memory.
+    /// The external caller/runtime is responsible for its lifetime.
+    /// </remarks>
+    /// <returns>A non-owning <see cref="RenderTarget2D"/> backed by the native resource handle.</returns>
+    public static unsafe RenderTarget2D FromNativeHandle(
+        GraphicsDevice graphicsDevice,
+        nint handle,
+        int width,
+        int height,
+        SurfaceFormat format = SurfaceFormat.Color,
+        DepthFormat preferredDepthFormat = DepthFormat.None,
+        int preferredMultiSampleCount = 0)
+    {
+        // Call native layer to create an MGG_Texture that wraps the external resource.
+        var nativeTexture = MGG.RenderTarget_WrapNativeHandle(
+            graphicsDevice.Handle,
+            handle,
+            format,
+            width,
+            height,
+            preferredDepthFormat,
+            preferredMultiSampleCount);
+
+        // Use the protected constructor that takes SurfaceType.SwapChainRenderTarget.
+        // This skips the PlatformConstruct() call.
+        var renderTarget = new RenderTarget2D(
+            graphicsDevice,
+            width,
+            height,
+            false,
+            format,
+            preferredDepthFormat,
+            preferredMultiSampleCount,
+            RenderTargetUsage.DiscardContents,
+            SurfaceType.SwapChainRenderTarget);
+
+        // Assign the handle to the native wrapper for the source image.
+        // We set Owned = true because MonoGame still owns the MGG_Texture* wrapper (including its views and depth buffer)
+        // and needs to manage its lifetime.
+        // MGG_Texture_Destroy will skip freeing the external image memory.
+        renderTarget.Handle = nativeTexture;
+        renderTarget.Owned = true;
+
+        return renderTarget;
+    }
 }

--- a/Tests/Framework/Graphics/RenderTarget2DTest.cs
+++ b/Tests/Framework/Graphics/RenderTarget2DTest.cs
@@ -1,4 +1,4 @@
-﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -184,6 +184,85 @@ namespace MonoGame.Tests.Graphics
             var resource = SharpDX.CppObject.FromPointer<SharpDX.DXGI.Resource>(sharedHandle);
 
             rt.Dispose();
+        }
+
+        [Test]
+        public void FromNativeHandle_DirectX()
+        {
+            var desc = new SharpDX.Direct3D11.Texture2DDescription
+            {
+                Width = 32,
+                Height = 32,
+                MipLevels = 1,
+                ArraySize = 1,
+                Format = SharpDX.DXGI.Format.R8G8B8A8_UNorm,
+                SampleDescription = new SharpDX.DXGI.SampleDescription(1, 0),
+                Usage = SharpDX.Direct3D11.ResourceUsage.Default,
+                BindFlags = SharpDX.Direct3D11.BindFlags.RenderTarget | SharpDX.Direct3D11.BindFlags.ShaderResource,
+            };
+
+            using (var d3dTexture = new SharpDX.Direct3D11.Texture2D(gd._d3dDevice, desc))
+            {
+                var rt = RenderTarget2D.FromNativeHandle(gd, d3dTexture.NativePointer, 32, 32);
+                Assert.IsNotNull(rt);
+                Assert.AreEqual(32, rt.Width);
+                Assert.AreEqual(32, rt.Height);
+
+                gd.SetRenderTarget(rt);
+                gd.Clear(Color.CornflowerBlue);
+                gd.SetRenderTarget(null);
+
+                var data = new Color[32 * 32];
+                rt.GetData(data);
+                Assert.AreEqual(Color.CornflowerBlue, data[0]);
+
+                rt.Dispose();
+
+                // Native texture should still be valid, and not destroyed.
+                Assert.IsFalse(d3dTexture.IsDisposed);
+            }
+        }
+#endif
+
+#if DESKTOPGL
+        [Test]
+        public void FromNativeHandle_OpenGL()
+        {
+            int texId = 0;
+            MonoGame.OpenGL.GL.GenTextures(1, out texId);
+            MonoGame.OpenGL.GL.BindTexture(MonoGame.OpenGL.TextureTarget.Texture2D, texId);
+            MonoGame.OpenGL.GL.TexImage2D(
+                MonoGame.OpenGL.TextureTarget.Texture2D,
+                0,
+                MonoGame.OpenGL.PixelInternalFormat.Rgba,
+                32,
+                32,
+                0,
+                MonoGame.OpenGL.PixelFormat.Rgba,
+                MonoGame.OpenGL.PixelType.UnsignedByte,
+                IntPtr.Zero);
+            MonoGame.OpenGL.GL.BindTexture(MonoGame.OpenGL.TextureTarget.Texture2D, 0);
+
+            var rt = RenderTarget2D.FromNativeHandle(gd, (nint)texId, 32, 32);
+            Assert.IsNotNull(rt);
+            Assert.AreEqual(32, rt.Width);
+            Assert.AreEqual(32, rt.Height);
+
+            gd.SetRenderTarget(rt);
+            gd.Clear(Color.CornflowerBlue);
+            gd.SetRenderTarget(null);
+
+            var data = new Color[32 * 32];
+            rt.GetData(data);
+            Assert.AreEqual(Color.CornflowerBlue, data[0]);
+
+            rt.Dispose();
+
+            // Native texture should still be valid and bindable, without a GL error.
+            MonoGame.OpenGL.GL.BindTexture(MonoGame.OpenGL.TextureTarget.Texture2D, texId);
+            Assert.AreEqual(MonoGame.OpenGL.ErrorCode.NoError, MonoGame.OpenGL.GL.GetError());
+            MonoGame.OpenGL.GL.BindTexture(MonoGame.OpenGL.TextureTarget.Texture2D, 0);
+            MonoGame.OpenGL.GL.DeleteTextures(1, ref texId);
         }
 #endif
 

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -2415,3 +2415,36 @@ mgbyte MGG_OcclusionQuery_GetResult(MGG_GraphicsDevice* device, MGG_OcclusionQue
 
 	return true;
 }
+
+MGG_Texture* MGG_RenderTarget_WrapNativeHandle(
+	MGG_GraphicsDevice* device,
+	void* nativeHandle,
+	MGSurfaceFormat format,
+	mgint width,
+	mgint height,
+	MGDepthFormat depthFormat,
+	mgint multiSampleCount)
+{
+	if (!device || !nativeHandle || !device->resources)
+	{
+		return nullptr;
+	}
+
+	auto* external_resource = static_cast<ID3D12Resource*>(nativeHandle);
+
+	const auto texture = new MGG_Texture();
+	texture->format = format;
+
+	// Create a Texture wrapper around the external resource.
+	// This creates RTV + SRV descriptors without allocating memory for the resource itself.
+	texture->texture = new Texture(device->resources, external_resource, format);
+
+	// Create depth buffer if requested (owned by this texture wrapper).
+	if (depthFormat != MGDepthFormat::None)
+	{
+		texture->depthTexture = new Texture(width, height, depthFormat);
+		texture->depthTexture->Create(device->resources);
+	}
+
+	return texture;
+}

--- a/native/monogame/directx12/Texture.cpp
+++ b/native/monogame/directx12/Texture.cpp
@@ -74,6 +74,45 @@ Texture::Texture(const Texture& other) {
     impl->m_currentState = D3D12_RESOURCE_STATE_COPY_DEST;
 }
 
+Texture::Texture(DeviceResources* device, ID3D12Resource* externalResource, MGSurfaceFormat format) {
+    impl = new InternalData();
+    impl->m_type = SurfaceType::RenderTarget;
+    impl->m_depthFormat = MGDepthFormat::None;
+    impl->m_levels = 1;
+    impl->m_dimension = TextureDimension::Texture2D;
+
+    impl->m_currentState = D3D12_RESOURCE_STATE_RENDER_TARGET;
+    impl->m_alloc = nullptr; // No allocation. This is externally owned.
+
+    impl->m_res = externalResource;
+    impl->m_desc = externalResource->GetDesc();
+
+    DXGI_FORMAT viewFormat = TextureFormatToDXGI_FORMAT(format);
+    impl->m_desc.Format = viewFormat;
+
+    // Create SRV descriptor
+    D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
+    srv_desc.Format = viewFormat;
+    srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+
+    bool isMSAA = CheckMSAA(device->GetD3DDevice());
+    srv_desc.ViewDimension = isMSAA ? D3D12_SRV_DIMENSION_TEXTURE2DMS : D3D12_SRV_DIMENSION_TEXTURE2D;
+
+    srv_desc.Texture2D.MostDetailedMip = 0;
+    srv_desc.Texture2D.MipLevels = impl->m_levels;
+    srv_desc.Texture2D.PlaneSlice = 0;
+    impl->m_srvHandle = device->GetGraphicsHeaps()->CreateSRVHandle(externalResource, srv_desc);
+
+    if (impl->m_desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET) {
+        // Create RTV descriptor.
+        D3D12_RENDER_TARGET_VIEW_DESC rtvDesc = {};
+        rtvDesc.Format = impl->m_desc.Format;
+        rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
+
+        impl->m_rtvHandles.push_back(device->GetGraphicsHeaps()->CreateRTVHandle(externalResource, rtvDesc));
+    }
+}
+
 #ifndef _GAMING_XBOX
 Texture::Texture(DeviceResources* device, IDXGISwapChain3* swapchain, int bufferId) {
     impl = new InternalData();

--- a/native/monogame/directx12/Texture.h
+++ b/native/monogame/directx12/Texture.h
@@ -15,6 +15,10 @@ public:
     Texture(SurfaceType type, TextureDimension dimension, int width, int height, int depth, int mipLevels, MGSurfaceFormat format);
     Texture(int width, int height, MGDepthFormat format);
     Texture(const Texture& other);
+
+    // Wrap an externally owned resource (e.g. OpenXR swapchain image or other native texture).
+    Texture(DeviceResources* device, ID3D12Resource* externalResource, MGSurfaceFormat format);
+
 #ifndef _GAMING_XBOX
     Texture(DeviceResources* device, IDXGISwapChain3* swapchain, int bufferId);
 #endif

--- a/native/monogame/include/api_MGG.h
+++ b/native/monogame/include/api_MGG.h
@@ -82,3 +82,4 @@ MG_EXPORT void MGG_OcclusionQuery_Destroy(MGG_GraphicsDevice* device, MGG_Occlus
 MG_EXPORT void MGG_OcclusionQuery_Begin(MGG_GraphicsDevice* device, MGG_OcclusionQuery* query);
 MG_EXPORT void MGG_OcclusionQuery_End(MGG_GraphicsDevice* device, MGG_OcclusionQuery* query);
 MG_EXPORT mgbyte MGG_OcclusionQuery_GetResult(MGG_GraphicsDevice* device, MGG_OcclusionQuery* query, mgint& pixelCount);
+MG_EXPORT MGG_Texture* MGG_RenderTarget_WrapNativeHandle(MGG_GraphicsDevice* device, void* nativeHandle, MGSurfaceFormat format, mgint width, mgint height, MGDepthFormat depthFormat, mgint multiSampleCount);

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -365,6 +365,7 @@ struct MGG_Texture
 
 	mgbool isTarget = false;
 	mgbool isSwapchain = false;
+	mgbool isExternal = false;
 
 	mgint multiSampleCount = 0;
 
@@ -2447,7 +2448,10 @@ static void MGVK_DestroyFrameResources(MGG_GraphicsDevice* device, FrameCounter 
 				vmaDestroyImage(device->allocator, texture->msImage, texture->msAllocation);
 			}
 
-			vmaDestroyImage(device->allocator, texture->image, texture->allocation);
+			if (texture->allocation != VK_NULL_HANDLE)
+			{
+				vmaDestroyImage(device->allocator, texture->image, texture->allocation);
+			}
 			mg_remove(device->all_textures, texture);
 			delete texture;
 		}
@@ -3186,8 +3190,8 @@ static void MGVK_UpdateRenderPass(MGG_GraphicsDevice* device, FrameCounter curre
                 {
                     desc.loadOp = firstUse ? VK_ATTACHMENT_LOAD_OP_DONT_CARE : VK_ATTACHMENT_LOAD_OP_LOAD;
                     desc.stencilLoadOp = firstUse ? VK_ATTACHMENT_LOAD_OP_DONT_CARE : VK_ATTACHMENT_LOAD_OP_LOAD;
-                    desc.initialLayout = firstUse ? VK_IMAGE_LAYOUT_UNDEFINED : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-                    desc.finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                    desc.initialLayout = firstUse ? VK_IMAGE_LAYOUT_UNDEFINED : target->optimal_layout;
+                    desc.finalLayout = target->optimal_layout;
                 }
             }
 
@@ -3236,7 +3240,7 @@ static void MGVK_UpdateRenderPass(MGG_GraphicsDevice* device, FrameCounter curre
 			desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 			desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 			desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-			desc.finalLayout = firstTarget->isSwapchain ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			desc.finalLayout = firstTarget->isSwapchain ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR : firstTarget->optimal_layout;
 
 			num_attachments++;
 		}
@@ -3342,7 +3346,7 @@ static void MGVK_UpdateRenderPass(MGG_GraphicsDevice* device, FrameCounter curre
 		if (target->isSwapchain)
 			target->layouts[0] = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 		else
-			target->layouts[0] = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			target->layouts[0] = target->optimal_layout;
 	}
 
 	// Set the cache for the changed pipeline state.
@@ -5324,6 +5328,57 @@ void MGG_Texture_Destroy(MGG_GraphicsDevice* device, MGG_Texture* texture)
 	if (texture->depthTexture)
 		MGG_Texture_Destroy(device, texture->depthTexture);
 
+	// If this is an externally owned texture (like an external swapchain or image wrapped in a RenderTarget2D).
+	if (texture->isExternal && texture->allocation == VK_NULL_HANDLE)
+	{
+		// Wait for the device to be idle to safely destroy views before the external caller destroys the underlying VkImage.
+		vkDeviceWaitIdle(device->device);
+
+		if (texture->isTarget)
+		{
+			MGVK_DestroyPipelines(device, [texture](const MGVK_PipelineState& s)
+				{
+					for (int i = 0; i < s.targets->set.numTargets; i++)
+					{
+						if (s.targets->set.targets[i] == texture)
+						{
+							return true;
+						}
+					}
+					return false;
+				});
+
+			MGVK_DestroyTargetSets(device, [texture](const MGVK_TargetSetCache* s)
+				{
+					for (int i = 0; i < s->set.numTargets; i++)
+					{
+						if (s->set.targets[i] == texture)
+						{
+							return true;
+						}
+					}
+					return false;
+				});
+
+			if (device->pipelineState.targets && device->pipelineState.targets->set.targets[0] == texture)
+			{
+				device->pipelineState.targets = nullptr;
+			}
+		}
+
+		if (texture->target_view != VK_NULL_HANDLE)
+		{
+			vkDestroyImageView(device->device, texture->target_view, nullptr);
+		}
+		if (texture->view != VK_NULL_HANDLE)
+		{
+			vkDestroyImageView(device->device, texture->view, nullptr);
+		}
+
+		delete texture;
+		return;
+	}
+
 	// Queue the texture for later destruction.
 	device->destroyTextures.push(texture);
 }
@@ -5889,4 +5944,99 @@ mgbyte MGG_OcclusionQuery_GetResult(MGG_GraphicsDevice* device, MGG_OcclusionQue
 		pixelCount = 0;
 		return false; // Return false indicating the result is not available.
 	}
+}
+
+MGG_Texture* MGG_RenderTarget_WrapNativeHandle(
+	MGG_GraphicsDevice* device,
+	void* nativeHandle,
+	MGSurfaceFormat format,
+	mgint width,
+	mgint height,
+	MGDepthFormat depthFormat,
+	mgint multiSampleCount)
+{
+	assert(device != nullptr);
+	assert(nativeHandle != nullptr);
+	assert(width > 0);
+	assert(height > 0);
+
+	auto texture = new MGG_Texture();
+	texture->isTarget = true;
+	texture->isExternal = true; // Marks as externally owned. Prevents image/memory destruction.
+	texture->type = MGTextureType::_2D;
+	texture->format = format;
+	texture->id = ++device->currentTextureId;
+	texture->multiSampleCount = multiSampleCount;
+	texture->usage = MGRenderTargetUsage::DiscardContents;
+
+	// Set the externally-owned VkImage. We don't allocate memory.
+	texture->image = static_cast<VkImage>(nativeHandle);
+	texture->allocation = VK_NULL_HANDLE; // We don't own the image. Prevents us from trying to free image memory.
+
+	// Populate VkImageCreateInfo for view creation.
+	VkImageCreateInfo& create_info = texture->info;
+	create_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+	create_info.imageType = ToVkImageType(texture->type);
+	create_info.flags = ToVkImageCreateFlags(texture->type);
+	create_info.format = ToVkFormat(format);
+	create_info.extent.width = width;
+	create_info.extent.height = height;
+	create_info.extent.depth = 1;
+	create_info.mipLevels = 1;
+	create_info.arrayLayers = 1;
+	create_info.samples = ToVkSampleCount(multiSampleCount);
+	create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+
+	create_info.usage =
+		VK_IMAGE_USAGE_SAMPLED_BIT
+		| VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+		| VK_IMAGE_USAGE_TRANSFER_SRC_BIT
+		| VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+
+	create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+	texture->layouts[0] = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+	texture->optimal_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+	// Create image view for shader sampling.
+	texture->view = CreateImageView(device, texture, 1);
+	VK_SET_OBJECT_NAME(device->device,
+		texture->view,
+		VK_OBJECT_TYPE_IMAGE_VIEW,
+		"MGG_Texture.view (External RenderTarget id: %llu)",
+		texture->id);
+
+	// Create image view for render target.
+	texture->target_view = CreateImageView(device, texture, 1);
+	VK_SET_OBJECT_NAME(device->device,
+		texture->target_view,
+		VK_OBJECT_TYPE_IMAGE_VIEW,
+		"MGG_Texture.target_view (External RenderTarget id: %llu)",
+		texture->id);
+
+	// Create depth buffer if requested (owned by this texture wrapper).
+	if (depthFormat != MGDepthFormat::None)
+	{
+		texture->depthFormat = depthFormat;
+		texture->depthTexture = CreateDepthTexture(device, ToVkFormat(depthFormat), width, height, multiSampleCount);
+
+		VK_SET_OBJECT_NAME(device->device,
+			texture->depthTexture->image,
+			VK_OBJECT_TYPE_IMAGE,
+			"MGG_Texture.depthTexture (External RenderTarget id: %llu)",
+			texture->id);
+
+		texture->depthTexture->target_view = CreateImageView(device,
+			texture->depthTexture,
+			1);
+
+		VK_SET_OBJECT_NAME(device->device,
+			texture->depthTexture->target_view,
+			VK_OBJECT_TYPE_IMAGE_VIEW,
+			"MGG_Texture.depthTexture.target_view (External RenderTarget id: %llu)",
+			texture->id);
+	}
+
+	return texture;
 }


### PR DESCRIPTION
Wrapping external textures in render targets.

Fixes #7195
Related to #9289

### Description of Change

- Adding `RenderTarget2D.FromNativeHandle()` to wrap external textures in render targets.
Done for:
   - DesktopVK
   - WindowsDX12
   - WindowsDX
   - DesktopGL


### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

