### PR TITLE
Exposing Native GPU Handles

### DIFF
--- a/MonoGame.Framework/Graphics/NativeGraphicsHandles.cs
+++ b/MonoGame.Framework/Graphics/NativeGraphicsHandles.cs
@@ -1,0 +1,98 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using MonoGame.Framework.Utilities;
+
+namespace Microsoft.Xna.Framework.Graphics;
+
+/// <summary>
+/// Contains native graphics API handles for XR or other external interop.
+/// <see cref="PhysicalDevice"/>, <see cref="LogicalDevice"/> and <see cref="Queue"/> are always populated for the native backends (Vulkan and DX12).
+/// Other fields depend on <see cref="Backend"/>.
+/// </summary>
+public readonly struct NativeGraphicsHandles
+{
+    /// <summary>
+    /// The active graphics backend.
+    /// </summary>
+    public readonly GraphicsBackend Backend;
+
+    /// <summary>
+    /// Handle for the session between the application and the graphics API.
+    /// </summary>
+    /// <remarks>
+    /// Vulkan: <c>VkInstance</c> handle.
+    /// Others: Zero.
+    /// </remarks>
+    public readonly nint Instance;
+
+    /// <summary>
+    /// The physical adapter handle.
+    /// </summary>
+    /// <remarks>
+    /// Vulkan: <c>VkPhysicalDevice</c> handle.
+    /// DX12: <c>IDXGIAdapter1*</c>.
+    /// Others: Zero.
+    /// </remarks>
+    public readonly nint PhysicalDevice;
+
+    /// <summary>
+    /// The logical graphics device handle.
+    /// </summary>
+    /// <remarks>
+    /// Vulkan: <c>VkDevice</c> handle.
+    /// DX12: <c>ID3D12Device*</c>.
+    /// Others: Zero.
+    /// </remarks>
+    public readonly nint LogicalDevice;
+
+    /// <summary>
+    /// The graphics queue handle.
+    /// </summary>
+    /// <remarks>
+    /// Vulkan: <c>VkQueue</c> handle.
+    /// DX12: <c>ID3D12CommandQueue*</c>.
+    /// Others: Zero.
+    /// </remarks>
+    public readonly nint Queue;
+
+    /// <summary>
+    /// Index of the queue family/type.
+    /// </summary>
+    /// <remarks>
+    /// Vulkan: queue family index.
+    /// Others: Zero.
+    /// </remarks>
+    public readonly int QueueFamilyIndex;
+
+    /// <summary>
+    /// Index of the queue within its family/type.
+    /// </summary>
+    /// <remarks>
+    /// Vulkan: queue index within family.
+    /// Others: Zero.
+    /// </remarks>
+    public readonly int QueueIndex;
+
+    /// <summary>
+    /// Creates a new <see cref="NativeGraphicsHandles"/> instance that holds the provided handles (pointers).
+    /// </summary>
+    public NativeGraphicsHandles(
+        GraphicsBackend backend,
+        nint instance,
+        nint physicalDevice,
+        nint device,
+        nint queue,
+        int queueFamilyIndex,
+        int queueIndex)
+    {
+        Backend = backend;
+        Instance = instance;
+        PhysicalDevice = physicalDevice;
+        LogicalDevice = device;
+        Queue = queue;
+        QueueFamilyIndex = queueFamilyIndex;
+        QueueIndex = queueIndex;
+    }
+}

--- a/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
+++ b/MonoGame.Framework/Platform/Native/Graphics.Interop.cs
@@ -452,4 +452,25 @@ internal static unsafe partial class MGG
     public static extern byte OcclusionQuery_GetResult(MGG_GraphicsDevice* device, MGG_OcclusionQuery* query, out int pixelCount);
 
     #endregion
+
+    #region Native Interop
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct MGP_NativeGraphicsHandles
+    {
+        public int Backend;
+        public nint Instance;
+        public nint PhysicalDevice;
+        public nint LogicalDevice;
+        public nint Queue;
+        public int QueueFamilyIndex;
+        public int QueueIndex;
+    }
+
+    [DllImport(MGP.MonoGameNativeDLL, EntryPoint = "MGG_GraphicsDevice_GetNativeHandles", ExactSpelling = true)]
+    public static extern void GraphicsDevice_GetNativeHandles(
+        MGG_GraphicsDevice* device,
+        out MGP_NativeGraphicsHandles handles);
+
+    #endregion
 }

--- a/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
+++ b/MonoGame.Framework/Platform/Native/GraphicsDevice.Native.cs
@@ -536,4 +536,24 @@ public partial class GraphicsDevice
 
         return new Rectangle(x, y, width, height);
     }
+
+    /// <summary>
+    /// Retrieves the native graphics API handles for XR or external interop.
+    /// <see cref="NativeGraphicsHandles.PhysicalDevice"/>, <see cref="NativeGraphicsHandles.LogicalDevice"/> and <see cref="NativeGraphicsHandles.Queue"/>
+    /// are always populated for the native backends.
+    /// Check <see cref="NativeGraphicsHandles.Backend"/> for backend-specific field availability.
+    /// </summary>
+    public unsafe NativeGraphicsHandles GetNativeHandles()
+    {
+        MGG.GraphicsDevice_GetNativeHandles(Handle, out var native);
+
+        return new NativeGraphicsHandles(
+            (GraphicsBackend)native.Backend,
+            native.Instance,
+            native.PhysicalDevice,
+            native.LogicalDevice,
+            native.Queue,
+            native.QueueFamilyIndex,
+            native.QueueIndex);
+    }
 }

--- a/native/monogame/directx12/DeviceResources.cpp
+++ b/native/monogame/directx12/DeviceResources.cpp
@@ -23,6 +23,7 @@ private:
 #else
     Microsoft::WRL::ComPtr<IDXGIFactory6> m_dxgiFactory;
     Microsoft::WRL::ComPtr<IDXGISwapChain3> m_swapChain;
+    Microsoft::WRL::ComPtr<IDXGIAdapter1> m_adapter;
 
     DeviceResources::DeviceResetCallbackFunc m_lostCbk = nullptr;
 
@@ -206,6 +207,7 @@ public:
 #endif
 
         m_dxgiFactory = factory;
+        m_adapter = adapter;
 
         // Create the DX12 API device object.
         HRESULT hr;
@@ -511,6 +513,7 @@ public:
         m_d3dDevice.Reset();
         m_dxgiFactory.Reset();
         m_allocator.Reset();
+        m_adapter.Reset();
     }
 #endif
 
@@ -704,6 +707,14 @@ void DeviceResources::GetBackBufferData(uint32_t x, uint32_t y, uint32_t w, uint
 
 CommandContext* Graphics::DeviceResources::GetCommandContext() const {
     return pImpl->m_commandContext.get();
+}
+
+IDXGIAdapter1* Graphics::DeviceResources::GetAdapter() const {
+#if defined(_GAMING_XBOX)
+    return nullptr;
+#else
+    return pImpl->m_adapter.Get();
+#endif
 }
 
 ID3D12Device* Graphics::DeviceResources::GetD3DDevice() const {

--- a/native/monogame/directx12/DeviceResources.h
+++ b/native/monogame/directx12/DeviceResources.h
@@ -62,6 +62,7 @@ public:
 
     CommandContext* GetCommandContext() const;
 
+    IDXGIAdapter1* GetAdapter() const;
     ID3D12Device* GetD3DDevice() const;
     unsigned int GetBackBufferCount() const;
     CommandList* BeginCommandList() const;

--- a/native/monogame/directx12/MGG_DX12.cpp
+++ b/native/monogame/directx12/MGG_DX12.cpp
@@ -2415,3 +2415,19 @@ mgbyte MGG_OcclusionQuery_GetResult(MGG_GraphicsDevice* device, MGG_OcclusionQue
 
 	return true;
 }
+
+MG_EXPORT void MGG_GraphicsDevice_GetNativeHandles(const MGG_GraphicsDevice* device, MGP_NativeGraphicsHandles* handles)
+{
+	if (!device || !handles)
+	{
+		return;
+	}
+
+	handles->Backend          = MGGraphicsBackend::DirectX12;
+	handles->Instance         = nullptr;	// DX12 doesn't have an instance handle like Vulkan.
+	handles->PhysicalDevice   = device->resources->GetAdapter();
+	handles->LogicalDevice    = device->resources->GetD3DDevice();
+	handles->Queue            = device->resources->GetCommandQueue()->Get();
+	handles->QueueFamilyIndex = 0;	// DX12 doesn't have queue families.
+	handles->QueueIndex       = 0;
+}

--- a/native/monogame/include/api_MGG.h
+++ b/native/monogame/include/api_MGG.h
@@ -82,3 +82,4 @@ MG_EXPORT void MGG_OcclusionQuery_Destroy(MGG_GraphicsDevice* device, MGG_Occlus
 MG_EXPORT void MGG_OcclusionQuery_Begin(MGG_GraphicsDevice* device, MGG_OcclusionQuery* query);
 MG_EXPORT void MGG_OcclusionQuery_End(MGG_GraphicsDevice* device, MGG_OcclusionQuery* query);
 MG_EXPORT mgbyte MGG_OcclusionQuery_GetResult(MGG_GraphicsDevice* device, MGG_OcclusionQuery* query, mgint& pixelCount);
+MG_EXPORT void MGG_GraphicsDevice_GetNativeHandles(const MGG_GraphicsDevice* device, MGP_NativeGraphicsHandles* handles);

--- a/native/monogame/include/api_structs.h
+++ b/native/monogame/include/api_structs.h
@@ -252,3 +252,14 @@ struct MGP_ControllerCaps
     mgbool HasVoiceSupport;
 };
 
+struct MGP_NativeGraphicsHandles
+{
+    MGGraphicsBackend Backend;
+    void* Instance;
+    void* PhysicalDevice;
+    void* LogicalDevice;
+    void* Queue;
+    mgint QueueFamilyIndex;
+    mgint QueueIndex;
+};
+

--- a/native/monogame/vulkan/MGG_Vulkan.cpp
+++ b/native/monogame/vulkan/MGG_Vulkan.cpp
@@ -5890,3 +5890,19 @@ mgbyte MGG_OcclusionQuery_GetResult(MGG_GraphicsDevice* device, MGG_OcclusionQue
 		return false; // Return false indicating the result is not available.
 	}
 }
+
+MG_EXPORT void MGG_GraphicsDevice_GetNativeHandles(const MGG_GraphicsDevice* device, MGP_NativeGraphicsHandles* handles)
+{
+	if (!device || !handles)
+	{
+		return;
+	}
+
+	handles->Backend          = MGGraphicsBackend::Vulkan;
+	handles->Instance         = device->instance;
+	handles->PhysicalDevice   = device->physicalDevice;
+	handles->LogicalDevice    = device->device;
+	handles->Queue            = static_cast<void*>(device->queue);
+	handles->QueueFamilyIndex = static_cast<mgint>(device->graphicsQueueFamily);
+	handles->QueueIndex       = 0;
+}


### PR DESCRIPTION
Exposing Native GPU Handles

Fixes #9537
Related to #9289

### Description of Change

- Native API:
   - Adding `MGP_NativeGraphicsHandles` to represent the device, instance and queue data.
   - Adding `MGG_GraphicsDevice_GetNativeHandles` for both Vulkan and DX12.
- Managed API:
   - Adding `NativeGraphicsHandles` struct for the GPU data.
   - Adding `GraphicsDevice.GetNativeHandles()` in the native backends.

### Contributor Declaration

- [x] I certify that no LLM's were used to generate any code or documentation in this contribution.

> [!NOTE]
> We should carefully evaluate the managed API I'm proposing here. I think this is a simple, generic and good enough API, but I need you folks' feedback.
> However, if we have concerns or questions about it, we should at least be able to merge the native API, and then further discuss and distill the managed API separately.
> This would at least provide the bare minimum for people to be able to consume the handles via interop calls they wire up themselves.
